### PR TITLE
Output refactor

### DIFF
--- a/Apps/Common/AppCommon.h
+++ b/Apps/Common/AppCommon.h
@@ -15,9 +15,6 @@
 #define _APP_COMMON_H_
 
 #include "XMLInputBase.h"
-#include "HDF5Writer.h"
-#include "XMLWriter.h"
-#include "IFEM.h"
 
 
 namespace SIM
@@ -36,30 +33,6 @@ namespace SIM
   public:
     int dim; //!< Dimensionality of simulation
   };
-
-  //! \brief Handles application data output.
-  //! \param[in] simulator The top SIMbase instance of your application
-  //! \param[in] solver The SIMSolver instance of your application
-  //! \param[in] hdf5file The file to save to
-  //! \param[in] append Whether or not to append to file
-  //! \param[in] interval The stride in the output file
-  //! \param[in] restartInterval The stride in the restart file
-  template<class Simulator, class Solver>
-  DataExporter* handleDataOutput(Simulator& simulator, Solver& solver,
-                                 const std::string& hdf5file,
-                                 bool append = false,
-                                 int interval = 1,
-                                 int restartInterval = 0)
-  {
-    DataExporter* writer = new DataExporter(true,interval,restartInterval);
-    XMLWriter* xml = new XMLWriter(hdf5file,solver.getProcessAdm());
-    HDF5Writer* hdf = new HDF5Writer(hdf5file,solver.getProcessAdm(),append);
-    writer->registerWriter(xml);
-    writer->registerWriter(hdf);
-    simulator.registerFields(*writer);
-    IFEM::registerCallback(*writer);
-    return writer;
-  }
 }
 
 #endif

--- a/Apps/Common/SIMCoupled.h
+++ b/Apps/Common/SIMCoupled.h
@@ -166,14 +166,14 @@ public:
 
   //! \brief Serialize internal state for restarting purposes.
   //! \param data Container for serialized data
-  bool serialize(DataExporter::SerializeData& data)
+  bool serialize(std::map<std::string,std::string>& data)
   {
     return S1.serialize(data) && S2.serialize(data);
   }
 
   //! \brief Set internal state from a serialized state.
   //! \param[in] data Container for serialized data
-  bool deSerialize(const DataExporter::SerializeData& data)
+  bool deSerialize(const std::map<std::string,std::string>& data)
   {
     return S1.deSerialize(data) && S2.deSerialize(data);
   }

--- a/Apps/Common/SIMCoupled.h
+++ b/Apps/Common/SIMCoupled.h
@@ -67,12 +67,6 @@ public:
       return S2.solveStep(tp) && S1.solveStep(tp);
   }
 
-  //! \brief Postprocesses the solution of current time step.
-  bool postSolve(const TimeStep& tp, bool restart = false)
-  {
-    return S1.postSolve(tp,restart) && S2.postSolve(tp,restart);
-  }
-
   //! \brief Saves the converged results to VTF-file of a given time step.
   virtual bool saveStep(const TimeStep& tp, int& nBlock)
   {

--- a/Apps/Common/SIMCoupledSI.h
+++ b/Apps/Common/SIMCoupledSI.h
@@ -82,7 +82,7 @@ public:
   }
 
 protected:
-  int maxIter; // Maximum number of iterations
+  int maxIter; //!< Maximum number of iterations
 };
 
 #endif

--- a/Apps/Common/SIMExplicitRK.h
+++ b/Apps/Common/SIMExplicitRK.h
@@ -13,9 +13,11 @@
 #ifndef SIM_EXPLICIT_RK_H_
 #define SIM_EXPLICIT_RK_H_
 
-#include "DataExporter.h"
 #include "TimeIntUtils.h"
 #include "TimeStep.h"
+
+class DataExporter;
+
 
 namespace TimeIntegration {
 
@@ -77,20 +79,18 @@ public:
   }
 
   //! \copydoc ISolver::solveStep(TimeStep&)
