### PR TITLE
fixed: allow using the <refine> and <raiseorder> keywords in parallel

### DIFF
--- a/src/SIM/SIM2D.C
+++ b/src/SIM/SIM2D.C
@@ -81,8 +81,9 @@ bool SIM2D::parseGeometryTag (const TiXmlElement* elem)
     if (utl::getAttribute(elem,"lowerpatch",lowpatch))
       uppatch = myModel.size();
     utl::getAttribute(elem,"upperpatch",uppatch);
+    int nPatch = nGlPatches > 0 ? nGlPatches : myModel.size();
 
-    if (lowpatch < 1 || uppatch > (int)myModel.size())
+    if (lowpatch < 1 || uppatch > nPatch)
     {
       std::cerr <<" *** SIM2D::parse: Invalid patch indices, lower="
                 << lowpatch <<" upper="<< uppatch << std::endl;
@@ -96,28 +97,32 @@ bool SIM2D::parseGeometryTag (const TiXmlElement* elem)
       int addu = 0, addv = 0;
       utl::getAttribute(elem,"u",addu);
       utl::getAttribute(elem,"v",addv);
-      for (int j = lowpatch-1; j < uppatch; j++)
-        if ((pch = dynamic_cast<ASM2D*>(myModel[j])))
+      for (int j = lowpatch-1; j < uppatch; j++) {
+        int p = this->getLocalPatchIndex(j+1);
+        if (p > 0 && (pch = dynamic_cast<ASM2D*>(myModel[p-1])))
         {
-          IFEM::cout <<"\tRefining P"<< j+1
+          IFEM::cout <<"\tRefining P"<< p
                      <<" "<< addu <<" "<< addv << std::endl;
           pch->uniformRefine(0,addu);
           pch->uniformRefine(1,addv);
         }
+      }
     }
     else
     {
       int dir = 1;
       utl::getAttribute(elem,"dir",dir);
-      for (int j = lowpatch-1; j < uppatch; j++)
-        if ((pch = dynamic_cast<ASM2D*>(myModel[j])))
+      for (int j = lowpatch-1; j < uppatch; j++) {
+        int p = getLocalPatchIndex(j+1);
+        if (p > 0 && (pch = dynamic_cast<ASM2D*>(myModel[p-1])))
         {
-          IFEM::cout <<"\tRefining P"<< j+1 <<" dir="<< dir;
+          IFEM::cout <<"\tRefining P"<< p <<" dir="<< dir;
           for (size_t i = 0; i < xi.size(); i++)
             IFEM::cout <<" "<< xi[i];
           IFEM::cout << std::endl;
           pch->refine(dir-1,xi);
         }
+      }
     }
   }
 
@@ -130,7 +135,8 @@ bool SIM2D::parseGeometryTag (const TiXmlElement* elem)
       uppatch = myModel.size();
     utl::getAttribute(elem,"upperpatch",uppatch);
 
-    if (lowpatch < 1 || uppatch > (int)myModel.size())
+    int nPatch = nGlPatches > 0 ? nGlPatches : myModel.size();
+    if (lowpatch < 1 || uppatch > nPatch)
     {
       std::cerr <<" *** SIM2D::parse: Invalid patch indices, lower="
                 << lowpatch <<" upper="<< uppatch << std::endl;
@@ -141,13 +147,17 @@ bool SIM2D::parseGeometryTag (const TiXmlElement* elem)
     int addu = 0, addv = 0;
     utl::getAttribute(elem,"u",addu);
     utl::getAttribute(elem,"v",addv);
-    for (int j = lowpatch-1; j < uppatch; j++)
-      if ((pch = dynamic_cast<ASM2D*>(myModel[j])))
+    for (int j = lowpatch-1; j < uppatch; j++) {
+      int p = this->getLocalPatchIndex(j+1);
+      if (p < 1)
+        continue;
+      if ((pch = dynamic_cast<ASM2D*>(myModel[p-1])))
       {
-        IFEM::cout <<"\tRaising order of P"<< j+1
+        IFEM::cout <<"\tRaising order of P"<< p
                    <<" "<< addu <<" "<< addv << std::endl;
         pch->raiseOrder(addu,addv);
       }
+    }
   }
 
   else if (!strcasecmp(elem->Value(),"topology"))

