### PR TITLE
fixed: fix boundary condition output to VTF for mixed bases

### DIFF
--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -850,10 +850,10 @@ bool ASMs2Dmx::evalSolution (Matrix& sField, const Vector& locSol,
   std::vector<size_t> nc(nfx.size());
   std::copy(nfx.begin(), nfx.end(), nc.begin());
 
-  // assume geobasis only
+  // assume first basis only
   if (locSol.size() < std::inner_product(nb.begin(), nb.end(), nfx.begin(), 0u)) {
     std::fill(nc.begin(), nc.end(), 0);
-    nc[geoBasis-1] = nfx[geoBasis-1];
+    nc[0] = nfx[0];
   }
 
   if (std::inner_product(nb.begin(), nb.end(), nc.begin(), 0u) != locSol.size())
@@ -869,6 +869,8 @@ bool ASMs2Dmx::evalSolution (Matrix& sField, const Vector& locSol,
   {
     size_t comp=0;
     for (size_t b = 0; b < m_basis.size(); ++b) {
+      if (nc[b] == 0)
+        continue;
       IntVec ip;
       scatterInd(m_basis[b]->numCoefs_u(),m_basis[b]->numCoefs_v(),
                  m_basis[b]->order_u(),m_basis[b]->order_v(),splinex[b][i].left_idx,ip);

--- a/src/ASM/ASMs3Dmx.C
+++ b/src/ASM/ASMs3Dmx.C
@@ -824,10 +824,10 @@ bool ASMs3Dmx::evalSolution (Matrix& sField, const Vector& locSol,
   std::vector<size_t> nc(nfx.size());
   std::copy(nfx.begin(), nfx.end(), nc.begin());
 
-  // assume geobasis only
+  // assume first basis only
   if (locSol.size() < std::inner_product(nb.begin(), nb.end(), nfx.begin(), 0u)) {
     std::fill(nc.begin(), nc.end(), 0);
-    nc[geoBasis-1] = nfx[geoBasis-1];
+    nc[0] = nfx[0];
   }
 
   if (std::inner_product(nb.begin(), nb.end(), nc.begin(), 0u) != locSol.size())
@@ -843,6 +843,8 @@ bool ASMs3Dmx::evalSolution (Matrix& sField, const Vector& locSol,
   {
     size_t comp=0;
     for (size_t b = 0; b < m_basis.size(); ++b) {
+      if (nc[b] == 0)
+        continue;
       IntVec ip;
       scatterInd(m_basis[b]->numCoefs(0),m_basis[b]->numCoefs(1),m_basis[b]->numCoefs(2),
                  m_basis[b]->order(0), m_basis[b]->order(1), m_basis[b]->order(2),

--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -333,7 +333,7 @@ bool SIMoutput::writeGlvBC (int& nBlock, int iStep) const
 
     geomID++;
     size_t nbc = myModel[i]->getNoFields(1);
-    Matrix bc(nbc,myModel[i]->getNoNodes(-1));
+    Matrix bc(nbc,myModel[i]->getNoNodes(1));
     RealArray flag(3,0.0);
     ASMbase::BCVec::const_iterator bit;
     for (bit = myModel[i]->begin_BC(); bit != myModel[i]->end_BC(); bit++)


### PR DESCRIPTION
These are only generated for the first basis, not for the geometry basis.