-  bool solveStep(TimeStep& tp)
+  virtual bool solveStep(TimeStep& tp)
   {
     std::cout <<"\n  step = "<< tp.step <<"  time = "<< tp.time.t << std::endl;
 
-    std::vector<Vector> stages;
-    return solveRK(stages, tp);
-
-    return true;
+    Vectors stages;
+    return this->solveRK(stages, tp);
   }
 
-  //! \brief Apply the Runge-Kutta scheme
+  //! \brief Applies the Runge-Kutta scheme.
   //! \param stages Vector of stage vectors
-  //! \param tp Time stepping information
-  bool solveRK(std::vector<Vector>& stages, TimeStep& tp)
+  //! \param[in] tp Time stepping information
+  bool solveRK(Vectors& stages, const TimeStep& tp)
   {
     TimeDomain time(tp.time);
     Vector dum;
@@ -142,16 +142,22 @@ public:
     return solver.saveStep(tp, nBlock);
   }
 
+  //! \copydoc ISolver::registerFields(DataExporter&)
+  void registerFields(DataExporter& exporter)
+  {
+    solver.registerFields(exporter);
+  }
+
   //! \brief Serialize internal state for restarting purposes.
   //! \param data Container for serialized data
-  bool serialize(DataExporter::SerializeData& data)
+  bool serialize(std::map<std::string,std::string>& data)
   {
     return solver.serialize(data);
   }
 
   //! \brief Set internal state from a serialized state.
   //! \param[in] data Container for serialized data
-  bool deSerialize(const DataExporter::SerializeData& data)
+  bool deSerialize(const std::map<std::string,std::string>& data)
   {
     return solver.deSerialize(data);
   }

--- a/Apps/Common/SIMSemi3D.h
+++ b/Apps/Common/SIMSemi3D.h
@@ -45,7 +45,9 @@ template<class PlaneSolver>
 class SIMSemi3D : public SIMadmin, public SIMdependency
 {
 public:
-  typedef typename PlaneSolver::SetupProps SetupProps;
+  typedef typename PlaneSolver::SetupProps SetupProps; //!< Convenience type
+
+  //! \brief Enum announcing the dimensionality.
   enum { dimension = 2 };
 
   //! \brief The constructor initializes the setup properties.
@@ -122,7 +124,7 @@ public:
   }
 
   //! \brief Returns the name of this simulator (for use in the HDF5 export).
-  std::string getName() const { return "Semi3D"; }
+  virtual std::string getName() const { return "Semi3D"; }
 
   //! \brief Adds fields to a data exporter.
   void registerFields(DataExporter& exporter)
@@ -171,11 +173,10 @@ public:
     return true;
   }
 
-  //! \brief No serialization support.
-  bool serialize(DataExporter::SerializeData& data) { return false; }
-
-  //! \brief No deserialization support.
-  bool deSerialize(const DataExporter::SerializeData& data) { return false; }
+  //! \brief Dummy method, no serialization support.
+  bool serialize(DataExporter::SerializeData&) { return false; }
+  //! \brief Dummy method, no deserialization support.
+  bool deSerialize(const DataExporter::SerializeData&) { return false; }
 
   //! \brief Solves the nonlinear equations by Newton-Raphson iterations.
   bool solveStep(TimeStep& tp)
@@ -185,16 +186,6 @@ public:
       m_planes[i]->getProcessAdm().cout <<"\n  Plane = "<< startCtx+i+1 <<":";
       ok = m_planes[i]->solveStep(tp);
     }
-
-    return ok;
-  }
-
-  //! \brief Extracts the velocity vector from the nonlinear solution vector.
-  bool postSolve(const TimeStep& tp, bool restart = false)
-  {
-    bool ok = true;
-    for (size_t i = 0; i < m_planes.size() && ok; i++)
-      ok = m_planes[i]->postSolve(tp,restart);
 
     return ok;
   }
@@ -308,6 +299,7 @@ public:
   //! \param[in] nvc Number of components in field
   //! \param[in] patches The geometry the field is defined over
   //! \param[in] diffBasis Different basis for the SIM class and the field
