### PR TITLE
Add support for thick connections

### DIFF
--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -206,12 +206,12 @@ public:
   //! in one element
   virtual bool getElementCoordinates(Matrix& X, int iel) const = 0;
 
-  //! \brief Finds the global numbers of the nodes on a patch boundary.
+  //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
   //! \param[in] lIndex Local index of the boundary face/edge
-  //! \param glbNodes Array of global boundary node numbers
+  //! \param nodes Array of node numbers
   //! \param basis Which basis to grab nodes for (0 for all)
-  virtual void getBoundaryNodes(int lIndex, IntVec& glbNodes,
-                                int basis = 0) const = 0;
+  virtual void getBoundaryNodes(int lIndex, IntVec& nodes,
+                                int basis = 0, bool local = false) const = 0;
 
   //! \brief Finds the node that is closest to the given point.
   virtual std::pair<size_t,double> findClosestNode(const Vec3&) const

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -210,8 +210,11 @@ public:
   //! \param[in] lIndex Local index of the boundary face/edge
   //! \param nodes Array of node numbers
   //! \param basis Which basis to grab nodes for (0 for all)
+  //! \param thick Thickness of connection
+  //! \param local If true, return patch-local numbers
   virtual void getBoundaryNodes(int lIndex, IntVec& nodes,
-                                int basis = 0, bool local = false) const = 0;
+                                int basis = 0, int thick = 1,
+                                bool local = false) const = 0;
 
   //! \brief Finds the node that is closest to the given point.
   virtual std::pair<size_t,double> findClosestNode(const Vec3&) const

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -584,17 +584,20 @@ bool ASMs1D::updateRotations (const Vector& displ, bool reInit)
 }
 
 
-void ASMs1D::getBoundaryNodes (int lIndex, IntVec& glbNodes, int) const
+void ASMs1D::getBoundaryNodes (int lIndex, IntVec& nodes,
+                               int, bool local) const
 {
   if (!curv) return; // silently ignore empty patches
 
   size_t iel = lIndex == 1 ? 0 : nel-1;
   if (MLGE[iel] > 0)
   {
+    int node;
     if (lIndex == 1)
-      glbNodes.push_back(MLGN[MNPC[iel].front()]);
+      node = MNPC[iel].front();
     else if (lIndex == 2)
-      glbNodes.push_back(MLGN[MNPC[iel][curv->order()-1]]);
+      node = MNPC[iel][curv->order()-1];
+    nodes.push_back(local ? node+1 : MLGN[node]);
   }
 }
 

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -322,7 +322,7 @@ bool ASMs1D::connectPatch (int vertex, ASMs1D& neighbor, int nvertex, int thick)
 
 
 bool ASMs1D::connectBasis (int vertex, ASMs1D& neighbor, int nvertex,
-			   int basis, int slave, int master, int thick)
+                           int basis, int slave, int master, int thick)
 {
   if (shareFE && neighbor.shareFE)
     return true;
@@ -348,9 +348,9 @@ bool ASMs1D::connectBasis (int vertex, ASMs1D& neighbor, int nvertex,
     if (!neighbor.getCoord(master).equal(this->getCoord(slave),xtol))
     {
       std::cerr <<" *** ASMs1D::connectBasis: Non-matching nodes "
-	        << master <<": "<< neighbor.getCoord(master)
-	        <<"\n                                          and "
-	        << slave <<": "<< this->getCoord(slave) << std::endl;
+                << master <<": "<< neighbor.getCoord(master)
+                <<"\n                                          and "
+                << slave <<": "<< this->getCoord(slave) << std::endl;
       return false;
     }
     else

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -309,9 +309,11 @@ bool ASMs1D::generateTwistedFEModel (const RealFunc& twist, const Vec3& Zaxis)
 }
 
 
-bool ASMs1D::connectPatch (int vertex, ASMs1D& neighbor, int nvertex)
+bool ASMs1D::connectPatch (int vertex, ASMs1D& neighbor, int nvertex, int thick)
 {
-  if (!this->connectBasis(vertex,neighbor,nvertex))
+  int slave = vertex == 1 ? 0 : this->getSize(1)-thick;
+  int master = nvertex == 1 ? 0 : neighbor.getSize(1)-thick;
+  if (!this->connectBasis(vertex,neighbor,nvertex,1,slave,master,thick))
     return false;
 
   this->addNeighbor(&neighbor);
@@ -320,64 +322,40 @@ bool ASMs1D::connectPatch (int vertex, ASMs1D& neighbor, int nvertex)
 
 
 bool ASMs1D::connectBasis (int vertex, ASMs1D& neighbor, int nvertex,
-			   int basis, int slave, int master)
+			   int basis, int slave, int master, int thick)
 {
   if (shareFE && neighbor.shareFE)
     return true;
   else if (shareFE || neighbor.shareFE)
   {
-    std::cerr <<" *** ASMs1D::connectPatch: Logic error, cannot"
+    std::cerr <<" *** ASMs1D::connectBasis: Logic error, cannot"
 	      <<" connect a sharedFE patch with an unshared one"<< std::endl;
     return false;
-  }
-
-  // Set up the slave node number for this curve patch
-
-  int n1 = this->getSize(basis);
-
-  switch (vertex)
-    {
-    case 2: // Positive I-direction
-      slave += n1;
-    case 1: // Negative I-direction
-      slave += 1;
-      break;
-
-    default:
-      std::cerr <<" *** ASMs1D::connectPatch: Invalid slave vertex "
-		<< vertex << std::endl;
-      return false;
-    }
-
-  // Set up the master node number for the neighboring patch
-
-  n1 = neighbor.getSize(basis);
-
-  switch (nvertex)
-    {
-    case 2: // Positive I-direction
-      master += n1;
-    case 1: // Negative I-direction
-      master += 1;
-      break;
-
-    default:
-      std::cerr <<" *** ASMs1D::connectPatch: Invalid master vertex "
-		<< nvertex << std::endl;
-      return false;
-    }
-
-  const double xtol = 1.0e-4;
-  if (!neighbor.getCoord(master).equal(this->getCoord(slave),xtol))
-  {
-    std::cerr <<" *** ASMs1D::connectPatch: Non-matching nodes "
-	      << master <<": "<< neighbor.getCoord(master)
-	      <<"\n                                          and "
-	      << slave <<": "<< this->getCoord(slave) << std::endl;
+  } else if (vertex < 1 || vertex > 2) {
+    std::cerr <<" *** ASMs1D::connectBasis: Invalid slave vertex "
+              << vertex << std::endl;
+    return false;
+  } else if (nvertex < 1 || nvertex > 2) {
+    std::cerr <<" *** ASMs1D::connectBasis: Invalid master vertex "
+              << nvertex << std::endl;
     return false;
   }
-  else
-    ASMbase::collapseNodes(neighbor,master,*this,slave);
+
+  const double xtol = 1.0e-4;
+  for (int i = 0; i < thick; ++i) {
+    slave += 1; // add first, getCoord is 1-based
+    master += 1;
+    if (!neighbor.getCoord(master).equal(this->getCoord(slave),xtol))
+    {
+      std::cerr <<" *** ASMs1D::connectBasis: Non-matching nodes "
+	        << master <<": "<< neighbor.getCoord(master)
+	        <<"\n                                          and "
+	        << slave <<": "<< this->getCoord(slave) << std::endl;
+      return false;
+    }
+    else
+      ASMbase::collapseNodes(neighbor,master,*this,slave);
+  }
 
   return true;
 }
@@ -585,19 +563,21 @@ bool ASMs1D::updateRotations (const Vector& displ, bool reInit)
 
 
 void ASMs1D::getBoundaryNodes (int lIndex, IntVec& nodes,
-                               int, bool local) const
+                               int, int thick, bool local) const
 {
   if (!curv) return; // silently ignore empty patches
 
   size_t iel = lIndex == 1 ? 0 : nel-1;
   if (MLGE[iel] > 0)
   {
-    int node;
-    if (lIndex == 1)
-      node = MNPC[iel].front();
-    else if (lIndex == 2)
-      node = MNPC[iel][curv->order()-1];
-    nodes.push_back(local ? node+1 : MLGN[node]);
+    for (int i = 0; i < thick; ++i) {
+      int node;
+      if (lIndex == 1)
+        node = MNPC[iel][i];
+      else if (lIndex == 2)
+        node = MNPC[iel][curv->order()-thick+i];
+      nodes.push_back(local ? node+1 : MLGN[node]);
+    }
   }
 }
 

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -301,7 +301,7 @@ protected:
   //! \param[in] master 0-based index of the first master node in this basis
   //! \param[in] thick Thickness of connection
   bool connectBasis(int vertex, ASMs1D& neighbor, int nvertex,
-		    int basis = 1, int slave = 0, int master = 0, int thick = 1);
+                    int basis = 1, int slave = 0, int master = 0, int thick = 1);
 
   //! \brief Extracts parameter values of the Gauss points.
   //! \param[out] uGP Parameter values for all points

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -105,10 +105,12 @@ public:
   //! \brief Updates the previous nodal rotations for this patch at convergence.
   void updateRotations() { prevT = myT; }
 
