### PR TITLE
Added: Force scalar parsing of neumann condition if direction > nsd

### DIFF
--- a/src/SIM/SIMinput.C
+++ b/src/SIM/SIMinput.C
@@ -982,7 +982,7 @@ bool SIMinput::setTracProperty (int code, Property::Type ptype,
 bool SIMinput::setNeumann (const std::string& prop, const std::string& type,
                            int direction, int code)
 {
-  if (direction == 0 && this->getNoFields() == 1)
+  if ((direction == 0 && this->getNoFields() == 1) || direction > nsd)
   {
     RealFunc* f = utl::parseRealFunc(prop,type);
     if (!f)


### PR DESCRIPTION
Latest in the silly hacks series. Without this it's impossible to get scalar Neumann conditions on sims with more than one field. Useful e.g. in poroel for separate traction and flux conditions.