+  //! \param[in] component Component to use from field
   template<class T>
   void registerDependency(SIMSemi3D<T>* sim, const std::string& name,
                           short int nvc, const PatchVec& patches,
@@ -372,12 +364,12 @@ public:
   }
 
   //! \brief Dummy method.
-  int getLocalNode(int node) const { return -1; }
+  int getLocalNode(int) const { return -1; }
   //! \brief Dummy method.
-  int getGlobalNode(int node) const { return -1; }
+  int getGlobalNode(int) const { return -1; }
 
   //! \brief Returns the number of bases in the model.
-  int getNoBasis() const { return m_planes[0]->getNoBasis(); }
+  int getNoBasis() const { return m_planes.front()->getNoBasis(); }
 
 protected:
   std::vector<PlaneSolver*> m_planes; //!< Planar solvers

--- a/Apps/Common/SIMSolver.h
+++ b/Apps/Common/SIMSolver.h
@@ -72,11 +72,6 @@ public:
 
   //! \brief Advances the time step one step forward.
   bool advanceStep() { return tp.increment() && S1.advanceStep(tp); }
-  //! \brief Advances the time step \a n steps forward.
-  void fastForward(int n) { for (int i = 0; i < n; i++) this->advanceStep(); }
-
-  //! \brief Postprocesses the solution of current time step.
-  void postSolve(const TimeStep& t, bool rst = false) { S1.postSolve(t,rst); }
 
   //! \brief Solves the problem up to the final time.
   virtual int solveProblem(char* infile, const char* heading = nullptr,

--- a/Apps/Common/SIMSolverAdap.h
+++ b/Apps/Common/SIMSolverAdap.h
@@ -37,11 +37,10 @@ public:
   virtual ~SIMSolverAdap() {}
 
   //! \brief Solves the problem up to the final time.
-  virtual int solveProblem(char* infile, DataExporter* exporter = nullptr,
-                           const char* heading = nullptr, bool = false)
+  virtual int solveProblem(char* infile, const char* heading, bool = false)
   {
-    if (exporter)
-      exporter->setNormPrefixes(aSim.getNormPrefixes());
+    if (SIMSolver<T1>::exporter)
+      SIMSolver<T1>::exporter->setNormPrefixes(aSim.getNormPrefixes());
 
     aSim.setupProjections();
     aSim.initAdaptor(0,2);
@@ -53,8 +52,8 @@ public:
         return 1;
       else if (!aSim.writeGlv(infile,iStep,aSim.getNoNorms()))
         return 2;
-      else if (exporter)
-        exporter->dumpTimeLevel(nullptr,true);
+      else if (SIMSolver<T1>::exporter)
+        SIMSolver<T1>::exporter->dumpTimeLevel(nullptr,true);
 
     return 0;
   }

--- a/Apps/Common/SIMSolverTS.h
+++ b/Apps/Common/SIMSolverTS.h
@@ -43,8 +43,7 @@ public:
   virtual ~SIMSolverTS() {}
 
   //! \brief Solves the problem up to the final time.
-  virtual int solveProblem(char* infile, DataExporter* exporter = nullptr,
-                           const char* heading = nullptr, bool saveInit = true)
+  virtual int solveProblem(char* infile, const char* heading, bool saveInit)
   {
     // Perform some initial refinement to resolve geometric features, etc.
     if (!this->S1.initialRefine(beta,minFrac,maxRef))
@@ -52,7 +51,7 @@ public:
 
     // Save the initial FE model (and state) to VTF and HDF5 for visualization
     int geoBlk = 0, nBlock = 0;
-    if (!this->saveState(exporter,geoBlk,nBlock,true,infile,saveInit))
+    if (!this->saveState(geoBlk,nBlock,true,infile,saveInit))
       return 2;
 
     this->printHeading(heading);
@@ -81,7 +80,7 @@ public:
           if (!this->advanceStep()) // Final time reached
             // Save updated FE model if mesh has been refined
             // Save current results to VTF and HDF5 and then exit
-            return this->saveState(exporter,geoBlk,nBlock,refElms > 0) ? 0 : 2;
+            return this->saveState(geoBlk,nBlock,refElms > 0) ? 0 : 2;
           else if (!this->S1.solveStep(this->tp))
             return 3;
 
@@ -106,7 +105,7 @@ public:
         // The mesh is sufficiently refined at this state.
         // Save the current results to VTF and HDF5, and continue.
         // Note: We then miss the results from the preceding nPredict-1 steps.
-        if (!this->saveState(exporter,geoBlk,nBlock,refElms > 0))
+        if (!this->saveState(geoBlk,nBlock,refElms > 0))
           return 2;
       }
       else
@@ -124,7 +123,7 @@ public:
             return 0; // Final time reached, we're done
           else if (!this->S1.solveStep(this->tp))
             return 3;
-          else if (!this->saveState(exporter,geoBlk,nBlock,j < 1))
+          else if (!this->saveState(geoBlk,nBlock,j < 1))
             return 2;
       }
     }

