### PR TITLE
Allow specifying refinement and raiseorder using a topologyset

### DIFF
--- a/src/SIM/SIM1D.C
+++ b/src/SIM/SIM1D.C
@@ -50,8 +50,10 @@ bool SIM1D::parseGeometryTag (const TiXmlElement* elem)
 {
   IFEM::cout <<"  Parsing <"<< elem->Value() <<">"<< std::endl;
 
-  if (!strcasecmp(elem->Value(),"refine"))
+  if (!strcasecmp(elem->Value(),"refine") ||
+      !strcasecmp(elem->Value(),"raiseorder"))
   {
+    bool isRefine = !strcasecmp(elem->Value(),"refine");
     int lowpatch = 1, uppatch = 1;
     if (utl::getAttribute(elem,"patch",lowpatch))
       uppatch = lowpatch;
@@ -67,55 +69,42 @@ bool SIM1D::parseGeometryTag (const TiXmlElement* elem)
     }
 
     ASM1D* pch = nullptr;
-    RealArray xi;
-    if (!utl::parseKnots(elem,xi))
+    if (isRefine)
+    {
+      RealArray xi;
+      if (!utl::parseKnots(elem,xi))
+      {
+        int addu = 0;
+        utl::getAttribute(elem,"u",addu);
+        for (int j = lowpatch; j <= uppatch; j++)
+          if ((pch = dynamic_cast<ASM1D*>(this->getPatch(j,true))))
+          {
+            IFEM::cout <<"\tRefining P"<< j <<" "<< addu << std::endl;
+            pch->uniformRefine(addu);
+          }
+      }
+      else
+        for (int j = lowpatch; j <= uppatch; j++)
+          if ((pch = dynamic_cast<ASM1D*>(this->getPatch(j,true))))
+          {
+            IFEM::cout <<"\tRefining P"<< j;
+            for (size_t i = 0; i < xi.size(); i++)
+              IFEM::cout <<" "<< xi[i];
+            IFEM::cout << std::endl;
+            pch->refine(xi);
+          }
+    }
+    else
     {
       int addu = 0;
       utl::getAttribute(elem,"u",addu);
       for (int j = lowpatch; j <= uppatch; j++)
         if ((pch = dynamic_cast<ASM1D*>(this->getPatch(j,true))))
         {
-          IFEM::cout <<"\tRefining P"<< j <<" "<< addu << std::endl;
-          pch->uniformRefine(addu);
+          IFEM::cout <<"\tRaising order of P"<< j <<" "<< addu << std::endl;
+          static_cast<ASM1D*>(pch)->raiseOrder(addu);
         }
     }
-    else
-      for (int j = lowpatch; j <= uppatch; j++)
-        if ((pch = dynamic_cast<ASM1D*>(this->getPatch(j,true))))
-        {
-          IFEM::cout <<"\tRefining P"<< j;
-          for (size_t i = 0; i < xi.size(); i++)
-            IFEM::cout <<" "<< xi[i];
-          IFEM::cout << std::endl;
-          pch->refine(xi);
-        }
-  }
-
-  else if (!strcasecmp(elem->Value(),"raiseorder"))
-  {
-    int lowpatch = 1, uppatch = 1;
-    if (utl::getAttribute(elem,"patch",lowpatch))
-      uppatch = lowpatch;
-    if (utl::getAttribute(elem,"lowerpatch",lowpatch))
-      uppatch = myModel.size();
-    utl::getAttribute(elem,"upperpatch",uppatch);
-
-    if (lowpatch < 1 || uppatch > nGlPatches)
-    {
-      std::cerr <<" *** SIM1D::parse: Invalid patch indices, lower="
-                << lowpatch <<" upper="<< uppatch << std::endl;
-      return false;
-    }
-
-    ASM1D* pch = nullptr;
-    int addu = 0;
-    utl::getAttribute(elem,"u",addu);
-    for (int j = lowpatch; j <= uppatch; j++)
-      if ((pch = dynamic_cast<ASM1D*>(this->getPatch(j,true))))
-      {
-        IFEM::cout <<"\tRaising order of P"<< j <<" "<< addu << std::endl;
-        static_cast<ASM1D*>(pch)->raiseOrder(addu);
-      }
   }
 
   else if (!strcasecmp(elem->Value(),"topology"))