-  //! \brief Finds the global number of the node on a patch end.
+  //! \brief Finds the global (or patch-local) node number on a patch end.
   //! \param[in] lIndex Local index of the end point
-  //! \param glbNodes Array of global boundary node numbers
-  virtual void getBoundaryNodes(int lIndex, IntVec& glbNodes, int) const;
+  //! \param nodes Array of global boundary node numbers
+  //! \param local If \e true, return patch-local node numbers
+  virtual void getBoundaryNodes(int lIndex, IntVec& nodes,
+                                int, bool local) const;
 
   //! \brief Finds the node that is closest to the given point.
   //! \param[in] X Global coordinates of point to search for

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -108,9 +108,10 @@ public:
   //! \brief Finds the global (or patch-local) node number on a patch end.
   //! \param[in] lIndex Local index of the end point
   //! \param nodes Array of global boundary node numbers
+  //! \param thick Thickness of connection
   //! \param local If \e true, return patch-local node numbers
   virtual void getBoundaryNodes(int lIndex, IntVec& nodes,
-                                int, bool local) const;
+                                int, int thick, bool local) const;
 
   //! \brief Finds the node that is closest to the given point.
   //! \param[in] X Global coordinates of point to search for
@@ -149,7 +150,9 @@ public:
   //! \param[in] vertex Local vertex index of this patch, in range [1,2]
   //! \param neighbor The neighbor patch
   //! \param[in] nvertex Local vertex index of neighbor patch, in range [1,2]
-  virtual bool connectPatch(int vertex, ASMs1D& neighbor, int nvertex);
+  //! \param[in] thick Thickness of connection
+  virtual bool connectPatch(int vertex, ASMs1D& neighbor, int nvertex,
+                            int thick = 1);
 
   //! \brief Makes the two end vertices of the curve periodic.
   //! \param[in] basis Which basis to connect (mixed methods), 0 means both
@@ -296,8 +299,9 @@ protected:
   //! \param[in] basis Which basis to connect the nodes for (mixed methods)
   //! \param[in] slave 0-based index of the first slave node in this basis
   //! \param[in] master 0-based index of the first master node in this basis
+  //! \param[in] thick Thickness of connection
   bool connectBasis(int vertex, ASMs1D& neighbor, int nvertex,
-		    int basis = 1, int slave = 0, int master = 0);
+		    int basis = 1, int slave = 0, int master = 0, int thick = 1);
 
   //! \brief Extracts parameter values of the Gauss points.
   //! \param[out] uGP Parameter values for all points

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -1292,7 +1292,7 @@ bool ASMs2D::updateCoords (const Vector& displ)
 }
 
 
-void ASMs2D::getBoundaryNodes (int lIndex, IntVec& nodes, int basis) const
+void ASMs2D::getBoundaryNodes (int lIndex, IntVec& nodes, int basis, bool local) const
 {
   if (basis == 0)
     basis = 1;
@@ -1316,14 +1316,14 @@ void ASMs2D::getBoundaryNodes (int lIndex, IntVec& nodes, int basis) const
       node += n1-1;
     case 1: // Left edge (negative I-direction)
       for (int i2 = 1; i2 <= n2; i2++, node += n1)
-        nodes.push_back(getNodeID(node));
+        nodes.push_back(local ? node : this->getNodeID(node));
       break;
 
     case  4: // Back edge (positive J-direction)
       node += n1*(n2-1);
     case  3: // Front edge (negative J-direction)
       for (int i1 = 1; i1 <= n1; i1++, node++)
-        nodes.push_back(getNodeID(node));
+        nodes.push_back(local ? node : this->getNodeID(node));
       break;
     }
 

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -635,7 +635,7 @@ bool ASMs2D::connectBasis (int edge, ASMs2D& neighbor, int nedge, bool revers,
   if (masterNodes.size() != slaveNodes.size())
   {
     std::cerr <<" *** ASMs2D::connectBasis: Non-matching edges, sizes "
-	      << masterNodes.size() <<" and "<< slaveNodes.size() << std::endl;
+              << masterNodes.size() <<" and "<< slaveNodes.size() << std::endl;
     return false;
   }
 

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -183,9 +183,11 @@ public:
   //! \param[in] lIndex Local index of the boundary edge
   //! \param nodes Array of node numbers
   //! \param basis Which basis to grab nodes for (0 for all)
-  //! \param local If \e true, return patch-local node numbers
+  //! \param thick Thickness of connection
+  //! \param local If \e true return patch-local node numbers
   virtual void getBoundaryNodes(int lIndex, IntVec& nodes,
-                                int basis, bool local) const;
+                                int basis, int thick = 1,
+                                bool local = false) const;
 
   //! \brief Returns the node index for a given corner.
   virtual int getCorner(int I, int J, int basis = 1) const;
@@ -273,8 +275,9 @@ public:
   //! \param[in] nedge Local edge index of neighbor patch, in range [1,4]
   //! \param[in] revers Indicates whether the two edges have opposite directions
   //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
+  //! \param[in] thick Thickness of connection
   virtual bool connectPatch(int edge, ASMs2D& neighbor, int nedge, bool revers,
-                            int = 0, bool coordCheck = true);
+                            int = 0, bool coordCheck = true, int thick = 1);
 
   //! \brief Makes two opposite boundary edges periodic.
   //! \param[in] dir Parameter direction defining the periodic edges
@@ -480,9 +483,10 @@ protected:
   //! \param[in] slave 0-based index of the first slave node in this basis
   //! \param[in] master 0-based index of the first master node in this basis
   //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
+  //! \param[in] thick Thickness of connection
   bool connectBasis(int edge, ASMs2D& neighbor, int nedge, bool revers,
                     int basis = 1, int slave = 0, int master = 0,
-                    bool coordCheck = true);
+                    bool coordCheck = true, int thick = 1);
 
   //! \brief Extracts parameter values of the Gauss points in one direction.
   //! \param[out] uGP Parameter values in given direction for all points

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -179,11 +179,13 @@ public:
   //! \param[in] displ Incremental displacements to update the coordinates with
   virtual bool updateCoords(const Vector& displ);
 
-  //! \brief Finds the global numbers of the nodes on a patch boundary.
+  //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
   //! \param[in] lIndex Local index of the boundary edge