--- a/Apps/Common/Test/TestSIMCoupled.C
+++ b/Apps/Common/Test/TestSIMCoupled.C
@@ -26,7 +26,6 @@ public:
     preprocess_called(false),
     advancestep_called(false),
     solvestep_called(false),
-    postsolve_called(false),
     savestep_called(false),
     savemodel_called(false),
     init_called(false),
@@ -46,7 +45,6 @@ public:
   bool preprocess() { return preprocess_called = true; }
   bool advanceStep(TimeStep& tp) { return advancestep_called = true; }
   bool solveStep(TimeStep& tp) { return solvestep_called = true; }
-  bool postSolve(const TimeStep&, bool) { return postsolve_called = true; }
   bool saveStep(const TimeStep&, int&) { return savestep_called = true; }
   bool saveModel(char*, int&, int&) { return savemodel_called = true; }
   bool init(const TimeStep&) { return init_called = true; }
@@ -87,7 +85,6 @@ public:
   bool preprocess_called;
   bool advancestep_called;
   bool solvestep_called;
-  bool postsolve_called;
   bool savestep_called;
   bool savemodel_called;
   bool init_called;
@@ -115,7 +112,6 @@ TEST(TestSIMCoupled, Override)
   sim.preprocess();
   sim.advanceStep(tp);
   sim.solveStep(tp);
-  sim.postSolve(tp);
   sim.saveStep(tp, nBlock);
   sim.saveModel((char*)"", geoBlk, nBlock);
   sim.init(tp);
@@ -136,8 +132,6 @@ TEST(TestSIMCoupled, Override)
   ASSERT_TRUE(ovr2.advancestep_called);
   ASSERT_TRUE(ovr1.solvestep_called);
   ASSERT_TRUE(ovr2.solvestep_called);
-  ASSERT_TRUE(ovr1.postsolve_called);
-  ASSERT_TRUE(ovr2.postsolve_called);
   ASSERT_TRUE(ovr1.savemodel_called);
   ASSERT_TRUE(ovr1.init_called);
   ASSERT_TRUE(ovr2.init_called);

--- a/src/ASM/ASMunstruct.h
+++ b/src/ASM/ASMunstruct.h
@@ -20,7 +20,8 @@
 class ThreadGroups;
 
 
