### PR TITLE
Add support for solution vectors with additional DOFs

### DIFF
--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -989,6 +989,29 @@ void ASMbase::extractNodeVec (const Vector& globRes, Vector& nodeVec,
   }
 }
 
+void ASMbase::injectNodeVec (const std::vector<int>& madof,
+                             const Vector& nodeVec, Vector& globVec,
+                             int basis) const
+{
+  size_t ldof = 0;
+  char bType = basis == 1 ? 'D' : 'P'+basis-2;
+  for (size_t i = 0; i < MLGN.size(); i++)
+  {
+    if (basis == 0 || getNodeType(i+1) == bType) {
+      int inod = MLGN[i];
+      int idof = madof[inod-1] - 1;
+      int jdof = madof[inod] - 1;
+#ifdef INDEX_CHECK
+      if (inod < 1 || jdof > (int)globVec.size())
+        std::cerr <<" *** ASMbase::injectNodeVec: Global DOF "<< jdof
+                  <<" is out of range [1,"<< globVec.size() <<"]"<< std::endl;
+#endif
+      std::copy(nodeVec.begin()+ldof, nodeVec.begin()+ldof+(jdof-idof), globVec.begin()+idof);
+      ldof += jdof-idof;
+    }
+  }
+}
+
 
 void ASMbase::extractNodeVec (const Vector& globRes, Vector& nodeVec,
 			      unsigned char nndof, int basis) const

--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -989,9 +989,8 @@ void ASMbase::extractNodeVec (const Vector& globRes, Vector& nodeVec,
   }
 }
 