--- a/src/SIM/SIM2D.C
+++ b/src/SIM/SIM2D.C
@@ -117,8 +117,10 @@ bool SIM2D::parseGeometryTag (const TiXmlElement* elem)
 {
   IFEM::cout <<"  Parsing <"<< elem->Value() <<">"<< std::endl;
 
-  if (!strcasecmp(elem->Value(),"refine") && !isRefined)
+  if ((!strcasecmp(elem->Value(),"refine") ||
+       !strcasecmp(elem->Value(),"raiseorder")) && !isRefined)
   {
+    bool isRefine = !strcasecmp(elem->Value(),"refine");
     int lowpatch = 1, uppatch = 1;
     if (utl::getAttribute(elem,"patch",lowpatch))
       uppatch = lowpatch;
@@ -134,8 +136,39 @@ bool SIM2D::parseGeometryTag (const TiXmlElement* elem)
     }
 
     ASM2D* pch = nullptr;
-    RealArray xi;
-    if (!utl::parseKnots(elem,xi))
+    if (isRefine)
+    {
+      RealArray xi;
+      if (!utl::parseKnots(elem,xi))
+      {
+        int addu = 0, addv = 0;
+        utl::getAttribute(elem,"u",addu);
+        utl::getAttribute(elem,"v",addv);
+        for (int j = lowpatch; j <= uppatch; j++)
+          if ((pch = dynamic_cast<ASM2D*>(this->getPatch(j,true))))
+          {
+            IFEM::cout <<"\tRefining P"<< j
+                       <<" "<< addu <<" "<< addv << std::endl;
+            pch->uniformRefine(0,addu);
+            pch->uniformRefine(1,addv);
+          }
+      }
+      else
+      {
+        int dir = 1;
+        utl::getAttribute(elem,"dir",dir);
+        for (int j = lowpatch; j <= uppatch; j++)
+          if ((pch = dynamic_cast<ASM2D*>(this->getPatch(j,true))))
+          {
+            IFEM::cout <<"\tRefining P"<< j <<" dir="<< dir;
+            for (size_t i = 0; i < xi.size(); i++)
+              IFEM::cout <<" "<< xi[i];
+            IFEM::cout << std::endl;
+            pch->refine(dir-1,xi);
+          }
+      }
+    }
+    else
     {
       int addu = 0, addv = 0;
       utl::getAttribute(elem,"u",addu);
@@ -143,55 +176,11 @@ bool SIM2D::parseGeometryTag (const TiXmlElement* elem)
       for (int j = lowpatch; j <= uppatch; j++)
         if ((pch = dynamic_cast<ASM2D*>(this->getPatch(j,true))))
         {
-          IFEM::cout <<"\tRefining P"<< j
+          IFEM::cout <<"\tRaising order of P"<< j
                      <<" "<< addu <<" "<< addv << std::endl;
-          pch->uniformRefine(0,addu);
-          pch->uniformRefine(1,addv);
+          pch->raiseOrder(addu,addv);
         }
     }
-    else
-    {
-      int dir = 1;
-      utl::getAttribute(elem,"dir",dir);
-      for (int j = lowpatch; j <= uppatch; j++)
-        if ((pch = dynamic_cast<ASM2D*>(this->getPatch(j,true))))
-        {
-          IFEM::cout <<"\tRefining P"<< j <<" dir="<< dir;
-          for (size_t i = 0; i < xi.size(); i++)
-            IFEM::cout <<" "<< xi[i];
-          IFEM::cout << std::endl;
-          pch->refine(dir-1,xi);
-        }
-    }
-  }
-
-  else if (!strcasecmp(elem->Value(),"raiseorder") && !isRefined)
-  {
-    int lowpatch = 1, uppatch = 1;
-    if (utl::getAttribute(elem,"patch",lowpatch))
-      uppatch = lowpatch;
-    if (utl::getAttribute(elem,"lowerpatch",lowpatch))
-      uppatch = myModel.size();
-    utl::getAttribute(elem,"upperpatch",uppatch);
-
-    if (lowpatch < 1 || uppatch > nGlPatches)
-    {
-      std::cerr <<" *** SIM2D::parse: Invalid patch indices, lower="
-                << lowpatch <<" upper="<< uppatch << std::endl;
-      return false;
-    }
-
-    ASM2D* pch = nullptr;
-    int addu = 0, addv = 0;
-    utl::getAttribute(elem,"u",addu);
-    utl::getAttribute(elem,"v",addv);
-    for (int j = lowpatch; j <= uppatch; j++)
-      if ((pch = dynamic_cast<ASM2D*>(this->getPatch(j,true))))
-      {
-        IFEM::cout <<"\tRaising order of P"<< j
-                   <<" "<< addu <<" "<< addv << std::endl;
-        pch->raiseOrder(addu,addv);
-      }
   }
 
   else if (!strcasecmp(elem->Value(),"topology"))

