### PR TITLE
fix: follow standard definition of G-matrix.

### DIFF
--- a/Apps/Common/Test/TestStabilizationUtils.C
+++ b/Apps/Common/Test/TestStabilizationUtils.C
@@ -51,7 +51,7 @@ TEST(TestStabilizationUtils, GetTauPt)
   Matrix G;
   utl::getGmat(J, &du[0], G);
   ASSERT_FLOAT_EQ(StabilizationUtils::getTauPt(0.1, 0.3, U, G, 4.0, 5.0),
-                  0.04884154);
+                  0.032328788);
 }
 
 TEST(TestStabilizationUtils, GetTauNSPt)
@@ -68,8 +68,8 @@ TEST(TestStabilizationUtils, GetTauNSPt)
 
   double tauM, tauC;
   ASSERT_TRUE(StabilizationUtils::getTauNSPt(0.1, 0.3, U, G, tauM, tauC));
-  ASSERT_FLOAT_EQ(tauM, 0.06156440419723151);
-  ASSERT_FLOAT_EQ(tauC, 4.060788100849391);
+  ASSERT_FLOAT_EQ(tauM, 0.016634906);
+  ASSERT_FLOAT_EQ(tauC, 1.87858);
 }
 
 TEST(TestStabilizationUtils, GetTauNSALEPt)
@@ -86,6 +86,6 @@ TEST(TestStabilizationUtils, GetTauNSALEPt)
 
   double tauM, tauC;
   ASSERT_TRUE(StabilizationUtils::getTauNSALEPt(0.1, 0.3, U, G, tauM, tauC));
-  ASSERT_FLOAT_EQ(tauM, 0.06156440419723151);
-  ASSERT_FLOAT_EQ(tauC, 0.1846932125916945);
+  ASSERT_FLOAT_EQ(tauM, 0.016634906);
+  ASSERT_FLOAT_EQ(tauC, 0.049904719);
 }

--- a/src/Utility/CoordinateMapping.C
+++ b/src/Utility/CoordinateMapping.C
@@ -188,4 +188,6 @@ void utl::getGmat (const matrix<Real>& Ji, const Real* du, matrix<Real>& G)
       for (size_t m = 1; m <= nsd; m++)
         G(k,l) += Ji(m,k)*Ji(m,l)*scale;
     }
+
+  G *= pow(2, nsd);
 }


### PR DESCRIPTION
Afaik the G-matrix definition uses a (-1,1)^d reference element, but this is mostly CFD-motivated, and this is the only place where the G-matrix is used in IFEM.