### PR TITLE
Add model generator class

### DIFF
--- a/Apps/Common/MultiPatchModelGenerator.C
+++ b/Apps/Common/MultiPatchModelGenerator.C
@@ -1,0 +1,457 @@
+// $Id$
+//==============================================================================
+//!
+//! \file MultiPatchModelGenerator.C
+//!
+//! \date Sep 2 2016
+//!
+//! \author Arne Morten Kvarving / SINTEF
+//!
+//! \brief Multi-patch model generators for NURBS-based FEM simulators.
+//!
+//==============================================================================
+
+#include "MultiPatchModelGenerator.h"
+#include "ASMs2D.h"
+#include "ASMs3D.h"
+#include "IFEM.h"
+#include "SIMbase.h"
+#include "Utilities.h"
+#include "Vec3.h"
+#include "Vec3Oper.h"
+#include "tinyxml.h"
+
+
+MultiPatchModelGenerator2D::MultiPatchModelGenerator2D (const TiXmlElement* geo) :
+  ModelGenerator(geo)
+{
+  nx = ny = 1;
+  periodic_x = periodic_y = 0;
+  utl::getAttribute(geo,"nx",nx);
+  utl::getAttribute(geo,"ny",ny);
+  utl::getAttribute(geo,"periodic_x", periodic_x);
+  utl::getAttribute(geo,"periodic_y", periodic_y);
+}
+
+
+std::string MultiPatchModelGenerator2D::createG2 (int nsd) const
+{
+  bool rational=false;
+  utl::getAttribute(geo,"rational",rational);
+  if (rational)
+    IFEM::cout << "\t Rational basis\n";
+  double scale = 1.0;
+  if (utl::getAttribute(geo,"scale",scale))
+    IFEM::cout <<"  Scale: "<< scale << std::endl;
+
+  double Lx = 1.0, Ly = 1.0;
+  if (utl::getAttribute(geo,"Lx",Lx))
+    IFEM::cout <<"  Length in X: "<< Lx << std::endl;
+  Lx *= scale;
+  if (utl::getAttribute(geo,"Ly",Ly))
+    IFEM::cout <<"  Length in Y: "<< Ly << std::endl;
+  Ly *= scale;
+
+  Vec3 X0;
+  std::string corner;
+  if (utl::getAttribute(geo,"X0",corner)) {
+    std::stringstream str(corner); str >> X0;
+    IFEM::cout <<"  Corner: "<< X0 << std::endl;
+  }
+
+  int nx = 1;
+  int ny = 1;
+  if (utl::getAttribute(geo,"nx",nx))
+    IFEM::cout << "  Split in X: " << nx  << std::endl;
+  if (utl::getAttribute(geo,"ny",ny))
+    IFEM::cout << "  Split in Y: " << ny << std::endl;
+
+  if (nx > 1)
+    Lx /= nx;
+  if (ny > 1)
+    Ly /= ny;
+
+  std::string g2;
+  for (int y = 0; y < ny; ++y) {
+    for (int x = 0; x < nx; ++x) {
+      g2.append("200 1 0 0\n");
+      g2.append(nsd > 2 ? "3" : "2");
+      g2.append(rational?" 1":" 0");
+      g2.append("\n2 2\n0 0 1 1\n2 2\n0 0 1 1");
+
+      std::stringstream str;
+      str <<"\n"<< X0.x+x*Lx <<" "<< X0.y+y*Ly;
+      if (nsd > 2) str <<" 0.0";
+      if (rational) str << " 1.0";
+      g2.append(str.str());
+      str.str("");
+      str <<"\n"<< X0.x+(x+1)*Lx <<" "<< X0.y+y*Ly;
+      if (nsd > 2) str <<" 0.0";
+      if (rational) str << " 1.0";
+      g2.append(str.str());
+      str.str("");
+      str <<"\n"<< X0.x+x*Lx <<" "<< X0.y+(y+1)*Ly;
+      if (nsd > 2) str <<" 0.0";
+      if (rational) str << " 1.0";
+      g2.append(str.str());
+      str.str("");
+      str <<"\n"<< X0.x+(x+1)*Lx <<" "<< X0.y+(y+1)*Ly;
+      if (nsd > 2) str <<" 0.0";
+      if (rational) str << " 1.0";
+      g2.append(str.str());
+      g2.append("\n");
+    }
+  }
+
+  return g2;
+}
+
+
+SIMdependency::PatchVec
+MultiPatchModelGenerator2D::createGeometry (const SIMbase& sim) const
+{
+  std::istringstream rect(this->createG2(sim.getNoSpaceDim()));
+  SIMdependency::PatchVec result;
+  sim.readPatches(rect,result,"\t");
+  return result;
+}
+
+
+bool MultiPatchModelGenerator2D::createTopology (SIMbase& sim) const
+{
+  auto&& IJ = [this](int i, int j) { return 1 + j*nx + i; };
+
+  for (int j = 0; j < ny; ++j)
+    for (int i = 0; i < nx-1; ++i)
+      if (!sim.addConnection(IJ(i,j), IJ(i+1,j), 2, 1, 0))
+        return false;
+
+  for (int j = 0; j < ny-1; ++j)
+    for (int i = 0; i < nx; ++i)
+      if (!sim.addConnection(IJ(i,j), IJ(i,j+1), 4, 3, 0))
+        return false;
+
+  if (periodic_x)
+    for (int i = 0; i < ny; ++i)
+      if (nx > 1) {
+        if (!sim.addConnection(IJ(0, i), IJ(nx-1, i), 1, 2, 0, false))
+          return false;
+      } else {
+         IFEM::cout <<"\tPeriodic I-direction P"<< IJ(0,i) << std::endl;
+         ASMs2D* pch = dynamic_cast<ASMs2D*>(sim.getPatch(IJ(0,i), true));
+         if (pch)
+           pch->closeEdges(1);
+      }
+
+  if (periodic_y)
+    for (int i = 0; i < nx; ++i)
+      if (ny > 1)
+        if (!sim.addConnection(IJ(i,0), IJ(i,ny-1), 3, 4, 0, false))
+          return false;
+      else {
+         IFEM::cout <<"\tPeriodic J-direction P"<< IJ(i,0)<< std::endl;
+         ASMs2D* pch = dynamic_cast<ASMs2D*>(sim.getPatch(IJ(i,0), true));
+         if (pch)
+           pch->closeEdges(2);
+      }
+
+  return true;
+}
+
+
+TopologySet
+MultiPatchModelGenerator2D::createTopologySets (const SIMbase& sim) const
+{
+  TopologySet result;
+  TopEntity& e1 = result["Edge1"];
+  TopEntity& e2 = result["Edge2"];
+  TopEntity& e3 = result["Edge3"];
+  TopEntity& e4 = result["Edge4"];
+  TopEntity& e5 = result["Boundary"];
+
+  auto&& insertion = [&sim, &e5](TopEntity& e, TopItem top)
+  {
+    if ((top.patch = sim.getLocalPatchIndex(top.patch)) > 0) {
+      e.insert(top);
+      e5.insert(top);
+    }
+  };
+
+  for (int i = 0; i < ny; ++i) {
+    insertion(e1, TopItem(i*nx+1,1,1));
+    insertion(e2, TopItem((i+1)*nx,2,1));
+  }
+  for (int i = 0; i < nx; ++i) {
+    insertion(e3, TopItem(i+1,3,1));
+    insertion(e4, TopItem(nx*(ny-1)+1+i,4,1));
+  }
+
+  TopEntity& c = result["Corners"];
+  auto&& insertionv = [&sim, &c](TopEntity& e, TopItem top)
+  {
+    if ((top.patch = sim.getLocalPatchIndex(top.patch)) > 0) {
+      e.insert(top);
+      c.insert(top);
+    }
+  };
+
+  insertionv(result["Vertex1"], TopItem(1,1,0));
+  insertionv(result["Vertex2"], TopItem(nx,2,0));
+  insertionv(result["Vertex3"], TopItem(nx*(ny-1)+1,3,0));
+  insertionv(result["Vertex4"], TopItem(nx*ny,4,0));
+
+  return result;
+}
+
+
+MultiPatchModelGenerator3D::MultiPatchModelGenerator3D (const TiXmlElement* geo) :
+  ModelGenerator(geo)
+{
+  nx = ny = nz = 1;
+  periodic_x = periodic_y = periodic_z = 0;
+  utl::getAttribute(geo,"nx",nx);
+  utl::getAttribute(geo,"ny",ny);
+  utl::getAttribute(geo,"nz",nz);
+  utl::getAttribute(geo,"periodic_x", periodic_x);
+  utl::getAttribute(geo,"periodic_y", periodic_y);
+  utl::getAttribute(geo,"periodic_z", periodic_z);
+}
+
+
+std::string MultiPatchModelGenerator3D::createG2 (int) const
+{
+  bool rational = false;
+  utl::getAttribute(geo,"rational",rational);
+  if (rational)
+    IFEM::cout <<"  Rational basis"<< std::endl;
+
+  double scale = 1.0;
+  if (utl::getAttribute(geo,"scale",scale))
+    IFEM::cout <<"  Scale: "<< scale << std::endl;
+
+  double Lx = 1.0, Ly = 1.0, Lz = 1.0;
+  if (utl::getAttribute(geo,"Lx",Lx))
+    IFEM::cout <<"  Length in X: "<< Lx << std::endl;
+  Lx *= scale;
+  if (utl::getAttribute(geo,"Ly",Ly))
+    IFEM::cout <<"  Length in Y: "<< Ly << std::endl;
+  Ly *= scale;
+  if (utl::getAttribute(geo,"Lz",Lz))
+    IFEM::cout <<"  Length in Z: "<< Lz << std::endl;
+  Lz *= scale;
+
+  int nx = 1;
+  int ny = 1;
+  int nz = 1;
+  if (utl::getAttribute(geo,"nx",nx))
+    IFEM::cout << "  Split in X: " << nx  << std::endl;
+  if (utl::getAttribute(geo,"ny",ny))
+    IFEM::cout << "  Split in Y: " << ny << std::endl;
+  if (utl::getAttribute(geo,"nz",nz))
+    IFEM::cout << "  Split in Z: " << nz << std::endl;
+
+  Lx /= nx;
+  Ly /= ny;
+  Lz /= nz;
+
+  std::string corner;
+  Vec3 X0;
+  if (utl::getAttribute(geo,"X0",corner)) {
+    std::stringstream str(corner);
+    str >> X0;
+    IFEM::cout <<"  Corner: "<< X0 << std::endl;
+  }
+
+  std::array<double,24> nodes =
+    {{ 0.0, 0.0, 0.0,
+       1.0, 0.0, 0.0,
+       0.0, 1.0, 0.0,
+       1.0, 1.0, 0.0,
+       0.0, 0.0, 1.0,
+       1.0, 0.0, 1.0,
+       0.0, 1.0, 1.0,
+       1.0, 1.0, 1.0 }};
+
+  std::string g2;
+  for (int z = 0; z < nz; ++z) {
+    for (int y = 0; y < ny; ++y) {
+      for (int x = 0; x < nx; ++x) {
+        g2.append("700 1 0 0\n3 ");
+        g2.append(rational ? "1\n" : "0\n");
+        g2.append("2 2\n0 0 1 1\n"
+                  "2 2\n0 0 1 1\n"
+                  "2 2\n0 0 1 1\n");
+
+        for (size_t i = 0; i < nodes.size(); i += 3)
+        {
+          std::stringstream str;
+          std::array<int,3> N {x,y,z};
+          std::array<double,3> L {Lx,Ly,Lz};
+          for (size_t j = 0; j < 3; j++)
+            str << (j==0?"":" ") << X0[j]+N[j]*L[j]+nodes[i+j]*L[j];
+          g2.append(str.str());
+          g2.append(rational ? " 1.0\n" : "\n");
+        }
+      }
+    }
+  }
+
+  return g2;
+}
+
+
+SIMdependency::PatchVec
+MultiPatchModelGenerator3D::createGeometry (const SIMbase& sim) const
+{
+  std::istringstream hex(this->createG2(sim.getNoSpaceDim()));
+  SIMdependency::PatchVec result;
+  sim.readPatches(hex,result,"\t");
+  return result;
+}
+
+
+bool MultiPatchModelGenerator3D::createTopology (SIMbase& sim) const
+{
+  auto&& IJK = [this](int i, int j, int k) { return 1 + (k*ny+j)*nx + i; };
+
+  for (int k = 0; k < nz; ++k)
+    for (int j = 0; j < ny; ++j)
+      for (int i = 0; i < nx-1; ++i)
+        if (!sim.addConnection(IJK(i,j,k), IJK(i+1,j,k), 2, 1, 0))
+          return false;
+
+  for (int k = 0; k < nz; ++k)
+    for (int j = 0; j < ny-1; ++j)
+      for (int i = 0; i < nx; ++i)
+        if (!sim.addConnection(IJK(i,j,k), IJK(i,j+1,k), 4, 3, 0))
+          return false;
+
+  for (int k = 0; k < nz-1; ++k)
+    for (int j = 0; j < ny; ++j)
+      for (int i = 0; i < nx; ++i)
+        if (!sim.addConnection(IJK(i,j,k), IJK(i,j,k+1), 6, 5, 0))
+          return false;
+
+  if (periodic_x)
+    for (int k = 0; k < nz; ++k)
+      for (int j = 0; j < ny; ++j)
+        if (nx > 1) {
+          if (!sim.addConnection(IJK(0,j,k), IJK(nx-1,j,k), 1, 2, 0, false))
+            return false;
+        } else {
+          IFEM::cout <<"\tPeriodic I-direction P"<< IJK(0,j,k) << std::endl;
+          ASMs3D* pch = dynamic_cast<ASMs3D*>(sim.getPatch(IJK(0,j,k), true));
+          if (pch)
+            pch->closeFaces(1);
+        }
+
+  if (periodic_y)
+    for (int k = 0; k < nz; ++k)
+      for (int i = 0; i < nx; ++i)
+        if (ny > 1) {
+          if (!sim.addConnection(IJK(i,0,k), IJK(i,ny-1,k), 3, 4, 0, false))
+            return false;
+         } else {
+          IFEM::cout <<"\tPeriodic J-direction P"<< IJK(i,0,k) << std::endl;
+          ASMs3D* pch = dynamic_cast<ASMs3D*>(sim.getPatch(IJK(i,0,k), true));
+          if (pch)
+            pch->closeFaces(2);
+         }
+
+  if (periodic_z)
+    for (int j = 0; j < ny; ++j)
+      for (int i = 0; i < nx; ++i)
+        if (nz > 1) {
+          if (!sim.addConnection(IJK(i,j,0), IJK(i,j,nz-1), 5, 6, 0, false))
+            return false;
+        } else {
+          IFEM::cout <<"\tPeriodic K-direction P"<< IJK(i,j,0) << std::endl;
+          ASMs3D* pch = dynamic_cast<ASMs3D*>(sim.getPatch(IJK(i,j,0), true));
+          if (pch)
+            pch->closeFaces(3);
+        }
+
+  return true;
+
+}
+
+TopologySet
+MultiPatchModelGenerator3D::createTopologySets (const SIMbase& sim) const
+{
+  // 0-based -> 1-based IJK
+  auto&& IJK = [this](int i, int j, int k) { return 1 + (k*ny+j)*nx + i; };
+
+  // start/end IJK
+  auto&& IJK2 = [this,IJK](int i, int j, int k) { return IJK(i*(nx-1), j*(ny-1), k*(nz-1)); };
+
+  // start/end JK
+  auto&& IJKI = [this,IJK](int i, int j, int k) { return IJK(i, j*(ny-1), k*(nz-1)); };
+  // start/end IK
+  auto&& IJKJ = [this,IJK](int i, int j, int k) { return IJK(i*(nx-1), j, k*(nz-1)); };
+  // start/end IJ
+  auto&& IJKK = [this,IJK](int i, int j, int k) { return IJK(i*(nx-1), j*(ny-1), k); };
+
+  // start/end I
+  auto&& IJK2I = [this,IJK](int i, int j, int k) { return IJK(i*(nx-1), j, k); };
+  // start/end J
+  auto&& IJK2J = [this,IJK](int i, int j, int k) { return IJK(i, j*(ny-1), k); };
+  // start/end K
+  auto&& IJK2K = [this,IJK](int i, int j, int k) { return IJK(i, j, k*(nz-1)); };
+
+  TopologySet result;
+
+  // insertion lambda
+  auto&& insertion = [&sim,&result](TopItem top,
+                                    const std::string& glob,
+                                    const std::string& type)
+                     {
+                       std::stringstream str;
+                       str << type << top.item;
+                       TopEntity& topI = result[str.str()];
+                       TopEntity& globI = result[glob];
+                       if ((top.patch = sim.getLocalPatchIndex(top.patch)) > 0) {
+                         topI.insert(top);
+                         globI.insert(top);
+                       }
+                     };
+
+  size_t r = 1;
+  for (int i = 0; i < 2; ++i, ++r)
+    for (int k = 0; k < nz; ++k)
+      for (int j = 0; j < ny; ++j)
+        insertion(TopItem(IJK2I(i,j,k),r,2), "Boundary", "Face");
+
+  for (int j = 0; j < 2; ++j, ++r)
+    for (int k = 0; k < nz; ++k)
+      for (int i = 0; i < nx; ++i)
+        insertion(TopItem(IJK2J(i,j,k),r,2), "Boundary", "Face");
+
+  for (int k = 0; k < 2; ++k, ++r)
+    for (int j = 0; j < ny; ++j)
+      for (int i = 0; i < nx; ++i)
+        insertion(TopItem(IJK2K(i,j,k),r,2), "Boundary", "Face");
+
+  r = 1;
+  for (int k = 0; k < 2; ++k)
+    for (int j = 0; j < 2; ++j)
+      for (int i = 0; i < 2; ++i, ++r)
+        insertion(TopItem(IJK2(i,j,k),r,0), "Corners", "Vertex");
+
+  r = 1;
+  for (int k = 0; k < 2; ++k)
+    for (int i = 0; i < 2; ++i, ++r)
+      for (int j = 0; j < ny; ++j)
+        insertion(TopItem(IJKJ(i,j,k),r,1), "Frame", "Edge");
+
+  for (int j = 0; j < 2; ++j)
+    for (int i = 0; i < 2; ++i, ++r)
+      for (int k = 0; k < nz; ++k)
+        insertion(TopItem(IJKK(i,j,k),r,1), "Frame", "Edge");
+
+  for (int k = 0; k < 2; ++k)
+    for (int j = 0; j < 2; ++j, ++r)
+      for (int i = 0; i < nx; ++i)
+        insertion(TopItem(IJKI(i,j,k),r,1), "Frame", "Edge");
+
+  return result;
+}

