### PR TITLE
fixed: node numbering for multi-patch mixed models

### DIFF
--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -672,7 +672,7 @@ bool ASMs2D::connectBasis (int edge, ASMs2D& neighbor, int nedge, bool revers,
   for (i = 0; i < n1; i++, node += i1)
   {
     int slave = slaveNodes[revers ? n1-i-1 : i];
-    if (!neighbor.getCoord(node).equal(this->getCoord(slave),xtol))
+    /*if (!neighbor.getCoord(node).equal(this->getCoord(slave),xtol))
     {
       std::cerr <<" *** ASMs2D::connectPatch: Non-matching nodes "
 		<< node <<": "<< neighbor.getCoord(node)
@@ -680,7 +680,7 @@ bool ASMs2D::connectBasis (int edge, ASMs2D& neighbor, int nedge, bool revers,
 		<< slave <<": "<< this->getCoord(slave) << std::endl;
       return false;
     }
-    else
+    else*/
       ASMbase::collapseNodes(neighbor,node,*this,slave);
   }
 

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -299,14 +299,15 @@ bool ASMs2Dmx::connectPatch (int edge, ASMs2D& neighbor, int nedge, bool revers)
 
   size_t nb1=0;
   size_t nb2=0;
-  for (size_t i = 1;i <= m_basis.size(); ++i) {
+  for (size_t i = 1; i <= m_basis.size(); ++i) {
     if (!this->connectBasis(edge,neighbor,nedge,revers,i,nb1,nb2))
       return false;
     nb1 += nb[i-1];
     nb2 += neighMx->nb[i-1];
+    if (i == 1)
+      this->addNeighbor(neighMx);
   }
 
-  this->addNeighbor(neighMx);
   return true;
 }
 


### PR DESCRIPTION
- a sanity check has been disabled (getCoord only works for first basis).
- make sure to add neighbor at correct point.

@kmokstad what do to with the sanity check ?