### PR TITLE
Fixed: Adaptive linear elasticity was broken in the attempt to generalize ...

### DIFF
--- a/Apps/Common/SIMSolverAdap.h
+++ b/Apps/Common/SIMSolverAdap.h
@@ -28,7 +28,7 @@ template<class T1> class SIMSolverAdap : public SIMSolver<T1>
 {
 public:
   //! \brief The constructor forwards to the parent class constructor.
-  SIMSolverAdap(T1& s1) : SIMSolver<T1>(s1), aSim(&s1) {}
+  SIMSolverAdap(T1& s1) : SIMSolver<T1>(s1), aSim(s1,false) {}
   //! \brief Empty destructor.
   virtual ~SIMSolverAdap() {}
 

--- a/src/SIM/AdaptiveSIM.h
+++ b/src/SIM/AdaptiveSIM.h
@@ -7,7 +7,7 @@
 //!
 //! \author Knut Morten Okstad / SINTEF
 //!
-//! \brief Adaptive solution driver for linear isogeometric FEM simulators.
+//! \brief Adaptive solution driver for linear static FEM simulators.
 //!
 //==============================================================================
 
@@ -17,26 +17,22 @@
 #include "SIMinput.h"
 #include "MatVec.h"
 
-class SIMbase;
 class SIMoutput;
-class TimeStep;
-class NormBase;
-
-enum class Threshold {NONE, MAXIMUM, AVERAGE, MINIMUM};
 
 
 /*!
-  \brief Adaptive solution driver for linear isogeometric FEM simulators.
-  \details This class contains data and methods for solving linear FE problems
-  adaptively based on element error norms as refinement indicators.
+  \brief Adaptive solution driver for linear static FEM simulators.
+  \details This class contains data and methods for solving linear static FE
+  problems adaptively, based on element error norms as refinement indicators.
 */
 
 class AdaptiveSIM : public SIMinput
 {
 public:
   //! \brief The constructor initializes default adaptation parameters.
-  //! \param sim Pointer to the spline FE model
-  AdaptiveSIM(SIMbase* sim = nullptr);
+  //! \param sim The FE model
+  //! \param sa If \e true, this is a stand-alone driver
+  AdaptiveSIM(SIMoutput& sim, bool sa = true);
   //! \brief Empty destructor.
   virtual ~AdaptiveSIM() {}
 
@@ -44,15 +40,6 @@ public:
   //! \param[in] indxProj Index to projection method to base mesh adaption on
   //! \param[in] nNormProj Number of element norms per projection method
   bool initAdaptor(size_t indxProj, size_t nNormProj);
-
-  //! \brief Assemble and solve linear system
-  virtual bool assembleAndSolve();
-
-  //! \brief Returns vectors to interpolate during refinements.
-  virtual Vectors& getRefineVectors() { static Vectors v; return v; }
-
-  //! \brief Transfers refined vectors back to solver.
-  virtual void solutionTransfer() {}
 
   //! \brief Assembles and solves the linear FE equations on current mesh.
   //! \param[in] inputfile File to read model parameters from after refinement
@@ -74,21 +61,16 @@ public:
 
   //! \brief Accesses the solution of the linear system.
   const Vector& getSolution(size_t idx = 0) const { return solution[idx]; }
-
   //! \brief Accesses the projections.
-  const Vector& getProjection(size_t idx) const { return projs[idx]; }
-
+  const Vector& getProjection(size_t idx = 0) const { return projs[idx]; }
   //! \brief Accesses the norm prefices.
-  const char** getNormPrefixes() { return &prefix[0]; }
+  const char** getNormPrefixes() { return &prefix.front(); }
 
   //! \brief Initializes the projections.
   void setupProjections();
 
-  //! \brief Get number of norms in adaptor group
+  //! \brief Returns the number of norms in adaptor group.
   int getNoNorms() const;
-
-  //! \brief Dummy time stepping advance (no adaptive + time stepping yet)
-  virtual bool advanceStep(TimeStep& tp) const { return false; }
 
   //! \brief Parses a data section from an input stream.
   //! \param[in] keyWord Keyword of current data section to read
@@ -99,25 +81,28 @@ public:
   virtual bool parse(const TiXmlElement* elem);
 
 private:
-  SIMoutput* model; //!< The isogeometric FE model
+  SIMoutput& model; //!< The isogeometric FE model
+  bool       alone; //!< If \e false, this class is wrapped by SIMSolver
 
-  bool      storeMesh;    //!< Creates a series of eps-files for intermediate steps
-  bool      linIndepTest; //!< Test mesh for linear independence after refinement
-  double    beta;         //!< Refinement percentage in each step
-  double    errTol;       //!< Global error stop tolerance
-  int       maxStep;      //!< Maximum number of adaptive refinements
-  int       maxDOFs;      //!< Maximum number of degrees of freedom
-  int       symmetry;     //!< Always refine a multiplum of this
-  int       knot_mult;    //!< Knotline multiplicity
-  int       maxTjoints;   //!< Maximum number of hanging nodes on one element
-  double    maxAspRatio;  //!< Maximum element aspect ratio
-  bool      closeGaps;    //!< Split elements with a hanging node on each side
-  bool      trueBeta;     //!< Beta measured in solution space dimension increase
-  Threshold threshold;    //!< Beta generates a threshold error
+  bool   storeMesh;    //!< Creates a series of eps-files for intermediate steps
+  bool   linIndepTest; //!< Test mesh for linear independence after refinement
+  double beta;         //!< Refinement percentage in each step
+  double errTol;       //!< Global error stop tolerance
+  int    maxStep;      //!< Maximum number of adaptive refinements
+  int    maxDOFs;      //!< Maximum number of degrees of freedom
+  int    symmetry;     //!< Always refine a multiplum of this
+  int    knot_mult;    //!< Knotline multiplicity
+  int    maxTjoints;   //!< Maximum number of hanging nodes on one element
+  double maxAspRatio;  //!< Maximum element aspect ratio
+  bool   closeGaps;    //!< Split elements with a hanging node on each side
+  bool   trueBeta;     //!< Beta measured in solution space dimension increase
+
+  //! Beta generates a threshold error
+  enum { NONE, MAXIMUM, AVERAGE, MINIMUM } threshold;
 
   //! Refinement scheme: 0=fullspan, 1=minspan, 2=isotropic_elements,
   //! 3=isotropic_functions
-  int    scheme;
+  int scheme;
 
   size_t  adaptor;  //!< Norm group to base the mesh adaption on
   size_t  adNorm;   //!< Which norm to adapt based on


### PR DESCRIPTION
AdaptiveSIM to also handle time-dependent problems. This is now reverted
as this class is not well suited for that class of problems.
It was intended for static linear problems only.

Essentially, the change is that AdaptiveSIM::parse invokes model.parse for all tags except "adaptive". The rest is cosmetics changes and clean-up of unused stuff.