### PR TITLE
Line search fix and output to correct cout

### DIFF
--- a/src/SIM/EigenModeSIM.C
+++ b/src/SIM/EigenModeSIM.C
@@ -138,7 +138,7 @@ SIM::ConvStatus EigenModeSIM::solveStep (TimeStep& param, SIM::SolutionMode,
   for (size_t i = 0; i < amplitude.size() && i < modes.size(); i++)
     solution.front().add(modes[i].eigVec,amplitude[i]*sin(modes[i].eigVal*t));
 
-  if (msgLevel >= 0 && myPid == 0) std::cout << std::endl;
+  if (msgLevel >= 0) model.getProcessAdm().cout << std::endl;
   return this->solutionNorms(param.time,zero_tolerance,outPrec) ?
     SIM::CONVERGED : SIM::FAILURE;
 }

--- a/src/SIM/NewmarkSIM.C
+++ b/src/SIM/NewmarkSIM.C
@@ -314,12 +314,11 @@ SIM::ConvStatus NewmarkSIM::solveStep (TimeStep& param, SIM::SolutionMode,
 
   if (msgLevel >= 0)
   {
-    std::streamsize oldPrec = 0;
+    utl::LogStream& cout = model.getProcessAdm().cout;
     double digits = log10(param.time.t)-log10(param.time.dt);
-    if (digits > 6.0) oldPrec = IFEM::cout.precision(ceil(digits));
-    IFEM::cout <<"\n  step="<< param.step
-               <<"  time="<< param.time.t << std::endl;
-    if (digits > 6.0) IFEM::cout.precision(oldPrec);
+    size_t stdPrec = digits > 6.0 ? cout.precision(ceil(digits)) : 0;
+    cout <<"\n  step="<< param.step <<"  time="<< param.time.t << std::endl;
+    if (digits > 6.0) cout.precision(stdPrec);
   }
 
   if (subiter&FIRST && !model.updateDirichlet(param.time.t,&solution.front()))
@@ -462,15 +461,16 @@ SIM::ConvStatus NewmarkSIM::checkConvergence (TimeStep& param)
   if (msgLevel > 0)
   {
     // Print convergence history
-    std::ios::fmtflags oldFlags = IFEM::cout.flags(std::ios::scientific);
-    std::streamsize oldPrec = IFEM::cout.precision(3);
-    IFEM::cout <<"  iter="<< param.iter
-               <<"  conv="<< fabs(norm)
-               <<"  enen="<< norms[0]
-               <<"  resn="<< norms[1]
-               <<"  incn="<< norms[2] << std::endl;
-    IFEM::cout.flags(oldFlags);
-    IFEM::cout.precision(oldPrec);
+    utl::LogStream& cout = model.getProcessAdm().cout;
+    std::ios::fmtflags stdFlags = cout.flags(std::ios::scientific);
+    std::streamsize stdPrec = cout.precision(3);
+    cout <<"  iter="<< param.iter
+         <<"  conv="<< fabs(norm)
+         <<"  enen="<< norms[0]
+         <<"  resn="<< norms[1]
+         <<"  incn="<< norms[2] << std::endl;
+    cout.flags(stdFlags);
+    cout.precision(stdPrec);
   }
 
   // Check for convergence or divergence

--- a/src/SIM/NonLinSIM.h
+++ b/src/SIM/NonLinSIM.h
@@ -105,6 +105,7 @@ protected:
   double divgLim; //!< Relative divergence limit
   double eta;     //!< Line search tolerance
   double alpha;   //!< Iteration acceleration parameter (for line search)
+  double alphaO;  //!< Final line search acceleration scaling (for output only)
   int    maxit;   //!< Maximum number of iterations in a load step
   int    maxIncr; //!< Maximum number of iterations with increasing norm
   int    nupdat;  //!< Number of iterations with updated tangent


### PR DESCRIPTION
Two things here:
1. Use the adm.cout for iteration output for all MultiStepSIM drivers (for consistency).
2. Fixed NonLinSIMM::lineSearch method. Now this method works as anticipated.