### PR TITLE
Some small fixes

### DIFF
--- a/src/LinAlg/LinSolParams.C
+++ b/src/LinAlg/LinSolParams.C
@@ -184,6 +184,7 @@ bool LinSolParams::read (const TiXmlElement* elem)
   const char* value = 0;
 
   const TiXmlElement* child = elem->FirstChildElement();
+  int parseblock = 0;
   for (; child; child = child->NextSiblingElement())
     if ((value = utl::getValue(child,"type")))
       method = value;
@@ -202,7 +203,7 @@ bool LinSolParams::read (const TiXmlElement* elem)
     }
 #endif
     else if (!strcasecmp(child->Value(),"block")) {
-      blocks.resize(blocks.size()+1);
+      blocks.resize(++parseblock);
       blocks.back().read(child);
     }
     else if ((value = utl::getValue(child,"atol")))
@@ -214,10 +215,8 @@ bool LinSolParams::read (const TiXmlElement* elem)
     else if ((value = utl::getValue(child,"maxits")))
       maxIts = atoi(value);
 
-  if (blocks.size() == 0) {
-    blocks.resize(1);
+  if (parseblock == 0)
     blocks.back().read(elem);
-  }
 
   return true;
 }

--- a/src/LinAlg/LinSolParams.C
+++ b/src/LinAlg/LinSolParams.C
@@ -94,8 +94,6 @@ bool LinSolParams::BlockParams::read(const TiXmlElement* elem)
         nullspace = NONE;
     }
 #endif
-    else
-      return false;
 
   return true;
 }

--- a/src/LinAlg/LinSolParams.C
+++ b/src/LinAlg/LinSolParams.C
@@ -346,6 +346,9 @@ static std::string ToString(T data)
 
 void LinSolParams::setMLOptions(const std::string& prefix, int block) const
 {
+#if PETSC_VERSION_MINOR > 6
+#define PetscOptionsSetValue(x,y) PetscOptionsSetValue(nullptr, x, y)
+#endif
   PetscOptionsSetValue(AddPrefix(prefix,"pc_ml_maxNLevels").c_str(),
                        ToString(blocks[block].mglevel).c_str());
   PetscOptionsSetValue(AddPrefix(prefix,"pc_ml_maxCoarseSize").c_str(),

--- a/src/LinAlg/LinSolParams.h
+++ b/src/LinAlg/LinSolParams.h
@@ -69,6 +69,7 @@ public:
 #ifdef HAS_PETSC
     schurPrec(SIMPLE),
 #endif
+    blocks(1),
     nsd(n),
     msgLev(m)
   {}


### PR DESCRIPTION
- Support for PETSc 3.7
- Do not dereference a pointer that may be nullptr
- Fix in LinSolParams where app would crash if no xml input tag was present
- Fix parsing LinSolParam blocks from top context (ignore unknown tags).