--- a/Apps/Common/MultiPatchModelGenerator.C
+++ b/Apps/Common/MultiPatchModelGenerator.C
@@ -162,6 +162,9 @@ bool MultiPatchModelGenerator2D::createTopology (SIMbase& sim) const
 TopologySet
 MultiPatchModelGenerator2D::createTopologySets (const SIMbase& sim) const
 {
+  if (!sets)
+    return TopologySet();
+
   TopologySet result;
   TopEntity& e1 = result["Edge1"];
   TopEntity& e2 = result["Edge2"];
@@ -378,6 +381,9 @@ bool MultiPatchModelGenerator3D::createTopology (SIMbase& sim) const
 TopologySet
 MultiPatchModelGenerator3D::createTopologySets (const SIMbase& sim) const
 {
+  if (!sets)
+    return TopologySet();
+
   // 0-based -> 1-based IJK
   auto&& IJK = [this](int i, int j, int k) { return 1 + (k*ny+j)*nx + i; };
 

--- a/Apps/Common/MultiPatchModelGenerator.h
+++ b/Apps/Common/MultiPatchModelGenerator.h
@@ -1,0 +1,100 @@
+// $Id$
+//==============================================================================
+//!
+//! \file MultiPatchModelGenerator.h
+//!
+//! \date Sep 2 2016
+//!
+//! \author Arne Morten Kvarving / SINTEF
+//!
+//! \brief Multi-patch model generators for NURBS-based FEM simulators.
+//!
+//==============================================================================
+
+#ifndef _MULTIPATCH_MODEL_GENERATOR_H
+#define _MULTIPATCH_MODEL_GENERATOR_H
+
+#include "ModelGenerator.h"
+#include <string>
+
+
+/*!
+  \brief 2D multi-patch model generator for FEM simulators.
+  \details Generate a rectangle split in a given number of blocks.
+*/
+
+class MultiPatchModelGenerator2D : public ModelGenerator
+{
+public:
+  //! \brief Constructor initializes common members.
+  //!\ param[in] elem XML element to parse
+  MultiPatchModelGenerator2D(const TiXmlElement* elem);
+
+  //! \brief Empty destructor.
+  virtual ~MultiPatchModelGenerator2D() {}
+
+  //! \brief Creates a geometry.
+  //! \param[in] sim SIM with patch read function to use
+  SIMdependency::PatchVec createGeometry(const SIMbase& sim) const override;
+
+  //! \brief Creates topology for geometry.
+  //! \param sim Simulator to apply topology to
+  bool createTopology(SIMbase& sim) const override;
+
+  //! \brief Creates topology sets for geometry.
+  TopologySet createTopologySets(const SIMbase& sim) const override;
+
+protected:
+  //! \brief Generates the G2 description of the geometry.
+  //! \param nsd Number of spatial dimension
+  std::string createG2 (int nsd = 2) const;
+
+  int nx; //!< Number of blocks in x
+  int ny; //!< Number of blocks in y
+  int periodic_x; //!< If non-zero, make model periodic in x for given bases
+  int periodic_y; //!< If non-zero, make model periodic in y for given bases
+};
+
+
+/*!
+ \brief 3D multi-patch model generator for FEM simulators.
+ \details Generates a hexahedra split in a given number of blocks.
+ */
+
+class MultiPatchModelGenerator3D : public ModelGenerator
+{
+public:
+  //! \brief Constructor initializes common members.
+  //! \param[in] elem XML element to parse
+  MultiPatchModelGenerator3D(const TiXmlElement* geo);
+
+  //! \brief Empty destructor.
+  virtual ~MultiPatchModelGenerator3D() {}
+
+  //! \brief Creates a geometry.
+  //! \param[in] sim SIM with patch read function to use
+  SIMdependency::PatchVec createGeometry(const SIMbase& sim) const override;
+
+  //! \brief Creates topology for geometry.
+  //! \param[in] geo XML element containing geometry defintion
+  //! \param sim Simulator to apply topology to
+  bool createTopology(SIMbase& sim) const override;
+
+  //! \brief Creates topology sets for geometry.
+  //! \param[in] SIM Simulator with patch ownerships
+  virtual TopologySet createTopologySets(const SIMbase& sim) const;
+
+protected:
+  //! \brief Generates the G2 description of the geometry.
+  //! \param nsd Number of spatial dimension
+  std::string createG2 (int nsd = 3) const;
+
+  int nx; //!< Number of blocks in x
+  int ny; //!< Number of blocks in y
+  int nz; //!< Number of blocks in z
+  int periodic_x; //!< If non-zero, make model periodic in x for given bases
+  int periodic_y; //!< If non-zero, make model periodic in y for given bases
+  int periodic_z; //!< If non-zero, make model periodic in z for given bases
+};
+
+#endif

--- a/Apps/Common/SIMMultiPatchModelGen.C
+++ b/Apps/Common/SIMMultiPatchModelGen.C
@@ -1,0 +1,34 @@
+// $Id$
+//==============================================================================
+//!
+//! \file SIMMultiPatchModelGen.C
+//!
+//! \date Sep 5 2016
+//!
+//! \author Arne Morten Kvarving / SINTEF
+//!
+//! \brief Base class for simulators equipped with multi-patch model generators.
+//!
+//==============================================================================
+
+#include "SIMMultiPatchModelGen.h"
+#include "MultiPatchModelGenerator.h"
+#include "IFEM.h"
+#include "SIM2D.h"
+#include "SIM3D.h"
+
+
+template<>
+ModelGenerator* SIMMultiPatchModelGen<SIM2D>::createModelGenerator(const TiXmlElement* geo) const
+{
+  IFEM::cout <<"  Using multi-patch model generator" << std::endl;
+  return new MultiPatchModelGenerator2D(geo);
+}
+
+
+template<>
+ModelGenerator* SIMMultiPatchModelGen<SIM3D>::createModelGenerator(const TiXmlElement* geo) const
+{
+  IFEM::cout <<"  Using multi-patch model generator" << std::endl;
+  return new MultiPatchModelGenerator3D(geo);
+}

--- a/Apps/Common/SIMMultiPatchModelGen.h
+++ b/Apps/Common/SIMMultiPatchModelGen.h
@@ -11,7 +11,7 @@
 //!
 //==============================================================================
 
-#ifndef _SIM_MULTPATCH_MODEL_GEN_H_
+#ifndef _SIM_MULTIPATCH_MODEL_GEN_H_
 #define _SIM_MULTIPATCH_MODEL_GEN_H_
 
 #include "SIMbase.h"
@@ -25,17 +25,11 @@ class SIMMultiPatchModelGen : public Dim {
 public:
   //! \brief Default constructor.
   //! \param[in] n1 Number of fields
-  //! \param[in] check If \e true, ensure the model is in a right-hand system
-  SIMMultiPatchModelGen(int n1,
-                        bool checkRHS=false) :
-    Dim(n1, checkRHS) {}
+  SIMMultiPatchModelGen(int n1) : Dim(n1) {}
 
   //! \brief Default constructor.
   //! \param[in] unf Number of fields on bases
-  //! \param[in] check If \e true, ensure the model is in a right-hand system
-  SIMMultiPatchModelGen(const SIMbase::CharVec& unf,
-                        bool checkRHS=false) :
-    Dim(unf,checkRHS) {}
+  SIMMultiPatchModelGen(const SIMbase::CharVec& unf) : Dim(unf) {}
 
   //! \brief Empty destructor
   virtual ~SIMMultiPatchModelGen() {}

--- a/Apps/Common/SIMMultiPatchModelGen.h
+++ b/Apps/Common/SIMMultiPatchModelGen.h
@@ -1,0 +1,49 @@
+// $Id$
+//==============================================================================
+//!
+//! \file SIMMultiPatchModelGen.h
+//!
+//! \date Sep 5 2016
+//!
+//! \author Arne Morten Kvarving / SINTEF
+//!
+//! \brief Base class for simulators equipped with multi-patch model generators.
+//!
+//==============================================================================
+
+#ifndef _SIM_MULTPATCH_MODEL_GEN_H_
+#define _SIM_MULTIPATCH_MODEL_GEN_H_
+
+#include "SIMbase.h"
+
+class TiXmlElement;
+
+
+//! \brief Inherit this class to equip your SIM multi-patch model generators.
+template<class Dim>
+class SIMMultiPatchModelGen : public Dim {
+public:
+  //! \brief Default constructor.
+  //! \param[in] n1 Number of fields
+  //! \param[in] check If \e true, ensure the model is in a right-hand system
+  SIMMultiPatchModelGen(int n1,
+                        bool checkRHS=false) :
+    Dim(n1, checkRHS) {}
+
+  //! \brief Default constructor.
+  //! \param[in] unf Number of fields on bases
+  //! \param[in] check If \e true, ensure the model is in a right-hand system
+  SIMMultiPatchModelGen(const SIMbase::CharVec& unf,
+                        bool checkRHS=false) :
+    Dim(unf,checkRHS) {}
+
+  //! \brief Empty destructor
+  virtual ~SIMMultiPatchModelGen() {}
+
+protected:
+  //! \brief Instantiate a generator for the finite element model.
+  //! \param[in] geo XML element containing geometry defintion
+  ModelGenerator* createModelGenerator(const TiXmlElement* geo) const override;
+};
+
+#endif

--- a/Apps/Common/Test/TestMultiPatchModelGenerator.C
+++ b/Apps/Common/Test/TestMultiPatchModelGenerator.C
@@ -1,0 +1,882 @@
+//==============================================================================
+//!
+//! \file TestMultiPatchModelGenerator.C
+//!
+//! \date Sep 2 2016
+//!
+//! \author Arne Morten Kvarving / SINTEF
+//!
+//! \brief Tests for multi-patch model generators.
+//!
+//==============================================================================
+
+#include "IFEM.h"
+#include "MultiPatchModelGenerator.h"
+#include "SIM2D.h"
+#include "SIM3D.h"
+#include "TopologySet.h"
+
+#include "gtest/gtest.h"
+#include "tinyxml.h"
+
+
+template<class Generator>
+class TestModelGeneratorWrapper : public Generator {
+public:
+  TestModelGeneratorWrapper(const TiXmlElement* geo) : Generator(geo) {}
+  std::string createG2(int nsd)
+  {
+    return Generator::createG2(nsd);
+  }
+};
+
+struct GeomTest {
+  std::string xml;
+  int dim;
+  std::string g2;
+  std::string sets;
+};
+
+
+class TestMultiPatchModelGenerator1D :
+  public testing::Test,
+  public testing::WithParamInterface<GeomTest>
+{
+};
+
+
+class TestMultiPatchModelGenerator2D :
+  public testing::Test,
+  public testing::WithParamInterface<GeomTest>
+{
+};
+
+
+class TestMultiPatchModelGenerator3D :
+  public testing::Test,
+  public testing::WithParamInterface<GeomTest>
+{
+};
+
+
+auto&& DoTest = [](const GeomTest& ref, const std::string& gen,
+                   const TopologySet& sets)
+{
+  ASSERT_STREQ(gen.c_str(), ref.g2.c_str());
+
+  if (!ref.sets.empty()) {
+    std::string gsets;
+    for (auto& it : sets) {
+      gsets += it.first + ": ";
+      for (auto& it2 : it.second) {
+        std::stringstream str;
+        str << it2.patch << " " << it2.item << " " << it2.idim << " ";
+        gsets += str.str();
+      }
+      gsets += "\n";
+    }
+    ASSERT_STREQ(gsets.c_str(), ref.sets.c_str());
+  }
+};
+
+
+
+TEST_P(TestMultiPatchModelGenerator2D, Generate)
+{
+  TiXmlDocument doc;
+  doc.Parse(GetParam().xml.c_str());
+  TestModelGeneratorWrapper<MultiPatchModelGenerator2D> gen(doc.RootElement());
+  std::string g2 = gen.createG2(GetParam().dim);
+  SIM2D sim;
+  TopologySet sets = gen.createTopologySets(sim);
+  DoTest(GetParam(), g2, sets);
+}
+
+
+TEST_P(TestMultiPatchModelGenerator3D, Generate)
+{
+  TiXmlDocument doc;
+  doc.Parse(GetParam().xml.c_str());
+  TestModelGeneratorWrapper<MultiPatchModelGenerator3D> gen(doc.RootElement());
+  std::string g2 = gen.createG2(GetParam().dim);
+  SIM3D sim;
+  TopologySet sets = gen.createTopologySets(sim);
+  DoTest(GetParam(), g2, sets);
+}
+
+
+const std::vector<GeomTest> geometry2D =
+  {{"<geometry sets=\"true\"/>", 2,
+    "200 1 0 0\n"
+    "2 0\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "0 0\n"
+    "1 0\n"
+    "0 1\n"
+    "1 1\n",
+    "Boundary: 1 1 1 1 2 1 1 3 1 1 4 1 \n"
+    "Corners: 1 1 0 1 2 0 1 3 0 1 4 0 \n"
+    "Edge1: 1 1 1 \n"
+    "Edge2: 1 2 1 \n"
+    "Edge3: 1 3 1 \n"
+    "Edge4: 1 4 1 \n"
+    "Vertex1: 1 1 0 \n"
+    "Vertex2: 1 2 0 \n"
+    "Vertex3: 1 3 0 \n"
+    "Vertex4: 1 4 0 \n"},
+
+   {"<geometry rational=\"1\"/>", 2,
+    "200 1 0 0\n"
+    "2 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "0 0 1.0\n"
+    "1 0 1.0\n"
+    "0 1 1.0\n"
+    "1 1 1.0\n", ""},
+
+   {"<geometry scale=\"2\"/>", 2,
+     "200 1 0 0\n"
+     "2 0\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "0 0\n"
+     "2 0\n"
+     "0 2\n"
+     "2 2\n", ""},
+
+   {"<geometry X0=\"2 0\"/>", 2,
+    "200 1 0 0\n"
+     "2 0\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "2 0\n"
+     "3 0\n"
+     "2 1\n"
+     "3 1\n"},
+
+    {"<geometry X0=\"0 2\"/>", 2,
+     "200 1 0 0\n"
+     "2 0\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "0 2\n"
+     "1 2\n"
+     "0 3\n"
+     "1 3\n", ""},
+
+    {"<geometry Lx=\"2\"/>", 2,
+     "200 1 0 0\n"
+     "2 0\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "0 0\n"
+     "2 0\n"
+     "0 1\n"
+     "2 1\n", ""},
+
+    {"<geometry Ly=\"2\"/>", 2,
+     "200 1 0 0\n"
+     "2 0\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "0 0\n"
+     "1 0\n"
+     "0 2\n"
+     "1 2\n", ""},
+
+    {"<geometry sets=\"true\" nx=\"2\"/>", 2,
+     "200 1 0 0\n"
+     "2 0\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "0 0\n"
+     "0.5 0\n"
+     "0 1\n"
+     "0.5 1\n"
+     "200 1 0 0\n"
+     "2 0\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "0.5 0\n"
+     "1 0\n"
+     "0.5 1\n"
+     "1 1\n",
+     "Boundary: 1 1 1 1 3 1 1 4 1 2 2 1 2 3 1 2 4 1 \n"
+     "Corners: 1 1 0 1 3 0 2 2 0 2 4 0 \n"
+     "Edge1: 1 1 1 \n"
+     "Edge2: 2 2 1 \n"
+     "Edge3: 1 3 1 2 3 1 \n"
+     "Edge4: 1 4 1 2 4 1 \n"
+     "Vertex1: 1 1 0 \n"
+     "Vertex2: 2 2 0 \n"
+     "Vertex3: 1 3 0 \n"
+     "Vertex4: 2 4 0 \n"},
+
+    {"<geometry sets=\"true\" ny=\"2\"/>", 2,
+     "200 1 0 0\n"
+     "2 0\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "0 0\n"
+     "1 0\n"
+     "0 0.5\n"
+     "1 0.5\n"
+     "200 1 0 0\n"
+     "2 0\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "0 0.5\n"
+     "1 0.5\n"
+     "0 1\n"
+     "1 1\n",
+     "Boundary: 1 1 1 1 2 1 1 3 1 2 1 1 2 2 1 2 4 1 \n"
+     "Corners: 1 1 0 1 2 0 2 3 0 2 4 0 \n"
+     "Edge1: 1 1 1 2 1 1 \n"
+     "Edge2: 1 2 1 2 2 1 \n"
+     "Edge3: 1 3 1 \n"
+     "Edge4: 2 4 1 \n"
+     "Vertex1: 1 1 0 \n"
+     "Vertex2: 1 2 0 \n"
+     "Vertex3: 2 3 0 \n"
+     "Vertex4: 2 4 0 \n"},
+
+    {"<geometry sets=\"true\" nx=\"2\" ny=\"2\"/>", 2,
+     "200 1 0 0\n"
+     "2 0\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "0 0\n"
+     "0.5 0\n"
+     "0 0.5\n"
+     "0.5 0.5\n"
+     "200 1 0 0\n"
+     "2 0\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "0.5 0\n"
+     "1 0\n"
+     "0.5 0.5\n"
+     "1 0.5\n"
+     "200 1 0 0\n"
+     "2 0\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "0 0.5\n"
+     "0.5 0.5\n"
+     "0 1\n"
+     "0.5 1\n"
+     "200 1 0 0\n"
+     "2 0\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "0.5 0.5\n"
+     "1 0.5\n"
+     "0.5 1\n"
+     "1 1\n",
+     "Boundary: 1 1 1 1 3 1 2 2 1 2 3 1 3 1 1 3 4 1 4 2 1 4 4 1 \n"
+     "Corners: 1 1 0 2 2 0 3 3 0 4 4 0 \n"
+     "Edge1: 1 1 1 3 1 1 \n"
+     "Edge2: 2 2 1 4 2 1 \n"
+     "Edge3: 1 3 1 2 3 1 \n"
+     "Edge4: 3 4 1 4 4 1 \n"
+     "Vertex1: 1 1 0 \n"
+     "Vertex2: 2 2 0 \n"
+     "Vertex3: 3 3 0 \n"
+     "Vertex4: 4 4 0 \n"}};
+
+
+INSTANTIATE_TEST_CASE_P(TestMultiPatchModelGenerator2D,
+                        TestMultiPatchModelGenerator2D,
+                        testing::ValuesIn(geometry2D));
+
+
+const std::vector<GeomTest> geometry3D =
+  {{"<geometry sets=\"true\"/>", 3,
+    "700 1 0 0\n"
+    "3 0\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "0 0 0\n"
+    "1 0 0\n"
+    "0 1 0\n"
+    "1 1 0\n"
+    "0 0 1\n"
+    "1 0 1\n"
+    "0 1 1\n"
+    "1 1 1\n",
+    "Boundary: 1 1 2 1 2 2 1 3 2 1 4 2 1 5 2 1 6 2 \n"
+    "Corners: 1 1 0 1 2 0 1 3 0 1 4 0 1 5 0 1 6 0 1 7 0 1 8 0 \n"
+    "Edge1: 1 1 1 \n"
+    "Edge10: 1 10 1 \n"
+    "Edge11: 1 11 1 \n"
+    "Edge12: 1 12 1 \n"
+    "Edge2: 1 2 1 \n"
+    "Edge3: 1 3 1 \n"
+    "Edge4: 1 4 1 \n"
+    "Edge5: 1 5 1 \n"
+    "Edge6: 1 6 1 \n"
+    "Edge7: 1 7 1 \n"
+    "Edge8: 1 8 1 \n"
+    "Edge9: 1 9 1 \n"
+    "Face1: 1 1 2 \n"
+    "Face2: 1 2 2 \n"
+    "Face3: 1 3 2 \n"
+    "Face4: 1 4 2 \n"
+    "Face5: 1 5 2 \n"
+    "Face6: 1 6 2 \n"
+    "Frame: 1 1 1 1 2 1 1 3 1 1 4 1 1 5 1 1 6 1 1 7 1 1 8 1 1 9 1 1 10 1 1 11 1 1 12 1 \n"
+    "Vertex1: 1 1 0 \n"
+    "Vertex2: 1 2 0 \n"
+    "Vertex3: 1 3 0 \n"
+    "Vertex4: 1 4 0 \n"
+    "Vertex5: 1 5 0 \n"
+    "Vertex6: 1 6 0 \n"
+    "Vertex7: 1 7 0 \n"
+    "Vertex8: 1 8 0 \n"},
+
+  {"<geometry rational=\"1\"/>", 3,
+   "700 1 0 0\n"
+   "3 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "0 0 0 1.0\n"
+   "1 0 0 1.0\n"
+   "0 1 0 1.0\n"
+   "1 1 0 1.0\n"
+   "0 0 1 1.0\n"
+   "1 0 1 1.0\n"
+   "0 1 1 1.0\n"
+   "1 1 1 1.0\n", ""},
+
+  {"<geometry scale=\"2\"/>", 3,
+   "700 1 0 0\n"
+   "3 0\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "0 0 0\n"
+   "2 0 0\n"
+   "0 2 0\n"
+   "2 2 0\n"
+   "0 0 2\n"
+   "2 0 2\n"
+   "0 2 2\n"
+   "2 2 2\n", ""},
+
+  {"<geometry X0=\"2 0 0\"/>", 3,
+   "700 1 0 0\n"
+   "3 0\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 0 0\n"
+   "3 0 0\n"
+   "2 1 0\n"
+   "3 1 0\n"
+   "2 0 1\n"
+   "3 0 1\n"
+   "2 1 1\n"
+   "3 1 1\n", ""},
+
+  {"<geometry X0=\"0 2 0\"/>", 3,
+   "700 1 0 0\n"
+   "3 0\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "0 2 0\n"
+   "1 2 0\n"
+   "0 3 0\n"
+   "1 3 0\n"
+   "0 2 1\n"
+   "1 2 1\n"
+   "0 3 1\n"
+   "1 3 1\n", ""},
+
+  {"<geometry X0=\"0 0 2\"/>", 3,
+   "700 1 0 0\n"
+   "3 0\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "0 0 2\n"
+   "1 0 2\n"
+   "0 1 2\n"
+   "1 1 2\n"
+   "0 0 3\n"
+   "1 0 3\n"
+   "0 1 3\n"
+   "1 1 3\n", ""},
+
+  {"<geometry Lx=\"2\"/>", 3,
+   "700 1 0 0\n"
+   "3 0\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "0 0 0\n"
+   "2 0 0\n"
+   "0 1 0\n"
+   "2 1 0\n"
+   "0 0 1\n"
+   "2 0 1\n"
+   "0 1 1\n"
+   "2 1 1\n", ""},
+
+  {"<geometry Ly=\"2\"/>", 3,
+   "700 1 0 0\n"
+   "3 0\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "0 0 0\n"
+   "1 0 0\n"
+   "0 2 0\n"
+   "1 2 0\n"
+   "0 0 1\n"
+   "1 0 1\n"
+   "0 2 1\n"
+   "1 2 1\n", ""},
+
+  {"<geometry Lz=\"2\"/>", 3,
+   "700 1 0 0\n"
+     "3 0\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "0 0 0\n"
+     "1 0 0\n"
+     "0 1 0\n"
+     "1 1 0\n"
+     "0 0 2\n"
+     "1 0 2\n"
+     "0 1 2\n"
+     "1 1 2\n", ""},
+
+  {"<geometry sets=\"true\" nx=\"2\"/>", 3,
+   "700 1 0 0\n"
+   "3 0\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "0 0 0\n"
+   "0.5 0 0\n"
+   "0 1 0\n"
+   "0.5 1 0\n"
+   "0 0 1\n"
+   "0.5 0 1\n"
+   "0 1 1\n"
+   "0.5 1 1\n"
+   "700 1 0 0\n"
+   "3 0\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "0.5 0 0\n"
+   "1 0 0\n"
+   "0.5 1 0\n"
+   "1 1 0\n"
+   "0.5 0 1\n"
+   "1 0 1\n"
+   "0.5 1 1\n"
+   "1 1 1\n",
+   "Boundary: 1 1 2 1 3 2 1 4 2 1 5 2 1 6 2 2 2 2 2 3 2 2 4 2 2 5 2 2 6 2 \n"
+   "Corners: 1 1 0 1 3 0 1 5 0 1 7 0 2 2 0 2 4 0 2 6 0 2 8 0 \n"
+   "Edge1: 1 1 1 \n"
+   "Edge10: 1 10 1 2 10 1 \n"
+   "Edge11: 1 11 1 2 11 1 \n"
+   "Edge12: 1 12 1 2 12 1 \n"
+   "Edge2: 2 2 1 \n"
+   "Edge3: 1 3 1 \n"
+   "Edge4: 2 4 1 \n"
+   "Edge5: 1 5 1 \n"
+   "Edge6: 2 6 1 \n"
+   "Edge7: 1 7 1 \n"
+   "Edge8: 2 8 1 \n"
+   "Edge9: 1 9 1 2 9 1 \n"
+   "Face1: 1 1 2 \n"
+   "Face2: 2 2 2 \n"
+   "Face3: 1 3 2 2 3 2 \n"
+   "Face4: 1 4 2 2 4 2 \n"
+   "Face5: 1 5 2 2 5 2 \n"
+   "Face6: 1 6 2 2 6 2 \n"
+   "Frame: 1 1 1 1 3 1 1 5 1 1 7 1 1 9 1 1 10 1 1 11 1 1 12 1 2 2 1 2 4 1 2 6 1 2 8 1 2 9 1 2 10 1 2 11 1 2 12 1 \n"
+   "Vertex1: 1 1 0 \n"
+   "Vertex2: 2 2 0 \n"
+   "Vertex3: 1 3 0 \n"
+   "Vertex4: 2 4 0 \n"
+   "Vertex5: 1 5 0 \n"
+   "Vertex6: 2 6 0 \n"
+   "Vertex7: 1 7 0 \n"
+   "Vertex8: 2 8 0 \n"},
+
+  {"<geometry sets=\"true\" ny=\"2\"/>", 3,
+   "700 1 0 0\n"
+   "3 0\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "0 0 0\n"
+   "1 0 0\n"
+   "0 0.5 0\n"
+   "1 0.5 0\n"
+   "0 0 1\n"
+   "1 0 1\n"
+   "0 0.5 1\n"
+   "1 0.5 1\n"
+   "700 1 0 0\n"
+   "3 0\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "0 0.5 0\n"
+   "1 0.5 0\n"
+   "0 1 0\n"
+   "1 1 0\n"
+   "0 0.5 1\n"
+   "1 0.5 1\n"
+   "0 1 1\n"
+   "1 1 1\n",
+   "Boundary: 1 1 2 1 2 2 1 3 2 1 5 2 1 6 2 2 1 2 2 2 2 2 4 2 2 5 2 2 6 2 \n"
+   "Corners: 1 1 0 1 2 0 1 5 0 1 6 0 2 3 0 2 4 0 2 7 0 2 8 0 \n"
+   "Edge1: 1 1 1 2 1 1 \n"
+   "Edge10: 2 10 1 \n"
+   "Edge11: 1 11 1 \n"
+   "Edge12: 2 12 1 \n"
+   "Edge2: 1 2 1 2 2 1 \n"
+   "Edge3: 1 3 1 2 3 1 \n"
+   "Edge4: 1 4 1 2 4 1 \n"
+   "Edge5: 1 5 1 \n"
+   "Edge6: 1 6 1 \n"
+   "Edge7: 2 7 1 \n"
+   "Edge8: 2 8 1 \n"
+   "Edge9: 1 9 1 \n"
+   "Face1: 1 1 2 2 1 2 \n"
+   "Face2: 1 2 2 2 2 2 \n"
+   "Face3: 1 3 2 \n"
+   "Face4: 2 4 2 \n"
+   "Face5: 1 5 2 2 5 2 \n"
+   "Face6: 1 6 2 2 6 2 \n"
+   "Frame: 1 1 1 1 2 1 1 3 1 1 4 1 1 5 1 1 6 1 1 9 1 1 11 1 2 1 1 2 2 1 2 3 1 2 4 1 2 7 1 2 8 1 2 10 1 2 12 1 \n"
+   "Vertex1: 1 1 0 \n"
+   "Vertex2: 1 2 0 \n"
+   "Vertex3: 2 3 0 \n"
+   "Vertex4: 2 4 0 \n"
+   "Vertex5: 1 5 0 \n"
+   "Vertex6: 1 6 0 \n"
+   "Vertex7: 2 7 0 \n"
+   "Vertex8: 2 8 0 \n"},
+
+   {"<geometry sets=\"true\" nz=\"2\"/>", 3,
+    "700 1 0 0\n"
+    "3 0\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "0 0 0\n"
+    "1 0 0\n"
+    "0 1 0\n"
+    "1 1 0\n"
+    "0 0 0.5\n"
+    "1 0 0.5\n"
+    "0 1 0.5\n"
+    "1 1 0.5\n"
+    "700 1 0 0\n"
+    "3 0\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "0 0 0.5\n"
+    "1 0 0.5\n"
+    "0 1 0.5\n"
+    "1 1 0.5\n"
+    "0 0 1\n"
+    "1 0 1\n"
+    "0 1 1\n"
+    "1 1 1\n",
+    "Boundary: 1 1 2 1 2 2 1 3 2 1 4 2 1 5 2 2 1 2 2 2 2 2 3 2 2 4 2 2 6 2 \n"
+    "Corners: 1 1 0 1 2 0 1 3 0 1 4 0 2 5 0 2 6 0 2 7 0 2 8 0 \n"
+    "Edge1: 1 1 1 \n"
+    "Edge10: 1 10 1 \n"
+    "Edge11: 2 11 1 \n"
+    "Edge12: 2 12 1 \n"
+    "Edge2: 1 2 1 \n"
+    "Edge3: 2 3 1 \n"
+    "Edge4: 2 4 1 \n"
+    "Edge5: 1 5 1 2 5 1 \n"
+    "Edge6: 1 6 1 2 6 1 \n"
+    "Edge7: 1 7 1 2 7 1 \n"
+    "Edge8: 1 8 1 2 8 1 \n"
+    "Edge9: 1 9 1 \n"
+    "Face1: 1 1 2 2 1 2 \n"
+    "Face2: 1 2 2 2 2 2 \n"
+    "Face3: 1 3 2 2 3 2 \n"
+    "Face4: 1 4 2 2 4 2 \n"
+    "Face5: 1 5 2 \n"
+    "Face6: 2 6 2 \n"
+    "Frame: 1 1 1 1 2 1 1 5 1 1 6 1 1 7 1 1 8 1 1 9 1 1 10 1 2 3 1 2 4 1 2 5 1 2 6 1 2 7 1 2 8 1 2 11 1 2 12 1 \n"
+    "Vertex1: 1 1 0 \n"
+    "Vertex2: 1 2 0 \n"
+    "Vertex3: 1 3 0 \n"
+    "Vertex4: 1 4 0 \n"
+    "Vertex5: 2 5 0 \n"
+    "Vertex6: 2 6 0 \n"
+    "Vertex7: 2 7 0 \n"
+    "Vertex8: 2 8 0 \n"},
+
+  {"<geometry sets=\"true\" nx=\"2\" ny=\"2\" nz=\"2\"/>", 3,
+    "700 1 0 0\n"
+    "3 0\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "0 0 0\n"
+    "0.5 0 0\n"
+    "0 0.5 0\n"
+    "0.5 0.5 0\n"
+    "0 0 0.5\n"
+    "0.5 0 0.5\n"
+    "0 0.5 0.5\n"
+    "0.5 0.5 0.5\n"
+    "700 1 0 0\n"
+    "3 0\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "0.5 0 0\n"
+    "1 0 0\n"
+    "0.5 0.5 0\n"
+    "1 0.5 0\n"
+    "0.5 0 0.5\n"
+    "1 0 0.5\n"
+    "0.5 0.5 0.5\n"
+    "1 0.5 0.5\n"
+    "700 1 0 0\n"
+    "3 0\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "0 0.5 0\n"
+    "0.5 0.5 0\n"
+    "0 1 0\n"
+    "0.5 1 0\n"
+    "0 0.5 0.5\n"
+    "0.5 0.5 0.5\n"
+    "0 1 0.5\n"
+    "0.5 1 0.5\n"
+    "700 1 0 0\n"
+    "3 0\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "0.5 0.5 0\n"
+    "1 0.5 0\n"
+    "0.5 1 0\n"
+    "1 1 0\n"
+    "0.5 0.5 0.5\n"
+    "1 0.5 0.5\n"
+    "0.5 1 0.5\n"
+    "1 1 0.5\n"
+    "700 1 0 0\n"
+    "3 0\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "0 0 0.5\n"
+    "0.5 0 0.5\n"
+    "0 0.5 0.5\n"
+    "0.5 0.5 0.5\n"
+    "0 0 1\n"
+    "0.5 0 1\n"
+    "0 0.5 1\n"
+    "0.5 0.5 1\n"
+    "700 1 0 0\n"
+    "3 0\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "0.5 0 0.5\n"
+    "1 0 0.5\n"
+    "0.5 0.5 0.5\n"
+    "1 0.5 0.5\n"
+    "0.5 0 1\n"
+    "1 0 1\n"
+    "0.5 0.5 1\n"
+    "1 0.5 1\n"
+    "700 1 0 0\n"
+    "3 0\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "0 0.5 0.5\n"
+    "0.5 0.5 0.5\n"
+    "0 1 0.5\n"
+    "0.5 1 0.5\n"
+    "0 0.5 1\n"
+    "0.5 0.5 1\n"
+    "0 1 1\n"
+    "0.5 1 1\n"
+    "700 1 0 0\n"
+    "3 0\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "0.5 0.5 0.5\n"
+    "1 0.5 0.5\n"
+    "0.5 1 0.5\n"
+    "1 1 0.5\n"
+    "0.5 0.5 1\n"
+    "1 0.5 1\n"
+    "0.5 1 1\n"
+    "1 1 1\n",
+    "Boundary: 1 1 2 1 3 2 1 5 2 "
+    "2 2 2 2 3 2 2 5 2 "
+    "3 1 2 3 4 2 3 5 2 "
+    "4 2 2 4 4 2 4 5 2 "
+    "5 1 2 5 3 2 5 6 2 "
+    "6 2 2 6 3 2 6 6 2 "
+    "7 1 2 7 4 2 7 6 2 "
+    "8 2 2 8 4 2 8 6 2 \n"
+    "Corners: 1 1 0 2 2 0 3 3 0 4 4 0 5 5 0 6 6 0 7 7 0 8 8 0 \n"
+    "Edge1: 1 1 1 3 1 1 \n"
+    "Edge10: 3 10 1 4 10 1 \n"
+    "Edge11: 5 11 1 6 11 1 \n"
+    "Edge12: 7 12 1 8 12 1 \n"
+    "Edge2: 2 2 1 4 2 1 \n"
+    "Edge3: 5 3 1 7 3 1 \n"
+    "Edge4: 6 4 1 8 4 1 \n"
+    "Edge5: 1 5 1 5 5 1 \n"
+    "Edge6: 2 6 1 6 6 1 \n"
+    "Edge7: 3 7 1 7 7 1 \n"
+    "Edge8: 4 8 1 8 8 1 \n"
+    "Edge9: 1 9 1 2 9 1 \n"
+    "Face1: 1 1 2 3 1 2 5 1 2 7 1 2 \n"
+    "Face2: 2 2 2 4 2 2 6 2 2 8 2 2 \n"
+    "Face3: 1 3 2 2 3 2 5 3 2 6 3 2 \n"
+    "Face4: 3 4 2 4 4 2 7 4 2 8 4 2 \n"
+    "Face5: 1 5 2 2 5 2 3 5 2 4 5 2 \n"
+    "Face6: 5 6 2 6 6 2 7 6 2 8 6 2 \n"
+    "Frame: 1 1 1 1 5 1 1 9 1 "
+    "2 2 1 2 6 1 2 9 1 "
+    "3 1 1 3 7 1 3 10 1 "
+    "4 2 1 4 8 1 4 10 1 "
+    "5 3 1 5 5 1 5 11 1 "
+    "6 4 1 6 6 1 6 11 1 "
+    "7 3 1 7 7 1 7 12 1 "
+    "8 4 1 8 8 1 8 12 1 \n"
+    "Vertex1: 1 1 0 \n"
+    "Vertex2: 2 2 0 \n"
+    "Vertex3: 3 3 0 \n"
+    "Vertex4: 4 4 0 \n"
+    "Vertex5: 5 5 0 \n"
+    "Vertex6: 6 6 0 \n"
+    "Vertex7: 7 7 0 \n"
+    "Vertex8: 8 8 0 \n"}};
+
+
+INSTANTIATE_TEST_CASE_P(TestMultiPatchModelGenerator3D,
+                        TestMultiPatchModelGenerator3D,
+                        testing::ValuesIn(geometry3D));

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -590,7 +590,8 @@ bool ASMs2D::assignNodeNumbers (BlockNodes& nodes, int basis)
 }
 
 
-bool ASMs2D::connectPatch (int edge, ASMs2D& neighbor, int nedge, bool revers)
+bool ASMs2D::connectPatch (int edge, ASMs2D& neighbor, int nedge,
+                           bool revers, bool coordCheck)
 {
   if (swapV && edge > 2) // Account for swapped parameter direction
     edge = 7-edge;
@@ -598,7 +599,7 @@ bool ASMs2D::connectPatch (int edge, ASMs2D& neighbor, int nedge, bool revers)
   if (neighbor.swapV && nedge > 2) // Account for swapped parameter direction
     nedge = 7-nedge;
 
-  if (!this->connectBasis(edge,neighbor,nedge,revers))
+  if (!this->connectBasis(edge,neighbor,nedge,revers,1,0,0,coordCheck))
     return false;
 
   this->addNeighbor(&neighbor);
@@ -607,7 +608,7 @@ bool ASMs2D::connectPatch (int edge, ASMs2D& neighbor, int nedge, bool revers)
 
 
 bool ASMs2D::connectBasis (int edge, ASMs2D& neighbor, int nedge, bool revers,
-			   int basis, int slave, int master)
+                           int basis, int slave, int master, bool coordCheck)
 {
   if (this->isShared() && neighbor.isShared())
     return true;
@@ -687,7 +688,7 @@ bool ASMs2D::connectBasis (int edge, ASMs2D& neighbor, int nedge, bool revers,
   for (i = 0; i < n1; i++, node += i1)
   {
     int slave = slaveNodes[revers ? n1-i-1 : i];
-    if (!neighbor.getCoord(node).equal(this->getCoord(slave),xtol))
+    if (coordCheck && !neighbor.getCoord(node).equal(this->getCoord(slave),xtol))
     {
       std::cerr <<" *** ASMs2D::connectPatch: Non-matching nodes "
 		<< node <<": "<< neighbor.getCoord(node)

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -591,7 +591,7 @@ bool ASMs2D::assignNodeNumbers (BlockNodes& nodes, int basis)
 
 
 bool ASMs2D::connectPatch (int edge, ASMs2D& neighbor, int nedge,
-                           bool revers, bool coordCheck)
+                           bool revers, int, bool coordCheck)
 {
   if (swapV && edge > 2) // Account for swapped parameter direction
     edge = 7-edge;

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -267,8 +267,9 @@ public:
   //! \param neighbor The neighbor patch
   //! \param[in] nedge Local edge index of neighbor patch, in range [1,4]
   //! \param[in] revers Indicates whether the two edges have opposite directions
+  //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
   virtual bool connectPatch(int edge, ASMs2D& neighbor, int nedge,
-			    bool revers = false);
+                            bool revers = false, bool coordCheck = true);
 
   //! \brief Makes two opposite boundary edges periodic.
   //! \param[in] dir Parameter direction defining the periodic edges
@@ -473,8 +474,10 @@ protected:
   //! \param[in] basis Which basis to connect the nodes for (mixed methods)
   //! \param[in] slave 0-based index of the first slave node in this basis
   //! \param[in] master 0-based index of the first master node in this basis
+  //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
   bool connectBasis(int edge, ASMs2D& neighbor, int nedge, bool revers,
-		    int basis = 1, int slave = 0, int master = 0);
+                    int basis = 1, int slave = 0, int master = 0,
+                    bool coordCheck = true);
 
   //! \brief Extracts parameter values of the Gauss points in one direction.
   //! \param[out] uGP Parameter values in given direction for all points

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -267,9 +267,10 @@ public:
   //! \param neighbor The neighbor patch
   //! \param[in] nedge Local edge index of neighbor patch, in range [1,4]
   //! \param[in] revers Indicates whether the two edges have opposite directions
+  //! \param[in] basis (ignored)
   //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
   virtual bool connectPatch(int edge, ASMs2D& neighbor, int nedge,
-                            bool revers = false, bool coordCheck = true);
+                            bool revers = false, int basis = 0, bool coordCheck = true);
 
   //! \brief Makes two opposite boundary edges periodic.
   //! \param[in] dir Parameter direction defining the periodic edges

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -267,10 +267,9 @@ public:
   //! \param neighbor The neighbor patch
   //! \param[in] nedge Local edge index of neighbor patch, in range [1,4]
   //! \param[in] revers Indicates whether the two edges have opposite directions
-  //! \param[in] basis (ignored)
   //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
   virtual bool connectPatch(int edge, ASMs2D& neighbor, int nedge,
-                            bool revers = false, int basis = 0, bool coordCheck = true);
+                            bool revers = false, int = 0, bool coordCheck = true);
 
   //! \brief Makes two opposite boundary edges periodic.
   //! \param[in] dir Parameter direction defining the periodic edges

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -292,7 +292,8 @@ bool ASMs2Dmx::generateFEMTopology ()
 }
 
 
-bool ASMs2Dmx::connectPatch (int edge, ASMs2D& neighbor, int nedge, bool revers)
+bool ASMs2Dmx::connectPatch (int edge, ASMs2D& neighbor, int nedge,
+                             bool revers, bool coordCheck)
 {
   ASMs2Dmx* neighMx = dynamic_cast<ASMs2Dmx*>(&neighbor);
   if (!neighMx) return false;
@@ -301,7 +302,7 @@ bool ASMs2Dmx::connectPatch (int edge, ASMs2D& neighbor, int nedge, bool revers)
   size_t nb2=0;
   this->addNeighbor(neighMx);
   for (size_t i = 1;i <= m_basis.size(); ++i) {
-    if (!this->connectBasis(edge,neighbor,nedge,revers,i,nb1,nb2))
+    if (!this->connectBasis(edge,neighbor,nedge,revers,i,nb1,nb2,coordCheck))
       return false;
     nb1 += nb[i-1];
     nb2 += neighMx->nb[i-1];

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -293,7 +293,7 @@ bool ASMs2Dmx::generateFEMTopology ()
 
 
 bool ASMs2Dmx::connectPatch (int edge, ASMs2D& neighbor, int nedge,
-                             bool revers, bool coordCheck)
+                             bool revers, int basis, bool coordCheck)
 {
   ASMs2Dmx* neighMx = dynamic_cast<ASMs2Dmx*>(&neighbor);
   if (!neighMx) return false;
@@ -302,8 +302,11 @@ bool ASMs2Dmx::connectPatch (int edge, ASMs2D& neighbor, int nedge,
   size_t nb2=0;
   this->addNeighbor(neighMx);
   for (size_t i = 1;i <= m_basis.size(); ++i) {
-    if (!this->connectBasis(edge,neighbor,nedge,revers,i,nb1,nb2,coordCheck))
+    if ((basis == 0 || i == (size_t)basis) &&
+        !this->connectBasis(edge,neighbor,nedge,
+                            revers,i,nb1,nb2,coordCheck))
       return false;
+
     nb1 += nb[i-1];
     nb2 += neighMx->nb[i-1];
   }

--- a/src/ASM/ASMs2Dmx.h
+++ b/src/ASM/ASMs2Dmx.h
@@ -101,8 +101,9 @@ public:
   //! \param neighbor The neighbor patch
   //! \param[in] nedge Local edge index of neighbor patch, in range [1,4]
   //! \param[in] revers Indicates whether the two edges have opposite directions
+  //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
   virtual bool connectPatch(int edge, ASMs2D& neighbor, int nedge,
-			    bool revers = false);
+                            bool revers = false, bool coordCheck=true);
 
   //! \brief Makes two opposite boundary edges periodic.
   //! \param[in] dir Parameter direction defining the periodic edges

--- a/src/ASM/ASMs2Dmx.h
+++ b/src/ASM/ASMs2Dmx.h
@@ -103,7 +103,7 @@ public:
   //! \param[in] revers Indicates whether the two edges have opposite directions
   //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
   virtual bool connectPatch(int edge, ASMs2D& neighbor, int nedge,
-                            bool revers = false, bool coordCheck=true);
+                            bool revers = false, int basis = 0, bool coordCheck=true);
 
   //! \brief Makes two opposite boundary edges periodic.
   //! \param[in] dir Parameter direction defining the periodic edges

--- a/src/ASM/ASMs2Dmx.h
+++ b/src/ASM/ASMs2Dmx.h
@@ -103,7 +103,8 @@ public:
   //! \param[in] revers Indicates whether the two edges have opposite directions
   //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
   virtual bool connectPatch(int edge, ASMs2D& neighbor, int nedge,
-                            bool revers = false, int basis = 0, bool coordCheck=true);
+                            bool revers = false, int basis = 0,
+                            bool coordCheck = true);
 
   //! \brief Makes two opposite boundary edges periodic.
   //! \param[in] dir Parameter direction defining the periodic edges

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -617,7 +617,7 @@ bool ASMs3D::assignNodeNumbers (BlockNodes& nodes, int basis)
 
 
 bool ASMs3D::connectPatch (int face, ASMs3D& neighbor, int nface,
-                           int norient, bool coordCheck)
+                           int norient, int, bool coordCheck)
 {
   if (swapW && face > 4) // Account for swapped parameter direction
     face = 11-face;

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -616,7 +616,8 @@ bool ASMs3D::assignNodeNumbers (BlockNodes& nodes, int basis)
 }
 
 