--- a/src/SIM/SIM3D.C
+++ b/src/SIM/SIM3D.C
@@ -59,8 +59,9 @@ bool SIM3D::parseGeometryTag (const TiXmlElement* elem)
     if (utl::getAttribute(elem,"lowerpatch",lowpatch))
       uppatch = myModel.size();
     utl::getAttribute(elem,"upperpatch",uppatch);
+    int nPatch = nGlPatches > 0 ? nGlPatches : myModel.size();
 
-    if (lowpatch < 1 || uppatch > (int)myModel.size())
+    if (lowpatch < 1 || uppatch > nPatch)
     {
       std::cerr <<" *** SIM3D::parse: Invalid patch indices, lower="
                 << lowpatch <<" upper="<< uppatch << std::endl;
@@ -75,30 +76,34 @@ bool SIM3D::parseGeometryTag (const TiXmlElement* elem)
       utl::getAttribute(elem,"u",addu);
       utl::getAttribute(elem,"v",addv);
       utl::getAttribute(elem,"w",addw);
-      for (int j = lowpatch-1; j < uppatch; j++)
-        if ((pch = dynamic_cast<ASM3D*>(myModel[j])))
+      for (int j = lowpatch-1; j < uppatch; j++) {
+        int p = getLocalPatchIndex(j+1);
+        if (p > 0 && (pch = dynamic_cast<ASM3D*>(myModel[p-1])))
         {
-          IFEM::cout <<"\tRefining P"<< j+1
+          IFEM::cout <<"\tRefining P"<< p
                      <<" "<< addu <<" "<< addv <<" "<< addw << std::endl;
           pch->uniformRefine(0,addu);
           pch->uniformRefine(1,addv);
           pch->uniformRefine(2,addw);
         }
+      }
     }
     else
     {
       // Non-uniform (graded) refinement
       int dir = 1;
       utl::getAttribute(elem,"dir",dir);
-      for (int j = lowpatch-1; j < uppatch; j++)
-        if ((pch = dynamic_cast<ASM3D*>(myModel[j])))
+      for (int j = lowpatch-1; j < uppatch; j++) {
+        int p = getLocalPatchIndex(j+1);
+        if (p > 0 && (pch = dynamic_cast<ASM3D*>(myModel[p-1])))
         {
-          IFEM::cout <<"\tRefining P"<< j+1 <<" dir="<< dir;
+          IFEM::cout <<"\tRefining P"<< p <<" dir="<< dir;
           for (size_t i = 0; i < xi.size(); i++)
             IFEM::cout <<" "<< xi[i];
           IFEM::cout << std::endl;
           pch->refine(dir-1,xi);
         }
+      }
     }
   }
 
@@ -111,7 +116,8 @@ bool SIM3D::parseGeometryTag (const TiXmlElement* elem)
       uppatch = myModel.size();
     utl::getAttribute(elem,"upperpatch",uppatch);
 
-    if (lowpatch < 1 || uppatch > (int)myModel.size())
+    int nPatch = nGlPatches > 0 ? nGlPatches : myModel.size();
+    if (lowpatch < 1 || uppatch > nPatch)
     {
       std::cerr <<" *** SIM3D::parse: Invalid patch indices, lower="
                 << lowpatch <<" upper="<< uppatch << std::endl;
@@ -123,13 +129,15 @@ bool SIM3D::parseGeometryTag (const TiXmlElement* elem)
     utl::getAttribute(elem,"u",addu);
     utl::getAttribute(elem,"v",addv);
     utl::getAttribute(elem,"w",addw);
-    for (int j = lowpatch-1; j < uppatch; j++)
-      if ((pch = dynamic_cast<ASM3D*>(myModel[j])))
+    for (int j = lowpatch-1; j < uppatch; j++) {
+      int p = this->getLocalPatchIndex(j+1);
+      if (p > 0 && (pch = dynamic_cast<ASM3D*>(myModel[p-1])))
       {
-        IFEM::cout <<"\tRaising order of P"<< j+1
+        IFEM::cout <<"\tRaising order of P"<< p
                    <<" "<< addu <<" "<< addv  <<" " << addw << std::endl;
         pch->raiseOrder(addu,addv,addw);
       }
+    }
   }
 
   else if (!strcasecmp(elem->Value(),"topology"))


### PR DESCRIPTION
translates to the local patch index and and ignore entries
for patches on other processes.