-  //! \param glbNodes Array of global boundary node numbers
-  //! \param basis Which basis to grab nodes for
-  virtual void getBoundaryNodes(int lIndex, IntVec& glbNodes, int basis) const;
+  //! \param nodes Array of node numbers
+  //! \param basis Which basis to grab nodes for (0 for all)
+  //! \param local If \e true, return patch-local node numbers
+  virtual void getBoundaryNodes(int lIndex, IntVec& nodes,
+                                int basis, bool local) const;
 
   //! \brief Returns the node index for a given corner.
   virtual int getCorner(int I, int J, int basis = 1) const;

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -293,7 +293,7 @@ bool ASMs2Dmx::generateFEMTopology ()
 
 
 bool ASMs2Dmx::connectPatch (int edge, ASMs2D& neighbor, int nedge, bool revers,
-                             int basis, bool coordCheck)
+                             int basis, bool coordCheck, int thick)
 {
   ASMs2Dmx* neighMx = dynamic_cast<ASMs2Dmx*>(&neighbor);
   if (!neighMx) return false;
@@ -301,7 +301,7 @@ bool ASMs2Dmx::connectPatch (int edge, ASMs2D& neighbor, int nedge, bool revers,
   size_t nb1 = 0, nb2 = 0;
   for (size_t i = 1; i <= m_basis.size(); ++i) {
     if (basis == 0 || i == (size_t)basis)
-      if (!this->connectBasis(edge,neighbor,nedge,revers,i,nb1,nb2,coordCheck))
+      if (!this->connectBasis(edge,neighbor,nedge,revers,i,nb1,nb2,coordCheck,thick))
         return false;
 
     nb1 += nb[i-1];
@@ -1014,12 +1014,12 @@ void ASMs2Dmx::generateThreadGroups (const Integrand& integrand, bool silence,
 }
 
 
-void ASMs2Dmx::getBoundaryNodes (int lIndex, IntVec& nodes,
-                                 int basis, bool local) const
+void ASMs2Dmx::getBoundaryNodes (int lIndex, IntVec& nodes, int basis,
+                                 int thick, bool local) const
 {
   if (basis > 0)
-    this->ASMs2D::getBoundaryNodes(lIndex, nodes, basis, local);
+    this->ASMs2D::getBoundaryNodes(lIndex, nodes, basis, thick, local);
   else
     for (size_t b = 1; b <= this->getNoBasis(); ++b)
-      this->ASMs2D::getBoundaryNodes(lIndex, nodes, b, local);
+      this->ASMs2D::getBoundaryNodes(lIndex, nodes, b, thick, local);
 }

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -1014,11 +1014,12 @@ void ASMs2Dmx::generateThreadGroups (const Integrand& integrand, bool silence,
 }
 
 
-void ASMs2Dmx::getBoundaryNodes (int lIndex, IntVec& nodes, int basis) const
+void ASMs2Dmx::getBoundaryNodes (int lIndex, IntVec& nodes,
+                                 int basis, bool local) const
 {
   if (basis > 0)
-    this->ASMs2D::getBoundaryNodes(lIndex, nodes, basis);
+    this->ASMs2D::getBoundaryNodes(lIndex, nodes, basis, local);
   else
     for (size_t b = 1; b <= this->getNoBasis(); ++b)
-      this->ASMs2D::getBoundaryNodes(lIndex, nodes, b);
+      this->ASMs2D::getBoundaryNodes(lIndex, nodes, b, local);
 }

--- a/src/ASM/ASMs2Dmx.h
+++ b/src/ASM/ASMs2Dmx.h
@@ -208,11 +208,12 @@ public:
   //! \param[in] basis Which basis to return size parameters for
   virtual bool getSize(int& n1, int& n2, int basis = 0) const;
 
-  //! \brief Finds the global numbers of the nodes on a patch boundary.
+  //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
   //! \param[in] lIndex Local index of the boundary edge
-  //! \param glbNodes Array of global boundary node numbers
+  //! \param nodes Array of node numbers
   //! \param basis Which basis to grab nodes for (0 for all)
-  virtual void getBoundaryNodes(int lIndex, IntVec& glbNodes, int basis) const;
+  virtual void getBoundaryNodes(int lIndex, IntVec& nodes,
+                                int basis, bool local = false) const;
 
 protected:
   std::vector<std::shared_ptr<Go::SplineSurface>> m_basis; //!< Vector of bases

--- a/src/ASM/ASMs2Dmx.h
+++ b/src/ASM/ASMs2Dmx.h
@@ -103,8 +103,9 @@ public:
   //! \param[in] revers Indicates whether the two edges have opposite directions
   //! \param[in] basis The basis to connect (for mixed problems)
   //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
+  //! \param[in] thick Thickness of connection
   virtual bool connectPatch(int edge, ASMs2D& neighbor, int nedge, bool revers,
-                            int basis = 0, bool coordCheck = true);
+                            int basis = 0, bool coordCheck = true, int thick = 1);
 
   //! \brief Makes two opposite boundary edges periodic.
   //! \param[in] dir Parameter direction defining the periodic edges
@@ -212,8 +213,10 @@ public:
   //! \param[in] lIndex Local index of the boundary edge
   //! \param nodes Array of node numbers
   //! \param basis Which basis to grab nodes for (0 for all)
-  virtual void getBoundaryNodes(int lIndex, IntVec& nodes,
-                                int basis, bool local = false) const;
+  //! \param thick Thickness of connection
+  //! \param local If \e true return patch-local node numbers
+  virtual void getBoundaryNodes(int lIndex, IntVec& nodes, int basis,
+                                int thick = 1, bool local = false) const;
 
 protected:
   std::vector<std::shared_ptr<Go::SplineSurface>> m_basis; //!< Vector of bases

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -1542,7 +1542,8 @@ bool ASMs3D::updateCoords (const Vector& displ)
 }
 
 
-void ASMs3D::getBoundaryNodes (int lIndex, IntVec& nodes, int basis) const
+void ASMs3D::getBoundaryNodes (int lIndex, IntVec& nodes,
+                               int basis, bool local) const
 {
   if (basis == 0)
     basis = 1;
@@ -1562,7 +1563,7 @@ void ASMs3D::getBoundaryNodes (int lIndex, IntVec& nodes, int basis) const
     case 1: // Left face (negative I-direction)
       for (int i3 = 1; i3 <= n3; i3++)
 	for (int i2 = 1; i2 <= n2; i2++, node += n1)
-          nodes.push_back(getNodeID(node));
+          nodes.push_back(local ? node : this->getNodeID(node));
       break;
 
     case 4: // Back face (positive J-direction)
@@ -1570,7 +1571,7 @@ void ASMs3D::getBoundaryNodes (int lIndex, IntVec& nodes, int basis) const
     case 3: // Front face (negative J-direction)
       for (int i3 = 1; i3 <= n3; i3++, node += n1*(n2-1))
 	for (int i1 = 1; i1 <= n1; i1++, node++)
-          nodes.push_back(getNodeID(node));
+          nodes.push_back(local ? node : this->getNodeID(node));
       break;
 
     case 6: // Top face (positive K-direction)
@@ -1578,7 +1579,7 @@ void ASMs3D::getBoundaryNodes (int lIndex, IntVec& nodes, int basis) const
     case 5: // Bottom face (negative K-direction)
       for (int i2 = 1; i2 <= n2; i2++)
 	for (int i1 = 1; i1 <= n1; i1++, node++)
-          nodes.push_back(getNodeID(node));
+          nodes.push_back(local ? node : this->getNodeID(node));
       break;
   }
 

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -662,7 +662,7 @@ bool ASMs3D::connectBasis (int face, ASMs3D& neighbor, int nface, int norient,
   if (!this->getFaceSize(m1,m2,basis,face)) return false;
 
   int n1, n2;
-  if (!neighbor.getFaceSize(n1,n2,basis,face)) return false;
+  if (!neighbor.getFaceSize(n1,n2,basis,nface)) return false;
 
   // Set up the slave node numbers for this volume patch
   IntVec slaveNodes;

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -654,7 +654,7 @@ bool ASMs3D::connectBasis (int face, ASMs3D& neighbor, int nface, int norient,
     return false;
   } else if (norient < 0 || norient > 7) {
     std::cerr <<" *** ASMs3D::connectPatch: Orientation flag "
-	      << norient <<" is out of range [0,7]"<< std::endl;
+              << norient <<" is out of range [0,7]"<< std::endl;
     return false;
   }
 

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -658,22 +658,11 @@ bool ASMs3D::connectBasis (int face, ASMs3D& neighbor, int nface, int norient,
     return false;
   }
 
-  // lambda function to set correct dimension of face
-  auto&& correctSizes = [](int& n1, int& n2, int& n3, int face)
-                  {
-                    if (face == 1 || face == 2)
-                      n1 = n2, n2 = n3;
-                    else if (face == 3 || face == 4)
-                      n2 = n3;
-                  };
+  int m1, m2;
+  if (!this->getFaceSize(m1,m2,basis,face)) return false;
 
-  int m1, m2, m3;
-  if (!this->getSize(m1,m2,m3,basis)) return false;
-  correctSizes(m1,m2,m3,face);
-
-  int n1, n2, n3;
-  if (!neighbor.getSize(n1,n2,n3,basis)) return false;
-  correctSizes(n1,n2,n3,nface);
+  int n1, n2;
+  if (!neighbor.getFaceSize(n1,n2,basis,face)) return false;
 
   // Set up the slave node numbers for this volume patch
   IntVec slaveNodes;
@@ -3206,4 +3195,19 @@ int ASMs3D::getCorner (int I, int J, int K, int basis) const
   if (K > 0) node += n1*n2*(n3-1);
 
   return node;
+}
+
+
+bool ASMs3D::getFaceSize(int& n1, int& n2, int basis, int face) const
+{
+  int n3;
+  if (!this->getSize(n1,n2,n3,basis))
+    return false;
+
+  if (face == 1 || face == 2)
+    n1 = n2, n2 = n3;
+  else if (face == 3 || face == 4)
+    n2 = n3;
+
+  return true;
 }

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -617,7 +617,7 @@ bool ASMs3D::assignNodeNumbers (BlockNodes& nodes, int basis)
 
 
 bool ASMs3D::connectPatch (int face, ASMs3D& neighbor, int nface,
-                           int norient, int, bool coordCheck)
+                           int norient, int, bool coordCheck, int thick)
 {
   if (swapW && face > 4) // Account for swapped parameter direction
     face = 11-face;
@@ -625,7 +625,7 @@ bool ASMs3D::connectPatch (int face, ASMs3D& neighbor, int nface,
   if (neighbor.swapW && nface > 4) // Account for swapped parameter direction
     nface = 11-nface;
 
-  if (!this->connectBasis(face,neighbor,nface,norient,1,0,0,coordCheck))
+  if (!this->connectBasis(face,neighbor,nface,norient,1,0,0,coordCheck,thick))
     return false;
 
   this->addNeighbor(&neighbor);
@@ -634,7 +634,8 @@ bool ASMs3D::connectPatch (int face, ASMs3D& neighbor, int nface,
 
 
 bool ASMs3D::connectBasis (int face, ASMs3D& neighbor, int nface, int norient,
-                           int basis, int slave, int master, bool coordCheck)
+                           int basis, int slave, int master,
+                           bool coordCheck, int thick)
 {
   if (this->isShared() && neighbor.isShared())
     return true;
@@ -643,94 +644,49 @@ bool ASMs3D::connectBasis (int face, ASMs3D& neighbor, int nface, int norient,
     std::cerr <<" *** ASMs3D::connectPatch: Logic error, cannot"
 	      <<" connect a shared patch with an unshared one"<< std::endl;
     return false;
-  }
-
-  // Set up the slave node numbers for this volume patch
-
-  int n1, n2, n3;
-  if (!this->getSize(n1,n2,n3,basis)) return false;
-  int node = slave+1, i1 = 0, i2 = 0;
-
-  switch (face)
-    {
-    case 2: // Positive I-direction
-      node += n1-1;
-    case 1: // Negative I-direction
-      i1 = n1;
-      n1 = n2;
-      n2 = n3;
-      break;
-
-    case 4: // Positive J-direction
-      node += n1*(n2-1);
-    case 3: // Negative J-direction
-      i2 = n1*(n2-1);
-      i1 = 1;
-      n2 = n3;
-      break;
-
-    case 6: // Positive K-direction
-      node += n1*n2*(n3-1);
-    case 5: // Negative K-direction
-      i1 = 1;
-      break;
-
-    default:
-      std::cerr <<" *** ASMs3D::connectPatch: Invalid slave face "
-		<< face << std::endl;
-      return false;
-    }
-
-  int i, j;
-  IntMat slaveNodes(n1,IntVec(n2,0));
-  for (j = 0; j < n2; j++, node += i2)
-    for (i = 0; i < n1; i++, node += i1)
-      slaveNodes[i][j] = node;
-
-  // Set up the master node numbers for the neighboring volume patch
-
-  if (!neighbor.getSize(n1,n2,n3,basis)) return false;
-  node = master+1; i1 = i2 = 0;
-
-  switch (nface)
-    {
-    case 2: // Positive I-direction
-      node += n1-1;
-    case 1: // Negative I-direction
-      i1 = n1;
-      n1 = n2;
-      n2 = n3;
-      break;
-
-    case 4: // Positive J-direction
-      node += n1*(n2-1);
-    case 3: // Negative J-direction
-      i2 = n1*(n2-1);
-      i1 = 1;
-      n2 = n3;
-      break;
-
-    case 6: // Positive K-direction
-      node += n1*n2*(n3-1);
-    case 5: // Negative K-direction
-      i1 = 1;
-      break;
-
-    default:
-      std::cerr <<" *** ASMs3D::connectPatch: Invalid master face "
-		<< nface << std::endl;
-      return false;
-    }
-
-  if (norient < 0 || norient > 7)
-  {
+  } else if (face < 1 || face > 6) {
+    std::cerr <<" *** ASMs3D::connectPatch: Invalid slave face "
+              << face << std::endl;
+    return false;
+  } else if (nface < 1 || nface > 6) {
+    std::cerr <<" *** ASMs3D::connectPatch: Invalid master face "
+              << nface << std::endl;
+    return false;
+  } else if (norient < 0 || norient > 7) {
     std::cerr <<" *** ASMs3D::connectPatch: Orientation flag "
 	      << norient <<" is out of range [0,7]"<< std::endl;
     return false;
   }
 
-  int m1 = slaveNodes.size();
-  int m2 = slaveNodes.front().size();
+  // lambda function to set correct dimension of face
+  auto&& correctSizes = [](int& n1, int& n2, int& n3, int face)
+                  {
+                    if (face == 1 || face == 2)
+                      n1 = n2, n2 = n3;
+                    else if (face == 3 || face == 4)
+                      n2 = n3;
+                  };
+
+  int m1, m2, m3;
+  if (!this->getSize(m1,m2,m3,basis)) return false;
+  correctSizes(m1,m2,m3,face);
+
+  int n1, n2, n3;
+  if (!neighbor.getSize(n1,n2,n3,basis)) return false;
+  correctSizes(n1,n2,n3,nface);
+
+  // Set up the slave node numbers for this volume patch
+  IntVec slaveNodes;
+  this->getBoundaryNodes(face, slaveNodes, basis, thick, true);
+  for (int& it : slaveNodes)
+    it += slave;
+
+  // Set up the master node numbers for the neighboring volume patch
+  IntVec masterNodes;
+  neighbor.getBoundaryNodes(nface, masterNodes, basis, thick, true);
+  for (int& it : masterNodes)
+    it += master;
+
   if (norient < 4 ? (n1 != m1 || n2 != m2) : (n2 != m1 || n1 != m2))
   {
     std::cerr <<" *** ASMs3D::connectPatch: Non-matching faces, sizes "
@@ -739,8 +695,9 @@ bool ASMs3D::connectBasis (int face, ASMs3D& neighbor, int nface, int norient,
   }
 
   const double xtol = 1.0e-4;
-  for (j = 0; j < n2; j++, node += i2)
-    for (i = 0; i < n1; i++, node += i1)
+  int node = 1;
+  for (int j = 0; j < n2; j++)
+    for (int i = 0; i < n1; i++, ++node)
     {
       int k = i, l = j;
       switch (norient)
@@ -755,18 +712,22 @@ bool ASMs3D::connectBasis (int face, ASMs3D& neighbor, int nface, int norient,
 	default: k =    i  ; l = j     ;
 	}
 
-      int slave = slaveNodes[k][l];
-      if (!coordCheck)
-        ASMbase::collapseNodes(neighbor,node,*this,slave);
-      else if (neighbor.getCoord(node).equal(this->getCoord(slave),xtol))
-        ASMbase::collapseNodes(neighbor,node,*this,slave);
-      else
+      for (int t = 0; t < thick; ++t)
       {
-	std::cerr <<" *** ASMs3D::connectPatch: Non-matching nodes "
-		  << node <<": "<< neighbor.getCoord(node)
-		  <<"\n                                          and "
-		  << slave <<": "<< this->getCoord(slave) << std::endl;
-	return false;
+        int slave = slaveNodes[(l*n1+k)*thick+t];
+        int node2 = masterNodes[(node-1)*thick+t];
+        if (!coordCheck)
+          ASMbase::collapseNodes(neighbor,node2,*this,slave);
+        else if (neighbor.getCoord(node2).equal(this->getCoord(slave),xtol))
+          ASMbase::collapseNodes(neighbor,node2,*this,slave);
+        else
+        {
+          std::cerr <<" *** ASMs3D::connectPatch: Non-matching nodes "
+                    << node2 <<": "<< neighbor.getCoord(node2)
+                    <<"\n                                          and "
+                    << slave <<": "<< this->getCoord(slave) << std::endl;
+          return false;
+        }
       }
     }
 
@@ -1543,7 +1504,7 @@ bool ASMs3D::updateCoords (const Vector& displ)
 
 
 void ASMs3D::getBoundaryNodes (int lIndex, IntVec& nodes,
-                               int basis, bool local) const
+                               int basis, int thick, bool local) const
 {
   if (basis == 0)
     basis = 1;
@@ -1556,30 +1517,36 @@ void ASMs3D::getBoundaryNodes (int lIndex, IntVec& nodes,
 
   int n1, n2, n3;
   int node = this->findStartNode(n1,n2,n3,basis);
+  if (local)
+    node = 1;
+
   switch (lIndex)
   {
     case 2: // Right face (positive I-direction)
-      node += n1-1;
+      node += n1-thick;
     case 1: // Left face (negative I-direction)
       for (int i3 = 1; i3 <= n3; i3++)
 	for (int i2 = 1; i2 <= n2; i2++, node += n1)
-          nodes.push_back(local ? node : this->getNodeID(node));
+          for (int t = 0; t < thick; ++t)
+            nodes.push_back(local ? node+t : this->getNodeID(node+t));
       break;
 
     case 4: // Back face (positive J-direction)
-      node += n1*(n2-1);
+      node += n1*(n2-thick);
     case 3: // Front face (negative J-direction)
       for (int i3 = 1; i3 <= n3; i3++, node += n1*(n2-1))
 	for (int i1 = 1; i1 <= n1; i1++, node++)
-          nodes.push_back(local ? node : this->getNodeID(node));
+          for (int t = 0; t < thick; ++t)
+            nodes.push_back(local ? node+t*n1 : this->getNodeID(node+t*n1));
       break;
 
     case 6: // Top face (positive K-direction)
-      node += n1*n2*(n3-1);
+      node += n1*n2*(n3-thick);
     case 5: // Bottom face (negative K-direction)
       for (int i2 = 1; i2 <= n2; i2++)
 	for (int i1 = 1; i1 <= n1; i1++, node++)
-          nodes.push_back(local ? node : this->getNodeID(node));
+          for (int t = 0; t < thick; ++t)
+            nodes.push_back(local ? node+t*n1*n2 : this->getNodeID(node+t*n1*n2));
       break;
   }
 

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -201,7 +201,7 @@ public:
   //! \param basis Which basis to grab nodes for (0 for all)
   //! \param thick Thickness of connection
   //! \param local If true return patch-local node numbers
-  virtual void getBoundaryNodes(int lIndex, IntVec& glbNodes,
+  virtual void getBoundaryNodes(int lIndex, IntVec& nodes,
                                 int basis, int thick = 1,
                                 bool local = false) const;
 

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -195,11 +195,13 @@ public:
   //! \param[in] displ Incremental displacements to update the coordinates with
   virtual bool updateCoords(const Vector& displ);
 
-  //! \brief Finds the global numbers of the nodes on a patch boundary.
+  //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
   //! \param[in] lIndex Local index of the boundary face
-  //! \param glbNodes Array of global boundary node numbers
+  //! \param nodes Array of node numbers
   //! \param basis Which basis to grab nodes for (0 for all)
-  virtual void getBoundaryNodes(int lIndex, IntVec& glbNodes, int basis) const;
+  //! \param local If \e true, return patch-local node numbers
+  virtual void getBoundaryNodes(int lIndex, IntVec& glbNodes, int basis,
+                                bool local) const;
 
   //! \brief Returns the node index for a given corner.
   virtual int getCorner(int I, int J, int K, int basis = 1) const;

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -687,6 +687,13 @@ private:
   //! \return 1-based index of start node for basis
   int findStartNode(int& n1, int& n2, int& n3, char basis) const;
 
+  //! \brief Find local sizes for a given face.
+  //! \param[out] n1 Number of nodes in first local parameter direction on face
+  //! \param[out] n2 Number of nodes in second local parameter direction face
+  //! \param[in] basis Basis to obtain sizes for
+  //! \param[in] face Face to obtain sizes for
+  bool getFaceSize(int& n1, int& n2, int basis, int face) const;
+
 protected:
   Go::SplineVolume* svol;  //!< Pointer to the actual spline volume object
   bool              swapW; //!< Has the w-parameter direction been swapped?

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -199,9 +199,11 @@ public:
   //! \param[in] lIndex Local index of the boundary face
   //! \param nodes Array of node numbers
   //! \param basis Which basis to grab nodes for (0 for all)
-  //! \param local If \e true, return patch-local node numbers
-  virtual void getBoundaryNodes(int lIndex, IntVec& glbNodes, int basis,
-                                bool local) const;
+  //! \param thick Thickness of connection
+  //! \param local If true return patch-local node numbers
+  virtual void getBoundaryNodes(int lIndex, IntVec& glbNodes,
+                                int basis, int thick = 1,
+                                bool local = false) const;
 
   //! \brief Returns the node index for a given corner.
   virtual int getCorner(int I, int J, int K, int basis = 1) const;
@@ -326,6 +328,7 @@ public:
   //! \param[in] nface Local face index of neighbor patch, in range [1,6]
   //! \param[in] norient Relative face orientation flag (see below)
   //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
+  //! \param[in] thick Thickness of connection
   //!
   //! \details The face orientation flag \a norient must be in range [0,7].
   //! When interpreted as a binary number, its 3 digits are decoded as follows:
@@ -333,7 +336,7 @@ public:
   //! - middle digit = 1: Parameter \a u in neighbor patch face is reversed
   //! - right digit = 1: Parameter \a v in neighbor patch face is reversed
   virtual bool connectPatch(int face, ASMs3D& neighbor, int nface, int norient,
-                            int = 0, bool coordCheck = true);
+                            int = 0, bool coordCheck = true, int thick = 1);
 
   //! \brief Makes two opposite boundary faces periodic.
   //! \param[in] dir Parameter direction defining the periodic faces
@@ -544,9 +547,10 @@ protected:
   //! \param[in] slave 0-based index of the first slave node in this basis
   //! \param[in] master 0-based index of the first master node in this basis
   //! \param[in] coordCheck False to turn off coordinate checks
+  //! \param[in] thick Thickness of connection
   bool connectBasis(int face, ASMs3D& neighbor, int nface, int norient,
                     int basis = 1, int slave = 0, int master = 0,
-                    bool coordCheck = true);
+                    bool coordCheck = true, int thick = 1);
 
   //! \brief Extracts parameter values of the Gauss points in one direction.
   //! \param[out] uGP Parameter values in given direction for all points

--- a/src/ASM/ASMs3Dmx.C
+++ b/src/ASM/ASMs3Dmx.C
@@ -299,7 +299,7 @@ bool ASMs3Dmx::generateFEMTopology ()
 
 
 bool ASMs3Dmx::connectPatch (int face, ASMs3D& neighbor, int nface, int norient,
-                             int basis, bool coordCheck)
+                             int basis, bool coordCheck, int thick)
 {
   ASMs3Dmx* neighMx = dynamic_cast<ASMs3Dmx*>(&neighbor);
   if (!neighMx) return false;
@@ -313,7 +313,7 @@ bool ASMs3Dmx::connectPatch (int face, ASMs3D& neighbor, int nface, int norient,
   size_t nb1 = 0, nb2 = 0;
   for (size_t i = 1; i <= m_basis.size(); ++i) {
     if (basis == 0 || i == (size_t)basis)
-      if (!this->connectBasis(face,neighbor,nface,norient,i,nb1,nb2,coordCheck))
+      if (!this->connectBasis(face,neighbor,nface,norient,i,nb1,nb2,coordCheck,thick))
         return false;
 
     nb1 += nb[i-1];
@@ -1109,12 +1109,12 @@ double ASMs3Dmx::getParametricArea (int iel, int dir) const
 }
 
 
-void ASMs3Dmx::getBoundaryNodes (int lIndex, IntVec& nodes,
-                                 int basis, bool local) const
+void ASMs3Dmx::getBoundaryNodes (int lIndex, IntVec& nodes, int basis,
+                                 int thick, bool local) const
 {
   if (basis > 0)
-    this->ASMs3D::getBoundaryNodes(lIndex, nodes, basis, local);
+    this->ASMs3D::getBoundaryNodes(lIndex, nodes, basis, thick, local);
   else
     for (size_t b = 1; b <= this->getNoBasis(); ++b)
-      this->ASMs3D::getBoundaryNodes(lIndex, nodes, b, local);
+      this->ASMs3D::getBoundaryNodes(lIndex, nodes, b, thick, local);
 }

--- a/src/ASM/ASMs3Dmx.C
+++ b/src/ASM/ASMs3Dmx.C
@@ -1109,11 +1109,12 @@ double ASMs3Dmx::getParametricArea (int iel, int dir) const
 }
 
 
-void ASMs3Dmx::getBoundaryNodes (int lIndex, IntVec& nodes, int basis) const
+void ASMs3Dmx::getBoundaryNodes (int lIndex, IntVec& nodes,
+                                 int basis, bool local) const
 {
   if (basis > 0)
-    this->ASMs3D::getBoundaryNodes(lIndex, nodes, basis);
+    this->ASMs3D::getBoundaryNodes(lIndex, nodes, basis, local);
   else
     for (size_t b = 1; b <= this->getNoBasis(); ++b)
-      this->ASMs3D::getBoundaryNodes(lIndex, nodes, b);
+      this->ASMs3D::getBoundaryNodes(lIndex, nodes, b, local);
 }

--- a/src/ASM/ASMs3Dmx.h
+++ b/src/ASM/ASMs3Dmx.h
@@ -96,6 +96,7 @@ public:
   //! \param[in] norient Relative face orientation flag (see class ASMs3D)
   //! \param[in] basis Which basis to connect, or 0 for all.
   //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
+  //! \param[in] thick Thickness of connection
   virtual bool connectPatch(int face, ASMs3D& neighbor, int nface, int norient,
                             int basis = 0, bool coordCheck = true, int thick = 1);
 

--- a/src/ASM/ASMs3Dmx.h
+++ b/src/ASM/ASMs3Dmx.h
@@ -214,11 +214,13 @@ protected:
   //! \param[in] dir Local face index of the boundary face
   double getParametricArea(int iel, int dir) const;
 
-  //! \brief Finds the global numbers of the nodes on a patch boundary.
+  //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
   //! \param[in] lIndex Local index of the boundary edge
-  //! \param glbNodes Array of global boundary node numbers
+  //! \param nodes Array of global boundary node numbers
   //! \param basis Which basis to grab nodes for (0 for all)
-  virtual void getBoundaryNodes(int lIndex, IntVec& glbNodes, int basis = 0) const;
+  //! \param local If \e true, return patch-local node numbers
+  virtual void getBoundaryNodes(int lIndex, IntVec& nodes,
+                                int basis, bool local) const;
 
 private:
   std::vector<std::shared_ptr<Go::SplineVolume>> m_basis; //!< Vector of bases

--- a/src/ASM/ASMs3Dmx.h
+++ b/src/ASM/ASMs3Dmx.h
@@ -97,7 +97,7 @@ public:
   //! \param[in] basis Which basis to connect, or 0 for all.
   //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
   virtual bool connectPatch(int face, ASMs3D& neighbor, int nface, int norient,
-                            int basis = 0, bool coordCheck = true);
+                            int basis = 0, bool coordCheck = true, int thick = 1);
 
   //! \brief Makes two opposite boundary faces periodic.
   //! \param[in] dir Parameter direction defining the periodic faces
@@ -216,11 +216,12 @@ protected:
 
   //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
   //! \param[in] lIndex Local index of the boundary edge
-  //! \param nodes Array of global boundary node numbers
+  //! \param nodes Array of node numbers
   //! \param basis Which basis to grab nodes for (0 for all)
-  //! \param local If \e true, return patch-local node numbers
-  virtual void getBoundaryNodes(int lIndex, IntVec& nodes,
-                                int basis, bool local) const;
+  //! \param thick Thickness of connection
+  //! \param local If \e true return patch-local node numbers
+  virtual void getBoundaryNodes(int lIndex, IntVec& nodes, int basis = 0,
+                                int thick = 1, bool local = false) const;
 
 private:
   std::vector<std::shared_ptr<Go::SplineVolume>> m_basis; //!< Vector of bases

--- a/src/ASM/DomainDecomposition.C
+++ b/src/ASM/DomainDecomposition.C
@@ -303,9 +303,8 @@ void DomainDecomposition::setupNodeNumbers(int basis, IntVec& lNodes,
     // need to expand to all bases for corners and edges
     for (size_t b = 1; b <= pch->getNoBasis(); ++b)
       cbasis.insert(b);
-  else {// directly add nodes, cbasis remains empty
+  else // directly add nodes, cbasis remains empty
     pch->getBoundaryNodes(lidx, lNodes, 0, thick, false);
-  }
 
   const ASM2D* pch2D = dynamic_cast<const ASM2D*>(pch);
   const ASM3D* pch3D = dynamic_cast<const ASM3D*>(pch);
@@ -335,9 +334,8 @@ void DomainDecomposition::setupNodeNumbers(int basis, IntVec& lNodes,
       std::vector<int> eNodes = pch3D->getEdge(lidx, false, it2);
       for (const int& it : eNodes)
         lNodes.push_back(pch->getNodeID(it));
-    } else {
+    } else
       pch->getBoundaryNodes(lidx, lNodes, it2, thick, false);
-    }
 }
 
 

--- a/src/ASM/DomainDecomposition.h
+++ b/src/ASM/DomainDecomposition.h
@@ -41,6 +41,7 @@ public:
     int orient; //!< Orientation.
     int dim;    //!< Dimension of boundary.
     int basis;  //!< Basis of boundary.
+    int thick;  //!< Thickness of connection.
   };
 
   //! \brief Functor to order ghost connections.
@@ -184,10 +185,11 @@ private:
   //! \param pidx Patch index
   //! \param lidx Boundary index on patch
   //! \param cbasis If non-empty, bases to connect
+  //! \param thick Thickness of connection (subdivisions)
   std::vector<int> setupEquationNumbers(const SIMbase& sim,
                                         int pidx, int lidx,
                                         const std::set<int>& cbasis,
-                                        int dim);
+                                        int dim, int thick);
 
   //! \brief Setup node numbers for all bases on a boundary.
   //! \param basis Bases to grab nodes for