-bool ASMs3D::connectPatch (int face, ASMs3D& neighbor, int nface, int norient)
+bool ASMs3D::connectPatch (int face, ASMs3D& neighbor, int nface,
+                           int norient, bool coordCheck)
 {
   if (swapW && face > 4) // Account for swapped parameter direction
     face = 11-face;
@@ -624,7 +625,7 @@ bool ASMs3D::connectPatch (int face, ASMs3D& neighbor, int nface, int norient)
   if (neighbor.swapW && nface > 4) // Account for swapped parameter direction
     nface = 11-nface;
 
-  if (!this->connectBasis(face,neighbor,nface,norient))
+  if (!this->connectBasis(face,neighbor,nface,norient,1,0,0,coordCheck))
     return false;
 
   this->addNeighbor(&neighbor);
@@ -633,7 +634,7 @@ bool ASMs3D::connectPatch (int face, ASMs3D& neighbor, int nface, int norient)
 
 
 bool ASMs3D::connectBasis (int face, ASMs3D& neighbor, int nface, int norient,
-			   int basis, int slave, int master)
+                           int basis, int slave, int master, bool coordCheck)
 {
   if (this->isShared() && neighbor.isShared())
     return true;
@@ -755,7 +756,7 @@ bool ASMs3D::connectBasis (int face, ASMs3D& neighbor, int nface, int norient,
 	}
 
       int slave = slaveNodes[k][l];
-      if (!neighbor.getCoord(node).equal(this->getCoord(slave),xtol))
+      if (coordCheck && !neighbor.getCoord(node).equal(this->getCoord(slave),xtol))
       {
 	std::cerr <<" *** ASMs3D::connectPatch: Non-matching nodes "
 		  << node <<": "<< neighbor.getCoord(node)

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -317,6 +317,7 @@ public:
   //! \param neighbor The neighbor patch
   //! \param[in] nface Local face index of neighbor patch, in range [1,6]
   //! \param[in] norient Relative face orientation flag (see below)
+  //! \param[in] basis (ignored)
   //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
   //!
   //! \details The face orientation flag \a norient must be in range [0,7].
@@ -325,7 +326,7 @@ public:
   //! - middle digit = 1: Parameter \a u in neighbor patch face is reversed
   //! - right digit = 1: Parameter \a v in neighbor patch face is reversed
   virtual bool connectPatch(int face, ASMs3D& neighbor, int nface, int norient,
-                            bool coordCheck=true);
+                            int basis = 0, bool coordCheck=true);
 
   //! \brief Makes two opposite boundary faces periodic.
   //! \param[in] dir Parameter direction defining the periodic faces

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -317,13 +317,15 @@ public:
   //! \param neighbor The neighbor patch
   //! \param[in] nface Local face index of neighbor patch, in range [1,6]
   //! \param[in] norient Relative face orientation flag (see below)
+  //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
   //!
   //! \details The face orientation flag \a norient must be in range [0,7].
   //! When interpreted as a binary number, its 3 digits are decoded as follows:
   //! - left digit = 1: The u and v parameters of the neighbor face are swapped
   //! - middle digit = 1: Parameter \a u in neighbor patch face is reversed
   //! - right digit = 1: Parameter \a v in neighbor patch face is reversed
-  virtual bool connectPatch(int face, ASMs3D& neighbor, int nface, int norient);
+  virtual bool connectPatch(int face, ASMs3D& neighbor, int nface, int norient,
+                            bool coordCheck=true);
 
   //! \brief Makes two opposite boundary faces periodic.
   //! \param[in] dir Parameter direction defining the periodic faces
@@ -533,8 +535,10 @@ protected:
   //! \param[in] basis Which basis to connect the nodes for (mixed methods)
   //! \param[in] slave 0-based index of the first slave node in this basis
   //! \param[in] master 0-based index of the first master node in this basis
+  //! \param[in] coordCheck False to turn off coordinate checks
   bool connectBasis(int face, ASMs3D& neighbor, int nface, int norient,
-		    int basis = 1, int slave = 0, int master = 0);
+                    int basis = 1, int slave = 0, int master = 0,
+                    bool coordCheck=true);
 
   //! \brief Extracts parameter values of the Gauss points in one direction.
   //! \param[out] uGP Parameter values in given direction for all points

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -317,7 +317,6 @@ public:
   //! \param neighbor The neighbor patch
   //! \param[in] nface Local face index of neighbor patch, in range [1,6]
   //! \param[in] norient Relative face orientation flag (see below)
