### PR TITLE
Support multipatch LR models

### DIFF
--- a/Apps/Common/Test/TestMultiPatchModelGenerator.C
+++ b/Apps/Common/Test/TestMultiPatchModelGenerator.C
@@ -152,6 +152,28 @@ TEST_P(TestMultiPatchModelGenerator2D, Generate)
 }
 
 
+TEST(TestMultiPatchModelGenerator2D, GenerateLR)
+{
+  SIMMultiPatchModelGen<SIM2D> sim(1);
+  sim.opt.discretization = ASM::LRSpline;
+  ASSERT_TRUE(sim.read("refdata/modelgen2d_lr.xinp"));
+  sim.preprocess();
+  ASSERT_EQ(sim.getNoNodes(), 32U);
+  ASSERT_EQ(sim.getNoNodes(true), 28U);
+}
+
+
+TEST(TestMultiPatchModelGenerator2D, GenerateLRmx)
+{
+  SIMMultiPatchModelGen<SIM2D> sim({2,1});
+  sim.opt.discretization = ASM::LRSpline;
+  ASSERT_TRUE(sim.read("refdata/modelgen2d_lr.xinp"));
+  sim.preprocess();
+  ASSERT_EQ(sim.getNoNodes(), 82U);
+  ASSERT_EQ(sim.getNoNodes(true), 73U);
+}
+
+
 TEST(TestMultiPatchModelGenerator2D, Subdivisions)
 {
   SIMMultiPatchModelGen<SIM2D> sim(1);
@@ -209,6 +231,17 @@ TEST_P(TestMultiPatchModelGenerator3D, Generate)
   SIM3D sim;
   TopologySet sets = gen.createTopologySets(sim);
   DoTest(GetParam(), g2, sets);
+}
+
+
+TEST(TestMultiPatchModelGenerator3D, GenerateLR)
+{
+  SIMMultiPatchModelGen<SIM3D> sim(1);
+  sim.opt.discretization = ASM::LRSpline;
+  ASSERT_TRUE(sim.read("refdata/modelgen3d_lr.xinp"));
+  sim.preprocess();
+  ASSERT_EQ(sim.getNoNodes(), 128U);
+  ASSERT_EQ(sim.getNoNodes(true), 112U);
 }
 
 

--- a/Apps/Common/Test/refdata/modelgen2d_lr.xinp
+++ b/Apps/Common/Test/refdata/modelgen2d_lr.xinp
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<simulation>
+  <geometry nx="2" sets="true">
+    <refine patch="1" u="2" v="2"/>
+    <refine patch="2" u="2" v="2"/>
+  </geometry>
+</simulation>

--- a/Apps/Common/Test/refdata/modelgen3d_lr.xinp
+++ b/Apps/Common/Test/refdata/modelgen3d_lr.xinp
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<simulation>
+  <geometry nx="2" sets="true">
+    <refine patch="1" u="2" v="2" w="2"/>
+    <refine patch="2" u="2" v="2" w="2"/>
+  </geometry>
+</simulation>

--- a/src/ASM/ASM2D.h
+++ b/src/ASM/ASM2D.h
@@ -132,6 +132,16 @@ public:
   //! \brief Returns the node index for a given corner.
   virtual int getCorner(int I, int J, int basis) const = 0;
 
+  //! \brief Connects all matching nodes on two adjacent boundary edges.
+  //! \param[in] edge Local edge index of this patch, in range [1,4]
+  //! \param neighbor The neighbor patch
+  //! \param[in] nedge Local edge index of neighbor patch, in range [1,4]
+  //! \param[in] revers Indicates whether the two edges have opposite directions
+  //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
+  //! \param[in] thick Thickness of connection
+  virtual bool connectPatch(int edge, ASM2D& neighbor, int nedge, bool revers,
+                            int = 0, bool coordCheck = true, int thick = 1) = 0;
+
 protected:
   //! \brief Returns characteristic element size based on corner coordinates.
   static double getElementSize(const std::vector<Vec3>& XC);

--- a/src/ASM/ASM3D.h
+++ b/src/ASM/ASM3D.h
@@ -166,6 +166,22 @@ public:
   //! \brief Returns the node indices for a given edge.
   virtual std::vector<int> getEdge(int lEdge, bool open, int basis) const = 0;
 