@@ -196,10 +198,11 @@ private:
   //! \param pch Patch to obtain nodes for
   //! \param dim Dimension of boundary to obtain nodes for
   //! \param lidx Local index of boundary to obtain nodes for
+  //! \param thick Thickness of connection (subdivisions)
   void setupNodeNumbers(int basis, std::vector<int>& lNodes,
                         std::set<int>& cbasis,
                         const ASMbase* pch,
-                        int dim, int lidx);
+                        int dim, int lidx, int thick);
 
   //! \brief Calculate the global node numbers for given finite element model.
   bool calcGlobalNodeNumbers(const ProcessAdm& adm, const SIMbase& sim);

--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -1813,7 +1813,7 @@ bool ASMu2D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
 
 
 void ASMu2D::getBoundaryNodes (int lIndex, IntVec& nodes, int basis,
-                               bool local) const
+                               int, bool local) const
 {
   if (basis == 0)
     basis = 1;

--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -1812,7 +1812,8 @@ bool ASMu2D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
 }
 
 
-void ASMu2D::getBoundaryNodes (int lIndex, IntVec& nodes, int basis) const
+void ASMu2D::getBoundaryNodes (int lIndex, IntVec& nodes, int basis,
+                               bool local) const
 {
   if (basis == 0)
     basis = 1;

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -94,9 +94,10 @@ public:
   //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
   //! \param[in] lIndex Local index of the boundary edge
   //! \param nodes Array of node numbers
-  //! \param local If true return patch-local node numbers
+  //! \param basis Which basis to grab nodes for (0 for all)
+  //! \param local If \e true return patch-local node numbers
   virtual void getBoundaryNodes(int lIndex, IntVec& nodes,
-                                int basis, bool local = false) const;
+                                int basis, int, bool local = false) const;
 
   //! \brief Returns the polynomial order in each parameter direction.
   //! \param[out] p1 Order in first (u) direction

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -91,10 +91,12 @@ public:
   //! \param[in] displ Incremental displacements to update the coordinates with
   virtual bool updateCoords(const Vector& displ);
 