-void ASMbase::injectNodeVec (const std::vector<int>& madof,
-                             const Vector& nodeVec, Vector& globVec,
-                             int basis) const
+void ASMbase::injectNodeVec (const Vector& nodeVec, Vector& globVec,
+                             const std::vector<int>& madof, int basis) const
 {
   size_t ldof = 0;
   char bType = basis == 1 ? 'D' : 'P'+basis-2;

--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -995,20 +995,27 @@ void ASMbase::injectNodeVec (const Vector& nodeVec, Vector& globVec,
   size_t ldof = 0;
   char bType = basis == 1 ? 'D' : 'P'+basis-2;
   for (size_t i = 0; i < MLGN.size(); i++)
-  {
-    if (basis == 0 || getNodeType(i+1) == bType) {
+    if (basis == 0 || this->getNodeType(i+1) == bType) {
       int inod = MLGN[i];
       int idof = madof[inod-1] - 1;
       int jdof = madof[inod] - 1;
+      bool ok = true;
 #ifdef INDEX_CHECK
-      if (inod < 1 || jdof > (int)globVec.size())
-        std::cerr <<" *** ASMbase::injectNodeVec: Global DOF "<< jdof
+      ok = false;
+      if (jdof < 1 || ldof + (jdof-idof) > nodeVec.size())
+        std::cerr <<" *** ASMbase::injectNodeVec: Local DOF "<< ldof + (jdof-idof)
+                  <<" is out of range [1,"<< nodeVec.size() <<"]"<< std::endl;
+      else if (idof + (jdof-idof) > (int)globVec.size())
+        std::cerr <<" *** ASMbase::injectNodeVec: Global DOF "<< idof + (jdof-idof)
                   <<" is out of range [1,"<< globVec.size() <<"]"<< std::endl;
+      else
+        ok = true;
 #endif
-      std::copy(nodeVec.begin()+ldof, nodeVec.begin()+ldof+(jdof-idof), globVec.begin()+idof);
-      ldof += jdof-idof;
+      if (ok) {
+        std::copy(nodeVec.begin()+ldof, nodeVec.begin()+ldof+(jdof-idof), globVec.begin()+idof);
+        ldof += jdof-idof;
+      }
     }
-  }
 }
 
 

--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -997,6 +997,13 @@ void ASMbase::injectNodeVec (const Vector& nodeVec, Vector& globVec,
   for (size_t i = 0; i < MLGN.size(); i++)
     if (basis == 0 || this->getNodeType(i+1) == bType) {
       int inod = MLGN[i];
+#ifdef INDEX_CHECK
+      if (inod < 1 || inod > (int)madof.size()) {
+        std::cerr <<" *** ASMbase::injectNodeVec: Node "<< inod
+                  <<" outside given madof (of size " << madof.size() << ")"<< std::endl;
+        continue;
+      }
+#endif
       int idof = madof[inod-1] - 1;
       int jdof = madof[inod] - 1;
       bool ok = true;

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -560,6 +560,14 @@ public:
   virtual bool injectNodeVec(const Vector& nodeVec, Vector& globVec,
 			     unsigned char nndof = 0, int basis = 0) const;
 
+  //! \brief Extracts nodal results for this patch from the global vector.
+  //! \param[in] globVec Global solution vector in DOF-order
+  //! \param[out] nodeVec Nodal result vector for this patch
+  //! \param[in] madof Global Matrix of Accumulated DOFs
+  //! \param[in] basis Which basis to inject nodal values for (mixed methods)
+  void injectNodeVec(const std::vector<int>& madof, const Vector& nodeVec,
+                     Vector& globVec, int basis=0) const;
+
   //! \brief Creates and adds a two-point constraint to this patch.
   //! \param[in] slave Global node number of the node to constrain
   //! \param[in] dir Which local DOF to constrain (1, 2, 3)

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -560,13 +560,13 @@ public:
   virtual bool injectNodeVec(const Vector& nodeVec, Vector& globVec,
 			     unsigned char nndof = 0, int basis = 0) const;
 
-  //! \brief Extracts nodal results for this patch from the global vector.
+  //! \brief Injects nodal results for this patch into the global vector.
   //! \param[in] globVec Global solution vector in DOF-order
   //! \param[out] nodeVec Nodal result vector for this patch
   //! \param[in] madof Global Matrix of Accumulated DOFs
   //! \param[in] basis Which basis to inject nodal values for (mixed methods)
-  void injectNodeVec(const std::vector<int>& madof, const Vector& nodeVec,
-                     Vector& globVec, int basis=0) const;
+  void injectNodeVec(const Vector& nodeVec, Vector& globVec,
+                     const std::vector<int>& madof, int basis=0) const;
 
   //! \brief Creates and adds a two-point constraint to this patch.
   //! \param[in] slave Global node number of the node to constrain

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -2518,8 +2518,7 @@ size_t SIMbase::extractPatchSolution (const Vector& sol, Vector& vec,
       nndof != this->getNoFields(basis) && this->getNoFields(2) > 0) {
     int key = basis << 16 + nndof;
     if (addMADOFs.find(key) == addMADOFs.end())
-      this->setupAdditionalMADOF(myModel, this->getNoNodes(true),
-                                 basis, nndof, addMADOFs[key]);
+      this->setupAdditionalMADOF(basis, nndof, addMADOFs[key]);
 
     pch->extractNodeVec(sol,vec,&addMADOFs[key][0]);
   }
@@ -2543,8 +2542,7 @@ bool SIMbase::injectPatchSolution (Vector& sol, const Vector& vec,
       nndof != this->getNoFields(basis) && this->getNoFields(2) > 0) {
     int key = basis << 16 + nndof;
     if (addMADOFs.find(key) == addMADOFs.end())
-      this->setupAdditionalMADOF(myModel, this->getNoNodes(true),
-                                 basis, nndof, addMADOFs[key]);
+      this->setupAdditionalMADOF(basis, nndof, addMADOFs[key]);
 
     pch->injectNodeVec(vec, sol, addMADOFs[key], basis);
     return true;
@@ -2641,12 +2639,11 @@ bool SIMbase::refine (const LR::RefineData& prm,
 }
 
 
-void SIMbase::setupAdditionalMADOF(const PatchVec& myModel,
-                                   size_t nodes,
-                                   unsigned char basis,
+void SIMbase::setupAdditionalMADOF(unsigned char basis,
                                    unsigned char nndof,
                                    std::vector<int>& madof) const
 {
+  size_t nodes = this->getNoNodes(true);
   madof.resize(nodes+1, 0);
   for (size_t i = 0; i < myModel.size(); i++) {
     char nType = basis == 1 ? 'D' : 'P'+basis-2;

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -2515,7 +2515,7 @@ size_t SIMbase::extractPatchSolution (const Vector& sol, Vector& vec,
 
   // Need an additional MADOF
   if (basis != 0 && nndof != 0 &&
-      nndof != getNoFields(basis) && this->getNoFields(2) > 0) {
+      nndof != this->getNoFields(basis) && this->getNoFields(2) > 0) {
     int key = basis << 16 + nndof;
     if (addMADOFs.find(key) == addMADOFs.end())
       setupAdditionalMADOF(myModel, this->getNoNodes(true),
@@ -2540,7 +2540,7 @@ bool SIMbase::injectPatchSolution (Vector& sol, const Vector& vec,
 
   // Need an additional MADOF
   if (basis != 0 && nndof != 0 &&
-      nndof != getNoFields(basis) && this->getNoFields(2) > 0) {
+      nndof != this->getNoFields(basis) && this->getNoFields(2) > 0) {
     int key = basis << 16 + nndof;
     if (addMADOFs.find(key) == addMADOFs.end())
       setupAdditionalMADOF(myModel, this->getNoNodes(true),

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -44,6 +44,27 @@ bool SIMbase::preserveNOrder  = false;
 bool SIMbase::ignoreDirichlet = false;
 
 
+SIMbase::MADof::MADof(const PatchVec& myModel, size_t nodes,
+                      unsigned char basis, unsigned char nndof)
+{
+  madof.resize(nodes+1, 0);
+  for (size_t i = 0; i < myModel.size(); i++) {
+    char nType = basis == 1 ? 'D' : 'P'+basis-2;
+    for (size_t j = 0; j < myModel[i]->getNoNodes(); j++) {
+      int n = myModel[i]->getNodeID(j+1);
+      if (n > 0 && myModel[i]->getNodeType(j+1) == nType)
+        madof[n] = nndof;
+      else if (n > 0)
+        madof[n] = myModel[i]->getNodalDOFs(j+1);
+    }
+  }
+
+  madof[0] = 1;
+  for (size_t n = 0; n < nodes; n++)
+    madof[n+1] += madof[n];
+}
+
+
 SIMbase::SIMbase (IntegrandBase* itg) : g2l(&myGlb2Loc)
 {
   isRefined = false;
@@ -2507,23 +2528,48 @@ bool SIMbase::extractPatchSolution (IntegrandBase* problem,
 
 
 size_t SIMbase::extractPatchSolution (const Vector& sol, Vector& vec,
-                                      int pindx, unsigned char nndof) const
+                                      int pindx, unsigned char nndof,
+                                      unsigned char basis) const
 {
   ASMbase* pch = pindx >= 0 ? this->getPatch(pindx+1) : nullptr;
   if (!pch || sol.empty()) return 0;
 
-  pch->extractNodeVec(sol,vec,nndof);
+  // Need an additional MADOF
+  if (basis != 0 && nndof != 0 &&
+      nndof != getNoFields(basis) && this->getNoFields(2) > 0) {
+    int key = basis << 16 + nndof;
+    if (addMADOFs.find(key) == addMADOFs.end())
+      addMADOFs[key] = MADof(myModel, this->getNoNodes(true), basis, nndof);
 
-  return (nndof > 0 ? nndof : pch->getNoFields(1))*pch->getNoNodes(1);
+    pch->extractNodeVec(sol,vec,&addMADOFs[key].get()[0]);
+  }
+  else
+    pch->extractNodeVec(sol,vec,nndof,basis);
+
+  return vec.size();
 }
 
 
 bool SIMbase::injectPatchSolution (Vector& sol, const Vector& vec,
-                                   int pindx, unsigned char nndof) const
+                                   int pindx, unsigned char nndof,
+                                   unsigned char basis) const
 {
   ASMbase* pch = pindx >= 0 ? this->getPatch(pindx+1) : nullptr;
+  if (!pch)
+    return false;
 
-  return pch ? pch->injectNodeVec(vec,sol,nndof) : false;
+  // Need an additional MADOF
+  if (basis != 0 && nndof != 0 &&
+      nndof != getNoFields(basis) && this->getNoFields(2) > 0) {
+    int key = basis << 16 + nndof;
+    if (addMADOFs.find(key) == addMADOFs.end())
+      addMADOFs[key] = MADof(myModel, this->getNoNodes(true), basis, nndof);
+
+    pch->injectNodeVec(addMADOFs[key].get(), vec, sol, basis);
+    return true;
+  }
+  else
+    return pch->injectNodeVec(vec,sol,nndof);
 }
 
 

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -2518,9 +2518,8 @@ size_t SIMbase::extractPatchSolution (const Vector& sol, Vector& vec,
       nndof != getNoFields(basis) && this->getNoFields(2) > 0) {
     int key = basis << 16 + nndof;
     if (addMADOFs.find(key) == addMADOFs.end())
-      addMADOFs[key] = std::move(setupAdditionalMADOF(myModel,
-                                                      this->getNoNodes(true),
-                                                      basis, nndof));
+      setupAdditionalMADOF(myModel, this->getNoNodes(true),
+                           basis, nndof, addMADOFs[key]);
 
     pch->extractNodeVec(sol,vec,&addMADOFs[key][0]);
   }
@@ -2544,9 +2543,8 @@ bool SIMbase::injectPatchSolution (Vector& sol, const Vector& vec,
       nndof != getNoFields(basis) && this->getNoFields(2) > 0) {
     int key = basis << 16 + nndof;
     if (addMADOFs.find(key) == addMADOFs.end())
-      addMADOFs[key] = std::move(setupAdditionalMADOF(myModel,
-                                                      this->getNoNodes(true),
-                                                      basis, nndof));
+      setupAdditionalMADOF(myModel, this->getNoNodes(true),
+                           basis, nndof, addMADOFs[key]);
 
     pch->injectNodeVec(vec, sol, addMADOFs[key], basis);
     return true;
@@ -2643,12 +2641,13 @@ bool SIMbase::refine (const LR::RefineData& prm,
 }
 
 
-std::vector<int> SIMbase::setupAdditionalMADOF(const PatchVec& myModel,
-                                               size_t nodes,
-                                               unsigned char basis,
-                                               unsigned char nndof) const
+void SIMbase::setupAdditionalMADOF(const PatchVec& myModel,
+                                   size_t nodes,
+                                   unsigned char basis,
+                                   unsigned char nndof,
+                                   std::vector<int>& madof) const
 {
-  std::vector<int> madof(nodes+1, 0);
+  madof.resize(nodes+1, 0);
   for (size_t i = 0; i < myModel.size(); i++) {
     char nType = basis == 1 ? 'D' : 'P'+basis-2;
     for (size_t j = 0; j < myModel[i]->getNoNodes(); j++) {
@@ -2663,6 +2662,4 @@ std::vector<int> SIMbase::setupAdditionalMADOF(const PatchVec& myModel,
   madof[0] = 1;
   for (size_t n = 0; n < nodes; n++)
     madof[n+1] += madof[n];
-
-  return madof;
 }

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -2518,8 +2518,8 @@ size_t SIMbase::extractPatchSolution (const Vector& sol, Vector& vec,
       nndof != this->getNoFields(basis) && this->getNoFields(2) > 0) {
     int key = basis << 16 + nndof;
     if (addMADOFs.find(key) == addMADOFs.end())
-      setupAdditionalMADOF(myModel, this->getNoNodes(true),
-                           basis, nndof, addMADOFs[key]);
+      this->setupAdditionalMADOF(myModel, this->getNoNodes(true),
+                                 basis, nndof, addMADOFs[key]);
 
     pch->extractNodeVec(sol,vec,&addMADOFs[key][0]);
   }
@@ -2543,8 +2543,8 @@ bool SIMbase::injectPatchSolution (Vector& sol, const Vector& vec,
       nndof != this->getNoFields(basis) && this->getNoFields(2) > 0) {
     int key = basis << 16 + nndof;
     if (addMADOFs.find(key) == addMADOFs.end())
-      setupAdditionalMADOF(myModel, this->getNoNodes(true),
-                           basis, nndof, addMADOFs[key]);
+      this->setupAdditionalMADOF(myModel, this->getNoNodes(true),
+                                 basis, nndof, addMADOFs[key]);
 
     pch->injectNodeVec(vec, sol, addMADOFs[key], basis);
     return true;

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -760,9 +760,11 @@ private:
   //! \param[in] nodes Total number of global nodes in model
   //! \param[in] basis The basis to specify number of DOFs for
   //! \param[in] nndof Number of DOFs on given basis
-  std::vector<int> setupAdditionalMADOF(const PatchVec& myModel, size_t nodes,
-                                        unsigned char basis,
-                                        unsigned char nndof) const;
+  //! \param[out] madof Generated MADOF array
+  void setupAdditionalMADOF(const PatchVec& myModel, size_t nodes,
+                            unsigned char basis,
+                            unsigned char nndof,
+                            std::vector<int>& madof) const;
 
   mutable std::map<int, std::vector<int>> addMADOFs; //!< Additional MADOF arrays.
 };

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -755,27 +755,16 @@ private:
   size_t nIntGP; //!< Number of interior integration points in the whole model
   size_t nBouGP; //!< Number of boundary integration points in the whole model
 
-  //! \brief Class holding a MADOF for a given number of dofs on a given basis
-  class MADof {
-    public:
-      //! \brief Dummy constructor needed due to std::map.
-      MADof() {}
-      //! \brief Constructor.
-      //! \param[in] myModel The patch vector to setup the MADOF for
-      //! \param[in] nodes Total number of global nodes in model
-      //! \param[in] basis The basis to specify number of DOFs for
-      //! \param[in] nndof Number of DOFs on given basis
-      MADof(const PatchVec& myModel, size_t nodes,
-            unsigned char basis, unsigned char nndof);
+  //! \brief Setup a MADOF with an extraordinary amount of DOFs on a basis.
+  //! \param[in] myModel The patch vector to setup the MADOF for
+  //! \param[in] nodes Total number of global nodes in model
+  //! \param[in] basis The basis to specify number of DOFs for
+  //! \param[in] nndof Number of DOFs on given basis
+  std::vector<int> setupAdditionalMADOF(const PatchVec& myModel, size_t nodes,
+                                        unsigned char basis,
+                                        unsigned char nndof) const;
 
-      //! \brief Access MADof array.
-      const std::vector<int>& get() const { return madof; }
-
-    protected:
-      std::vector<int> madof; //!< The MADOF array
-  };
-
-  mutable std::map<int, MADof> addMADOFs; //!< Additional MADOF arrays.
+  mutable std::map<int, std::vector<int>> addMADOFs; //!< Additional MADOF arrays.
 };
 
 #endif

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -756,13 +756,10 @@ private:
   size_t nBouGP; //!< Number of boundary integration points in the whole model
 
   //! \brief Setup a MADOF with an extraordinary amount of DOFs on a basis.
-  //! \param[in] myModel The patch vector to setup the MADOF for
-  //! \param[in] nodes Total number of global nodes in model
   //! \param[in] basis The basis to specify number of DOFs for
   //! \param[in] nndof Number of DOFs on given basis
   //! \param[out] madof Generated MADOF array
-  void setupAdditionalMADOF(const PatchVec& myModel, size_t nodes,
-                            unsigned char basis,
+  void setupAdditionalMADOF(unsigned char basis,
                             unsigned char nndof,
                             std::vector<int>& madof) const;
 

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -588,9 +588,11 @@ public:
   //! \param[out] vec Local solution vector associated with specified patch
   //! \param[in] pindx Local patch index to extract solution vector for
   //! \param[in] nndof Number of DOFs per node (optional)
+  //! \param[in] basis Basis to extract for (optional)
   //! \return Total number of DOFs in the patch (first basis only if mixed)
   size_t extractPatchSolution(const Vector& sol, Vector& vec, int pindx,
-                              unsigned char nndof = 0) const;
+                              unsigned char nndof = 0,
+                              unsigned char basis = 0) const;
 
   //! \brief Injects a patch-wise solution vector into the global vector.
   //! \param sol Global primary solution vector in DOF-order
@@ -598,7 +600,8 @@ public:
   //! \param[in] pindx Local patch index to inject solution vector for
   //! \param[in] nndof Number of DOFs per node (optional)
   bool injectPatchSolution(Vector& sol, const Vector& vec, int pindx,
-                           unsigned char nndof = 0) const;
+                           unsigned char nndof = 0,
+                           unsigned char basis = 0) const;
 
   //! \brief Extracts element results for a specified patch.
   //! \param[in] glbRes Global element result array
@@ -751,6 +754,28 @@ protected:
 private:
   size_t nIntGP; //!< Number of interior integration points in the whole model
   size_t nBouGP; //!< Number of boundary integration points in the whole model
+
+  //! \brief Class holding a MADOF for a given number of dofs on a given basis
+  class MADof {
+    public:
+      //! \brief Dummy constructor needed due to std::map.
+      MADof() {}
+      //! \brief Constructor.
+      //! \param[in] myModel The patch vector to setup the MADOF for
+      //! \param[in] nodes Total number of global nodes in model
+      //! \param[in] basis The basis to specify number of DOFs for
+      //! \param[in] nndof Number of DOFs on given basis
+      MADof(const PatchVec& myModel, size_t nodes,
+            unsigned char basis, unsigned char nndof);
+
+      //! \brief Access MADof array.
+      const std::vector<int>& get() const { return madof; }
+
+    protected:
+      std::vector<int> madof; //!< The MADOF array
+  };
+
+  mutable std::map<int, MADof> addMADOFs; //!< Additional MADOF arrays.
 };
 
 #endif

--- a/src/SIM/Test/TestSIM.C
+++ b/src/SIM/Test/TestSIM.C
@@ -129,3 +129,40 @@ TEST(TestSIM3D, ProjectSolutionMixed)
       for (size_t i = 0; i < 3; ++i)
         ASSERT_FLOAT_EQ(ssol(1, n++), i/2.0 + j/2.0 + k/2.0);
 }
+
+
+TEST(TestSIM, InjectPatchSolution)
+{
+  TestProjectSIM<SIM2D> sim({1,1});
+  sim.createDefaultModel();
+  ASSERT_TRUE(sim.preprocess());
+
+  Vector sol(2*sim.getNoNodes(true, 1) + sim.getNoNodes(true, 2));
+  Vector lsol(2*sim.getNoNodes(true, 1));
+  for (size_t i = 0; i < sim.getNoNodes(true,1); ++i)
+    lsol[2*i] = lsol[2*i+1] = i+1;
+
+  sim.injectPatchSolution(sol, lsol, 0, 2, 1);
+  size_t ofs = 0;
+  for (size_t i = 0; i < sim.getNoNodes(true,1); ++i, ofs += 2) {
+    ASSERT_FLOAT_EQ(sol[ofs], i+1);
+    ASSERT_FLOAT_EQ(sol[ofs+1], i+1);
+  }
+  for (size_t i = 0; i < sim.getNoNodes(true,2); ++i, ++ofs)
+    ASSERT_FLOAT_EQ(sol[ofs], 0);
+
+  Vector sol2(sim.getNoNodes(true, 1) + 2*sim.getNoNodes(true, 2));
+  Vector lsol2(2*sim.getNoNodes(true, 2));
+  for (size_t i = 0; i < sim.getNoNodes(true,2); ++i)
+    lsol2[2*i] = lsol2[2*i+1] = i+1;
+
+  sim.injectPatchSolution(sol2, lsol2, 0, 2, 2);
+  ofs = 0;
+  for (size_t i = 0; i < sim.getNoNodes(true,1); ++i, ++ofs)
+    ASSERT_FLOAT_EQ(sol2[ofs], 0);
+
+  for (size_t i = 0; i < sim.getNoNodes(true,2); ++i, ofs += 2) {
+    ASSERT_FLOAT_EQ(sol2[ofs], i+1);
+    ASSERT_FLOAT_EQ(sol2[ofs+1], i+1);
+  }
+}

--- a/src/Utility/HDF5Writer.C
+++ b/src/Utility/HDF5Writer.C
@@ -397,7 +397,7 @@ void HDF5Writer::writeSIM (int level, const DataEntry& entry,
   if (level == 0 || geometryUpdated || (abs(entry.second.results) & DataExporter::GRID)) {
     writeBasis(sim,basisname,1,level);
     if (sim->mixedProblem())
-      for (size_t b=2; b <= sim->getPatch(1)->getNoBasis(); ++b) {
+      for (size_t b=2; b <= sim->getNoBasis(); ++b) {
         std::stringstream str;
         str << sim->getName() << "-" << b;
         writeBasis(sim,str.str(),b,level);
@@ -454,7 +454,7 @@ void HDF5Writer::writeSIM (int level, const DataEntry& entry,
           if (sim->mixedProblem())
           {
             size_t ofs = 0;
-            for (size_t b=1; b <= sim->getPatch(loc)->getNoBasis(); ++b) {
+            for (size_t b=1; b <= sim->getNoBasis(); ++b) {
               ndof1 = sim->getPatch(loc)->getNoNodes(b)*sim->getPatch(loc)->getNoFields(b);
               writeArray(group2,prefix+prob->getField1Name(10+b),ndof1,
                          psol.ptr()+ofs,H5T_NATIVE_DOUBLE);
@@ -545,7 +545,7 @@ void HDF5Writer::writeSIM (int level, const DataEntry& entry,
         }
         else if (sim->mixedProblem())
         {
-          for (size_t b=1; b <= sim->getPatch(1)->getNoBasis(); ++b)
+          for (size_t b=1; b <= sim->getNoBasis(); ++b)
             writeArray(group2,prefix+prob->getField1Name(10+b),0,&dummy,H5T_NATIVE_DOUBLE);
         }
         else

--- a/src/Utility/XMLWriter.C
+++ b/src/Utility/XMLWriter.C
@@ -222,7 +222,10 @@ void XMLWriter::writeSIM (int level, const DataEntry& entry, bool,
   }
 
   if (results & DataExporter::PRIMARY) {
-    if (sim->mixedProblem())
+    if (entry.second.results < 0)
+      addField(entry.second.description, entry.second.description,
+               basisname, cmps, sim->getNoPatches(), "field");
+    else if (sim->mixedProblem())
     {
       // primary solution vector
       addField(prefix+entry.first,entry.second.description,basisname,


### PR DESCRIPTION
This adds support for solution vectors with additional DOFs on them.

In the NavierStokes application when doing statistically stationary simulations (i.e. turbulent channel flow) we need to output the averaged reynolds stresses. This is a vector which has 6 components. 

Since HDF5 needs these on the spline basis, this is implemented in a secondary integrand. The resulting vector thus has more components on the first basis than 3.

To keep things as simple as possible, and avoid special-case code I have added support for such vectors in the SIM layer. To pull this off, we need additional MADOF arrays for these vector layouts.

This includes https://github.com/OPM/IFEM/pull/54 because some testing facilities is shared. The code itself is independent as such, but please process #54 first.