### PR TITLE
Fixed: 1D default geometry with nonzero X0

### DIFF
--- a/src/SIM/ModelGenerator.C
+++ b/src/SIM/ModelGenerator.C
@@ -52,32 +52,35 @@ std::string DefaultGeometry1D::createG2 (int nsd) const
   g2.append("\n2 2\n0 0 1 1\n");
 
   unsigned char d;
-  std::string XYZ;
-  if (utl::getAttribute(geo,"X0",XYZ))
+  std::string X0("0"), X1("1");
+  if (utl::getAttribute(geo,"X0",X0))
   {
-    IFEM::cout <<"\n\tX0 = "<< XYZ;
-    g2.append(XYZ);
+    IFEM::cout <<"\n\tX0 = "<< X0;
+    g2.append(X0);
   }
   else
   {
-    g2.append("0.0");
+    g2.append("0");
     for (d = 1; d < nsd; d++)
-      g2.append(" 0.0");
+      g2.append(" 0");
   }
   g2.append(rational ? " 1.0\n" : "\n");
-  if (utl::getAttribute(geo,"X1",XYZ))
+  if (utl::getAttribute(geo,"X1",X1))
   {
-    IFEM::cout <<"\n\tX1 = "<< XYZ;
-    g2.append(XYZ);
+    IFEM::cout <<"\n\tX1 = "<< X1;
+    g2.append(X1);
   }
   else
   {
-    XYZ = "1.0";
-    if (utl::getAttribute(geo,"L",XYZ))
-      IFEM::cout <<"\n\tLength = "<< XYZ;
-    g2.append(XYZ);
+    double Xend, L = 1.0;
+    std::stringstream is(X0); is >> Xend;
+    if (utl::getAttribute(geo,"L",L))
+      IFEM::cout <<"\n\tLength = "<< L;
+    Xend += L;
+    std::stringstream os; os << Xend;
+    g2.append(os.str());
     for (d = 1; d < nsd; d++)
-      g2.append(" 0.0");
+      g2.append(" 0");
   }
   g2.append(rational ? " 1.0\n" : "\n");
 

--- a/src/SIM/Test/TestModelGenerator.C
+++ b/src/SIM/Test/TestModelGenerator.C
@@ -123,8 +123,8 @@ const std::vector<DefaultGeomTest> geometry1D =
     "1 0\n"
     "2 2\n"
     "0 0 1 1\n"
-    "0.0\n"
-    "1.0\n",
+    "0\n"
+    "1\n",
     "Boundary: 1 1 0 1 2 0 \n"
     "Corners: 1 1 0 1 2 0 \n"
     "Vertex1: 1 1 0 \n"
@@ -135,8 +135,8 @@ const std::vector<DefaultGeomTest> geometry1D =
     "3 0\n"
     "2 2\n"
     "0 0 1 1\n"
-    "0.0 0.0 0.0\n"
-    "1.0 0.0 0.0\n",
+    "0 0 0\n"
+    "1 0 0\n",
     ""},
 
    {"<geometry X0=\"1.0 1.0 0.0\" X1=\"1.0 2.0 0.0\"/>", 3,
@@ -148,13 +148,22 @@ const std::vector<DefaultGeomTest> geometry1D =
     "1.0 2.0 0.0\n",
     ""},
 
-   {"<geometry L=\"2.0\"/>", 1,
+   {"<geometry L=\"2\"/>", 1,
     "100 1 0 0\n"
     "1 0\n"
     "2 2\n"
     "0 0 1 1\n"
-    "0.0\n"
-    "2.0\n",
+    "0\n"
+    "2\n",
+    ""},
+
+   {"<geometry X0=\"-1\" L=\"2\"/>", 1,
+    "100 1 0 0\n"
+    "1 0\n"
+    "2 2\n"
+    "0 0 1 1\n"
+    "-1\n"
+    "1\n",
     ""},
 
    {"<geometry rational=\"true\" sets=\"true\"/>", 1,
@@ -162,8 +171,8 @@ const std::vector<DefaultGeomTest> geometry1D =
     "1 1\n"
     "2 2\n"
     "0 0 1 1\n"
-    "0.0 1.0\n"
-    "1.0 1.0\n",
+    "0 1.0\n"
+    "1 1.0\n",
     "Boundary: 1 1 0 1 2 0 \n"
     "Corners: 1 1 0 1 2 0 \n"
     "Vertex1: 1 1 0 \n"


### PR DESCRIPTION
The single-patch 1D model generator produce incorrect geometry if you specify X0.
This is a proposed fix to that.