-  //! \param[in] basis (ignored)
   //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
   //!
   //! \details The face orientation flag \a norient must be in range [0,7].
@@ -326,7 +325,7 @@ public:
   //! - middle digit = 1: Parameter \a u in neighbor patch face is reversed
   //! - right digit = 1: Parameter \a v in neighbor patch face is reversed
   virtual bool connectPatch(int face, ASMs3D& neighbor, int nface, int norient,
-                            int basis = 0, bool coordCheck = true);
+                            int = 0, bool coordCheck = true);
 
   //! \brief Makes two opposite boundary faces periodic.
   //! \param[in] dir Parameter direction defining the periodic faces

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -326,7 +326,7 @@ public:
   //! - middle digit = 1: Parameter \a u in neighbor patch face is reversed
   //! - right digit = 1: Parameter \a v in neighbor patch face is reversed
   virtual bool connectPatch(int face, ASMs3D& neighbor, int nface, int norient,
-                            int basis = 0, bool coordCheck=true);
+                            int basis = 0, bool coordCheck = true);
 
   //! \brief Makes two opposite boundary faces periodic.
   //! \param[in] dir Parameter direction defining the periodic faces
@@ -539,7 +539,7 @@ protected:
   //! \param[in] coordCheck False to turn off coordinate checks
   bool connectBasis(int face, ASMs3D& neighbor, int nface, int norient,
                     int basis = 1, int slave = 0, int master = 0,
-                    bool coordCheck=true);
+                    bool coordCheck = true);
 
   //! \brief Extracts parameter values of the Gauss points in one direction.
   //! \param[out] uGP Parameter values in given direction for all points

--- a/src/ASM/ASMs3Dmx.C
+++ b/src/ASM/ASMs3Dmx.C
@@ -299,7 +299,7 @@ bool ASMs3Dmx::generateFEMTopology ()
 
 
 bool ASMs3Dmx::connectPatch (int face, ASMs3D& neighbor, int nface, int norient,
-                             bool coordCheck)
+                             int basis, bool coordCheck)
 {
   ASMs3Dmx* neighMx = dynamic_cast<ASMs3Dmx*>(&neighbor);
   if (!neighMx) return false;
@@ -313,8 +313,11 @@ bool ASMs3Dmx::connectPatch (int face, ASMs3D& neighbor, int nface, int norient,
   size_t nb1=0;
   size_t nb2=0;
   for (size_t i = 1;i <= m_basis.size(); ++i) {
-    if (!this->connectBasis(face,neighbor,nface,norient,i,nb1,nb2,coordCheck))
+    if ((basis == 0 || i == (size_t)basis) &&
+        !this->connectBasis(face,neighbor,nface,
+                            norient,i,nb1,nb2,coordCheck))
       return false;
+
     nb1 += nb[i-1];
     nb2 += neighMx->nb[i-1];
   }

--- a/src/ASM/ASMs3Dmx.C
+++ b/src/ASM/ASMs3Dmx.C
@@ -298,7 +298,8 @@ bool ASMs3Dmx::generateFEMTopology ()
 }
 
 
-bool ASMs3Dmx::connectPatch (int face, ASMs3D& neighbor, int nface, int norient)
+bool ASMs3Dmx::connectPatch (int face, ASMs3D& neighbor, int nface, int norient,
+                             bool coordCheck)
 {
   ASMs3Dmx* neighMx = dynamic_cast<ASMs3Dmx*>(&neighbor);
   if (!neighMx) return false;
@@ -309,11 +310,13 @@ bool ASMs3Dmx::connectPatch (int face, ASMs3D& neighbor, int nface, int norient)
   if (neighMx->swapW && face > 4) // Account for swapped parameter direction
     nface = 11-nface;
 
-  size_t nbi=0;
+  size_t nb1=0;
+  size_t nb2=0;
   for (size_t i = 1;i <= m_basis.size(); ++i) {
-    if (!this->connectBasis(face,neighbor,nface,norient,i,nbi,nbi))
+    if (!this->connectBasis(face,neighbor,nface,norient,i,nb1,nb2,coordCheck))
       return false;
-    nbi += nb[i-1];
+    nb1 += nb[i-1];
+    nb2 += neighMx->nb[i-1];
   }
 
   this->addNeighbor(neighMx);

--- a/src/ASM/ASMs3Dmx.h
+++ b/src/ASM/ASMs3Dmx.h
@@ -94,9 +94,10 @@ public:
   //! \param neighbor The neighbor patch
   //! \param[in] nface Local face index of neighbor patch, in range [1,6]
   //! \param[in] norient Relative face orientation flag (see class ASMs3D)
+  //! \param[in] basis Which basis to connect, or 0 for all.
   //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
   virtual bool connectPatch(int face, ASMs3D& neighbor, int nface,
-                            int norient = 0, bool coordCheck = true);
+                            int norient = 0, int basis = 0, bool coordCheck = true);
 
   //! \brief Makes two opposite boundary faces periodic.
   //! \param[in] dir Parameter direction defining the periodic faces

--- a/src/ASM/ASMs3Dmx.h
+++ b/src/ASM/ASMs3Dmx.h
@@ -94,8 +94,9 @@ public:
   //! \param neighbor The neighbor patch
   //! \param[in] nface Local face index of neighbor patch, in range [1,6]
   //! \param[in] norient Relative face orientation flag (see class ASMs3D)
+  //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
   virtual bool connectPatch(int face, ASMs3D& neighbor, int nface,
-			    int norient = 0);
+                            int norient = 0, bool coordCheck = true);
 
   //! \brief Makes two opposite boundary faces periodic.
   //! \param[in] dir Parameter direction defining the periodic faces

