### PR TITLE
add utl::Matrix constructor to DenseMatrix

### DIFF
--- a/src/LinAlg/DenseMatrix.C
+++ b/src/LinAlg/DenseMatrix.C
@@ -67,6 +67,14 @@ DenseMatrix::DenseMatrix (const RealArray& data, size_t nrows)
 }
 
 
+DenseMatrix::DenseMatrix (const Matrix& A, bool s)
+{
+  myMat = A;
+  ipiv = nullptr;
+  symm = s;
+}
+
+
 size_t DenseMatrix::dim (int idim) const
 {
   if (idim == 1)

--- a/src/LinAlg/DenseMatrix.h
+++ b/src/LinAlg/DenseMatrix.h
@@ -32,6 +32,8 @@ public:
   DenseMatrix(const DenseMatrix& A);
   //! \brief Special constructor taking data from a one-dimensional array.
   DenseMatrix(const RealArray& data, size_t nrows = 0);
+  //! \brief Special constructor, type conversion from Matrix.
+  DenseMatrix(const Matrix& A, bool s = false);
   //! \brief The destructor frees the dynamically allocated arrays.
   virtual ~DenseMatrix() { if (ipiv) delete[] ipiv; }
 


### PR DESCRIPTION
allows easy access to the solve method, which will be require in NavierStokes for div-compatible VMS