-  //! \brief Finds the global numbers of the nodes on a patch boundary.
+  //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
   //! \param[in] lIndex Local index of the boundary edge
-  //! \param glbNodes Array of global boundary node numbers
-  virtual void getBoundaryNodes(int lIndex, IntVec& glbNodes, int basis) const;
+  //! \param nodes Array of node numbers
+  //! \param local If true return patch-local node numbers
+  virtual void getBoundaryNodes(int lIndex, IntVec& nodes,
+                                int basis, bool local = false) const;
 
   //! \brief Returns the polynomial order in each parameter direction.
   //! \param[out] p1 Order in first (u) direction

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -1966,7 +1966,7 @@ std::vector<int> ASMu3D::getFaceNodes (int face, int basis) const
 }
 
 
-void ASMu3D::getBoundaryNodes (int lIndex, IntVec& nodes, int basis, bool) const
+void ASMu3D::getBoundaryNodes (int lIndex, IntVec& nodes, int basis, int, bool) const
 {
   if (basis == 0)
     basis = 1;

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -1966,7 +1966,7 @@ std::vector<int> ASMu3D::getFaceNodes (int face, int basis) const
 }
 
 
-void ASMu3D::getBoundaryNodes (int lIndex, IntVec& nodes, int basis) const
+void ASMu3D::getBoundaryNodes (int lIndex, IntVec& nodes, int basis, bool) const
 {
   if (basis == 0)
     basis = 1;

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -87,10 +87,12 @@ public:
   //! \brief Returns the node indices for a given face.
   std::vector<int> getFaceNodes(int face, int basis = 1) const;
 
-  //! \brief Finds the global numbers of the nodes on a patch boundary.
+  //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
   //! \param[in] lIndex Local index of the boundary edge
-  //! \param glbNodes Array of global boundary node numbers
-  virtual void getBoundaryNodes(int lIndex, IntVec& glbNodes, int basis) const;
+  //! \param nodes Array of global boundary node numbers
+  //! \param local If \e true return patch-local node numbers
+  virtual void getBoundaryNodes(int lIndex, IntVec& nodes,
+                                int basis, bool local) const;
 
   //! \brief Returns the node index for a given corner.
   virtual int getCorner(int I, int J, int K, int basis = 1) const;

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -89,10 +89,10 @@ public:
 
   //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
   //! \param[in] lIndex Local index of the boundary edge
-  //! \param nodes Array of global boundary node numbers
+  //! \param glbNodes Array of global boundary node numbers
   //! \param local If \e true return patch-local node numbers
   virtual void getBoundaryNodes(int lIndex, IntVec& nodes,
-                                int basis, bool local) const;
+                                int basis, int, bool local) const;
 
   //! \brief Returns the node index for a given corner.
   virtual int getCorner(int I, int J, int K, int basis = 1) const;

