### PR TITLE
fixed: the scalar laplacian residual operator

### DIFF
--- a/Apps/Common/EqualOrderOperators.h
+++ b/Apps/Common/EqualOrderOperators.h
@@ -183,7 +183,7 @@ public:
       for (size_t i = 1;i <= fe.basis(basis).size();i++) {
         for (size_t k = 1;k <= cmp;k++) {
           double diff = 0.0;
-          for (size_t l = 1;l <= cmp;l++)
+          for (size_t l = 1;l <= fe.grad(basis).cols();l++)
             diff += dUdX(k,l)*fe.grad(basis)(i,l);
           diff *= scale*fe.detJxW;
 

--- a/Apps/Common/SIMExplicitRKE.h
+++ b/Apps/Common/SIMExplicitRKE.h
@@ -60,7 +60,7 @@ public:
       this->RK.A(3,2) = 0.75;
       this->RK.A(4,1) = 2.0/9.0;
       this->RK.A(4,2) = 1.0/3.0;
-      this->RK.A(4,3) = 2.0/9.0;
+      this->RK.A(4,3) = 4.0/9.0;
     }
     if (type == FEHLBERG) {
       this->RK.order = 4;

--- a/Apps/Common/TimeIntUtils.C
+++ b/Apps/Common/TimeIntUtils.C
@@ -19,7 +19,7 @@ int Order(Method method)
   if (method == EULER || method == BE)
     return 1;
 
-  if (method == HEUN || method == BDF2)
+  if (method == HEUN || method == BDF2 || method == THETA)
     return 2;
 
   if (method == RK3)

--- a/src/Utility/BDF.C
+++ b/src/Utility/BDF.C
@@ -57,15 +57,6 @@ const std::vector<double>& TimeIntegration::BDF::getCoefs () const
 }
 
 
-double TimeIntegration::BDF::extrapolate (const double* values) const
-{
-  if (step > 1 && this->getActualOrder() == 2) // second order
-    return 2.0*values[0] - values[1];
-  else // first order
-    return values[0];
-}
-
-
 void TimeIntegration::BDFD2::setOrder (int order)
 {
   if (order >= 1) {

--- a/src/Utility/BDF.h
+++ b/src/Utility/BDF.h
@@ -56,7 +56,14 @@ namespace TimeIntegration //! Utilities for time integration.
     //! \brief Extrapolates values.
     //! \param[in] values The values to be extrapolated
     //! \return The extrapolated value
-    double extrapolate(const double* values) const;
+    template<class T>
+    T extrapolate(const std::vector<T>& values) const
+    {
+      if (step > 1 && this->getActualOrder() == 2) // second order
+        return 2.0*values[0] - values[1];
+      else // first order
+        return values[0];
+    }
 
   protected:
     int                 step;   //!< Time step counter


### PR DESCRIPTION
used cmp instead of nsd.

second commit adds theta to the time integration order table, and the third makes the bdf extrapolate function more useful.

finally the missing adaptive loop is added to SIMExplicitRKE and the bogacki-shampine rke coefficients are fixed.