### PR TITLE
fixed: allow usage of <periodic> in parallel

### DIFF
--- a/src/SIM/SIM2D.C
+++ b/src/SIM/SIM2D.C
@@ -235,19 +235,24 @@ bool SIM2D::parseGeometryTag (const TiXmlElement* elem)
     utl::getAttribute(elem,"patch",patch);
     utl::getAttribute(elem,"dir",pedir);
 
-    if (patch < 1 || patch > (int)myModel.size())
+    if (patch < 1 || patch > nGlPatches)
     {
       std::cerr <<" *** SIM2D::parse: Invalid patch index "
                 << patch << std::endl;
       return false;
     }
-    IFEM::cout <<"\tPeriodic "<< char('H'+pedir) <<"-direction P"<< patch
-               << std::endl;
-    static_cast<ASMs2D*>(myModel[patch-1])->closeEdges(pedir);
+
+    ASMs2D* pch;
+    if ((pch = dynamic_cast<ASMs2D*>(this->getPatch(patch,true))))
+    {
+      IFEM::cout <<"\tPeriodic "<< char('H'+pedir) <<"-direction P"<< patch
+                 << std::endl;
+      pch->closeEdges(pedir);
 #ifdef USE_OPENMP
-    // Cannot do multi-threaded assembly with periodicities
-    omp_set_num_threads(1);
+      // Cannot do multi-threaded assembly with periodicities
+      omp_set_num_threads(1);
 #endif
+    }
   }
 
   else if (!strcasecmp(elem->Value(),"immersedboundary"))

--- a/src/SIM/SIM3D.C
+++ b/src/SIM/SIM3D.C
@@ -202,19 +202,24 @@ bool SIM3D::parseGeometryTag (const TiXmlElement* elem)
     utl::getAttribute(elem,"patch",patch);
     utl::getAttribute(elem,"dir",pfdir);
 
-    if (patch < 1 || patch > (int)myModel.size())
+    if (patch < 1 || patch > nGlPatches)
     {
       std::cerr <<" *** SIM3D::parse: Invalid patch index "
                 << patch << std::endl;
       return false;
     }
-    IFEM::cout <<"\tPeriodic "<< char('H'+pfdir) <<"-direction P"<< patch
-               << std::endl;
-    static_cast<ASMs3D*>(myModel[patch-1])->closeFaces(pfdir);
+
+    ASMs3D* pch;
+    if ((pch = dynamic_cast<ASMs3D*>(this->getPatch(patch,true))))
+    {
+      IFEM::cout <<"\tPeriodic "<< char('H'+pfdir) <<"-direction P"<< patch
+                 << std::endl;
+      pch->closeFaces(pfdir);
 #ifdef USE_OPENMP
-    // Cannot do multi-threaded assembly with periodicities
-    omp_set_num_threads(1);
+      // Cannot do multi-threaded assembly with periodicities
+      omp_set_num_threads(1);
 #endif
+    }
   }
 
   return true;


### PR DESCRIPTION
need to use number of global patches, check local patch index
like everything else.