--- a/src/ASM/LR/Test/TestASMu2D.C
+++ b/src/ASM/LR/Test/TestASMu2D.C
@@ -31,16 +31,6 @@ class TestASMu2D : public testing::Test,
 };
 
 
-static void getBoundaryNodes (const char* edgeName, std::vector<int>& nodes)
-{
-  SIM2D sim(1);
-  sim.opt.discretization = ASM::LRSpline;
-  ASSERT_TRUE(sim.read("src/ASM/LR/Test/refdata/boundary_nodes.xinp"));
-  ASSERT_TRUE(sim.createFEMmodel());
-  sim.getBoundaryNodes(sim.getUniquePropertyCode(edgeName,0),nodes);
-}
-
-
 static ASMu2D* getPatch (SIMinput& sim)
 {
   sim.opt.discretization = ASM::LRSpline;
@@ -50,54 +40,14 @@ static ASMu2D* getPatch (SIMinput& sim)
 }
 
 
-TEST(TestASMu2D, BoundaryNodesE1)
-{
-  std::vector<int> vec;
-  getBoundaryNodes("Edge1",vec);
-  ASSERT_EQ(vec.size(), 4U);
-  for (int i = 0; i < 4; ++i)
-    ASSERT_EQ(vec[i], 4*i+1);
-}
-
-
-TEST(TestASMu2D, BoundaryNodesE2)
-{
-  std::vector<int> vec;
-  getBoundaryNodes("Edge2",vec);
-  ASSERT_EQ(vec.size(), 4U);
-  for (int i = 0; i < 4; ++i)
-    ASSERT_EQ(vec[i], 2+4*i);
-}
-
-
-TEST(TestASMu2D, BoundaryNodesE3)
-{
-  std::vector<int> vec;
-  getBoundaryNodes("Edge3",vec);
-  ASSERT_EQ(vec.size(), 4U);
-  for (int i = 0; i < 4; ++i)
-    ASSERT_EQ(vec[i], i+1);
-}
-
-
-TEST(TestASMu2D, BoundaryNodesE4)
-{
-  std::vector<int> vec;
-  getBoundaryNodes("Edge4",vec);
-  ASSERT_EQ(vec.size(), 4U);
-  for (int i = 0; i < 4; ++i)
-    ASSERT_EQ(vec[i], 5+i);
-}
-
-
 TEST_P(TestASMu2D, ConstrainEdge)
 {
   SIM2D sim(1);
-  ASMu2D* pch = getPatch(sim);
+  ASMu2D*pch = getPatch(sim);
   ASSERT_TRUE(pch != nullptr);
   pch->constrainEdge(GetParam().edgeIdx, false, 1, 1, 1);
   std::vector<int> glbNodes;
-  pch->getBoundaryNodes(GetParam().edge, glbNodes, 1);
+  pch->getBoundaryNodes(GetParam().edge, glbNodes, 1, 1);
   for (int& it : glbNodes)
     ASSERT_TRUE(pch->findMPC(it, 1) != nullptr);
 }
