### PR TITLE
Added: Optional second argument to the solveStep method

### DIFF
--- a/Apps/Common/SIMCoupled.h
+++ b/Apps/Common/SIMCoupled.h
@@ -53,9 +53,12 @@ public:
   }
 
   //! \brief Computes the solution for the current time step.
-  virtual bool solveStep(TimeStep& tp)
+  virtual bool solveStep(TimeStep& tp, bool firstS1 = true)
   {
-    return S1.solveStep(tp) && S2.solveStep(tp);
+    if (firstS1)
+      return S1.solveStep(tp) && S2.solveStep(tp);
+    else
+      return S2.solveStep(tp) && S1.solveStep(tp);
   }
 
   //! \brief Postprocesses the solution of current time step.

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -568,14 +568,12 @@ void ASMs1D::getBoundaryNodes (int lIndex, IntVec& nodes,
   if (!curv) return; // silently ignore empty patches
 
   size_t iel = lIndex == 1 ? 0 : nel-1;
-  if (MLGE[iel] > 0)
+  if (MLGE[iel] > 0 && (lIndex == 1 || lIndex == 2))
   {
-    for (int i = 0; i < thick; ++i) {
-      int node;
-      if (lIndex == 1)
-        node = MNPC[iel][i];
-      else if (lIndex == 2)
-        node = MNPC[iel][curv->order()-thick+i];
+    int offset = lIndex == 1 ? 0 : curv->order() - thick;
+    for (int i = 0; i < thick; i++)
+    {
+      int node = MNPC[iel][offset+i];
       nodes.push_back(local ? node+1 : MLGN[node]);
     }
   }

--- a/src/SIM/MultiStepSIM.h
+++ b/src/SIM/MultiStepSIM.h
@@ -172,7 +172,7 @@ protected:
   NormOp refNopt; //!< Reference norm option
   double refNorm; //!< Reference norm value used in convergence checks
   double rCond;   //!< Reciprocal condition number of the linear equation system
-  SubIt  subiter; //!< Subiteration flag
+  SubIt  subiter; //!< Sub-iteration flag
   size_t nRHSvec; //!< Number of right-hand-side vectors to assemble
   char   rotUpd;  //!< Option for how to update of nodal rotations
 

--- a/src/Utility/Tensor.C
+++ b/src/Utility/Tensor.C
@@ -255,7 +255,7 @@ Tensor::Tensor (const std::vector<Real>& a, bool transpose) : n(sqrt(a.size()))
 }
 
 
-void Tensor::diag(double value)
+void Tensor::diag (Real value)
 {
   this->zero();
   for (t_ind i = 1; i <= n; i++)
@@ -263,7 +263,7 @@ void Tensor::diag(double value)
 }
 
 
-void Tensor::diag(const Vec3& diagonal)
+void Tensor::diag (const Vec3& diagonal)
 {
   this->zero();
   for (t_ind i = 1; i <= n; i++)

--- a/src/Utility/Tensor.h
+++ b/src/Utility/Tensor.h
@@ -62,13 +62,12 @@ public:
   //! \brief Constructor copying its content from a one-dimensional array.
   Tensor(const std::vector<Real>& a, bool transpose = false);
 
-  //! \brief Sets \a this to the 0-tensor.
+  //! \brief Sets \a *this to the 0-tensor.
   void zero() { std::fill(v.begin(),v.end(),Real(0)); }
 
-  //! \brief Sets \a this to a diagonal tensor with identical entries on the diagonal.
-  void diag(double value=1.0);
-
-  //! \brief Sets \a this to a diagonal tensor.
+  //! \brief Sets \a *this to a diagonal tensor with \a value on the diagonal.
+  void diag(Real value = Real(1));
+  //! \brief Sets \a *this to a diagonal tensor with given vector as diagonal.
   void diag(const Vec3& diagonal);
 
   //! \brief Type casting to a one-dimensional vector, for referencing.


### PR DESCRIPTION
telling which one of the two sub-step solvers to invoke first.

Not sure if there is a better way of doing this. But the clue is that I want the option to solve S2 before S1 without swapping the template argument (because VTF export, etc. is connected to S1).