### PR TITLE
Added: An overloded writeGlvS method that writes a single scalar field

### DIFF
--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -434,6 +434,40 @@ bool SIMoutput::writeGlvV (const Vector& vec, const char* fieldName,
 }
 
 
+bool SIMoutput::writeGlvS (const Vector& scl, const char* fieldName,
+                           int iStep, int& nBlock, int idBlock) const
+{
+  if (scl.empty())
+    return true;
+  else if (!myVtf)
+    return false;
+
+  Matrix field;
+  Vector lovec;
+  IntVec sID;
+
+  int geomID = myGeomID;
+  for (size_t i = 0; i < myModel.size(); i++)
+  {
+    if (myModel[i]->empty()) continue; // skip empty patches
+
+    if (msgLevel > 1)
+      IFEM::cout <<"Writing scalar field for patch "<< i+1 << std::endl;
+
+    myModel[i]->extractNodeVec(scl,lovec,1);
+    if (!myModel[i]->evalSolution(field,lovec,opt.nViz))
+      return false;
+
+    if (!myVtf->writeNres(field,++nBlock,++geomID))
+      return false;
+    else
+      sID.push_back(nBlock);
+  }
+
+  return myVtf->writeSblk(sID,fieldName,idBlock,iStep);
+}
+
+
 bool SIMoutput::writeGlvS (const Vector& psol, int iStep, int& nBlock,
                            double time, const char* pvecName,
                            int idBlock, int psolComps)

--- a/src/SIM/SIMoutput.h
+++ b/src/SIM/SIMoutput.h
@@ -87,10 +87,19 @@ public:
   //! \param[in] fieldName Name identifying the vector field
   //! \param[in] iStep Load/time step identifier
   //! \param nBlock Running result block counter
-  //! \param[in] idBlock Starting value of result block numbering
+  //! \param[in] idBlock Result block ID number
   //! \param[in] ncmp Number of components in vector field
   bool writeGlvV(const Vector& vec, const char* fieldName,
                  int iStep, int& nBlock, int idBlock = 2, int ncmp = 0) const;
+
+  //! \brief Writes a scalar field for a given load/time step to the VTF-file.
+  //! \param[in] scl The scalar field to output (nodal values)
+  //! \param[in] fieldName Name identifying the scalar field
+  //! \param[in] iStep Load/time step identifier
+  //! \param nBlock Running result block counter
+  //! \param[in] idBlock Result block ID number
+  bool writeGlvS(const Vector& scl, const char* fieldName,
+                 int iStep, int& nBlock, int idBlock = 2) const;
 
   //! \brief Writes solution fields for a given load/time step to the VTF-file.
   //! \param[in] psol Primary solution vector


### PR DESCRIPTION
Equvialent to writeGlvV, but output as fringe plot instead of vectors.
Used in OPM/IFEM-OpenFrac to dump the phase field residual as a scalar field.