### PR TITLE
Fixed: Allow using the <refine> and <raiseorder> keywords in parallel

### DIFF
--- a/Apps/Common/Test/TestMeshUtils.C
+++ b/Apps/Common/Test/TestMeshUtils.C
@@ -16,22 +16,24 @@
 
 #include "gtest/gtest.h"
 
-class DummyIntegrand : public IntegrandBase {
-};
 
-class TestSIM : public SIM2D {
-  public:
-    TestSIM() : SIM2D(new DummyIntegrand, 2)
-    {
-      myModel.resize(1,this->createDefaultGeometry(NULL));
-    }
+class TestSIM : public SIM2D
+{
+  class DummyIntegrand : public IntegrandBase {};
+
+public:
+  TestSIM() : SIM2D(new DummyIntegrand())
+  {
+    this->createDefaultModel();
+    this->preprocess();
+  }
+  virtual ~TestSIM() {}
 };
 
 
 TEST(TestMeshUtils, Aspect2D)
 {
   TestSIM model;
-  model.preprocess();
 
   Vector aspect;
   MeshUtils::computeAspectRatios(aspect, model);
@@ -47,7 +49,6 @@ TEST(TestMeshUtils, Aspect2D)
 TEST(TestMeshUtils, Skewness2D)
 {
   TestSIM model;
-  model.preprocess();
 
   Vector skewness;
   MeshUtils::computeMeshSkewness(skewness, model);

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -149,7 +149,7 @@ bool SIMbase::parseGeometryTag (const TiXmlElement* elem)
       for (int i = 1; i <= nGlPatches; i++)
       {
         std::vector<int> nodes;
-        ASMbase* pch = this->getPatch(this->getLocalPatchIndex(i));
+        ASMbase* pch = this->getPatch(i,true);
         if (pch && hdf5.readVector(0, field ? field : "node numbers", i, nodes))
           pch->setNodeNumbers(nodes);
       }
@@ -849,9 +849,10 @@ int SIMbase::getLocalPatchIndex (int patchNo) const
 }
 
 
-ASMbase* SIMbase::getPatch (size_t idx) const
+ASMbase* SIMbase::getPatch (int idx, bool glbIndex) const
 {
-  return idx > 0 && idx <= myModel.size() ? myModel[idx-1] : nullptr;
+  int pid = glbIndex ? this->getLocalPatchIndex(idx) : idx;
+  return pid > 0 && (size_t)pid <= myModel.size() ? myModel[pid-1] : nullptr;
 }
 
 

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -613,7 +613,11 @@ public:
   //! \brief Returns a const reference to our FEM model.
   const PatchVec& getFEModel() const { return myModel; }
   //! \brief Returns a pointer to a specified patch of our FEM model.
-  ASMbase* getPatch(size_t idx) const;
+  //! \param[in] idx 1-based patch index
+  //! \param[in] glbIndex If \e true, the patch index is assumed to be global
+  //! for the whole model, otherwise it is assumed local within current process.
+  //! For serial applications this option has no effect.
+  ASMbase* getPatch(int idx, bool glbIndex = false) const;
 
   //! \brief Initializes material properties for the given patch.
   bool setPatchMaterial(size_t patch);


### PR DESCRIPTION
Translates to local patch index and ignores patch entries on other processes.
The nGlPatches member of SIMbase is now default equal to myModel.size() for
serial runs, such that we don't need to check that it is non-zero all the time
(except for in getLocalPatchIndex, which may be called before it is set).
The latter is now treated as an error conditions and indicates missing
partitioning information for parallel runs.

Alternative to #42, checking.