### PR TITLE
changed: allow specifying number of components in vector field

### DIFF
--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -401,7 +401,7 @@ bool SIMoutput::writeGlvT (int iStep, int& geoBlk, int& nBlock) const
 
 
 bool SIMoutput::writeGlvV (const Vector& vec, const char* fieldName,
-                           int iStep, int& nBlock, int idBlock) const
+                           int iStep, int& nBlock, int idBlock, int ncmp) const
 {
   if (vec.empty())
     return true;
@@ -420,7 +420,7 @@ bool SIMoutput::writeGlvV (const Vector& vec, const char* fieldName,
     if (msgLevel > 1)
       IFEM::cout <<"Writing vector field for patch "<< i+1 << std::endl;
 
-    myModel[i]->extractNodeVec(vec,lovec);
+    myModel[i]->extractNodeVec(vec,lovec,ncmp);
     if (!myModel[i]->evalSolution(field,lovec,opt.nViz))
       return false;
 

--- a/src/SIM/SIMoutput.h
+++ b/src/SIM/SIMoutput.h
@@ -88,8 +88,9 @@ public:
   //! \param[in] iStep Load/time step identifier
   //! \param nBlock Running result block counter
   //! \param[in] idBlock Starting value of result block numbering
+  //! \param[in] ncmp Number of components in vector field
   bool writeGlvV(const Vector& vec, const char* fieldName,
-                 int iStep, int& nBlock, int idBlock = 2) const;
+                 int iStep, int& nBlock, int idBlock = 2, int ncmp = 0) const;
 
   //! \brief Writes solution fields for a given load/time step to the VTF-file.
   //! \param[in] psol Primary solution vector


### PR DESCRIPTION
useful when writing vector fields derived from a scalar equation.

noticed while wanting to output the derived velocities in the darcy application as a vector field.