-namespace LR {
+namespace LR //! Utilities for LR-splines.
+{
   class LRSpline;
 
   /*!
@@ -72,12 +73,12 @@ namespace LR {
   //! \param[in] iel Element index
   //! \param[in] xi Dimensionless Gauss point coordinates [-1,1]
   void getGaussPointParameters(const LRSpline* spline, RealArray& uGP,
-                               int dir, int nGauss, int iel, const double* xi);
+                               int d, int nGauss, int iel, const double* xi);
 
-  //! \brief Generate thread groups for a LRSpline mesh.
+  //! \brief Generates thread groups for a LR-spline mesh.
   //! \param[out] threadGroups The generated thread groups
-  //! \param[in] lr The LR spline to generate thread groups for
-  void generateThreadGroups(ThreadGroups& threadGroups, const LR::LRSpline* lr);
+  //! \param[in] lr The LR-spline to generate thread groups for
+  void generateThreadGroups(ThreadGroups& threadGroups, const LRSpline* lr);
 }
 
 
@@ -104,7 +105,7 @@ public:
   virtual ~ASMunstruct();
 
   //! \brief Checks if the patch is empty.
-  virtual bool empty() const { return geo == 0; }
+  virtual bool empty() const { return geo == nullptr; }
 
   //! \brief Refines the mesh adaptively.
   //! \param[in] prm Input data used to control the mesh refinement
@@ -122,7 +123,8 @@ public:
   virtual LR::LRSpline* evalSolution(const IntegrandBase& integrand) const = 0;
 
   //! \brief Returns a Bezier basis of order \a p.
-  static Go::BsplineBasis getBezierBasis(int p, double start=-1.0, double end=1.0);
+  static Go::BsplineBasis getBezierBasis(int p,
+                                         double start = -1.0, double end = 1.0);
 
   //! \brief Returns a list of basis functions having support on given elements.
   IntVec getFunctionsForElements(const IntVec& elements);

--- a/src/LinAlg/MatVec.h
+++ b/src/LinAlg/MatVec.h
@@ -80,16 +80,16 @@ namespace utl
 
   //! \brief Congruence transformation of a symmetric matrix.
   //! \param A The matrix to be transformed
-  //! \param[in] Tn Nodal transformation matrix
-  //! \param[in] k Index telling where to insert \b Tn on the diagonal of \b T
-  bool transform(Matrix& A, const Matrix& Tn, size_t k);
+  //! \param[in] T Nodal transformation matrix
+  //! \param[in] K Index telling where to insert \b T on the diagonal
+  bool transform(Matrix& A, const Matrix& T, size_t K);
 
   //! \brief Congruence transformation of a vector.
   //! \param V The vector to be transformed
-  //! \param[in] Tn Nodal transformation matrix
-  //! \param[in] k Index telling where to insert \b Tn on the diagonal of \b T
-  //! \param[in] transpose If \e true, the transpose of \b Tn is used instead
-  bool transform(Vector& V, const Matrix& Tn, size_t k, bool transpose = false);
+  //! \param[in] T Nodal transformation matrix
+  //! \param[in] K Index telling where to insert \b T on the diagonal
+  //! \param[in] transpose If \e true, the transpose of \b T is used instead
+  bool transform(Vector& V, const Matrix& T, size_t K, bool transpose = false);
 
   //! \brief Inverts the square matrix \b A.
   bool invert(Matrix& A);

--- a/src/LinAlg/matrix.h
+++ b/src/LinAlg/matrix.h
@@ -289,7 +289,7 @@ namespace utl //! General utility classes and functions.
       elem.std::template vector<T>::resize(n[0]*n[1]*n[2],T(0));
     }
 
-    // brief Clears the matrix content if the first dimension(s) changed.
+    //! \brief Clears the matrix content if the first dimension(s) changed.
     virtual void clearIfNrowChanged(size_t n1, size_t n2) = 0;
 
   public:
@@ -823,7 +823,7 @@ namespace utl //! General utility classes and functions.
     }
 
   protected:
-    // brief Clears the content if the number of rows changed.
+    //! \brief Clears the content if the number of rows changed.
     virtual void clearIfNrowChanged(size_t n1, size_t)
     {
       if (n1 != nrow) this->elem.clear();
@@ -951,7 +951,7 @@ namespace utl //! General utility classes and functions.
     }
 
   protected:
-    // brief Clears the content if any of the first two dimensions changed.
+    //! \brief Clears the content if any of the first two dimensions changed.
     virtual void clearIfNrowChanged(size_t n1, size_t n2)
     {
       if (n1 != this->n[0] || n2 != this->n[1]) this->elem.clear();


### PR DESCRIPTION
After the very nice restart refactor, I think this follows naturally. It will make sense to let SIMSolver also handle the result output as well as restart such that you don't need the static method in AppCommon.

Downstream changes are modest, and ready, and will be pushed to respective branches after general acceptance of this one. But maybe @akva2 have something to say on it first.