### PR TITLE
Fixes for correct handling of nodal point loads in multi-patch models

### DIFF
--- a/Apps/Common/SIMMultiPatchModelGen.C
+++ b/Apps/Common/SIMMultiPatchModelGen.C
@@ -14,16 +14,16 @@
 #include "ModelGenerator.h"
 #include "SIMMultiPatchModelGen.h"
 #include "MultiPatchModelGenerator.h"
-#include "IFEM.h"
 #include "SIM1D.h"
 #include "SIM2D.h"
 #include "SIM3D.h"
+#include "IFEM.h"
 
 
 template<>
 ModelGenerator* SIMMultiPatchModelGen<SIM1D>::getModelGenerator(const TiXmlElement* geo) const
 {
-  IFEM::cout <<"  Using multi-patch model generator" << std::endl;
+  IFEM::cout <<"  Using 1D multi-patch model generator."<< std::endl;
   return new MultiPatchModelGenerator1D(geo);
 }
 
@@ -31,7 +31,7 @@ ModelGenerator* SIMMultiPatchModelGen<SIM1D>::getModelGenerator(const TiXmlEleme
 template<>
 ModelGenerator* SIMMultiPatchModelGen<SIM2D>::getModelGenerator(const TiXmlElement* geo) const
 {
-  IFEM::cout <<"  Using multi-patch model generator" << std::endl;
+  IFEM::cout <<"  Using 2D multi-patch model generator."<< std::endl;
   return new MultiPatchModelGenerator2D(geo);
 }
 
@@ -39,6 +39,6 @@ ModelGenerator* SIMMultiPatchModelGen<SIM2D>::getModelGenerator(const TiXmlEleme
 template<>
 ModelGenerator* SIMMultiPatchModelGen<SIM3D>::getModelGenerator(const TiXmlElement* geo) const
 {
-  IFEM::cout <<"  Using multi-patch model generator" << std::endl;
+  IFEM::cout <<"  Using 3D multi-patch model generator."<< std::endl;
   return new MultiPatchModelGenerator3D(geo);
 }

--- a/Apps/Common/SIMMultiPatchModelGen.h
+++ b/Apps/Common/SIMMultiPatchModelGen.h
@@ -14,9 +14,10 @@
 #ifndef _SIM_MULTI_PATCH_MODEL_GEN_H_
 #define _SIM_MULTI_PATCH_MODEL_GEN_H_
 
-#include "SIMbase.h"
+#include <vector>
 
 class ModelGenerator;
+class TiXmlElement;
 
 
 /*!
@@ -28,19 +29,22 @@ class SIMMultiPatchModelGen : public Dim
 {
 public:
   //! \brief Constructor for standard problems.
-  //! \param[in] n1 Number of fields
-  SIMMultiPatchModelGen(int n1) : Dim(n1) {}
+  //! \param[in] n1 Dimension of the primary solution field
+  //! \param[in] checkRHS If \e true, ensure the model is in a right-hand system
+  SIMMultiPatchModelGen(int n1, bool checkRHS = false) : Dim(n1,checkRHS) {}
 
   //! \brief Constructor for mixed problems.
-  //! \param[in] unf Number of fields on bases
-  SIMMultiPatchModelGen(const SIMbase::CharVec& unf) : Dim(unf) {}
+  //! \param[in] unf Dimension of the primary solution field
+  //! \param[in] checkRHS If \e true, ensure the model is in a right-hand system
+  SIMMultiPatchModelGen(const std::vector<unsigned char>& unf,
+                        bool checkRHS = false) : Dim(unf,checkRHS) {}
 
   //! \brief Empty destructor.
   virtual ~SIMMultiPatchModelGen() {}
 
 protected:
-  //! \brief Instantiates a generator for the finite element model.
-  //! \param[in] geo XML element containing geometry defintion
+  //! \brief Instantiates a FEM model generator for a multi-patch model.
+  //! \param[in] geo XML element containing geometry definition
   virtual ModelGenerator* getModelGenerator(const TiXmlElement* geo) const;
 };
 

--- a/src/SIM/ModelGenerator.h
+++ b/src/SIM/ModelGenerator.h
@@ -68,7 +68,7 @@ class DefaultGeometry1D : public ModelGenerator
 {
 public:
   //! \brief The constructor forwards to the base class.
-  //! \param[in] geo XML element containing geometry defintion
+  //! \param[in] geo XML element containing geometry definition
   DefaultGeometry1D(const TiXmlElement* geo) : ModelGenerator(geo) {}
   //! \brief Empty destructor.
   virtual ~DefaultGeometry1D() {}
@@ -92,7 +92,7 @@ class DefaultGeometry2D : public ModelGenerator
 {
 public:
   //! \brief The constructor forwards to the base class.
-  //! \param[in] geo XML element containing geometry defintion
+  //! \param[in] geo XML element containing geometry definition
   DefaultGeometry2D(const TiXmlElement* geo) : ModelGenerator(geo) {}
   //! \brief Empty destructor.
   virtual ~DefaultGeometry2D() {}
@@ -116,7 +116,7 @@ class DefaultGeometry3D : public ModelGenerator
 {
 public:
   //! \brief The constructor forwards to the base class.
-  //! \param[in] geo XML element containing geometry defintion
+  //! \param[in] geo XML element containing geometry definition
   DefaultGeometry3D(const TiXmlElement* geo) : ModelGenerator(geo) {}
   //! \brief Empty destructor.
   virtual ~DefaultGeometry3D() {}

--- a/src/SIM/SIM1D.h
+++ b/src/SIM/SIM1D.h
@@ -114,7 +114,7 @@ protected:
                              int dirs, int code, int&, char basis = 1);
 
   //! \brief Returns a FEM model generator for a default single-patch model.
-  //! \param[in] geo XML element containing geometry defintion
+  //! \param[in] geo XML element containing geometry definition
   virtual ModelGenerator* getModelGenerator(const TiXmlElement* geo) const;
 
 public:

--- a/src/SIM/SIM2D.h
+++ b/src/SIM/SIM2D.h
@@ -136,7 +136,7 @@ protected:
                              int dirs, int code, int& ngnod, char basis = 1);
 
   //! \brief Returns a FEM model generator for a default single-patch model.
-  //! \param[in] geo XML element containing geometry defintion
+  //! \param[in] geo XML element containing geometry definition
   virtual ModelGenerator* getModelGenerator(const TiXmlElement* geo) const;
 
 protected:

--- a/src/SIM/SIM3D.h
+++ b/src/SIM/SIM3D.h
@@ -141,7 +141,7 @@ protected:
                      int dirs, char basis = 1);
 
   //! \brief Returns a FEM model generator for a default single-patch model.
-  //! \param[in] geo XML element containing geometry defintion
+  //! \param[in] geo XML element containing geometry definition
   virtual ModelGenerator* getModelGenerator(const TiXmlElement* geo) const;
 
 protected:

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -246,9 +246,9 @@ bool SIMbase::preprocess (const IntVec& ignored, bool fixDup)
   if (renum > 0)
     IFEM::cout <<"\nRenumbered "<< renum <<" nodes."<< std::endl;
 
-  for (mit = myModel.begin(); mit != myModel.end(); ++mit)
-    (*mit)->renumberNodes(*g2l);
-  ASMs2DC1::renumberNodes(*g2l);
+  // Apply the old-to-new node number mapping to all node tables in the model
+  if (!this->renumberNodes(*g2l))
+    return false;
 
   // Perform specialized preprocessing before the assembly initialization.
   // This typically involves the system-level Lagrange multipliers, etc.
@@ -365,6 +365,17 @@ bool SIMbase::preprocess (const IntVec& ignored, bool fixDup)
 
   // Now perform the sub-class specific final preprocessing, if any
   return this->preprocessB() && ierr == 0;
+}
+
+
+bool SIMbase::renumberNodes (const std::map<int,int>& nodeMap)
+{
+  bool ok = true;
+  for (PatchVec::const_iterator it = myModel.begin(); it != myModel.end(); ++it)
+    ok &= (*it)->renumberNodes(nodeMap);
+
+  ASMs2DC1::renumberNodes(nodeMap);
+  return ok;
 }
 
 

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -480,6 +480,9 @@ protected:
   virtual bool preprocessB() { return true; }
   //! \brief Preprocesses the result sampling points.
   virtual void preprocessResultPoints() = 0;
+  //! \brief Renumbers all global node numbers if the model.
+  //! \param[in] nodeMap Mapping from old to new node number
+  virtual bool renumberNodes(const std::map<int,int>& nodeMap);
 
   //! \brief Extracts all local solution vector(s) for a specified patch.
   //! \param[in] problem Integrand to receive the patch-level solution vectors

--- a/src/SIM/SIMgeneric.C
+++ b/src/SIM/SIMgeneric.C
@@ -56,11 +56,12 @@ Vector SIMgeneric::getSolution (const Vector& psol, const double* par,
 
 
 int SIMgeneric::evalPoint (const double* xi, Vec3& X, double* param,
-                           int patch) const
+                           int patch, bool global) const
 {
   ASMbase* pch = this->getPatch(patch,true);
   if (!pch) return -1;
 
   double dummy[3];
-  return pch->evalPoint(xi, param ? param : dummy, X);
+  int inod = pch->evalPoint(xi, param ? param : dummy, X);
+  return inod > 0 && global ? pch->getNodeID(inod) : inod;
 }

--- a/src/SIM/SIMgeneric.h
+++ b/src/SIM/SIMgeneric.h
@@ -51,9 +51,9 @@ public:
   //! \param[out] X The Cartesian coordinates of the point
   //! \param[out] param The parameters of the point in the knot-span domain
   //! \param[in] patch 1-based patch index containing the evaluation point
-  //! \return Local node number within the patch that matches the point
-  int evalPoint(const double* xi, Vec3& X,
-                double* param = nullptr, int patch = 1) const;
+  //! \return Patch-local or global node number of node that matches the point
+  int evalPoint(const double* xi, Vec3& X, double* param = nullptr,
+                int patch = 1, bool global = false) const;
 };
 
 #endif

--- a/src/SIM/SIMinput.h
+++ b/src/SIM/SIMinput.h
@@ -203,7 +203,7 @@ protected:
   virtual void readNodes(std::istream& isn) {}
 
   //! \brief Instantiates a FEM model generator.
-  //! \param[in] geo XML element containing geometry defintion
+  //! \param[in] geo XML element containing geometry definition
   virtual ModelGenerator* getModelGenerator(const TiXmlElement* geo) const = 0;
 
 public:

--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -207,14 +207,14 @@ void SIMoutput::preprocessResPtGroup (std::string& ptFile, ResPointVec& points)
 {
   for (ResPointVec::iterator p = points.begin(); p != points.end();)
   {
-    int pid = this->getLocalPatchIndex(p->patch);
-    if (pid < 1 || myModel[pid-1]->empty())
+    ASMbase* pch = this->getPatch(p->patch,true);
+    if (!pch || pch->empty())
       p = points.erase(p);
-    else if ((p->inod = myModel[pid-1]->evalPoint(p->u,p->u,p->X)) < 0)
+    else if ((p->inod = pch->evalPoint(p->u,p->u,p->X)) < 0)
       p = points.erase(p);
     else
     {
-      p->npar = myModel[pid-1]->getNoParamDim();
+      p->npar = pch->getNoParamDim();
       int ipt = 1 + (int)(p-points.begin());
       if (ipt == 1) IFEM::cout <<'\n';
       IFEM::cout <<"Result point #"<< ipt <<": patch #"<< p->patch;
@@ -229,7 +229,7 @@ void SIMoutput::preprocessResPtGroup (std::string& ptFile, ResPointVec& points)
       if (p->npar > 1) IFEM::cout <<')';
       if (p->inod > 0) IFEM::cout <<", node #"<< p->inod;
       if (p->inod > 0 && myModel.size() > 1)
-        IFEM::cout <<", global #"<< myModel[pid-1]->getNodeID(p->inod);
+        IFEM::cout <<", global #"<< pch->getNodeID(p->inod);
       IFEM::cout <<", X = "<< p->X << std::endl;
       p++;
     }


### PR DESCRIPTION
The first commit is more or less cosmetic, except for the propagation of the checkRHS flag.
The other two are changes needed to handle nodal loads correctly in multi-patch models.
External nodal loads are used in Elasticty apps only, so others should not be affected.