--- a/src/SIM/ModelGenerator.C
+++ b/src/SIM/ModelGenerator.C
@@ -1,0 +1,301 @@
+// $Id$
+//==============================================================================
+//!
+//! \file ModelGenerator.C
+//!
+//! \date Sep 2 2016
+//!
+//! \author Arne Morten Kvarving / SINTEF
+//!
+//! \brief Base class for model generators for NURBS-based FEM simulators.
+//!
+//==============================================================================
+
+
+#include "ModelGenerator.h"
+#include "IFEM.h"
+#include "SIMbase.h"
+#include "Utilities.h"
+#include "Vec3.h"
+#include "Vec3Oper.h"
+#include "tinyxml.h"
+
+
+ModelGenerator::ModelGenerator (const TiXmlElement* elem) :
+  sets(false), geo(elem)
+{
+  utl::getAttribute(geo, "sets", sets);
+}
+
+
+std::string DefaultGeometry1D::createG2 (int nsd) const
+{
+  std::string g2("100 1 0 0\n");
+  g2.append(1,'0'+nsd);
+
+  bool rational=false;
+  utl::getAttribute(geo,"rational",rational);
+  if (rational)
+    IFEM::cout << "\t Rational basis\n";
+  g2.append(rational?" 1":" 0");
+  g2.append("\n2 2\n0 0 1 1\n");
+
+  unsigned char d;
+  std::string XYZ;
+  if (utl::getAttribute(geo,"X0",XYZ))
+  {
+    IFEM::cout <<"  X0 = "<< XYZ << std::endl;
+    g2.append(XYZ);
+  }
+  else
+  {
+    g2.append("0.0");
+    for (d = 1; d < nsd; d++)
+      g2.append(" 0.0");
+  }
+  if (rational)
+    g2.append(" 1.0");
+  g2.append("\n");
+  if (utl::getAttribute(geo,"X1",XYZ))
+  {
+    IFEM::cout <<"\tX1 = "<< XYZ << std::endl;
+    g2.append(XYZ);
+  }
+  else
+  {
+    XYZ = "1.0";
+    if (utl::getAttribute(geo,"L",XYZ))
+      IFEM::cout <<"  Length scale: "<< XYZ << std::endl;
+    g2.append(XYZ);
+    for (d = 1; d < nsd; d++)
+      g2.append(" 0.0");
+  }
+  if (rational)
+    g2.append(" 1.0");
+  g2.append("\n");
+
+  return g2;
+}
+
+
+SIMdependency::PatchVec DefaultGeometry1D::createGeometry (const SIMbase& sim) const
+{
+  std::istringstream unitLine(this->createG2(sim.getNoSpaceDim()));
+  SIMdependency::PatchVec result;
+  sim.readPatches(unitLine,result,"\t");
+  return result;
+}
+
+
+TopologySet DefaultGeometry1D::createTopologySets (const SIMbase&) const
+{
+  if (!sets)
+    return TopologySet();
+
+  TopologySet result;
+  result["Vertex1"].insert(TopItem(1,1,0));
+  result["Vertex2"].insert(TopItem(1,2,0));
+  result["Boundary"].insert(TopItem(1,1,0));
+  result["Boundary"].insert(TopItem(1,2,0));
+  result["Corners"].insert(TopItem(1,1,0));
+  result["Corners"].insert(TopItem(1,2,0));
+
+  return result;
+}
+
+
+std::string DefaultGeometry2D::createG2 (int nsd) const
+{
+  std::string g2("200 1 0 0\n");
+  g2.append(nsd > 2 ? "3" : "2");
+  bool rational=false;
+  utl::getAttribute(geo,"rational",rational);
+  if (rational)
+    IFEM::cout << "\t Rational basis\n";
+  g2.append(rational?" 1":" 0");
+  g2.append("\n2 2\n0 0 1 1\n2 2\n0 0 1 1");
+
+  Vec3 X0;
+  std::string corner;
+  if (utl::getAttribute(geo,"X0",corner)) {
+    std::stringstream str(corner); str >> X0;
+    IFEM::cout <<"  Corner: "<< X0 << std::endl;
+  }
+
+  double scale = 1.0;
+  if (utl::getAttribute(geo,"scale",scale))
+    IFEM::cout <<"  Scale: "<< scale << std::endl;
+
+  double Lx = 1.0, Ly = 1.0;
+  if (utl::getAttribute(geo,"Lx",Lx))
+    IFEM::cout <<"  Length in X: "<< Lx << std::endl;
+  Lx *= scale;
+  if (utl::getAttribute(geo,"Ly",Ly))
+    IFEM::cout <<"  Length in Y: "<< Ly << std::endl;
+  Ly *= scale;
+
+  std::stringstream str;
+  str <<"\n"<< X0.x <<" "<< X0.y;
+  if (nsd > 2) str <<" 0.0";
+  if (rational) str << " 1.0";
+  g2.append(str.str());
+  str.str("");
+  str <<"\n"<< X0.x+Lx <<" "<< X0.y;
+  if (nsd > 2) str <<" 0.0";
+  if (rational) str << " 1.0";
+  g2.append(str.str());
+  str.str("");
+  str <<"\n"<< X0.x <<" "<< X0.y+Ly;
+  if (nsd > 2) str <<" 0.0";
+  if (rational) str << " 1.0";
+  g2.append(str.str());
+  str.str("");
+  str <<"\n"<< X0.x+Lx <<" "<< X0.y+Ly;
+  if (nsd > 2) str <<" 0.0";
+  if (rational) str << " 1.0";
+  g2.append(str.str());
+  g2.append("\n");
+
+  return g2;
+}
+
+
+SIMdependency::PatchVec DefaultGeometry2D::createGeometry (const SIMbase& sim) const
+{
+  std::istringstream unitSquare(this->createG2(sim.getNoSpaceDim()));
+  SIMdependency::PatchVec result;
+  sim.readPatches(unitSquare,result,"\t");
+  return result;
+}
+
+
+TopologySet DefaultGeometry2D::createTopologySets (const SIMbase&) const
+{
+  if (!sets)
+    return TopologySet();
+
+  TopologySet result;
+  std::string vert = "Vertex1";
+  std::string edge = "Edge1";
+  for (size_t i = 1; i <= 4; ++i, ++vert.back(), ++edge.back()) {
+    result[vert].insert(TopItem(1,i,0));
+    result[edge].insert(TopItem(1,i,1));
+    result["Corners"].insert(TopItem(1,i,0));
+    result["Boundary"].insert(TopItem(1,i,1));
+  }
+
+  return result;
+}
+
+
+std::string DefaultGeometry3D::createG2 (int) const
+{
+  std::string g2("700 1 0 0\n3 ");
+
+  bool rational = false;
+  utl::getAttribute(geo,"rational",rational);
+  if (rational)
+    IFEM::cout <<"  Rational basis"<< std::endl;
+
+  g2.append(rational ? "1\n" : "0\n");
+  g2.append("2 2\n0 0 1 1\n"
+            "2 2\n0 0 1 1\n"
+            "2 2\n0 0 1 1\n");
+
+  std::array<double,24> nodes =
+    {{ 0.0, 0.0, 0.0,
+       1.0, 0.0, 0.0,
+       0.0, 1.0, 0.0,
+       1.0, 1.0, 0.0,
+       0.0, 0.0, 1.0,
+       1.0, 0.0, 1.0,
+       0.0, 1.0, 1.0,
+       1.0, 1.0, 1.0 }};
+
+  double scale = 1.0;
+  if (utl::getAttribute(geo,"scale",scale))
+    IFEM::cout <<"\tscale = "<< scale << std::endl;
+
+  double Lx = 1.0, Ly = 1.0, Lz = 1.0;
+  if (utl::getAttribute(geo,"Lx",Lx))
+    IFEM::cout <<"\tLength in X: "<< Lx << std::endl;
+  Lx *= scale;
+  if (utl::getAttribute(geo,"Ly",Ly))
+    IFEM::cout <<"\tLength in Y: "<< Ly << std::endl;
+  Ly *= scale;
+  if (utl::getAttribute(geo,"Lz",Lz))
+    IFEM::cout <<"\tLength in Z: "<< Lz << std::endl;
+  Lz *= scale;
+
+  if (Lx != 1.0)
+    nodes[3] = nodes[9] = nodes[15] = nodes[21] = Lx;
+  if (Ly != 1.0)
+    nodes[7] = nodes[10] = nodes[19] = nodes[22] = Ly;
+  if (Lz != 1.0)
+    nodes[14] = nodes[17] = nodes[20] = nodes[23] = Lz;
+
+  std::string corner;
+  if (utl::getAttribute(geo,"X0",corner)) {
+    std::stringstream str(corner);
+    Vec3 X0;
+    str >> X0;
+    IFEM::cout <<"\tCorner: "<< X0 << std::endl;
+    for (size_t i = 0; i < nodes.size(); i += 3)
+    {
+      nodes[i]   += X0.x;
+      nodes[i+1] += X0.y;
+      nodes[i+2] += X0.z;
+    }
+  }
+
+  for (size_t i = 0; i < nodes.size(); i += 3)
+  {
+    std::stringstream str;
+    for (size_t j = 0; j < 3; j++)
+      str << nodes[i+j] <<" ";
+    g2.append(str.str());
+    g2.append(rational ? "1.0\n" : "\n");
+  }
+
+  return g2;
+}
+
+
+SIMdependency::PatchVec DefaultGeometry3D::createGeometry (const SIMbase& sim) const
+{
+  std::istringstream unitCube(this->createG2());
+  SIMdependency::PatchVec result;
+  sim.readPatches(unitCube,result,"\t");
+  return result;
+}
+
+
+TopologySet DefaultGeometry3D::createTopologySets (const SIMbase&) const
+{
+  if (!sets)
+    return TopologySet();
+
+  TopologySet result;
+
+  std::string face = "Face1";
+  for (size_t i = 1; i <= 6; ++i, ++face.back()) {
+    result[face].insert(TopItem(1,i,2));
+    result["Boundary"].insert(TopItem(1,i,2));
+  }
+
+  std::string edge = "Edge1";
+  for (size_t i = 1; i <= 12; ++i, ++edge.back()) {
+    result[edge].insert(TopItem(1,i,1));
+    result["Frame"].insert(TopItem(1,i,1));
+    if (i == 9)
+      edge = "Edge1/"; // '/' + 1 == '0'
+  }
+
+  std::string vert = "Vertex1";
+  for (size_t i = 1; i <= 8; ++i, ++vert.back()) {
+    result[vert].insert(TopItem(1,i,0));
+    result["Corners"].insert(TopItem(1,i,0));
+  }
+
+  return result;
+}

--- a/src/SIM/ModelGenerator.C
+++ b/src/SIM/ModelGenerator.C
@@ -11,7 +11,6 @@
 //!
 //==============================================================================
 
-
 #include "ModelGenerator.h"
 #include "IFEM.h"
 #include "SIMbase.h"

--- a/src/SIM/ModelGenerator.h
+++ b/src/SIM/ModelGenerator.h
@@ -1,0 +1,147 @@
+// $Id$
+//==============================================================================
+//!
+//! \file ModelGenerator.h
+//!
+//! \date Sep 2 2016
+//!
+//! \author Arne Morten Kvarving / SINTEF
+//!
+//! \brief Base class for model generators for NURBS-based FEM simulators.
+//!
+//==============================================================================
+
+#ifndef _MODEL_GENERATOR_H
+#define _MODEL_GENERATOR_H
+
+#include "SIMdependency.h"
+#include "TopologySet.h"
+#include <string>
+
+class SIMbase;
+class TiXmlElement;
+
+/*!
+  \brief Base class for model generators for FEM simulators.
+*/
+
+class ModelGenerator
+{
+public:
+  //! \brief Constructor initializes common members
+  //!\ param elem XML element to parse
+  ModelGenerator(const TiXmlElement* elem);
+
+  //! \brief Empty destructor.
+  virtual ~ModelGenerator() {}
+
+  //! \brief Creates a geometry.
+  //! \param[in] sim SIM with patch read function to use
+  virtual SIMdependency::PatchVec createGeometry(const SIMbase& sim) const = 0;
+
+  //! \brief Creates topology for geometry.
+  //! \param[in] geo XML element containing geometry defintion
+  //! \param sim Simulator to apply topology to
+  virtual bool createTopology(SIMbase& sim) const = 0;
+
+  //! \brief Creates topology sets for geometry.
+  //! \param[in] sim Simulator with patch ownerships
+  virtual TopologySet createTopologySets(const SIMbase& sim) const = 0;
+
+protected:
+  bool sets; //!< Whether to generate topologysets or not
+  const TiXmlElement* geo; //!< Pointer to xml element describing geometry
+};
+
+
+/*!
+  \brief Default model generator for 1D FEM simulators.
+  \details Generates a line.
+*/
+
+class DefaultGeometry1D : public ModelGenerator {
+public:
+  //! \brief The constructor forwards to the base class.
+  //! \param[in] geo XML element containing geometry defintion
+  DefaultGeometry1D(const TiXmlElement* geo) : ModelGenerator(geo) {}
+
+  //! \brief Creates a 1D single-patch geometry.
+  //! \param[in] sim SIM with patch read function to use
+  SIMdependency::PatchVec createGeometry(const SIMbase& sim) const override;
+
+  //! \brief Creates the topology
+  //! \details No topology information for single patch models
+  bool createTopology(SIMbase&) const override
+  { return true; }
+
+  //! \brief Creates topology sets for geometry.
+  TopologySet createTopologySets(const SIMbase&) const override;
+
+protected:
+  //! \brief Generates the G2 description of the geometry.
+  //! \param nsd Number of spatial dimension
+  std::string createG2 (int nsd = 2) const;
+};
+
+
+/*!
+  \brief Default model generator for 2D FEM simulators.
+  \details Generates a rectangle.
+*/
+
+class DefaultGeometry2D : public ModelGenerator {
+public:
+  //! \brief The constructor forwards to the base class.
+  //! \param[in] geo XML element containing geometry defintion
+  DefaultGeometry2D(const TiXmlElement* geo) : ModelGenerator(geo) {}
+
+  //! \brief Creates a 2D rectangular single-patch geometry.
+  //! \param[in] sim SIM with patch read function to use
+  SIMdependency::PatchVec createGeometry(const SIMbase& sim) const override;
+
+  //! \brief Creates the topology
+  //! \param sim Simulator to apply topology to
+  //! \details No topology information for single patch models
+  bool createTopology(SIMbase&) const override
+  { return true; }
+
+  //! \brief Creates topology sets for geometry.
+  TopologySet createTopologySets(const SIMbase&) const override;
+
+protected:
+  //! \brief Generates the G2 description of the geometry.
+  //! \param nsd Number of spatial dimension
+  std::string createG2 (int nsd = 3) const;
+};
+
+
+/*!
+  \brief Default model generator for 3D FEM simulators.
+  \details Generates a hexahedra.
+*/
+
+class DefaultGeometry3D : public ModelGenerator {
+public:
+  //! \brief The constructor forwards to the base class.
+  //! \param[in] geo XML element containing geometry defintion
+  DefaultGeometry3D(const TiXmlElement* geo) : ModelGenerator(geo) {}
+
+  //! \brief Creates a 3D hexahedral single-patch geometry.
+  //! \param[in] sim Simulator with patch read function to use
+  SIMdependency::PatchVec createGeometry(const SIMbase& sim) const override;
+
+  //! \brief Creates the topology
+  //! \param sim Simulator to apply topology to
+  //! \details No topology information for single patch models
+  bool createTopology(SIMbase&) const override
+  { return true; }
+
+  //! \brief Creates topology sets for geometry.
+  TopologySet createTopologySets(const SIMbase&) const override;
+
+protected:
+  //! \brief Generates the G2 description of the geometry.
+  std::string createG2 (int = 3) const;
+};
+
+#endif

--- a/src/SIM/SIM1D.C
+++ b/src/SIM/SIM1D.C
@@ -494,7 +494,7 @@ ASMbase* SIM1D::readPatch (std::istream& isp, int pchInd,
 
 
 bool SIM1D::readPatches (std::istream& isp, PatchVec& patches,
-                         const char* whiteSpace)
+                         const char* whiteSpace) const
 {
   ASMbase* pch = nullptr;
   for (int pchInd = 1; isp.good(); pchInd++)

--- a/src/SIM/SIM1D.C
+++ b/src/SIM/SIM1D.C
@@ -15,6 +15,7 @@
 #include "IFEM.h"
 #include "ASMs1D.h"
 #include "Functions.h"
+#include "ModelGenerator.h"
 #include "Utilities.h"
 #include "Vec3Oper.h"
 #include "tinyxml.h"
@@ -532,6 +533,12 @@ bool SIM1D::createFEMmodel (char)
       ok = myModel[i]->generateFEMTopology();
 
   return ok;
+}
+
+
+ModelGenerator* SIM1D::createModelGenerator(const TiXmlElement* geo) const
+{
+  return new DefaultGeometry1D(geo);
 }
 
 

--- a/src/SIM/SIM1D.C
+++ b/src/SIM/SIM1D.C
@@ -538,58 +538,8 @@ bool SIM1D::createFEMmodel (char)
 
 ModelGenerator* SIM1D::createModelGenerator(const TiXmlElement* geo) const
 {
+  IFEM::cout <<"  Using default linear geometry basis on unit domain [0,1]";
   return new DefaultGeometry1D(geo);
-}
-
-
-ASMbase* SIM1D::createDefaultGeometry (const TiXmlElement* geo) const
-{
-  std::string g2("100 1 0 0\n");
-  g2.append(1,'0'+nsd);
-
-  bool rational=false;
-  utl::getAttribute(geo,"rational",rational);
-  if (rational)
-    IFEM::cout << "\t Rational basis\n";
-  g2.append(rational?" 1":" 0");
-  g2.append("\n2 2\n0 0 1 1\n");
-
-  unsigned char d;
-  std::string XYZ;
-  if (utl::getAttribute(geo,"X0",XYZ))
-  {
-    IFEM::cout <<"\tX0 = "<< XYZ << std::endl;
-    g2.append(XYZ);
-  }
-  else
-  {
-    g2.append("0.0");
-    for (d = 1; d < nsd; d++)
-      g2.append(" 0.0");
-  }
-  if (rational)
-    g2.append(" 1.0");
-  g2.append("\n");
-  if (utl::getAttribute(geo,"X1",XYZ))
-  {
-    IFEM::cout <<"\tX1 = "<< XYZ << std::endl;
-    g2.append(XYZ);
-  }
-  else
-  {
-    XYZ = "1.0";
-    if (utl::getAttribute(geo,"L",XYZ))
-      IFEM::cout <<"\tLength scale = "<< XYZ << std::endl;
-    g2.append(XYZ);
-    for (d = 1; d < nsd; d++)
-      g2.append(" 0.0");
-  }
-  if (rational)
-    g2.append(" 1.0");
-  g2.append("\n");
-
-  std::istringstream unitLine(g2);
-  return this->readPatch(unitLine,0,{nf});
 }
 
 

--- a/src/SIM/SIM1D.h
+++ b/src/SIM/SIM1D.h
@@ -50,6 +50,13 @@ public:
   virtual ASMbase* readPatch(std::istream& isp, int pchInd,
                              const CharVec& unf) const;
 
