### PR TITLE
Quell warnings with clang

### DIFF
--- a/Apps/Common/SIMSemi3D.h
+++ b/Apps/Common/SIMSemi3D.h
@@ -256,6 +256,7 @@ public:
     return true;
   }
 
+  using SIMadmin::parse;
   //! \brief Parses a data section from an XML element.
   //! \param[in] elem The XML element to parse
   virtual bool parse(const TiXmlElement* elem)

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -529,6 +529,7 @@ protected:
   //! \param[out] XC Coordinates of the element corners
   void getElementCorners(int i1, int i2, std::vector<Vec3>& XC) const;
 
+  using ASMbase::generateThreadGroups;
   //! \brief Generates element groups for multi-threading of interior integrals.
   //! \param[in] integrand Object with problem-specific data and methods
   //! \param[in] silence If \e true, suppress threading group outprint

--- a/src/ASM/ASMs2DmxLag.C
+++ b/src/ASM/ASMs2DmxLag.C
@@ -194,8 +194,8 @@ bool ASMs2DmxLag::generateFEMTopology ()
 }
 
 
-bool ASMs2DmxLag::connectPatch (int edge, ASMs2D& neighbor,
-				int nedge, bool revers)
+bool ASMs2DmxLag::connectPatch (int edge, ASMs2D& neighbor, int nedge, bool revers,
+                                int basis, bool coordCheck, int thick)
 {
   ASMs2DmxLag* neighMx = dynamic_cast<ASMs2DmxLag*>(&neighbor);
   if (!neighMx) return false;
@@ -203,8 +203,9 @@ bool ASMs2DmxLag::connectPatch (int edge, ASMs2D& neighbor,
   size_t nb1=0;
   size_t nb2=0;
   for (size_t i = 1;i <= nxx.size(); ++i) {
-    if (!this->connectBasis(edge,neighbor,nedge,revers,i,nb1,nb2))
-      return false;
+    if (basis == 0 || i == (size_t)basis)
+      if (!this->connectBasis(edge,neighbor,nedge,revers,i,nb1,nb2,coordCheck,thick))
+        return false;
     nb1 += nb[i-1];
     nb2 += neighMx->nb[i-1];
   }

--- a/src/ASM/ASMs2DmxLag.h
+++ b/src/ASM/ASMs2DmxLag.h
@@ -69,8 +69,11 @@ public:
   //! \param neighbor The neighbor patch
   //! \param[in] nedge Local edge index of neighbor patch, in range [1,4]
   //! \param[in] revers Indicates whether the two edges have opposite directions
-  virtual bool connectPatch(int edge, ASMs2D& neighbor, int nedge,
-			    bool revers = false);
+  //! \param[in] basis The basis to connect (for mixed problems)
+  //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
+  //! \param[in] thick Thickness of connection
+  virtual bool connectPatch(int edge, ASMs2D& neighbor, int nedge, bool revers,
+                            int basis = 0, bool coordCheck = true, int thick = 1);
 
   //! \brief Makes two opposite boundary edges periodic.
   //! \param[in] dir Parameter direction defining the periodic edges

--- a/src/ASM/ASMs3DmxLag.C
+++ b/src/ASM/ASMs3DmxLag.C
@@ -214,8 +214,9 @@ bool ASMs3DmxLag::generateFEMTopology ()
 }
 
 
-bool ASMs3DmxLag::connectPatch (int face, ASMs3D& neighbor,
-				int nface, int norient)
+bool ASMs3DmxLag::connectPatch (int face, ASMs3D& neighbor, int nface,
+                                int norient, int basis,
+                                bool coordCheck, int thick)
 {
   ASMs3DmxLag* neighMx = dynamic_cast<ASMs3DmxLag*>(&neighbor);
   if (!neighMx) return false;
@@ -229,8 +230,10 @@ bool ASMs3DmxLag::connectPatch (int face, ASMs3D& neighbor,
   size_t nb1=0;
   size_t nb2=0;
   for (size_t i = 1;i <= nxx.size(); ++i) {
-    if (!this->connectBasis(face,neighbor,nface,norient,i,nb1,nb2))
-      return false;
+    if (basis == 0 || i == (size_t)basis)
+      if (!this->connectBasis(face,neighbor,nface,norient,i,nb1,nb2,coordCheck,thick))
+        return false;
+
     nb1 += nb[i-1];
     nb2 += neighMx->nb[i-1];
   }

--- a/src/ASM/ASMs3DmxLag.h
+++ b/src/ASM/ASMs3DmxLag.h
@@ -69,8 +69,11 @@ public:
   //! \param neighbor The neighbor patch
   //! \param[in] nface Local face index of neighbor patch, in range [1,6]
   //! \param[in] norient Relative face orientation flag (see class ASMs3D)
-  virtual bool connectPatch(int face, ASMs3D& neighbor, int nface,
-			    int norient = 0);
+  //! \param[in] basis Which basis to connect, or 0 for all.
+  //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
+  //! \param[in] thick Thickness of connection
+  virtual bool connectPatch(int face, ASMs3D& neighbor, int nface, int norient,
+                            int basis = 0, bool coordCheck = true, int thick = 1);
 
   //! \brief Makes two opposite boundary faces periodic.
   //! \param[in] dir Parameter direction defining the periodic faces

--- a/src/ASM/SAMpatchPETSc.h
+++ b/src/ASM/SAMpatchPETSc.h
@@ -94,12 +94,14 @@ private:
 
   // Parameters for parallel computing
   int    nProc;      //!< Number of processes
-  int    nleq;       //!< Number of equations for this processor
-  int    nnodGlob;   //!< Number of global nodes;
   IntVec ghostNodes; //!< Indices for the ghost nodes
   IntVec l2gn;       //!< Local-to-global node numbers for this processor
+#ifdef HAVE_MPI
+  int    nleq;       //!< Number of equations for this processor
+  int    nnodGlob;   //!< Number of global nodes;
   int    ieqmin;     //!< Minium equation number
-  int    ieqmax;     //!< Maximun equation number
+  int    ieqmax;     //!< Maximum equation number
+#endif
 
   const ProcessAdm& adm; //!< Parallel process administrator
 

--- a/src/LinAlg/PETScMatrix.C
+++ b/src/LinAlg/PETScMatrix.C
@@ -266,7 +266,7 @@ void PETScMatrix::initAssembly (const SAM& sam, bool b)
 
     // map from sparse matrix indices to block matrix indices
     glb2Blk.resize(SparseMatrix::A.size());
-    std::vector<std::array<int,2>> eq2b(sam.getNoEquations(), {-1, 0}); // cache
+    std::vector<std::array<int,2>> eq2b(sam.getNoEquations(), {{-1, 0}}); // cache
     for (size_t j = 0; j < cols(); ++j) {
       for (int i = IA[j]; i < IA[j+1]; ++i) {
         int iblk = -1;

--- a/src/SIM/Test/TestModelGenerator.C
+++ b/src/SIM/Test/TestModelGenerator.C
@@ -25,7 +25,7 @@ template<class Generator>
 class TestModelGeneratorWrapper : public Generator {
 public:
   TestModelGeneratorWrapper(const TiXmlElement* geo) : Generator(geo) {}
-  std::string createG2(int nsd)
+  std::string createG2(int nsd) const
   {
     return Generator::createG2(nsd);
   }


### PR DESCRIPTION
With these fixes, clang now compiles IFEM-core and CFD applications warnings-less except a few issues which are taken care of in https://github.com/OPM/IFEM/pull/102

Replaces #117 