### PR TITLE
fixed: mark functions as non-copyable

### DIFF
--- a/src/Utility/ExprFunctions.h
+++ b/src/Utility/ExprFunctions.h
@@ -48,6 +48,8 @@ public:
   virtual ~EvalFunc();
 
 protected:
+  EvalFunc(const EvalFunc&);
+  EvalFunc& operator=(const EvalFunc&);
   //! \brief Evaluates the function expression.
   virtual Real evaluate(const Real& x) const;
 };
@@ -78,6 +80,8 @@ public:
 protected:
   //! \brief Evaluates the function expression.
   virtual Real evaluate(const Vec3& X) const;
+  EvalFunction(const EvalFunction&);
+  EvalFunction& operator=(const EvalFunction&);
 };
 
 


### PR DESCRIPTION
lots of pointer members so these cannot be copied