+  //! \brief Reads patches from given input stream.
+  //! \param[in] isp The input stream to read from
+  //! \param[out] patches Array of patches that were read
+  //! \param[in] whiteSpace For message formatting
+  virtual bool readPatches(std::istream& isp, PatchVec& patches,
+                           const char* whiteSpace) const;
+
   //! \brief Evaluates the primary solution at the given point.
   //! \param[in] psol Primary solution vector
   //! \param[in] u Parameter of the point to evaluate at
@@ -83,13 +90,6 @@ protected:
   //! \param[in] keyWord Keyword of current data section to read
   //! \param is The file stream to read from
   virtual bool parse(char* keyWord, std::istream& is);
-
-  //! \brief Reads patches from given input stream.
-  //! \param[in] isp The input stream to read from
-  //! \param[out] patches Array of patches that were read
-  //! \param[in] whiteSpace For message formatting
-  virtual bool readPatches(std::istream& isp, PatchVec& patches,
-                           const char* whiteSpace);
 
   //! \brief Preprocesses a user-defined Dirichlet boundary property.
   //! \param[in] patch 1-based index of the patch to receive the property

--- a/src/SIM/SIM1D.h
+++ b/src/SIM/SIM1D.h
@@ -109,9 +109,6 @@ protected:
   //! \details Reimplemented to account for twist angle in beam problems.
   virtual bool createFEMmodel(char = 'y');
 
-  //! \brief Creates a default single-patch geometry.
-  virtual ASMbase* createDefaultGeometry(const TiXmlElement* geo) const;
-
 protected:
   unsigned char nf; //!< Number of scalar fields
 

--- a/src/SIM/SIM1D.h
+++ b/src/SIM/SIM1D.h
@@ -82,6 +82,10 @@ protected:
   //! \brief Parses the twist angle description along the curve.
   bool parseTwist(const TiXmlElement* elem);
 
+  //! \brief Creates a default single-patch model generator.
+  //! \param[in] geo XML element containing geometry defintion
+  virtual ModelGenerator* createModelGenerator(const TiXmlElement* geo) const;
+
   //! \brief Parses a data section from an XML document.
   //! \param[in] elem The XML element to parse
   virtual bool parse(const TiXmlElement* elem);

--- a/src/SIM/SIM2D.C
+++ b/src/SIM/SIM2D.C
@@ -793,64 +793,8 @@ void SIM2D::clonePatches (const PatchVec& patches,
 
 ModelGenerator* SIM2D::createModelGenerator(const TiXmlElement* geo) const
 {
+  IFEM::cout <<"  Using default linear geometry basis on unit domain [0,1]^2";
   return new DefaultGeometry2D(geo);
-}
-
-
-ASMbase* SIM2D::createDefaultGeometry (const TiXmlElement* geo) const
-{
-  std::string g2("200 1 0 0\n");
-  g2.append(nsd > 2 ? "3" : "2");
-  bool rational=false;
-  utl::getAttribute(geo,"rational",rational);
-  if (rational)
-    IFEM::cout << "\t Rational basis\n";
-  g2.append(rational?" 1":" 0");
-  g2.append("\n2 2\n0 0 1 1\n2 2\n0 0 1 1");
-
-  Vec3 X0;
-  std::string corner;
-  if (utl::getAttribute(geo,"X0",corner)) {
-    std::stringstream str(corner); str >> X0;
-    IFEM::cout <<"  Corner: "<< X0 << std::endl;
-  }
-
-  double scale = 1.0;
-  if (utl::getAttribute(geo,"scale",scale))
-    IFEM::cout <<"  Scale: "<< scale << std::endl;
-
-  double Lx = 1.0, Ly = 1.0;
-  if (utl::getAttribute(geo,"Lx",Lx))
-    IFEM::cout <<"  Length in X: "<< Lx << std::endl;
-  Lx *= scale;
-  if (utl::getAttribute(geo,"Ly",Ly))
-    IFEM::cout <<"  Length in Y: "<< Ly << std::endl;
-  Ly *= scale;
-
-  std::stringstream str;
-  str <<"\n"<< X0.x <<" "<< X0.y;
-  if (nsd > 2) str <<" 0.0";
-  if (rational) str << " 1.0";
-  g2.append(str.str());
-  str.str("");
-  str <<"\n"<< X0.x+Lx <<" "<< X0.y;
-  if (nsd > 2) str <<" 0.0";
-  if (rational) str << " 1.0";
-  g2.append(str.str());
-  str.str("");
-  str <<"\n"<< X0.x <<" "<< X0.y+Ly;
-  if (nsd > 2) str <<" 0.0";
-  if (rational) str << " 1.0";
-  g2.append(str.str());
-  str.str("");
-  str <<"\n"<< X0.x+Lx <<" "<< X0.y+Ly;
-  if (nsd > 2) str <<" 0.0";
-  if (rational) str << " 1.0";
-  g2.append(str.str());
-  g2.append("\n");
-
-  std::istringstream unitSquare(g2);
-  return this->readPatch(unitSquare,0,nf);
 }
 
 

--- a/src/SIM/SIM2D.C
+++ b/src/SIM/SIM2D.C
@@ -238,7 +238,6 @@ bool SIM2D::parseGeometryTag (const TiXmlElement* elem)
                                       it->master.first,
                                       it->master.second,
                                       it->reversed)) return false;
-
   }
 
   else if (!strcasecmp(elem->Value(),"periodic"))

--- a/src/SIM/SIM2D.C
+++ b/src/SIM/SIM2D.C
@@ -207,14 +207,6 @@ bool SIM2D::parseGeometryTag (const TiXmlElement* elem)
         return false;
       }
     }
-
-    // Second pass for C1-continuous patches, to set up additional constraints
-    std::vector<Interface>::const_iterator it;
-    for (it = top.begin(); it != top.end(); it++)
-      if (!it->slave.first->connectC1(it->slave.second,
-                                      it->master.first,
-                                      it->master.second,
-                                      it->reversed)) return false;
   }
 
   else if (!strcasecmp(elem->Value(),"periodic"))
@@ -277,6 +269,14 @@ bool SIM2D::parseGeometryTag (const TiXmlElement* elem)
           myModel.front()->addHole(R,X1,Y1,X2,Y2);
       }
   }
+
+  // Second pass for C1-continuous patches, to set up additional constraints
+  std::vector<Interface>::const_iterator it;
+  for (it = top.begin(); it != top.end(); it++)
+    if (!it->slave.first->connectC1(it->slave.second,
+                                    it->master.first,
+                                    it->master.second,
+                                    it->reversed)) return false;
 
   return true;
 }

--- a/src/SIM/SIM2D.C
+++ b/src/SIM/SIM2D.C
@@ -689,7 +689,7 @@ ASMbase* SIM2D::readPatch (std::istream& isp, int pchInd,
 
 
 bool SIM2D::readPatches (std::istream& isp, PatchVec& patches,
-                         const char* whiteSpace)
+                         const char* whiteSpace) const
 {
   ASMbase* pch = nullptr;
   for (int pchInd = 1; isp.good(); pchInd++)

--- a/src/SIM/SIM2D.C
+++ b/src/SIM/SIM2D.C
@@ -16,6 +16,7 @@
 #include "ASMs2DC1.h"
 #include "ImmersedBoundaries.h"
 #include "Functions.h"
+#include "ModelGenerator.h"
 #include "Utilities.h"
 #include "Vec3Oper.h"
 #include "tinyxml.h"
@@ -787,6 +788,12 @@ void SIM2D::clonePatches (const PatchVec& patches,
 
   if (nGlPatches == 0)
     nGlPatches = myModel.size();
+}
+
+
+ModelGenerator* SIM2D::createModelGenerator(const TiXmlElement* geo) const
+{
+  return new DefaultGeometry2D(geo);
 }
 
 

--- a/src/SIM/SIM2D.C
+++ b/src/SIM/SIM2D.C
@@ -26,25 +26,6 @@
 #include <sstream>
 
 
-/*!
-  \brief A struct defining a patch interface for C1-continuous models.
-*/
-
-struct Interface
-{
-  std::pair<ASMs2DC1*,int> master; //!< Patch and edge index of the master
-  std::pair<ASMs2DC1*,int> slave;  //!< Patch and edge index of the slave
-  bool reversed;                   //!< Relative orientation toggle
-  //! \brief Constructor initializing an Interface instance.
-  Interface(ASMs2DC1* m, int me, ASMs2DC1* s, int se, bool r = false)
-  {
-    master = std::make_pair(m,me);
-    slave = std::make_pair(s,se);
-    reversed = r;
-  }
-};
-
-
 SIM2D::SIM2D (unsigned char n1, bool check)
 {
   nsd = 2;
@@ -65,6 +46,46 @@ SIM2D::SIM2D (IntegrandBase* itg, unsigned char n, bool check) : SIMgeneric(itg)
   nsd = 2;
   nf.push_back(n);
   checkRHSys = check;
+}
+
+
+bool SIM2D::addConnection(int master, int slave, int mIdx,
+                          int sIdx, int orient, int basis, bool coordCheck)
+{
+  if (orient < 0 || orient > 1) {
+    std::cerr << "** SIM2D::addConnection ** Invalid orientation "
+              << orient <<"." << std::endl;
+    return false;
+  }
+
+  int lmaster = this->getLocalPatchIndex(master);
+  int lslave = this->getLocalPatchIndex(slave);
+
+  if (lmaster > 0 && lslave > 0)
+  {
+    IFEM::cout <<"\tConnecting P"<< lslave <<" E"<< sIdx
+               <<" to P"<< lmaster <<" E"<< mIdx
+               <<" reversed? " << orient << std::endl;
+
+    ASMs2D* spch = static_cast<ASMs2D*>(myModel[lslave-1]);
+    ASMs2D* mpch = static_cast<ASMs2D*>(myModel[lmaster-1]);
+    std::set<int> bases;
+    if (basis == 0)
+      for (size_t b = 1; b <= spch->getNoBasis(); ++b)
+        bases.insert(b);
+    else
+      bases = utl::getDigits(basis);
+    for (const int& b : bases)
+      if (!spch->connectPatch(sIdx,*mpch,mIdx,orient==1?true:false,b,coordCheck))
+        return false;
+      else if (opt.discretization == ASM::SplineC1 && b == 1)
+        top.push_back(Interface(static_cast<ASMs2DC1*>(mpch),mIdx,
+                                static_cast<ASMs2DC1*>(spch),sIdx,orient==1?true:false));
+  }
+  else
+    adm.dd.ghostConnections.insert(DomainDecomposition::Interface{master, slave, mIdx, sIdx, orient, 1});
+
+  return true;
 }
 
 
@@ -157,15 +178,17 @@ bool SIM2D::parseGeometryTag (const TiXmlElement* elem)
     const TiXmlElement* child = elem->FirstChildElement("connection");
     for (; child; child = child->NextSiblingElement())
     {
-      int master = 0, slave = 0, mEdge = 0, sEdge = 0, basis = 0;
+      int master = 0, slave = 0, mIdx = 0, sIdx = 0, basis = 0, orient = 0;
       bool rever = false, periodic = false;
       utl::getAttribute(child,"master",master);
-      utl::getAttribute(child,"medge",mEdge);
+      if (!utl::getAttribute(child,"midx",mIdx))
+        utl::getAttribute(child,"medge",mIdx);
       utl::getAttribute(child,"slave",slave);
-      utl::getAttribute(child,"sedge",sEdge);
+      if (!utl::getAttribute(child,"sidx",sIdx))
+        utl::getAttribute(child,"sedge",sIdx);
       utl::getAttribute(child,"reverse",rever);
       if (!utl::getAttribute(child,"orient",orient))
-        orient = reverse ? 1 : 0;
+        orient = rever ? 1 : 0;
       utl::getAttribute(child,"basis",basis);
       utl::getAttribute(child,"periodic",periodic);
 
@@ -177,24 +200,11 @@ bool SIM2D::parseGeometryTag (const TiXmlElement* elem)
                   << master <<" "<< slave << std::endl;
         return false;
       }
-      int lmaster = this->getLocalPatchIndex(master);
-      int lslave = this->getLocalPatchIndex(slave);
 
-      if (lmaster > 0 && lslave > 0)
-      {
-        IFEM::cout <<"\tConnecting P"<< lslave <<" E"<< sEdge
-                   <<" to P"<< lmaster <<" E"<< mEdge
-                   <<" reversed? "<< rever << std::endl;
-        ASMs2D* spch = static_cast<ASMs2D*>(myModel[lslave-1]);
-        ASMs2D* mpch = static_cast<ASMs2D*>(myModel[lmaster-1]);
-        if (!spch->connectPatch(sEdge,*mpch,mEdge,basis,orient==1?true:false,!periodic))
-          return false;
-        else if (opt.discretization == ASM::SplineC1)
-          top.push_back(Interface(static_cast<ASMs2DC1*>(mpch),mEdge,
-                                  static_cast<ASMs2DC1*>(spch),sEdge,rever));
+      if (!this->addConnection(master, slave, mIdx, sIdx, orient, basis, !periodic)) {
+        std::cerr <<" ** SIM2D::parse: Error establishing connection." << std::endl;
+        return false;
       }
-      else
-        adm.dd.ghostConnections.insert(DomainDecomposition::Interface{master, slave, mEdge, sEdge, orient, 1});
     }
 
     // Second pass for C1-continuous patches, to set up additional constraints

--- a/src/SIM/SIM2D.h
+++ b/src/SIM/SIM2D.h
@@ -16,8 +16,6 @@
 
 #include "SIMgeneric.h"
 
-class ASMs2DC1;
-
 
 /*!
   \brief Driver class for 2D NURBS-based FEM solver.
@@ -78,9 +76,10 @@ public:
   //! \param mEdge Edge on master
   //! \param sEdge Edge on slave
   //! \param orient Orientation flag for connection (1 for reversed)
+  //! \param basis Which bases to connect (0 for all)
   //! \param coordCheck False to turn off coordinate checks
   bool addConnection(int master, int slave, int mEdge, int sEdge,
-                     int orient, int basis=0, bool coordCheck=true);
+                     int orient, int basis = 0, bool coordCheck = true);
 
   //! \brief Evaluates the primary solution at the given point.
   //! \param[in] psol Primary solution vector

--- a/src/SIM/SIM2D.h
+++ b/src/SIM/SIM2D.h
@@ -16,6 +16,8 @@
 
 #include "SIMgeneric.h"
 
+class ASMs2DC1;
+
 
 /*!
   \brief Driver class for 2D NURBS-based FEM solver.
@@ -69,6 +71,16 @@ public:
   //! \param[in] whiteSpace For message formatting
   virtual bool readPatches(std::istream& isp, PatchVec& patches,
                            const char* whiteSpace) const;
+
+  //! \brief Connect two patches.
+  //! \param master Master patch
+  //! \param slave Slave patch
+  //! \param mEdge Edge on master
+  //! \param sEdge Edge on slave
+  //! \param orient Orientation flag for connection (1 for reversed)
+  //! \param coordCheck False to turn off coordinate checks
+  bool addConnection(int master, int slave, int mEdge, int sEdge,
+                     int orient, int basis=0, bool coordCheck=true);
 
   //! \brief Evaluates the primary solution at the given point.
   //! \param[in] psol Primary solution vector
@@ -126,6 +138,27 @@ protected:
 protected:
   CharVec nf;         //!< Number of scalar fields
   bool    checkRHSys; //!< Check if all patches are in a right-hand system
+
+
+  /*!
+    \brief A struct defining a patch interface for C1-continuous models.
+  */
+
+  struct Interface
+  {
+    std::pair<ASMs2DC1*,int> master; //!< Patch and edge index of the master
+    std::pair<ASMs2DC1*,int> slave;  //!< Patch and edge index of the slave
+    bool reversed;                   //!< Relative orientation toggle
+    //! \brief Constructor initializing an Interface instance.
+    Interface(ASMs2DC1* m, int me, ASMs2DC1* s, int se, bool r = false)
+    {
+      master = std::make_pair(m,me);
+      slave = std::make_pair(s,se);
+      reversed = r;
+    }
+  };
+
+  std::vector<Interface> top; //!< Interfaces for C1 connection handling
 };
 
 #endif

--- a/src/SIM/SIM2D.h
+++ b/src/SIM/SIM2D.h
@@ -63,6 +63,13 @@ public:
   virtual ASMbase* readPatch(std::istream& isp, int pchInd,
                              const CharVec& unf) const;
 
+  //! \brief Reads patches from given input stream.
+  //! \param[in] isp The input stream to read from
+  //! \param[out] patches Array of patches that were read
+  //! \param[in] whiteSpace For message formatting
+  virtual bool readPatches(std::istream& isp, PatchVec& patches,
+                           const char* whiteSpace) const;
+
   //! \brief Evaluates the primary solution at the given point.
   //! \param[in] psol Primary solution vector
   //! \param[in] u First parameter of the point to evaluate at
@@ -89,12 +96,6 @@ protected:
   //! \param is The file stream to read from
   virtual bool parse(char* keyWord, std::istream& is);
 
-  //! \brief Reads patches from given input stream.
-  //! \param[in] isp The input stream to read from
-  //! \param[out] patches Array of patches that were read
-  //! \param[in] whiteSpace For message formatting
-  virtual bool readPatches(std::istream& isp, PatchVec& patches,
-                           const char* whiteSpace);
   //! \brief Reads global node data for a patch from given input stream.
   //! \param[in] isn The input stream to read from
   //! \param[in] pchInd 0-based index of the patch to read node data for

--- a/src/SIM/SIM2D.h
+++ b/src/SIM/SIM2D.h
@@ -135,6 +135,10 @@ protected:
   //! \brief Creates a default single-patch geometry.
   virtual ASMbase* createDefaultGeometry(const TiXmlElement* geo) const;
 
+  //! \brief Creates a default single-patch model generator.
+  //! \param[in] geo XML element containing geometry defintion
+  virtual ModelGenerator* createModelGenerator(const TiXmlElement* geo) const;
+
 protected:
   CharVec nf;         //!< Number of scalar fields
   bool    checkRHSys; //!< Check if all patches are in a right-hand system

--- a/src/SIM/SIM2D.h
+++ b/src/SIM/SIM2D.h
@@ -139,27 +139,6 @@ protected:
 protected:
   CharVec nf;         //!< Number of scalar fields
   bool    checkRHSys; //!< Check if all patches are in a right-hand system
