### PR TITLE
Changed: Cleaned away some unused/defunct items from AdaptiveSIM

### DIFF
--- a/Apps/Common/SIMSolverAdap.h
+++ b/Apps/Common/SIMSolverAdap.h
@@ -39,18 +39,15 @@ public:
   //! \brief Solves the problem up to the final time.
   virtual int solveProblem(char* infile, const char* heading, bool = false)
   {
-    if (SIMSolver<T1>::exporter)
-      SIMSolver<T1>::exporter->setNormPrefixes(aSim.getNormPrefixes());
-
-    aSim.setupProjections();
-    aSim.initAdaptor(0,2);
+    if (!aSim.initAdaptor())
+      return 1;
 
     this->printHeading(heading);
 
     for (int iStep = 1; aSim.adaptMesh(iStep); iStep++)
       if (!aSim.solveStep(infile,iStep))
         return 1;
-      else if (!aSim.writeGlv(infile,iStep,aSim.getNoNorms()))
+      else if (!aSim.writeGlv(infile,iStep))
         return 2;
       else if (SIMSolver<T1>::exporter)
         SIMSolver<T1>::exporter->dumpTimeLevel(nullptr,true);

--- a/src/SIM/AdaptiveSIM.h
+++ b/src/SIM/AdaptiveSIM.h
@@ -36,10 +36,9 @@ public:
   //! \brief Empty destructor.
   virtual ~AdaptiveSIM() {}
 
-  //! \brief Initializes index to element norms to base the mesh adaption on.
-  //! \param[in] indxProj Index to projection method to base mesh adaption on
-  //! \param[in] nNormProj Number of element norms per projection method
-  bool initAdaptor(size_t indxProj, size_t nNormProj);
+  //! \brief Sets the index to the norm group to base the mesh adaptation on.
+  //! \param[in] indxProj Index to projection method to base mesh adaptation on
+  bool initAdaptor(size_t indxProj = 0);
 
   //! \brief Assembles and solves the linear FE equations on current mesh.
   //! \param[in] inputfile File to read model parameters from after refinement
@@ -53,8 +52,7 @@ public:
   //! \brief Writes current mesh and results to the VTF-file.
   //! \param[in] infile File name used to construct the VTF-file name from
   //! \param[in] iStep  Refinement step identifier
-  //! \param[in] nNormProj Number of element norms per projection method
-  bool writeGlv(const char* infile, int iStep, size_t nNormProj);
+  bool writeGlv(const char* infile, int iStep);
 
   //! \brief Prints out the global norms to the log stream.
   void printNorms(size_t w = 36) const;
@@ -63,14 +61,6 @@ public:
   const Vector& getSolution(size_t idx = 0) const { return solution[idx]; }
   //! \brief Accesses the projections.
   const Vector& getProjection(size_t idx = 0) const { return projs[idx]; }
-  //! \brief Accesses the norm prefices.
-  const char** getNormPrefixes() { return &prefix.front(); }
-
-  //! \brief Initializes the projections.
-  void setupProjections();
-
-  //! \brief Returns the number of norms in adaptor group.
-  int getNoNorms() const;
 
   //! \brief Parses a data section from an input stream.
   //! \param[in] keyWord Keyword of current data section to read
@@ -95,17 +85,16 @@ private:
   int    maxTjoints;   //!< Maximum number of hanging nodes on one element
   double maxAspRatio;  //!< Maximum element aspect ratio
   bool   closeGaps;    //!< Split elements with a hanging node on each side
-  bool   trueBeta;     //!< Beta measured in solution space dimension increase
 
-  //! Beta generates a threshold error
-  enum { NONE, MAXIMUM, AVERAGE, MINIMUM } threshold;
+  //! Threshold flag for how to interpret the refinement percentage, \a beta
+  enum { NONE, MAXIMUM, AVERAGE, MINIMUM, TRUE_BETA } threshold;
 
   //! Refinement scheme: 0=fullspan, 1=minspan, 2=isotropic_elements,
   //! 3=isotropic_functions
   int scheme;
 
-  size_t  adaptor;  //!< Norm group to base the mesh adaption on
-  size_t  adNorm;   //!< Which norm to adapt based on
+  size_t  adaptor;  //!< Norm group to base the mesh adaptation on
+  size_t  adNorm;   //!< Which norm to base the mesh adaptation on
   Vectors solution; //!< All solutions (galerkin projections)
   Vectors gNorm;    //!< Global norms
   Matrix  eNorm;    //!< Element norms


### PR DESCRIPTION
Suggest this cleanup to reduce potential confusion:
* The initAdaptor and writeGlv methods no longer use the nNormProj argument, which means that the getNoNorms method is not needed either.
* The getNormPrefixes method is not needed. There is no point in passing the projection names as prefixes to the HDF5-exporter, because norms of the projected solutions are not exported to HDF5 as it is implemented now (only for FE solution and analytical, when existing). If we also want to have norms of projected solutions on HDF5, this has to be implemented in a different way (do the solutionNorms call outside the exporter method, and only pass the resulting arrays, like we do for the solutions themselves. This, eventually, has to be a separate PR, though, not that urgent).
* The setupProjections method (which only resizes the proj array) is removed. This task is moved to initAdaptor instead, which means that this method has to be invoked _before_ registering the projection arrays with the DataExporter. Notice that SIMSolverAdap still cannot be used if projections are wanted on the HDF5.export (since there is no hookup for doing this call in the SIMSolver template). initAdaptor is currently invoked by SIMSolverAdap::solveProblem, which is too late for achieving this. This is not a big problem though, as it is only the Elasticity app that exports projected fields for adaptive simulations to HDF5, and this app does not use SIMSolverAdap, yet.
* The other changes are cosmetics