--- a/src/SIM/SIM2D.C
+++ b/src/SIM/SIM2D.C
@@ -128,11 +128,40 @@ bool SIM2D::parseGeometryTag (const TiXmlElement* elem)
       uppatch = myModel.size();
     utl::getAttribute(elem,"upperpatch",uppatch);
 
-    if (lowpatch < 1 || uppatch > nGlPatches)
+    std::string set;
+    utl::getAttribute(elem,"set",set);
+    IntVec patches;
+    if (set.empty())
     {
-      std::cerr <<" *** SIM2D::parse: Invalid patch indices, lower="
-                << lowpatch <<" upper="<< uppatch << std::endl;
-      return false;
+      if (lowpatch < 1 || uppatch > nGlPatches)
+      {
+        std::cerr <<" *** SIM2D::parse: Invalid patch indices, lower="
+                  << lowpatch <<" upper="<< uppatch << std::endl;
+        return false;
+      }
+      patches.resize(uppatch-lowpatch+1);
+      std::iota(patches.begin(), patches.end(), lowpatch);
+    }
+    else
+    {
+      auto tit = myEntitys.find(set);
+      if (tit == myEntitys.end())
+      {
+        std::cerr <<" *** SIM2D::parse: Unknown topologyset " << set
+                  <<" given for " << (isRefine?"refine":"raiseorder") << "."
+                  << std::endl;
+        return false;
+      }
+      for (auto& it : tit->second)
+        if (it.idim == 2)
+          patches.push_back(it.patch);
+      if (patches.empty())
+      {
+        std::cerr <<" *** SIM2D::parse: Invalid topologyset " << set
+                  <<" given for " << (isRefine?"refine":"raiseorder")
+                  << " (no patches in set)." << std::endl;
+        return false;
+      }
     }
 
     ASM2D* pch = nullptr;
@@ -144,7 +173,7 @@ bool SIM2D::parseGeometryTag (const TiXmlElement* elem)
         int addu = 0, addv = 0;
         utl::getAttribute(elem,"u",addu);
         utl::getAttribute(elem,"v",addv);
-        for (int j = lowpatch; j <= uppatch; j++)
+        for (int j : patches)
           if ((pch = dynamic_cast<ASM2D*>(this->getPatch(j,true))))
           {
             IFEM::cout <<"\tRefining P"<< j
@@ -157,7 +186,7 @@ bool SIM2D::parseGeometryTag (const TiXmlElement* elem)
       {
         int dir = 1;
         utl::getAttribute(elem,"dir",dir);
-        for (int j = lowpatch; j <= uppatch; j++)
+        for (int j : patches)
           if ((pch = dynamic_cast<ASM2D*>(this->getPatch(j,true))))
           {
             IFEM::cout <<"\tRefining P"<< j <<" dir="<< dir;
@@ -173,7 +202,7 @@ bool SIM2D::parseGeometryTag (const TiXmlElement* elem)
       int addu = 0, addv = 0;
       utl::getAttribute(elem,"u",addu);
       utl::getAttribute(elem,"v",addv);
-      for (int j = lowpatch; j <= uppatch; j++)
+      for (int j : patches)
         if ((pch = dynamic_cast<ASM2D*>(this->getPatch(j,true))))
         {
           IFEM::cout <<"\tRaising order of P"<< j


### PR DESCRIPTION
See title. This is useful since you can save on the amount of generator code you have to write, making it easier to script setups.