+  //! \brief Connects all matching nodes on two adjacent boundary faces.
+  //! \param[in] face Local face index of this patch, in range [1,6]
+  //! \param neighbor The neighbor patch
+  //! \param[in] nface Local face index of neighbor patch, in range [1,6]
+  //! \param[in] norient Relative face orientation flag (see below)
+  //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
+  //! \param[in] thick Thickness of connection
+  //!
+  //! \details The face orientation flag \a norient must be in range [0,7].
+  //! When interpreted as a binary number, its 3 digits are decoded as follows:
+  //! - left digit = 1: The u and v parameters of the neighbor face are swapped
+  //! - middle digit = 1: Parameter \a u in neighbor patch face is reversed
+  //! - right digit = 1: Parameter \a v in neighbor patch face is reversed
+  virtual bool connectPatch(int face, ASM3D& neighbor, int nface, int norient,
+                            int = 0, bool coordCheck = true, int thick = 1) = 0;
+
 protected:
   //! \brief Returns characteristic element size based on corner coordinates.
   static double getElementSize(const std::vector<Vec3>& XC);

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -590,19 +590,23 @@ bool ASMs2D::assignNodeNumbers (BlockNodes& nodes, int basis)
 }
 
 
-bool ASMs2D::connectPatch (int edge, ASMs2D& neighbor, int nedge,
+bool ASMs2D::connectPatch (int edge, ASM2D& neighbor, int nedge,
                            bool revers, int, bool coordCheck, int thick)
 {
+  ASMs2D* neighS = dynamic_cast<ASMs2D*>(&neighbor);
+  if (!neighS)
+    return false;
+
   if (swapV && edge > 2) // Account for swapped parameter direction
     edge = 7-edge;
 
-  if (neighbor.swapV && nedge > 2) // Account for swapped parameter direction
+  if (neighS->swapV && nedge > 2) // Account for swapped parameter direction
     nedge = 7-nedge;
 
-  if (!this->connectBasis(edge,neighbor,nedge,revers,1,0,0,coordCheck,thick))
+  if (!this->connectBasis(edge,*neighS,nedge,revers,1,0,0,coordCheck,thick))
     return false;
 
-  this->addNeighbor(&neighbor);
+  this->addNeighbor(neighS);
   return true;
 }
 

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -276,7 +276,7 @@ public:
   //! \param[in] revers Indicates whether the two edges have opposite directions
   //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
   //! \param[in] thick Thickness of connection
-  virtual bool connectPatch(int edge, ASMs2D& neighbor, int nedge, bool revers,
+  virtual bool connectPatch(int edge, ASM2D& neighbor, int nedge, bool revers,
                             int = 0, bool coordCheck = true, int thick = 1);
 
   //! \brief Makes two opposite boundary edges periodic.

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -292,7 +292,7 @@ bool ASMs2Dmx::generateFEMTopology ()
 }
 
 
-bool ASMs2Dmx::connectPatch (int edge, ASMs2D& neighbor, int nedge, bool revers,
+bool ASMs2Dmx::connectPatch (int edge, ASM2D& neighbor, int nedge, bool revers,
                              int basis, bool coordCheck, int thick)
 {
   ASMs2Dmx* neighMx = dynamic_cast<ASMs2Dmx*>(&neighbor);
@@ -301,7 +301,7 @@ bool ASMs2Dmx::connectPatch (int edge, ASMs2D& neighbor, int nedge, bool revers,
   size_t nb1 = 0, nb2 = 0;
   for (size_t i = 1; i <= m_basis.size(); ++i) {
     if (basis == 0 || i == (size_t)basis)
-      if (!this->connectBasis(edge,neighbor,nedge,revers,i,nb1,nb2,coordCheck,thick))
+      if (!this->connectBasis(edge,*neighMx,nedge,revers,i,nb1,nb2,coordCheck,thick))
         return false;
 
     nb1 += nb[i-1];

--- a/src/ASM/ASMs2Dmx.h
+++ b/src/ASM/ASMs2Dmx.h
@@ -104,7 +104,7 @@ public:
   //! \param[in] basis The basis to connect (for mixed problems)
   //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
   //! \param[in] thick Thickness of connection
-  virtual bool connectPatch(int edge, ASMs2D& neighbor, int nedge, bool revers,
+  virtual bool connectPatch(int edge, ASM2D& neighbor, int nedge, bool revers,
                             int basis = 0, bool coordCheck = true, int thick = 1);
 
   //! \brief Makes two opposite boundary edges periodic.

--- a/src/ASM/ASMs2DmxLag.C
+++ b/src/ASM/ASMs2DmxLag.C
@@ -194,7 +194,7 @@ bool ASMs2DmxLag::generateFEMTopology ()
 }
 
 
-bool ASMs2DmxLag::connectPatch (int edge, ASMs2D& neighbor, int nedge, bool revers,
+bool ASMs2DmxLag::connectPatch (int edge, ASM2D& neighbor, int nedge, bool revers,
                                 int basis, bool coordCheck, int thick)
 {
   ASMs2DmxLag* neighMx = dynamic_cast<ASMs2DmxLag*>(&neighbor);
@@ -204,7 +204,7 @@ bool ASMs2DmxLag::connectPatch (int edge, ASMs2D& neighbor, int nedge, bool reve
   size_t nb2=0;
   for (size_t i = 1;i <= nxx.size(); ++i) {
     if (basis == 0 || i == (size_t)basis)
-      if (!this->connectBasis(edge,neighbor,nedge,revers,i,nb1,nb2,coordCheck,thick))
+      if (!this->connectBasis(edge,*neighMx,nedge,revers,i,nb1,nb2,coordCheck,thick))
         return false;
     nb1 += nb[i-1];
     nb2 += neighMx->nb[i-1];

--- a/src/ASM/ASMs2DmxLag.h
+++ b/src/ASM/ASMs2DmxLag.h
@@ -72,7 +72,7 @@ public:
   //! \param[in] basis The basis to connect (for mixed problems)
   //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
   //! \param[in] thick Thickness of connection
-  virtual bool connectPatch(int edge, ASMs2D& neighbor, int nedge, bool revers,
+  virtual bool connectPatch(int edge, ASM2D& neighbor, int nedge, bool revers,
                             int basis = 0, bool coordCheck = true, int thick = 1);
 
   //! \brief Makes two opposite boundary edges periodic.

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -616,19 +616,23 @@ bool ASMs3D::assignNodeNumbers (BlockNodes& nodes, int basis)
 }
 
 
-bool ASMs3D::connectPatch (int face, ASMs3D& neighbor, int nface,
+bool ASMs3D::connectPatch (int face, ASM3D& neighbor, int nface,
                            int norient, int, bool coordCheck, int thick)
 {
+  ASMs3D* neighS = dynamic_cast<ASMs3D*>(&neighbor);
+  if (!neighS)
+    return false;
+
   if (swapW && face > 4) // Account for swapped parameter direction
     face = 11-face;
 
-  if (neighbor.swapW && nface > 4) // Account for swapped parameter direction
+  if (neighS->swapW && nface > 4) // Account for swapped parameter direction
     nface = 11-nface;
 
-  if (!this->connectBasis(face,neighbor,nface,norient,1,0,0,coordCheck,thick))
+  if (!this->connectBasis(face,*neighS,nface,norient,1,0,0,coordCheck,thick))
     return false;
 
-  this->addNeighbor(&neighbor);
+  this->addNeighbor(neighS);
   return true;
 }
 

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -334,7 +334,7 @@ public:
   //! - left digit = 1: The u and v parameters of the neighbor face are swapped
   //! - middle digit = 1: Parameter \a u in neighbor patch face is reversed
   //! - right digit = 1: Parameter \a v in neighbor patch face is reversed
-  virtual bool connectPatch(int face, ASMs3D& neighbor, int nface, int norient,
+  virtual bool connectPatch(int face, ASM3D& neighbor, int nface, int norient,
                             int = 0, bool coordCheck = true, int thick = 1);
 
   //! \brief Makes two opposite boundary faces periodic.

--- a/src/ASM/ASMs3Dmx.C
+++ b/src/ASM/ASMs3Dmx.C
@@ -298,7 +298,7 @@ bool ASMs3Dmx::generateFEMTopology ()
 }
 
 
-bool ASMs3Dmx::connectPatch (int face, ASMs3D& neighbor, int nface, int norient,
+bool ASMs3Dmx::connectPatch (int face, ASM3D& neighbor, int nface, int norient,
                              int basis, bool coordCheck, int thick)
 {
   ASMs3Dmx* neighMx = dynamic_cast<ASMs3Dmx*>(&neighbor);
@@ -313,7 +313,7 @@ bool ASMs3Dmx::connectPatch (int face, ASMs3D& neighbor, int nface, int norient,
   size_t nb1 = 0, nb2 = 0;
   for (size_t i = 1; i <= m_basis.size(); ++i) {
     if (basis == 0 || i == (size_t)basis)
-      if (!this->connectBasis(face,neighbor,nface,norient,i,nb1,nb2,coordCheck,thick))
+      if (!this->connectBasis(face,*neighMx,nface,norient,i,nb1,nb2,coordCheck,thick))
         return false;
 
     nb1 += nb[i-1];

--- a/src/ASM/ASMs3Dmx.h
+++ b/src/ASM/ASMs3Dmx.h
@@ -97,7 +97,7 @@ public:
   //! \param[in] basis Which basis to connect, or 0 for all.
   //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
   //! \param[in] thick Thickness of connection
-  virtual bool connectPatch(int face, ASMs3D& neighbor, int nface, int norient,
+  virtual bool connectPatch(int face, ASM3D& neighbor, int nface, int norient,
                             int basis = 0, bool coordCheck = true, int thick = 1);
 
   //! \brief Makes two opposite boundary faces periodic.

--- a/src/ASM/ASMs3DmxLag.C
+++ b/src/ASM/ASMs3DmxLag.C
@@ -214,7 +214,7 @@ bool ASMs3DmxLag::generateFEMTopology ()
 }
 
 
-bool ASMs3DmxLag::connectPatch (int face, ASMs3D& neighbor, int nface,
+bool ASMs3DmxLag::connectPatch (int face, ASM3D& neighbor, int nface,
                                 int norient, int basis,
                                 bool coordCheck, int thick)
 {
@@ -231,7 +231,7 @@ bool ASMs3DmxLag::connectPatch (int face, ASMs3D& neighbor, int nface,
   size_t nb2=0;
   for (size_t i = 1;i <= nxx.size(); ++i) {
     if (basis == 0 || i == (size_t)basis)
-      if (!this->connectBasis(face,neighbor,nface,norient,i,nb1,nb2,coordCheck,thick))
+      if (!this->connectBasis(face,*neighMx,nface,norient,i,nb1,nb2,coordCheck,thick))
         return false;
 
     nb1 += nb[i-1];

--- a/src/ASM/ASMs3DmxLag.h
+++ b/src/ASM/ASMs3DmxLag.h
@@ -72,7 +72,7 @@ public:
   //! \param[in] basis Which basis to connect, or 0 for all.
   //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
   //! \param[in] thick Thickness of connection
-  virtual bool connectPatch(int face, ASMs3D& neighbor, int nface, int norient,
+  virtual bool connectPatch(int face, ASM3D& neighbor, int nface, int norient,
                             int basis = 0, bool coordCheck = true, int thick = 1);
 
   //! \brief Makes two opposite boundary faces periodic.

--- a/src/ASM/ASMunstruct.h
+++ b/src/ASM/ASMunstruct.h
@@ -22,6 +22,7 @@ class ThreadGroups;
 
 namespace LR //! Utilities for LR-splines.
 {
+  class Basisfunction;
   class LRSpline;
 
   /*!
@@ -128,6 +129,9 @@ public:
 
   //! \brief Returns a list of basis functions having support on given elements.
   IntVec getFunctionsForElements(const IntVec& elements);
+
+  //! \brief Sort basis functions based on greville points and local knot vectors.
+  static void Sort(std::vector<LR::Basisfunction*>& functions);
 
 protected:
   LR::LRSpline* geo; //!< Pointer to the actual spline geometry object

--- a/src/ASM/LR/ASMLRSpline.C
+++ b/src/ASM/LR/ASMLRSpline.C
@@ -13,6 +13,7 @@
 
 #include "ASMunstruct.h"
 #include "LRSpline/LRSplineSurface.h"
+#include "LRSpline/Basisfunction.h"
 #include "Profiler.h"
 #include "ThreadGroups.h"
 #include <fstream>
@@ -304,4 +305,26 @@ IntVec ASMunstruct::getFunctionsForElements (const IntVec& elements)
   std::copy(functions.begin(), functions.end(), result.begin());
 
   return result;
+}
+
+
+void ASMunstruct::Sort(std::vector<LR::Basisfunction*>& functions)
+{
+  std::sort(functions.begin(), functions.end(),
+            [](const LR::Basisfunction* a, const LR::Basisfunction* b)
+            {
+              int ndir = a->getGrevilleParameter().size();
+              for (int dir = ndir-1; dir >= 0; --dir)
+                if (a->getGrevilleParameter()[dir] != b->getGrevilleParameter()[dir])
+                  return a->getGrevilleParameter()[dir] < b->getGrevilleParameter()[dir];
+
+              for (int dir = ndir-1; dir >= 0; --dir) {
+                size_t idx = 0;
+                for (auto& it : const_cast<LR::Basisfunction*>(a)->getknots(dir))
+                  if (it != const_cast<LR::Basisfunction*>(b)->getknots(dir)[idx])
+                    return it < const_cast<LR::Basisfunction*>(b)->getknots(dir)[idx++];
+               }
+
+              return false;
+            });
 }

--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -470,16 +470,14 @@ bool ASMu2D::generateFEMTopology ()
 }
 
 
-/*
-// this is connecting multiple patches and handling deformed geometries.
-// We'll deal with at a later time, for now we only allow single patch models
-
-bool ASMu2D::connectPatch (int edge, ASMu2D& neighbor, int nedge, bool revers)
+bool ASMu2D::connectPatch (int edge, ASM2D& neighbor, int nedge, bool revers,
+                           int basis, bool coordCheck, int thick)
 {
-  return this->connectBasis(edge,neighbor,nedge,revers);
+  return false;
 }
 
 
+/*
 bool ASMu2D::connectBasis (int edge, ASMu2D& neighbor, int nedge, bool revers,
                            int basis, int slave, int master)
 {
@@ -598,8 +596,8 @@ std::vector<int> ASMu2D::getEdgeNodes (int edge, int basis) const
     ofs += this->getNoNodes(i);
 
   std::vector<LR::Basisfunction*> edgeFunctions;
-  this->getBasis(basis)->getEdgeFunctions(edgeFunctions,
-                                          static_cast<LR::parameterEdge>(edge));
+  this->getBasis(basis)->edgeCurve(static_cast<LR::parameterEdge>(edge),
+                                   edgeFunctions,false);
 
   std::vector<int> result(edgeFunctions.size());
   std::transform(edgeFunctions.begin(), edgeFunctions.end(), result.begin(),

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -441,8 +441,11 @@ protected:
   //! \param[in] basis Which basis to connect the nodes for (mixed methods)
   //! \param[in] slave 0-based index of the first slave node in this basis
   //! \param[in] master 0-based index of the first master node in this basis
+  //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
+  //! \param[in] thick Thickness of connection
   bool connectBasis(int edge, ASMu2D& neighbor, int nedge, bool revers,
-                    int basis = 1, int slave = 0, int master = 0);
+                    int basis = 1, int slave = 0, int master = 0,
+                    bool coordCheck = true, int thick = 1);
 
   //! \brief Extracts parameter values of the Gauss points in one direction.
   //! \param[out] uGP Parameter values in given direction for all points

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -194,15 +194,17 @@ public:
   //! and \a n is the number of nodes along that parameter direction.
   virtual void constrainNode(double xi, double eta, int dof, int code = 0);
 
-  /* More multipatch stuff, maybe later...
   //! \brief Connects all matching nodes on two adjacent boundary edges.
   //! \param[in] edge Local edge index of this patch, in range [1,4]
   //! \param neighbor The neighbor patch
   //! \param[in] nedge Local edge index of neighbor patch, in range [1,4]
   //! \param[in] revers Indicates whether the two edges have opposite directions
-  virtual bool connectPatch(int edge, ASMu2D& neighbor, int nedge,
-                            bool revers = false);
+  //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
+  //! \param[in] thick Thickness of connection
+  virtual bool connectPatch(int edge, ASM2D& neighbor, int nedge, bool revers,
+                            int = 0, bool coordCheck = true, int thick = 1);
 
+  /*
   //! \brief Makes two opposite boundary edges periodic.
   //! \param[in] dir Parameter direction defining the periodic edges
   //! \param[in] basis Which basis to connect (mixed methods), 0 means both

--- a/src/ASM/LR/ASMu2Dmx.C
+++ b/src/ASM/LR/ASMu2Dmx.C
@@ -172,6 +172,9 @@ bool ASMu2Dmx::getSolution (Matrix& sField, const Vector& locSol,
 
 bool ASMu2Dmx::generateFEMTopology ()
 {
+  if (!myMLGN.empty())
+    return true;
+
   if (m_basis.empty()) {
     auto vec = ASMmxBase::establishBases(tensorspline, ASMmxBase::Type);
     m_basis.resize(vec.size());
@@ -754,4 +757,20 @@ void ASMu2Dmx::generateThreadGroups (const Integrand& integrand, bool silence,
     std::cout <<"\n Color "<< i+1;
     std::cout << ": "<< threadGroups[0][i].size() <<" elements";
   }
+}
+
+
+bool ASMu2Dmx::connectPatch (int edge, ASM2D& neighbor, int nedge, bool revers,
+                             int basis, bool coordCheck, int thick)
+{
+  ASMu2Dmx* neighMx = dynamic_cast<ASMu2Dmx*>(&neighbor);
+  if (!neighMx) return false;
+
+  for (size_t i = 1; i <= m_basis.size(); ++i)
+    if (basis == 0 || i == (size_t)basis)
+      if (!this->connectBasis(edge,*neighMx,nedge,revers,i,0,0,coordCheck,thick))
+        return false;
+
+  this->addNeighbor(neighMx);
+  return true;
 }

--- a/src/ASM/LR/ASMu2Dmx.h
+++ b/src/ASM/LR/ASMu2Dmx.h
@@ -172,6 +172,16 @@ public:
   virtual bool refine(const LR::RefineData& prm, Vectors& sol,
                       const char* fName = nullptr);
 
+  //! \brief Connects all matching nodes on two adjacent boundary edges.
+  //! \param[in] edge Local edge index of this patch, in range [1,4]
+  //! \param neighbor The neighbor patch
+  //! \param[in] nedge Local edge index of neighbor patch, in range [1,4]
+  //! \param[in] revers Indicates whether the two edges have opposite directions
+  //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
+  //! \param[in] thick Thickness of connection
+  virtual bool connectPatch(int edge, ASM2D& neighbor, int nedge, bool revers,
+                            int = 0, bool coordCheck = true, int thick = 1);
+
 protected:
   using ASMu2D::generateThreadGroups;
   //! \brief Generates element groups for multi-threading of interior integrals.

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -251,15 +251,16 @@ bool ASMu3D::generateFEMTopology ()
 }
 
 
+bool ASMu3D::connectPatch (int face, ASM3D& neighbor, int nface,
+                           int norient, int, bool coordCheck, int thick)
+{
+  return false;
+}
+
+
 /*
 // this is connecting multiple patches and handling deformed geometries.
 // We'll deal with at a later time, for now we only allow single patch models
-
-bool ASMu3D::connectPatch (int face, ASMu3D& neighbor, int nface, int norient)
-{
-  return this->connectBasis(face,neighbor,nface,norient);
-}
-
 
 bool ASMu3D::connectBasis (int face, ASMu3D& neighbor, int nface, int norient,
                            int basis, int slave, int master)

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -86,7 +86,7 @@ public:
   virtual bool updateCoords(const Vector& displ);
 
   //! \brief Returns the node indices for a given face.
-  std::vector<int> getFaceNodes(int face, int basis = 1) const;
+  std::vector<int> getFaceNodes(int face, int basis = 1, int orient = -1) const;
 
   //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
   //! \param[in] lIndex Local index of the boundary face
@@ -383,8 +383,11 @@ protected:
   //! \param[in] basis Which basis to connect the nodes for (mixed methods)
   //! \param[in] slave 0-based index of the first slave node in this basis
   //! \param[in] master 0-based index of the first master node in this basis
+  //! \param[in] coordCheck False to turn off coordinate checks
+  //! \param[in] thick Thickness of connection
   bool connectBasis(int face, ASMu3D& neighbor, int nface, int norient,
-                    int basis = 1, int slave = 0, int master = 0);
+                    int basis = 1, int slave = 0, int master = 0,
+                    bool coordCheck = true, int thick = 1);
 
   //! \brief Extracts parameter values of the Gauss points in one direction.
   //! \param[out] uGP Parameter values in given direction for all points

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -194,21 +194,23 @@ public:
   void constrainNode(double xi, double eta, double zeta,
                      int dof = 123, int code = 0, char = 1);
 
-  /* More multipatch stuff, maybe later...
   //! \brief Connects all matching nodes on two adjacent boundary faces.
   //! \param[in] face Local face index of this patch, in range [1,6]
   //! \param neighbor The neighbor patch
   //! \param[in] nface Local face index of neighbor patch, in range [1,6]
   //! \param[in] norient Relative face orientation flag (see below)
+  //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
+  //! \param[in] thick Thickness of connection
   //!
   //! \details The face orientation flag \a norient must be in range [0,7].
   //! When interpreted as a binary number, its 3 digits are decoded as follows:
   //! - left digit = 1: The u and v parameters of the neighbor face are swapped
   //! - middle digit = 1: Parameter \a u in neighbor patch face is reversed
   //! - right digit = 1: Parameter \a v in neighbor patch face is reversed
-  virtual bool connectPatch(int face, ASMu3D& neighbor, int nface,
-                            int norient = 0);
+  virtual bool connectPatch(int face, ASM3D& neighbor, int nface, int norient,
+                            int = 0, bool coordCheck = true, int thick = 1);
 
+  /* More multipatch stuff, maybe later...
   //! \brief Makes two opposite boundary faces periodic.
   //! \param[in] dir Parameter direction defining the periodic faces
   //! \param[in] basis Which basis to connect (mixed methods), 0 means both

--- a/src/SIM/SIM2D.C
+++ b/src/SIM/SIM2D.C
@@ -88,12 +88,12 @@ bool SIM2D::addConnection (int master, int slave, int mIdx,
                <<" to P"<< master <<" E"<< mIdx
                <<" reversed? "<< orient << std::endl;
 
-    ASMs2D* spch = static_cast<ASMs2D*>(myModel[lslave-1]);
-    ASMs2D* mpch = static_cast<ASMs2D*>(myModel[lmaster-1]);
+    ASM2D* spch = dynamic_cast<ASM2D*>(myModel[lslave-1]);
+    ASM2D* mpch = dynamic_cast<ASM2D*>(myModel[lmaster-1]);
 
     std::set<int> bases;
     if (basis == 0)
-      for (size_t b = 1; b <= spch->getNoBasis(); ++b)
+      for (size_t b = 1; b <= myModel[lslave-1]->getNoBasis(); ++b)
         bases.insert(b);
     else
       bases = utl::getDigits(basis);

--- a/src/SIM/SIM3D.C
+++ b/src/SIM/SIM3D.C
@@ -66,12 +66,12 @@ bool SIM3D::addConnection (int master, int slave, int mIdx,
                <<" to P"<< master <<" F"<< mIdx
                <<" orient "<< orient << std::endl;
 
-    ASMs3D* spch = static_cast<ASMs3D*>(myModel[lslave-1]);
-    ASMs3D* mpch = static_cast<ASMs3D*>(myModel[lmaster-1]);
+    ASM3D* spch = dynamic_cast<ASM3D*>(myModel[lslave-1]);
+    ASM3D* mpch = dynamic_cast<ASM3D*>(myModel[lmaster-1]);
 
     std::set<int> bases;
     if (basis == 0)
-      for (size_t b = 1; b <= spch->getNoBasis(); ++b)
+      for (size_t b = 1; b <= myModel[lslave-1]->getNoBasis(); ++b)
         bases.insert(b);
     else
       bases = utl::getDigits(basis);


### PR DESCRIPTION
This adds support for multipatch LR models in a very naive way. It has only been tested to work for tensor-converted models and I suspect it to crash and burn for more realistic models.

Opening early so you can look at it. I do not anticipate large changes to this part of the code, the major expectation being that we likely need to sort the nodes on the edges for generic models.

@kmokstad this is interface changes, input on that bit appreciated in particular.