@@ -110,7 +60,7 @@ TEST_P(TestASMu2D, ConstrainEdgeOpen)
   ASSERT_TRUE(pch != nullptr);
   pch->constrainEdge(GetParam().edgeIdx, true, 1, 1, 1);
   std::vector<int> glbNodes;
-  pch->getBoundaryNodes(GetParam().edge, glbNodes, 1);
+  pch->getBoundaryNodes(GetParam().edge, glbNodes, 1, 1);
   int crn = pch->getCorner(GetParam().c1[0], GetParam().c1[1], 1);
   ASSERT_TRUE(pch->findMPC(crn, 1) == nullptr);
   glbNodes.erase(std::find(glbNodes.begin(), glbNodes.end(), crn));

--- a/src/ASM/LR/Test/TestASMu2D.C
+++ b/src/ASM/LR/Test/TestASMu2D.C
@@ -43,7 +43,7 @@ static ASMu2D* getPatch (SIMinput& sim)
 TEST_P(TestASMu2D, ConstrainEdge)
 {
   SIM2D sim(1);
-  ASMu2D*pch = getPatch(sim);
+  ASMu2D* pch = getPatch(sim);
   ASSERT_TRUE(pch != nullptr);
   pch->constrainEdge(GetParam().edgeIdx, false, 1, 1, 1);
   std::vector<int> glbNodes;

--- a/src/ASM/LR/Test/TestASMu3D.C
+++ b/src/ASM/LR/Test/TestASMu3D.C
@@ -15,74 +15,47 @@
 
 #include "gtest/gtest.h"
 
+class TestASMu3D :
+  public testing::Test,
+  public testing::WithParamInterface<int>
+{
+};
 
-static void getBoundaryNodes (const char* faceName, std::vector<int>& nodes)
+
+TEST_P(TestASMu3D, BoundaryNodes)
 {
   SIM3D sim(1);
   sim.opt.discretization = ASM::LRSpline;
   ASSERT_TRUE(sim.read("src/ASM/LR/Test/refdata/boundary_nodes_3d.xinp"));
-  ASSERT_TRUE(sim.createFEMmodel());
-  sim.getBoundaryNodes(sim.getUniquePropertyCode(faceName,0),nodes);
-}
+  sim.preprocess();
 
-
-TEST(TestASMu3D, BoundaryNodesF1)
-{
+  std::stringstream str;
+  str << "Face" << GetParam();
+  int bcode = sim.getUniquePropertyCode(str.str(),0);
   std::vector<int> vec;
-  getBoundaryNodes("Face1",vec);
+  sim.getBoundaryNodes(bcode,vec);
   ASSERT_EQ(vec.size(), 16U);
-  for (int i = 0; i < 16; ++i)
-    ASSERT_EQ(vec[i], 1+4*i);
+  auto it = vec.begin();
+  for (int i = 0; i < 4; ++i) {
+    for (int j = 0; j < 4; ++j) {
+      if (GetParam() == 1)
+        ASSERT_EQ(*it++, 1+4*(4*i+j));
+      else if (GetParam() == 2)
+        ASSERT_EQ(*it++, 2+4*(4*i+j));
+      else if (GetParam() == 3)
+        ASSERT_EQ(*it++, 16*i+j+1);
+      else if (GetParam() == 4)
+        ASSERT_EQ(*it++, 5+16*i+j);
+      else if (GetParam() == 5)
+        ASSERT_EQ(*it++, 4*i+j+1);
+      else if (GetParam() == 6)
+        ASSERT_EQ(*it++, 17+4*i+j);
+    }
+  }
 }
 
 
-TEST(TestASMu3D, BoundaryNodesF2)
-{
-  std::vector<int> vec;
-  getBoundaryNodes("Face2",vec);
-  ASSERT_EQ(vec.size(), 16U);
-  for (int i = 0; i < 16; ++i)
-    ASSERT_EQ(vec[i], 2+4*i);
-}
-
-
-TEST(TestASMu3D, BoundaryNodesF3)
-{
-  std::vector<int> vec;
-  getBoundaryNodes("Face3",vec);
-  ASSERT_EQ(vec.size(), 16U);
-  for (int i = 0; i < 4; ++i)
-    for (int j = 0; j < 4; ++j)
-      ASSERT_EQ(vec[4*i+j], 16*i+j+1);
-}
-
-
-TEST(TestASMu3D, BoundaryNodesF4)
-{
-  std::vector<int> vec;
-  getBoundaryNodes("Face4",vec);
-  ASSERT_EQ(vec.size(), 16U);
-  for (int i = 0; i < 4; ++i)
-    for (int j = 0; j < 4; ++j)
-      ASSERT_EQ(vec[4*i+j], 5+16*i+j);
-}
-
-
-TEST(TestASMu3D, BoundaryNodesF5)
-{
-  std::vector<int> vec;
-  getBoundaryNodes("Face5",vec);
-  ASSERT_EQ(vec.size(), 16U);
-  for (int i = 0; i < 16; ++i)
-    ASSERT_EQ(vec[i], i+1);
-}
-
-
-TEST(TestASMu3D, BoundaryNodesF6)
-{
-  std::vector<int> vec;
-  getBoundaryNodes("Face6",vec);
-  ASSERT_EQ(vec.size(), 16U);
-  for (int i = 0; i < 16; ++i)
-    ASSERT_EQ(vec[i], 17+i);
-}
+const std::vector<int> tests = {1,2,3,4,5,6};
+INSTANTIATE_TEST_CASE_P(TestASMu3D,
+                        TestASMu3D,
+                        testing::ValuesIn(tests));

--- a/src/SIM/SIM1D.C
+++ b/src/SIM/SIM1D.C
@@ -46,47 +46,6 @@ SIM1D::SIM1D (IntegrandBase* itg, unsigned char n) : SIMgeneric(itg)
 }
 
 
