### PR TITLE
Fix mixed LR

### DIFF
--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -1289,6 +1289,8 @@ bool ASMu2D::integrate (Integrand& integrand, int lIndex,
     // Get integration gauss points over this element
     this->getGaussPointParameters(gpar[t2-1],t2-1,nGP,iel,xg);
 
+    if (integrand.getIntegrandType() & Integrand::ELEMENT_CORNERS)
+      this->getElementCorners(iel,fe.XC);
 
     // --- Integration loop over all Gauss points along the edge -------------
 

--- a/src/ASM/LR/ASMu2Dmx.C
+++ b/src/ASM/LR/ASMu2Dmx.C
@@ -445,6 +445,9 @@ bool ASMu2Dmx::integrate (Integrand& integrand, int lIndex,
       return false;
     }
 
+    if (integrand.getIntegrandType() & Integrand::ELEMENT_CORNERS)
+      this->getElementCorners(iel,fe.XC);
+
     // Get integration gauss points over this element
     this->getGaussPointParameters(gpar[t2-1],t2-1,nGP,geoEl,xg);
 

--- a/src/ASM/LR/ASMu2Dmx.C
+++ b/src/ASM/LR/ASMu2Dmx.C
@@ -96,11 +96,8 @@ void ASMu2Dmx::clear (bool retainGeometry)
 
 size_t ASMu2Dmx::getNoNodes (int basis) const
 {
-  if (basis > (int)nb.size() || basis < 0)
-    basis = 0;
-
-  if (basis == 0)
-    return std::accumulate(nb.begin(), nb.end(), 0);
+  if (basis > (int)nb.size() || basis < 1)
+    return this->ASMbase::getNoNodes(basis);
 
   return nb[basis-1];
 }

--- a/src/ASM/LR/ASMu2Dmx.C
+++ b/src/ASM/LR/ASMu2Dmx.C
@@ -237,6 +237,8 @@ bool ASMu2Dmx::generateFEMTopology ()
   std::cout <<"NEL = "<< nel <<" NNOD = "<< nnod << std::endl;
 #endif
 
+  geo = m_basis[geoBasis-1].get();
+
   return true;
 }
 

--- a/src/ASM/LR/ASMu2Dmx.C
+++ b/src/ASM/LR/ASMu2Dmx.C
@@ -668,3 +668,22 @@ bool ASMu2Dmx::refine (const LR::RefineData& prm,
 
   return true;
 }
+
+
+Vec3 ASMu2Dmx::getCoord (size_t inod) const
+{
+  size_t b = 0;
+  size_t nbb = 0;
+  while (nbb + nb[b] < inod && b < nb.size())
+    nbb += nb[b++];
+  ++b;
+
+  const LR::Basisfunction* basis = this->getBasis(b)->getBasisfunction(inod-nbb-1);
+  if (!basis) {
+    std::cerr << "Asked to get coordinate for node " << inod
+              << ", but only have " << this->getBasis(b)->nBasisFunctions()
+              << " nodes in basis " << b << std::endl;
+    return Vec3();
+  }
+  return Vec3(&(*basis->cp()),nsd);
+}

--- a/src/ASM/LR/ASMu2Dmx.h
+++ b/src/ASM/LR/ASMu2Dmx.h
@@ -72,6 +72,9 @@ public:
   //! \brief Returns the classification of a node.
   //! \param[in] inod 1-based node index local to current patch
   virtual char getNodeType(size_t inod) const;
+  //! \brief Returns the global coordinates for the given node.
+  //! \param[in] inod 1-based node index local to current patch
+  virtual Vec3 getCoord(size_t inod) const;
 
   //! \brief Initializes the patch level MADOF array for mixed problems.
   virtual void initMADOF(const int* sysMadof);


### PR DESCRIPTION
Some fixes for the mixed LR ASM module. I can now run 'mixed' Stokes fine through LR. More stuff will be amended to fix compatible stokes + LR, so hold on the merge (but feel free to review now)!

@kmokstad please have a look at the printing commit.