-
-
-  /*!
-    \brief A struct defining a patch interface for C1-continuous models.
-  */
-
-  struct Interface
-  {
-    std::pair<ASMs2DC1*,int> master; //!< Patch and edge index of the master
-    std::pair<ASMs2DC1*,int> slave;  //!< Patch and edge index of the slave
-    bool reversed;                   //!< Relative orientation toggle
-    //! \brief Constructor initializing an Interface instance.
-    Interface(ASMs2DC1* m, int me, ASMs2DC1* s, int se, bool r = false)
-    {
-      master = std::make_pair(m,me);
-      slave = std::make_pair(s,se);
-      reversed = r;
-    }
-  };
-
-  std::vector<Interface> top; //!< Interfaces for C1 connection handling
 };
 
 #endif

--- a/src/SIM/SIM2D.h
+++ b/src/SIM/SIM2D.h
@@ -132,9 +132,6 @@ protected:
   virtual bool addConstraint(int patch, int lndx, int ldim,
                              int dirs, int code, int& ngnod, char basis = 1);
 
-  //! \brief Creates a default single-patch geometry.
-  virtual ASMbase* createDefaultGeometry(const TiXmlElement* geo) const;
-
   //! \brief Creates a default single-patch model generator.
   //! \param[in] geo XML element containing geometry defintion
   virtual ModelGenerator* createModelGenerator(const TiXmlElement* geo) const;

--- a/src/SIM/SIM3D.C
+++ b/src/SIM/SIM3D.C
@@ -814,81 +814,8 @@ bool SIM3D::readNodes (std::istream& isn, int pchInd, int basis, bool oneBased)
 
 ModelGenerator* SIM3D::createModelGenerator(const TiXmlElement* geo) const
 {
+  IFEM::cout <<"  Using default linear geometry basis on unit domain [0,1]^3";
   return new DefaultGeometry3D(geo);
-}
-
-
-ASMbase* SIM3D::createDefaultGeometry (const TiXmlElement* geo) const
-{
-  std::string g2("700 1 0 0\n3 ");
-
-  bool rational = false;
-  utl::getAttribute(geo,"rational",rational);
-  if (rational)
-    IFEM::cout <<"  Rational basis"<< std::endl;
-
-  g2.append(rational ? "1\n" : "0\n");
-  g2.append("2 2\n0 0 1 1\n"
-            "2 2\n0 0 1 1\n"
-            "2 2\n0 0 1 1\n");
-
-  std::array<double,24> nodes =
-    {{ 0.0, 0.0, 0.0,
-       1.0, 0.0, 0.0,
-       0.0, 1.0, 0.0,
-       1.0, 1.0, 0.0,
-       0.0, 0.0, 1.0,
-       1.0, 0.0, 1.0,
-       0.0, 1.0, 1.0,
-       1.0, 1.0, 1.0 }};
-
-  double scale = 1.0;
-  if (utl::getAttribute(geo,"scale",scale))
-    IFEM::cout <<"\tscale = "<< scale << std::endl;
-
-  double Lx = 1.0, Ly = 1.0, Lz = 1.0;
-  if (utl::getAttribute(geo,"Lx",Lx))
-    IFEM::cout <<"\tLength in X: "<< Lx << std::endl;
-  Lx *= scale;
-  if (utl::getAttribute(geo,"Ly",Ly))
-    IFEM::cout <<"\tLength in Y: "<< Ly << std::endl;
-  Ly *= scale;
-  if (utl::getAttribute(geo,"Lz",Lz))
-    IFEM::cout <<"\tLength in Z: "<< Lz << std::endl;
-  Lz *= scale;
-
-  if (Lx != 1.0)
-    nodes[3] = nodes[9] = nodes[15] = nodes[21] = Lx;
-  if (Ly != 1.0)
-    nodes[7] = nodes[10] = nodes[19] = nodes[22] = Ly;
-  if (Lz != 1.0)
-    nodes[14] = nodes[17] = nodes[20] = nodes[23] = Lz;
-
-  std::string corner;
-  if (utl::getAttribute(geo,"X0",corner)) {
-    std::stringstream str(corner);
-    Vec3 X0;
-    str >> X0;
-    IFEM::cout <<"\tCorner: "<< X0 << std::endl;
-    for (size_t i = 0; i < nodes.size(); i += 3)
-    {
-      nodes[i]   += X0.x;
-      nodes[i+1] += X0.y;
-      nodes[i+2] += X0.z;
-    }
-  }
-
-  for (size_t i = 0; i < nodes.size(); i += 3)
-  {
-    std::stringstream str;
-    for (size_t j = 0; j < 3; j++)
-      str << nodes[i+j] <<" ";
-    g2.append(str.str());
-    g2.append(rational ? "1.0\n" : "\n");
-  }
-
-  std::istringstream unitCube(g2);
-  return this->readPatch(unitCube,0,nf);
 }
 
 

--- a/src/SIM/SIM3D.C
+++ b/src/SIM/SIM3D.C
@@ -14,6 +14,7 @@
 #include "SIM3D.h"
 #include "ASMs3D.h"
 #include "Functions.h"
+#include "ModelGenerator.h"
 #include "Utilities.h"
 #include "IFEM.h"
 #include "Vec3Oper.h"
@@ -808,6 +809,12 @@ bool SIM3D::readNodes (std::istream& isn, int pchInd, int basis, bool oneBased)
   }
 
   return static_cast<ASMs3D*>(myModel[pchInd])->assignNodeNumbers(n,basis);
+}
+
+
+ModelGenerator* SIM3D::createModelGenerator(const TiXmlElement* geo) const
+{
+  return new DefaultGeometry3D(geo);
 }
 
 

--- a/src/SIM/SIM3D.C
+++ b/src/SIM/SIM3D.C
@@ -138,12 +138,15 @@ bool SIM3D::parseGeometryTag (const TiXmlElement* elem)
     const TiXmlElement* child = elem->FirstChildElement("connection");
     for (; child; child = child->NextSiblingElement())
     {
-      int master = 0, slave = 0, mFace = 0, sFace = 0, orient = 0;
+      int master = 0, slave = 0, mFace = 0, sFace = 0, orient = 0, basis = 0;
+      bool periodic = false;
       utl::getAttribute(child,"master",master);
       utl::getAttribute(child,"mface",mFace);
       utl::getAttribute(child,"slave",slave);
       utl::getAttribute(child,"sface",sFace);
       utl::getAttribute(child,"orient",orient);
+      utl::getAttribute(child,"basis",basis);
+      utl::getAttribute(child,"periodic",periodic);
 
       if (master == slave ||
           master < 1 || master > nGlPatches ||
@@ -161,7 +164,7 @@ bool SIM3D::parseGeometryTag (const TiXmlElement* elem)
                    <<" orient "<< orient << std::endl;
         ASMs3D* spch = static_cast<ASMs3D*>(myModel[lslave-1]);
         ASMs3D* mpch = static_cast<ASMs3D*>(myModel[lmaster-1]);
-        if (!spch->connectPatch(sFace,*mpch,mFace,orient))
+        if (!spch->connectPatch(sFace,*mpch,mFace,orient,!periodic))
           return false;
       } else
         adm.dd.ghostConnections.insert(DomainDecomposition::Interface{master, slave, mFace, sFace, orient, 2});

--- a/src/SIM/SIM3D.C
+++ b/src/SIM/SIM3D.C
@@ -703,7 +703,7 @@ ASMbase* SIM3D::readPatch (std::istream& isp, int pchInd,
 
 
 bool SIM3D::readPatches (std::istream& isp, PatchVec& patches,
-                         const char* whiteSpace)
+                         const char* whiteSpace) const
 {
   ASMbase* pch = nullptr;
   for (int pchInd = 1; isp.good(); pchInd++)

--- a/src/SIM/SIM3D.C
+++ b/src/SIM/SIM3D.C
@@ -46,6 +46,42 @@ SIM3D::SIM3D (IntegrandBase* itg, unsigned char n, bool check) : SIMgeneric(itg)
 }
 
 
+bool SIM3D::addConnection(int master, int slave, int mIdx,
+                          int sIdx, int orient, int basis, bool coordCheck)
+{
+  if (orient < 0 || orient > 7) {
+    std::cerr << "** SIM3D::addConnection ** Invalid orientation "
+              << orient <<"." << std::endl;
+    return false;
+  }
+
+  int lmaster = this->getLocalPatchIndex(master);
+  int lslave = this->getLocalPatchIndex(slave);
+  if (lmaster > 0 && lslave > 0) {
+    IFEM::cout <<"\tConnecting P"<< lslave <<" F"<< sIdx
+               <<" to P"<< lmaster <<" F"<< mIdx;
+    if (orient != 0)
+      IFEM::cout <<" orientation "<< orient << std::endl;
+    IFEM::cout << std::endl;
+
+    ASMs3D* spch = static_cast<ASMs3D*>(myModel[lslave-1]);
+    ASMs3D* mpch = static_cast<ASMs3D*>(myModel[lmaster-1]);
+    std::set<int> bases;
+    if (basis == 0)
+      for (size_t b = 1; b <= spch->getNoBasis(); ++b)
+        bases.insert(b);
+    else
+      bases = utl::getDigits(basis);
+    for (const int& b : bases)
+      if (!spch->connectPatch(sIdx,*mpch,mIdx,orient,b,coordCheck))
+        return false;
+  } else
+    adm.dd.ghostConnections.insert(DomainDecomposition::Interface{master, slave, mIdx, sIdx, orient, 2});
+
+  return true;
+}
+
+
 bool SIM3D::parseGeometryTag (const TiXmlElement* elem)
 {
   IFEM::cout <<"  Parsing <"<< elem->Value() <<">"<< std::endl;
@@ -156,18 +192,12 @@ bool SIM3D::parseGeometryTag (const TiXmlElement* elem)
                   << master <<" "<< slave << std::endl;
         return false;
       }
-      int lmaster = this->getLocalPatchIndex(master);
-      int lslave = this->getLocalPatchIndex(slave);
-      if (lmaster > 0 && lslave > 0) {
-        IFEM::cout <<"\tConnecting P"<< lslave <<" F"<< sFace
-                   <<" to P"<< lmaster <<" F"<< mFace
-                   <<" orient "<< orient << std::endl;
-        ASMs3D* spch = static_cast<ASMs3D*>(myModel[lslave-1]);
-        ASMs3D* mpch = static_cast<ASMs3D*>(myModel[lmaster-1]);
-        if (!spch->connectPatch(sFace,*mpch,mFace,orient,!periodic))
-          return false;
-      } else
-        adm.dd.ghostConnections.insert(DomainDecomposition::Interface{master, slave, mFace, sFace, orient, 2});
+
+      if (!this->addConnection(master, slave, mFace, sFace,
+                               orient, basis, !periodic)) {
+        std::cerr <<" ** SIM2D::parse: Error establishing connection." << std::endl;
+        return false;
+      }
     }
   }
 

--- a/src/SIM/SIM3D.C
+++ b/src/SIM/SIM3D.C
@@ -62,7 +62,7 @@ bool SIM3D::addConnection(int master, int slave, int mIdx,
     IFEM::cout <<"\tConnecting P"<< lslave <<" F"<< sIdx
                <<" to P"<< lmaster <<" F"<< mIdx;
     if (orient != 0)
-      IFEM::cout <<" orientation "<< orient << std::endl;
+      IFEM::cout <<" orient "<< orient << std::endl;
     IFEM::cout << std::endl;
 
     ASMs3D* spch = static_cast<ASMs3D*>(myModel[lslave-1]);

--- a/src/SIM/SIM3D.h
+++ b/src/SIM/SIM3D.h
@@ -71,9 +71,10 @@ public:
   //! \param mFace Face on master
   //! \param sFace Face on slave
   //! \param orient Orientation flag for connection
+  //! \param basis Which bases to connect (0 for all)
   //! \param coordCheck False to turn off coordinate checks
   bool addConnection(int master, int slave, int mFace, int sFace,
-                     int orient, int basis=0, bool coordCheck=true);
+                     int orient, int basis = 0, bool coordCheck = true);
 
   //! \brief Evaluates the primary solution at the given point.
   //! \param[in] psol Primary solution vector

--- a/src/SIM/SIM3D.h
+++ b/src/SIM/SIM3D.h
@@ -58,6 +58,13 @@ public:
   virtual ASMbase* readPatch(std::istream& isp, int pchInd,
                              const CharVec& unf) const;
 
+  //! \brief Reads patches from given input stream.
+  //! \param[in] isp The input stream to read from
+  //! \param[out] patches Array of patches that were read
+  //! \param[in] whiteSpace For message formatting
+  virtual bool readPatches(std::istream& isp, PatchVec& patches,
+                           const char* whiteSpace) const;
+
   //! \brief Evaluates the primary solution at the given point.
   //! \param[in] psol Primary solution vector
   //! \param[in] u First parameter of the point to evaluate at
@@ -85,12 +92,6 @@ protected:
   //! \param is The file stream to read from
   virtual bool parse(char* keyWord, std::istream& is);
 
-  //! \brief Reads patches from given input stream.
-  //! \param[in] isp The input stream to read from
-  //! \param[out] patches Array of patches that were read
-  //! \param[in] whiteSpace For message formatting
-  virtual bool readPatches(std::istream& isp, PatchVec& patches,
-                           const char* whiteSpace);
   //! \brief Reads global node data for a patch from given input stream.
   //! \param[in] isn The input stream to read from
   //! \param[in] pchInd 0-based index of the patch to read node data for

--- a/src/SIM/SIM3D.h
+++ b/src/SIM/SIM3D.h
@@ -136,9 +136,6 @@ protected:
   bool addConstraint(int patch, int lndx, int line, double xi,
                      int dirs, char basis = 1);
 
-  //! \brief Creates a default single-patch geometry.
-  virtual ASMbase* createDefaultGeometry(const TiXmlElement* geo) const;
-
   //! \brief Creates a default single-patch model generator.
   //! \param[in] geo XML element containing geometry defintion
   virtual ModelGenerator* createModelGenerator(const TiXmlElement* geo) const;

--- a/src/SIM/SIM3D.h
+++ b/src/SIM/SIM3D.h
@@ -139,6 +139,10 @@ protected:
   //! \brief Creates a default single-patch geometry.
   virtual ASMbase* createDefaultGeometry(const TiXmlElement* geo) const;
 
+  //! \brief Creates a default single-patch model generator.
+  //! \param[in] geo XML element containing geometry defintion
+  virtual ModelGenerator* createModelGenerator(const TiXmlElement* geo) const;
+
 protected:
   CharVec nf;         //!< Number of scalar fields
   bool    checkRHSys; //!< Check if all patches are in a right-hand system

--- a/src/SIM/SIM3D.h
+++ b/src/SIM/SIM3D.h
@@ -65,6 +65,16 @@ public:
   virtual bool readPatches(std::istream& isp, PatchVec& patches,
                            const char* whiteSpace) const;
 
+  //! \brief Connect two patches.
+  //! \param master Master patch
+  //! \param slave Slave patch
+  //! \param mFace Face on master
+  //! \param sFace Face on slave
+  //! \param orient Orientation flag for connection
+  //! \param coordCheck False to turn off coordinate checks
+  bool addConnection(int master, int slave, int mFace, int sFace,
+                     int orient, int basis=0, bool coordCheck=true);
+
   //! \brief Evaluates the primary solution at the given point.
   //! \param[in] psol Primary solution vector
   //! \param[in] u First parameter of the point to evaluate at

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -29,6 +29,7 @@
 #include "AnaSol.h"
 #include "Vec3Oper.h"
 #include "Functions.h"
+#include "ModelGenerator.h"
 #include "Profiler.h"
 #include "Utilities.h"
 #include "HDF5Writer.h"
@@ -53,6 +54,7 @@ SIMbase::SIMbase (IntegrandBase* itg) : g2l(&myGlb2Loc)
   myEqSys = nullptr;
   mySam = nullptr;
   mySolParams = nullptr;
+  myGen = nullptr;
   nGlPatches = 0;
   nIntGP = nBouGP = 0;
 
@@ -74,6 +76,7 @@ SIMbase::~SIMbase ()
   if (myEqSys)     delete myEqSys;
   if (mySam)       delete mySam;
   if (mySolParams) delete mySolParams;
+  delete myGen;
 
   for (PatchVec::iterator i1 = myModel.begin(); i1 != myModel.end(); i1++)
     delete *i1;

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -502,11 +502,19 @@ bool SIMbase::parse (const TiXmlElement* elem)
   if (myModel.empty() && !strcasecmp(elem->Value(),"geometry"))
     if (this->getNoParamDim() > 0 && !elem->FirstChildElement("patchfile"))
     {
-      IFEM::cout <<"  Using default linear geometry basis on unit domain [0,1]";
-      if (this->getNoParamDim() > 1) IFEM::cout <<"^"<< this->getNoParamDim();
-      IFEM::cout << std::endl;
-      nGlPatches = 1;
-      myModel.resize(1,this->createDefaultGeometry(elem));
+      // parse partitioning first
+      for (const TiXmlElement* part = elem->FirstChildElement("partitioning");
+                         part; part = part->NextSiblingElement("partitioning"))
+        result &= this->parseGeometryTag(part);
+
+      myGen = this->createModelGenerator(elem);
+      myModel = myGen->createGeometry(*this);
+      if (myPatches.empty())
+        nGlPatches = myModel.size();
+
+      TopologySet set = myGen->createTopologySets(*this);
+      for (auto& it : set)
+        myEntitys[it.first] = it.second;
     }
 
   if (!strcasecmp(elem->Value(),"linearsolver")) {
@@ -531,6 +539,9 @@ bool SIMbase::parse (const TiXmlElement* elem)
       result &= this->opt.parseConsoleTag(child);
     else if (!strcasecmp(elem->Value(),"discretization"))
       result &= opt.parseDiscretizationTag(child);
+
+  if (myGen)
+    myGen->createTopology(*this);
 
   return result;
 }

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -91,6 +91,17 @@ public:
   //! \brief Returns a list of prioritized XML-tags.
   virtual const char** getPrioritizedTags() const;
 
+  //! \brief Connect two patches.
+  //! \param master Master patch
+  //! \param slave Slave patch
+  //! \param mIdx Index on master
+  //! \param sIdx Index on slave
+  //! \param orient Orientation flag
+  //! \param coordCheck False to turn off coordinate checks.
+  virtual bool addConnection(int master, int slave, int mIdx, int sIdx,
+                             int orient, bool coordCheck=true)
+  { return false; }
+
 protected:
   //! \brief Parses the "set" attribute of a material XML-tag.
   //! \param[in] elem The XML element extract the set name from

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -747,7 +747,6 @@ protected:
   IntegrandBase* myProblem; //!< The main integrand of this simulator
   IntegrandMap   myInts;    //!< Set of all integrands involved
   AnaSol*        mySol;     //!< Analytical/Exact solution
-  ModelGenerator* myGen;    //!< Model generator to use
 
   //! \brief A struct with data for system matrix/vector dumps.
   struct DumpData

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -98,9 +98,10 @@ public:
   //! \param mIdx Index on master
   //! \param sIdx Index on slave
   //! \param orient Orientation flag