-bool SIM1D::addConnection (int master, int slave, int mIdx,
-                           int sIdx, int orient, int basis,
-                           bool, int dim, int thick)
-{
-  if (orient < 0 || orient > 1) {
-    std::cerr <<" *** SIM1D::addConnection: Invalid orientation "<< orient <<".\n";
-    return false;
-  }
-  if (basis > 0) {
-    std::cerr <<" *** SIM1D::addConnection: Mixed not implemented.\n";
-    return false;
-  }
-  if (dim > 0) {
-    std::cerr <<" *** SIM1D::addConnection: Invalid dimensionality "<< dim <<".\n";
-    return false;
-  }
-
-  int lmaster = this->getLocalPatchIndex(master);
-  int lslave = this->getLocalPatchIndex(slave);
-
-  if (lmaster > 0 && lslave > 0)
-  {
-    IFEM::cout <<"\tConnecting P"<< slave <<" E"<< sIdx
-               <<" to P"<< master <<" E"<< mIdx
-               <<" reversed? "<< orient << std::endl;
-
-    ASMs1D* spch = static_cast<ASMs1D*>(myModel[lslave-1]);
-    ASMs1D* mpch = static_cast<ASMs1D*>(myModel[lmaster-1]);
-
-    if (!spch->connectPatch(sIdx,*mpch,mIdx,thick))
-      return false;
-  }
-  else
-    adm.dd.ghostConnections.insert(DomainDecomposition::Interface{master, slave,
-                                                                  mIdx, sIdx, orient,
-                                                                  dim, basis, thick});
-
-  return true;
-}
-
-
 bool SIM1D::parseGeometryTag (const TiXmlElement* elem)
 {
   IFEM::cout <<"  Parsing <"<< elem->Value() <<">"<< std::endl;

--- a/src/SIM/SIM1D.h
+++ b/src/SIM/SIM1D.h
@@ -57,6 +57,19 @@ public:
   virtual bool readPatches(std::istream& isp, PatchVec& patches,
                            const char* whiteSpace) const;
 
+  //! \brief Connect two patches.
+  //! \param master Master patch
+  //! \param slave Slave patch
+  //! \param mIdx Index on master
+  //! \param sIdx Index on slave
+  //! \param orient Orientation flag for connection (1 for reversed)
+  //! \param basis Bases to connect (0 for all)
+  //! \param dim Dimensionality of connection
+  //! \param thick Thickness of connection
+  bool addConnection(int master, int slave, int mIdx, int sIdx,
+                     int orient, int basis = 0, bool = true,
+                     int dim = 0, int thick = 1);
+
   //! \brief Evaluates the primary solution at the given point.
   //! \param[in] psol Primary solution vector
   //! \param[in] u Parameter of the point to evaluate at

--- a/src/SIM/SIM1D.h
+++ b/src/SIM/SIM1D.h
@@ -57,19 +57,6 @@ public:
   virtual bool readPatches(std::istream& isp, PatchVec& patches,
                            const char* whiteSpace) const;
 
-  //! \brief Connect two patches.
-  //! \param master Master patch
-  //! \param slave Slave patch
-  //! \param mIdx Index on master
-  //! \param sIdx Index on slave
-  //! \param orient Orientation flag for connection (1 for reversed)
-  //! \param basis Bases to connect (0 for all)
-  //! \param dim Dimensionality of connection
-  //! \param thick Thickness of connection
-  bool addConnection(int master, int slave, int mIdx, int sIdx,
-                     int orient, int basis = 0, bool = true,
-                     int dim = 0, int thick = 1);
-
   //! \brief Evaluates the primary solution at the given point.
   //! \param[in] psol Primary solution vector
   //! \param[in] u Parameter of the point to evaluate at

--- a/src/SIM/SIM2D.C
+++ b/src/SIM/SIM2D.C
@@ -69,7 +69,7 @@ SIM2D::SIM2D (IntegrandBase* itg, unsigned char n, bool check) : SIMgeneric(itg)
 
 bool SIM2D::addConnection (int master, int slave, int mIdx,
                            int sIdx, int orient, int basis,
-                           bool coordCheck, int dim)
+                           bool coordCheck, int dim, int thick)
 {
   if (orient < 0 || orient > 1)
   {
@@ -99,13 +99,13 @@ bool SIM2D::addConnection (int master, int slave, int mIdx,
       bases = utl::getDigits(basis);
 
     for (const int& b : bases)
-      if (!spch->connectPatch(sIdx,*mpch,mIdx,orient,b,coordCheck))
+      if (!spch->connectPatch(sIdx,*mpch,mIdx,orient,b,coordCheck,thick))
         return false;
   }
   else
     adm.dd.ghostConnections.insert(DomainDecomposition::Interface{master, slave,
-                                                                  mIdx, sIdx,
-                                                                  orient, dim, basis});
+                                                                  mIdx, sIdx, orient,
+                                                                  dim, basis, thick});
 
   return true;
 }

--- a/src/SIM/SIM2D.h
+++ b/src/SIM/SIM2D.h
@@ -80,9 +80,10 @@ public:
   //! \param[in] basis Which bases to connect (0 for all)
   //! \param[in] coordCheck If \e false, do not check for matching coordinates
   //! \param[in] dim Dimensionality of connection
-  virtual bool addConnection(int master, int slave, int mEdge, int sEdge,
-                             int orient, int basis = 0, bool coordCheck = true,
-                             int dim = 1);
+  //! \param thick Thickness of connection
+  bool addConnection(int master, int slave, int mIdx, int sIdx,
+                     int orient, int basis = 0, bool coordCheck = true,
+                     int dim = 1, int thick = 1);
 
   //! \brief Evaluates the primary solution at the given point.
   //! \param[in] psol Primary solution vector

--- a/src/SIM/SIM3D.C
+++ b/src/SIM/SIM3D.C
@@ -47,7 +47,7 @@ SIM3D::SIM3D (IntegrandBase* itg, unsigned char n, bool check) : SIMgeneric(itg)
 
 bool SIM3D::addConnection (int master, int slave, int mIdx,
                            int sIdx, int orient, int basis,
-                           bool coordCheck, int dim)
+                           bool coordCheck, int dim, int thick)
 {
   if (orient < 0 || orient > 7)
   {
@@ -77,13 +77,13 @@ bool SIM3D::addConnection (int master, int slave, int mIdx,
       bases = utl::getDigits(basis);
 
     for (const int& b : bases)
-      if (!spch->connectPatch(sIdx,*mpch,mIdx,orient,b,coordCheck))
+      if (!spch->connectPatch(sIdx,*mpch,mIdx,orient,b,coordCheck,thick))
         return false;
   }
   else
     adm.dd.ghostConnections.insert(DomainDecomposition::Interface{master, slave,
-                                                                  mIdx, sIdx,
-                                                                  orient, dim, basis});
+                                                                  mIdx, sIdx, orient,
+                                                                  dim, basis, thick});
 
   return true;
 }

--- a/src/SIM/SIM3D.h
+++ b/src/SIM/SIM3D.h
@@ -74,9 +74,10 @@ public:
   //! \param[in] basis Which bases to connect (0 for all)
   //! \param[in] coordCheck If \e false, do not check for matching coordinates
   //! \param[in] dim Dimensionality of connection
-  virtual bool addConnection(int master, int slave, int mFace, int sFace,
-                             int orient, int basis = 0, bool coordCheck = true,
-                             int dim = 2);
+  //! \param thick Thickness of connection
+  bool addConnection(int master, int slave, int mFace, int sFace,
+                     int orient, int basis = 0, bool coordCheck = true,
+                     int dim = 2, int thick = 1);
 
   //! \brief Evaluates the primary solution at the given point.
   //! \param[in] psol Primary solution vector

--- a/src/SIM/SIM3D.h
+++ b/src/SIM/SIM3D.h
@@ -75,9 +75,9 @@ public:
   //! \param[in] coordCheck If \e false, do not check for matching coordinates
   //! \param[in] dim Dimensionality of connection
   //! \param thick Thickness of connection
-  bool addConnection(int master, int slave, int mFace, int sFace,
-                     int orient, int basis = 0, bool coordCheck = true,
-                     int dim = 2, int thick = 1);
+  virtual bool addConnection(int master, int slave, int mFace, int sFace,
+                             int orient, int basis = 0, bool coordCheck = true,
+                             int dim = 2, int thick = 1);
 
   //! \brief Evaluates the primary solution at the given point.
   //! \param[in] psol Primary solution vector

--- a/src/SIM/SIMinput.h
+++ b/src/SIM/SIMinput.h
@@ -186,7 +186,7 @@ public:
   //! \param[in] dim Dimensionality of connection
   virtual bool addConnection(int master, int slave, int mIdx, int sIdx,
                              int orient, int basis = 0, bool coordCheck = true,
-                             int dim = 1) { return false; }
+                             int dim = 1, int thick = 1) { return false; }
 
 protected:
   //! \brief Reads global node data for a patch from given input stream.

--- a/src/SIM/SIMinput.h
+++ b/src/SIM/SIMinput.h
@@ -184,6 +184,7 @@ public:
   //! \param[in] basis Which bases to connect (0 for all)
   //! \param[in] coordCheck If \e false, do not check for matching coordinates
   //! \param[in] dim Dimensionality of connection
+  //! \param[in] thick Thickness of connection
   virtual bool addConnection(int master, int slave, int mIdx, int sIdx,
                              int orient, int basis = 0, bool coordCheck = true,
                              int dim = 1, int thick = 1) { return false; }


### PR DESCRIPTION
This adds support for 'thick' connections - i.e. non-trivial overlaps. This will be utilized by subdivision.

- Add support for obtaining patch-local node numbers from getBoundaryNodes
- Add thickness support to getBoundaryNodes
- Use getBoundaryNodes in connectBasis to avoid code duplication (and thus avoid having to add thickness support in both codes).