+  //! \param basis Which bases to connect (0 for all)
   //! \param coordCheck False to turn off coordinate checks.
   virtual bool addConnection(int master, int slave, int mIdx, int sIdx,
-                             int orient, bool coordCheck=true)
+                             int orient, int basis = 0, bool coordCheck = true)
   { return false; }
 
 protected:

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -651,6 +651,13 @@ public:
   virtual ASMbase* readPatch(std::istream& isp, int pchInd,
                              const CharVec& unf = CharVec()) const = 0;
 
+  //! \brief Reads patches from given input stream.
+  //! \param[in] isp The input stream to read from
+  //! \param[out] patches Array of patches that were read
+  //! \param[in] whiteSpace For message formatting
+  virtual bool readPatches(std::istream& isp, PatchVec& patches,
+                           const char* whiteSpace = "") const = 0;
+
   //! \brief Returns a scalar function associated with \a code.
   RealFunc* getSclFunc(int code) const;
 
@@ -666,12 +673,6 @@ protected:
   //! \brief Initializes for integration of Neumann terms for a given property.
   virtual bool initNeumann(size_t) { return true; }
 
-  //! \brief Reads patches from given input stream.
-  //! \param[in] isp The input stream to read from
-  //! \param[out] patches Array of patches that were read
-  //! \param[in] whiteSpace For message formatting
-  virtual bool readPatches(std::istream& isp, PatchVec& patches,
-                           const char* whiteSpace = "") = 0;
   //! \brief Reads global node data for a patch from given input stream.
   //! \param[in] isn The input stream to read from
   //! \param[in] pchInd 0-based index of the patch to read node data for

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -32,6 +32,7 @@ class LinSolParams;
 class TimeStep;
 class SystemVector;
 class Vec4;
+class ModelGenerator;
 namespace LR { struct RefineData; }
 
 //! Property code to integrand map
@@ -673,6 +674,9 @@ public:
   RealFunc* getSclFunc(int code) const;
 
 protected:
+  //! \brief Instantiate a generator for the finite element model.
+  //! \param[in] geo XML element containing geometry defintion
+  virtual ModelGenerator* createModelGenerator(const TiXmlElement* geo) const = 0;
   //! \brief Creates a default single-patch geometry.
   //! \param[in] geo XML element containing geometry defintion
   virtual ASMbase* createDefaultGeometry(const TiXmlElement* geo) const = 0;
@@ -746,6 +750,7 @@ protected:
   IntegrandBase* myProblem; //!< The main integrand of this simulator
   IntegrandMap   myInts;    //!< Set of all integrands involved
   AnaSol*        mySol;     //!< Analytical/Exact solution
+  ModelGenerator* myGen;    //!< Model generator to use
 
   //! \brief A struct with data for system matrix/vector dumps.
   struct DumpData

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -677,9 +677,6 @@ protected:
   //! \brief Instantiate a generator for the finite element model.
   //! \param[in] geo XML element containing geometry defintion
   virtual ModelGenerator* createModelGenerator(const TiXmlElement* geo) const = 0;
-  //! \brief Creates a default single-patch geometry.
-  //! \param[in] geo XML element containing geometry defintion
-  virtual ASMbase* createDefaultGeometry(const TiXmlElement* geo) const = 0;
 
   //! \brief Initializes material properties for integration of interior terms.
   virtual bool initMaterial(size_t) { return true; }

--- a/src/SIM/SIMdummy.h
+++ b/src/SIM/SIMdummy.h
@@ -38,7 +38,7 @@ public:
   { return nullptr; }
 protected:
   //! \brief Reads patches from given input stream.
-  virtual bool readPatches(std::istream&,SIMdependency::PatchVec&,const char*)
+  virtual bool readPatches(std::istream&,SIMdependency::PatchVec&,const char*) const
   { return false; }
   //! \brief Preprocesses a user-defined Dirichlet boundary property.
   virtual bool addConstraint(int,int,int,int,int,int&,char)

--- a/src/SIM/SIMdummy.h
+++ b/src/SIM/SIMdummy.h
@@ -48,6 +48,9 @@ protected:
   { return nullptr; }
   //! \brief Preprocesses the result sampling points.
   virtual void preprocessResultPoints() {}
+  //! \brief Creates a model generator.
+  virtual ModelGenerator* createModelGenerator(const TiXmlElement*) const
+  { return nullptr; }
 };
 
 #endif

--- a/src/SIM/SIMgeneric.C
+++ b/src/SIM/SIMgeneric.C
@@ -20,9 +20,10 @@ void SIMgeneric::createDefaultModel ()
 {
   if (!myModel.empty()) return;
 
-  myGen = this->createModelGenerator(nullptr);
-  myModel = myGen->createGeometry(*this);
+  ModelGenerator* gen = this->createModelGenerator(nullptr);
+  myModel = gen->createGeometry(*this);
   nGlPatches = myModel.size();
+  delete gen;
 }
 
 

--- a/src/SIM/SIMgeneric.C
+++ b/src/SIM/SIMgeneric.C
@@ -13,14 +13,16 @@
 
 #include "SIMgeneric.h"
 #include "ASMbase.h"
+#include "ModelGenerator.h"
 
 
 void SIMgeneric::createDefaultModel ()
 {
   if (!myModel.empty()) return;
 
-  nGlPatches = 1;
-  myModel.resize(1,this->createDefaultGeometry(nullptr));
+  myGen = this->createModelGenerator(nullptr);
+  myModel = myGen->createGeometry(*this);
+  nGlPatches = myModel.size();
 }
 
 

--- a/src/SIM/Test/TestModelGenerator.C
+++ b/src/SIM/Test/TestModelGenerator.C
@@ -1,0 +1,468 @@
+//==============================================================================
+//!
+//! \file TestModelGenerator.C
+//!
+//! \date Sep 2 2016
+//!
+//! \author Arne Morten Kvarving / SINTEF
+//!
+//! \brief Tests for default model generators.
+//!
+//==============================================================================
+
+#include "IFEM.h"
+#include "ModelGenerator.h"
+#include "SIM1D.h"
+#include "SIM2D.h"
+#include "SIM3D.h"
+#include "TopologySet.h"
+
+#include "gtest/gtest.h"
+#include "tinyxml.h"
+
+
+template<class Generator>
+class TestModelGeneratorWrapper : public Generator {
+public:
+  TestModelGeneratorWrapper(const TiXmlElement* geo) : Generator(geo) {}
+  std::string createG2(int nsd)
+  {
+    return Generator::createG2(nsd);
+  }
+};
+
+struct DefaultGeomTest {
+  std::string xml;
+  int dim;
+  std::string g2;
+  std::string sets;
+};
+
+
+class TestModelGenerator1D :
+  public testing::Test,
+  public testing::WithParamInterface<DefaultGeomTest>
+{
+};
+
+
+class TestModelGenerator2D :
+  public testing::Test,
+  public testing::WithParamInterface<DefaultGeomTest>
+{
+};
+
+
+class TestModelGenerator3D :
+  public testing::Test,
+  public testing::WithParamInterface<DefaultGeomTest>
+{
+};
+
+
+auto&& DoTest = [](const DefaultGeomTest& ref, const std::string& gen,
+                   const TopologySet& sets)
+{
+  ASSERT_STREQ(gen.c_str(), ref.g2.c_str());
+
+  if (!ref.sets.empty()) {
+    std::string gsets;
+    for (auto& it : sets) {
+      gsets += it.first + ": ";
+      for (auto& it2 : it.second) {
+        std::stringstream str;
+        str << it2.patch << " " << it2.item << " " << it2.idim << " ";
+        gsets += str.str();
+      }
+      gsets += "\n";
+    }
+    ASSERT_STREQ(gsets.c_str(), ref.sets.c_str());
+  }
+};
+
+
+TEST_P(TestModelGenerator1D, Generate)
+{
+  TiXmlDocument doc;
+  doc.Parse(GetParam().xml.c_str());
+  TestModelGeneratorWrapper<DefaultGeometry1D> gen(doc.RootElement());
+  std::string g2 = gen.createG2(GetParam().dim);
+  SIM1D sim;
+  TopologySet sets = gen.createTopologySets(sim);
+  DoTest(GetParam(), g2, sets);
+}
+
+
+TEST_P(TestModelGenerator2D, Generate)
+{
+  TiXmlDocument doc;
+  doc.Parse(GetParam().xml.c_str());
+  TestModelGeneratorWrapper<DefaultGeometry2D> gen(doc.RootElement());
+  std::string g2 = gen.createG2(GetParam().dim);
+  SIM2D sim;
+  TopologySet sets = gen.createTopologySets(sim);
+  DoTest(GetParam(), g2, sets);
+}
+
+
+TEST_P(TestModelGenerator3D, Generate)
+{
+  TiXmlDocument doc;
+  doc.Parse(GetParam().xml.c_str());
+  TestModelGeneratorWrapper<DefaultGeometry3D> gen(doc.RootElement());
+  std::string g2 = gen.createG2(GetParam().dim);
+  SIM3D sim;
+  TopologySet sets = gen.createTopologySets(sim);
+  DoTest(GetParam(), g2, sets);
+}
+
+
+const std::vector<DefaultGeomTest> geometry1D =
+  {{"<geometry sets=\"true\"/>", 1,
+    "100 1 0 0\n"
+    "1 0\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "0.0\n"
+    "1.0\n",
+    "Boundary: 1 1 0 1 2 0 \n"
+    "Corners: 1 1 0 1 2 0 \n"
+    "Vertex1: 1 1 0 \n"
+    "Vertex2: 1 2 0 \n"},
+
+   {"<geometry/>", 3,
+    "100 1 0 0\n"
+    "3 0\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "0.0 0.0 0.0\n"
+    "1.0 0.0 0.0\n",
+    ""},
+
+   {"<geometry X0=\"1.0 1.0 0.0\" X1=\"1.0 2.0 0.0\"/>", 3,
+    "100 1 0 0\n"
+    "3 0\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "1.0 1.0 0.0\n"
+    "1.0 2.0 0.0\n",
+    ""},
+
+   {"<geometry L=\"2.0\"/>", 1,
+    "100 1 0 0\n"
+    "1 0\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "0.0\n"
+    "2.0\n",
+    ""},
+
+   {"<geometry rational=\"true\" sets=\"true\"/>", 1,
+    "100 1 0 0\n"
+    "1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "0.0 1.0\n"
+    "1.0 1.0\n",
+    "Boundary: 1 1 0 1 2 0 \n"
+    "Corners: 1 1 0 1 2 0 \n"
+    "Vertex1: 1 1 0 \n"
+    "Vertex2: 1 2 0 \n"}};
+
+
+INSTANTIATE_TEST_CASE_P(TestModelGenerator1D, TestModelGenerator1D, testing::ValuesIn(geometry1D));
+
+
+const std::vector<DefaultGeomTest> geometry2D =
+  {{"<geometry sets=\"true\"/>", 2,
+    "200 1 0 0\n"
+    "2 0\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "0 0\n"
+    "1 0\n"
+    "0 1\n"
+    "1 1\n",
+    "Boundary: 1 1 1 1 2 1 1 3 1 1 4 1 \n"
+    "Corners: 1 1 0 1 2 0 1 3 0 1 4 0 \n"
+    "Edge1: 1 1 1 \n"
+    "Edge2: 1 2 1 \n"
+    "Edge3: 1 3 1 \n"
+    "Edge4: 1 4 1 \n"
+    "Vertex1: 1 1 0 \n"
+    "Vertex2: 1 2 0 \n"
+    "Vertex3: 1 3 0 \n"
+    "Vertex4: 1 4 0 \n"},
+
+   {"<geometry rational=\"1\"/>", 2,
+    "200 1 0 0\n"
+    "2 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "0 0 1.0\n"
+    "1 0 1.0\n"
+    "0 1 1.0\n"
+    "1 1 1.0\n", ""},
+
+   {"<geometry scale=\"2\"/>", 2,
+     "200 1 0 0\n"
+     "2 0\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "0 0\n"
+     "2 0\n"
+     "0 2\n"
+     "2 2\n", ""},
+
+   {"<geometry X0=\"2 0\"/>", 2,
+    "200 1 0 0\n"
+     "2 0\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "2 0\n"
+     "3 0\n"
+     "2 1\n"
+     "3 1\n"},
+
+    {"<geometry X0=\"0 2\"/>", 2,
+     "200 1 0 0\n"
+     "2 0\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "0 2\n"
+     "1 2\n"
+     "0 3\n"
+     "1 3\n", ""},
+
+    {"<geometry Lx=\"2\"/>", 2,
+     "200 1 0 0\n"
+     "2 0\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "0 0\n"
+     "2 0\n"
+     "0 1\n"
+     "2 1\n", ""},
+
+    {"<geometry Ly=\"2\"/>", 2,
+     "200 1 0 0\n"
+     "2 0\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "0 0\n"
+     "1 0\n"
+     "0 2\n"
+     "1 2\n", ""}};
+
+
+INSTANTIATE_TEST_CASE_P(TestModelGenerator2D, TestModelGenerator2D, testing::ValuesIn(geometry2D));
+
+
+const std::vector<DefaultGeomTest> geometry3D =
+  {{"<geometry sets=\"true\"/>", 3,
+    "700 1 0 0\n"
+    "3 0\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "0 0 0 \n"
+    "1 0 0 \n"
+    "0 1 0 \n"
+    "1 1 0 \n"
+    "0 0 1 \n"
+    "1 0 1 \n"
+    "0 1 1 \n"
+    "1 1 1 \n",
+    "Boundary: 1 1 2 1 2 2 1 3 2 1 4 2 1 5 2 1 6 2 \n"
+    "Corners: 1 1 0 1 2 0 1 3 0 1 4 0 1 5 0 1 6 0 1 7 0 1 8 0 \n"
+    "Edge1: 1 1 1 \n"
+    "Edge10: 1 10 1 \n"
+    "Edge11: 1 11 1 \n"
+    "Edge12: 1 12 1 \n"
+    "Edge2: 1 2 1 \n"
+    "Edge3: 1 3 1 \n"
+    "Edge4: 1 4 1 \n"
+    "Edge5: 1 5 1 \n"
+    "Edge6: 1 6 1 \n"
+    "Edge7: 1 7 1 \n"
+    "Edge8: 1 8 1 \n"
+    "Edge9: 1 9 1 \n"
+    "Face1: 1 1 2 \n"
+    "Face2: 1 2 2 \n"
+    "Face3: 1 3 2 \n"
+    "Face4: 1 4 2 \n"
+    "Face5: 1 5 2 \n"
+    "Face6: 1 6 2 \n"
+    "Frame: 1 1 1 1 2 1 1 3 1 1 4 1 1 5 1 1 6 1 1 7 1 1 8 1 1 9 1 1 10 1 1 11 1 1 12 1 \n"
+    "Vertex1: 1 1 0 \n"
+    "Vertex2: 1 2 0 \n"
+    "Vertex3: 1 3 0 \n"
+    "Vertex4: 1 4 0 \n"
+    "Vertex5: 1 5 0 \n"
+    "Vertex6: 1 6 0 \n"
+    "Vertex7: 1 7 0 \n"
+    "Vertex8: 1 8 0 \n"},
+
+  {"<geometry rational=\"1\"/>", 3,
+   "700 1 0 0\n"
+   "3 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "0 0 0 1.0\n"
+   "1 0 0 1.0\n"
+   "0 1 0 1.0\n"
+   "1 1 0 1.0\n"
+   "0 0 1 1.0\n"
+   "1 0 1 1.0\n"
+   "0 1 1 1.0\n"
+   "1 1 1 1.0\n", ""},
+
+  {"<geometry scale=\"2\"/>", 3,
+   "700 1 0 0\n"
+   "3 0\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "0 0 0 \n"
+   "2 0 0 \n"
+   "0 2 0 \n"
+   "2 2 0 \n"
+   "0 0 2 \n"
+   "2 0 2 \n"
+   "0 2 2 \n"
+   "2 2 2 \n", ""},
+
+  {"<geometry X0=\"2 0 0\"/>", 3,
+   "700 1 0 0\n"
+   "3 0\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 0 0 \n"
+   "3 0 0 \n"
+   "2 1 0 \n"
+   "3 1 0 \n"
+   "2 0 1 \n"
+   "3 0 1 \n"
+   "2 1 1 \n"
+   "3 1 1 \n", ""},
+
+  {"<geometry X0=\"0 2 0\"/>", 3,
+   "700 1 0 0\n"
+   "3 0\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "0 2 0 \n"
+   "1 2 0 \n"
+   "0 3 0 \n"
+   "1 3 0 \n"
+   "0 2 1 \n"
+   "1 2 1 \n"
+   "0 3 1 \n"
+   "1 3 1 \n", ""},
+
+  {"<geometry X0=\"0 0 2\"/>", 3,
+   "700 1 0 0\n"
+   "3 0\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "0 0 2 \n"
+   "1 0 2 \n"
+   "0 1 2 \n"
+   "1 1 2 \n"
+   "0 0 3 \n"
+   "1 0 3 \n"
+   "0 1 3 \n"
+   "1 1 3 \n", ""},
+
+  {"<geometry Lx=\"2\"/>", 3,
+   "700 1 0 0\n"
+   "3 0\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "0 0 0 \n"
+   "2 0 0 \n"
+   "0 1 0 \n"
+   "2 1 0 \n"
+   "0 0 1 \n"
+   "2 0 1 \n"
+   "0 1 1 \n"
+   "2 1 1 \n", ""},
+
+  {"<geometry Ly=\"2\"/>", 3,
+   "700 1 0 0\n"
+   "3 0\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "2 2\n"
+   "0 0 1 1\n"
+   "0 0 0 \n"
+   "1 0 0 \n"
+   "0 2 0 \n"
+   "1 2 0 \n"
+   "0 0 1 \n"
+   "1 0 1 \n"
+   "0 2 1 \n"
+   "1 2 1 \n", ""},
+
+  {"<geometry Lz=\"2\"/>", 3,
+   "700 1 0 0\n"
+     "3 0\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "2 2\n"
+     "0 0 1 1\n"
+     "0 0 0 \n"
+     "1 0 0 \n"
+     "0 1 0 \n"
+     "1 1 0 \n"
+     "0 0 2 \n"
+     "1 0 2 \n"
+     "0 1 2 \n"
+     "1 1 2 \n", ""}};
+
+
+INSTANTIATE_TEST_CASE_P(TestModelGenerator3D, TestModelGenerator3D, testing::ValuesIn(geometry3D));


### PR DESCRIPTION
This replaces the default geometry generation within the SIM classes with an abstract class interface for model generators, and default implementations of these interfaces generating single-patch models.

This allows for more complex model generators in applications. In particular, multi-patch generators for rectangles and hexahedra is also included ready for use in the applications.

Full test-coverage is included.