### PR TITLE
Added: Extract total rotation angles for result point print

### DIFF
--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -1108,6 +1108,28 @@ void ASMs1D::scatterInd (int p1, int start, IntVec& index)
 }
 
 
+bool ASMs1D::getSolution (Matrix& sField, const Vector& locSol,
+                          const IntVec& nodes) const
+{
+  if (!this->ASMbase::getSolution(sField,locSol,nodes))
+    return false;
+  else if (nf < 6)
+    return true;
+
+  // Extract the total angular rotations as components 4-6
+  for (size_t i = 0; i < nodes.size(); i++)
+    if (nodes[i] > 0 && (size_t)nodes[i] <= nodalT.size())
+    {
+      Vec3 rot = nodalT[nodes[i]-1].rotVec();
+      sField(4,1+i) = rot.x;
+      sField(5,1+i) = rot.y;
+      sField(6,1+i) = rot.z;
+    }
+
+  return true;
+}
+
+
 bool ASMs1D::evalSolution (Matrix& sField, const Vector& locSol,
 			   const int* npe) const
 {

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -197,6 +197,13 @@ public:
   //! \note The number of element nodes must be set in \a grid on input.
   virtual bool tesselate(ElementBlock& grid, const int* npe) const;
 
+  //! \brief Extract the primary solution field at the specified nodes.
+  //! \param[out] sField Solution field
+  //! \param[in] locSol Solution vector local to current patch
+  //! \param[in] nodes 1-based local node numbers to extract solution for
+  virtual bool getSolution(Matrix& sField, const Vector& locSol,
+                           const IntVec& nodes) const;
+
   //! \brief Evaluates the primary solution field at all visualization points.
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector in DOF-order

--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -1396,7 +1396,7 @@ bool SIMoutput::dumpVector (const Vector& vsol, const char* fname,
     }
     else
     {
-      if (!myModel[i]->getSolution(sol1,lsol,points))
+      if (!myModel[i]->ASMbase::getSolution(sol1,lsol,points))
         return false;
     }
 

--- a/src/Utility/Tensor.C
+++ b/src/Utility/Tensor.C
@@ -594,6 +594,32 @@ Real Tensor::trace () const
 }
 
 
+Vec3 Tensor::rotVec () const
+{
+  Vec3 rot;
+  if (n < 2) return rot;
+
+  double R = 0.5*this->trace() - 0.5;
+  double theta = R < 1.0 ? acos(R) : 0.0;
+
+  // Test if 1.0 = (1.0.-theta) in the computer
+  // (safe test to avoid division by zero)
+  double sinth = sin(theta);
+  if (1.0 > 1.0-fabs(sinth))
+    R = 0.5*theta/sinth;
+  else
+    R = 0.5;
+
+  // Compute rotation angles
+  rot.z = R*(v[this->index(2,1)] - v[this->index(1,2)]);
+  if (n < 3) return rot;
+
+  rot.x = R*(v[this->index(3,2)] - v[this->index(2,3)]);
+  rot.y = R*(v[this->index(1,3)] - v[this->index(3,1)]);
+  return rot;
+}
+
+
 Real Tensor::det () const
 {
   if (n == 3)
@@ -845,7 +871,6 @@ SymmTensor& SymmTensor::transform (const Tensor& T)
       v[0] = S11*T(1,1) + S12*T(1,2) + S13*T(1,3);
       v[1] = S21*T(2,1) + S22*T(2,2) + S23*T(2,3);
       v[2] = S31*T(3,1) + S32*T(3,2) + S33*T(3,3);
-
       v[3] = S11*T(2,1) + S12*T(2,2) + S13*T(2,3);
       v[4] = S21*T(3,1) + S22*T(3,2) + S23*T(3,3);
       v[5] = S31*T(1,1) + S32*T(1,2) + S33*T(1,3);
@@ -858,15 +883,12 @@ SymmTensor& SymmTensor::transform (const Tensor& T)
       S21 = T(2,1)*v[0] + T(2,2)*v[3];
       S22 = T(2,1)*v[3] + T(2,2)*v[1];
       S23 = T(2,1)*v[5] + T(2,2)*v[4];
-      S31 = v[5];
-      S32 = v[4];
-      S33 = v[2];
 
       v[0] = S11*T(1,1) + S12*T(1,2);
       v[1] = S21*T(2,1) + S22*T(2,2);
       v[3] = S11*T(2,1) + S12*T(2,2);
       v[4] = S23;
-      v[5] = S31*T(1,1) + S32*T(1,2);
+      v[5] = S13;
     }
     break;
 

--- a/src/Utility/Tensor.h
+++ b/src/Utility/Tensor.h
@@ -147,6 +147,9 @@ public:
   //! \return Determinant of the tensor
   virtual Real inverse(Real tol = Real(0));
 
+  //! \brief Returns the rotation angles corresponding to the tensor.
+  Vec3 rotVec() const;
+
   // Global operators
 
   //! \brief Multiplication between a tensor and a point vector.

--- a/src/Utility/Test/TestTensor.C
+++ b/src/Utility/Test/TestTensor.C
@@ -23,29 +23,29 @@ TEST(TestTensor, Multiply)
 
   Tensor T2 = 2.0*Tensor(std::vector<double>(data,data+4));
   ASSERT_EQ(T2.dim(), 2U);
-  ASSERT_FLOAT_EQ(T2(1,1), 2.0);
-  ASSERT_FLOAT_EQ(T2(2,1), 4.0);
-  ASSERT_FLOAT_EQ(T2(1,2), 6.0);
-  ASSERT_FLOAT_EQ(T2(2,2), 8.0);
+  EXPECT_FLOAT_EQ(T2(1,1), 2.0);
+  EXPECT_FLOAT_EQ(T2(2,1), 4.0);
+  EXPECT_FLOAT_EQ(T2(1,2), 6.0);
+  EXPECT_FLOAT_EQ(T2(2,2), 8.0);
 
   Tensor T3 = 0.5*Tensor(std::vector<double>(data,data+9));
   ASSERT_EQ(T3.dim(), 3U);
-  ASSERT_FLOAT_EQ(T3(1,1), 0.5);
-  ASSERT_FLOAT_EQ(T3(2,1), 1.0);
-  ASSERT_FLOAT_EQ(T3(3,1), 1.5);
-  ASSERT_FLOAT_EQ(T3(1,2), 2.0);
-  ASSERT_FLOAT_EQ(T3(2,2), 2.5);
-  ASSERT_FLOAT_EQ(T3(3,2), 3.0);
-  ASSERT_FLOAT_EQ(T3(1,3), 3.5);
-  ASSERT_FLOAT_EQ(T3(2,3), 4.0);
-  ASSERT_FLOAT_EQ(T3(3,3), 4.5);
+  EXPECT_FLOAT_EQ(T3(1,1), 0.5);
+  EXPECT_FLOAT_EQ(T3(2,1), 1.0);
+  EXPECT_FLOAT_EQ(T3(3,1), 1.5);
+  EXPECT_FLOAT_EQ(T3(1,2), 2.0);
+  EXPECT_FLOAT_EQ(T3(2,2), 2.5);
+  EXPECT_FLOAT_EQ(T3(3,2), 3.0);
+  EXPECT_FLOAT_EQ(T3(1,3), 3.5);
+  EXPECT_FLOAT_EQ(T3(2,3), 4.0);
+  EXPECT_FLOAT_EQ(T3(3,3), 4.5);
 
   Tensor T = T2*T3;
   ASSERT_EQ(T.dim(), 2U);
-  ASSERT_FLOAT_EQ(T(1,1),  7.0);
-  ASSERT_FLOAT_EQ(T(2,1), 10.0);
-  ASSERT_FLOAT_EQ(T(1,2), 19.0);
-  ASSERT_FLOAT_EQ(T(2,2), 28.0);
+  EXPECT_FLOAT_EQ(T(1,1),  7.0);
+  EXPECT_FLOAT_EQ(T(2,1), 10.0);
+  EXPECT_FLOAT_EQ(T(1,2), 19.0);
+  EXPECT_FLOAT_EQ(T(2,2), 28.0);
 }
 
 
@@ -58,73 +58,73 @@ TEST(TestTensor, Shift)
 
   Tensor t2(T2);
   t2.shift(1);
-  ASSERT_FLOAT_EQ(t2(1,1), 3.0);
-  ASSERT_FLOAT_EQ(t2(1,2), 1.0);
-  ASSERT_FLOAT_EQ(t2(2,1), 4.0);
-  ASSERT_FLOAT_EQ(t2(2,2), 2.0);
+  EXPECT_FLOAT_EQ(t2(1,1), 3.0);
+  EXPECT_FLOAT_EQ(t2(1,2), 1.0);
+  EXPECT_FLOAT_EQ(t2(2,1), 4.0);
+  EXPECT_FLOAT_EQ(t2(2,2), 2.0);
   t2 = T2;
   t2.shift(-1);
-  ASSERT_FLOAT_EQ(t2(1,1), 3.0);
-  ASSERT_FLOAT_EQ(t2(1,2), 1.0);
-  ASSERT_FLOAT_EQ(t2(2,1), 4.0);
-  ASSERT_FLOAT_EQ(t2(2,2), 2.0);
+  EXPECT_FLOAT_EQ(t2(1,1), 3.0);
+  EXPECT_FLOAT_EQ(t2(1,2), 1.0);
+  EXPECT_FLOAT_EQ(t2(2,1), 4.0);
+  EXPECT_FLOAT_EQ(t2(2,2), 2.0);
   t2 = T2;
   t2.shift(2);
-  ASSERT_FLOAT_EQ(t2(1,1), 1.0);
-  ASSERT_FLOAT_EQ(t2(1,2), 3.0);
-  ASSERT_FLOAT_EQ(t2(2,1), 2.0);
-  ASSERT_FLOAT_EQ(t2(2,2), 4.0);
+  EXPECT_FLOAT_EQ(t2(1,1), 1.0);
+  EXPECT_FLOAT_EQ(t2(1,2), 3.0);
+  EXPECT_FLOAT_EQ(t2(2,1), 2.0);
+  EXPECT_FLOAT_EQ(t2(2,2), 4.0);
   t2 = T2;
   t2.shift(-2);
-  ASSERT_FLOAT_EQ(t2(1,1), 1.0);
-  ASSERT_FLOAT_EQ(t2(1,2), 3.0);
-  ASSERT_FLOAT_EQ(t2(2,1), 2.0);
-  ASSERT_FLOAT_EQ(t2(2,2), 4.0);
+  EXPECT_FLOAT_EQ(t2(1,1), 1.0);
+  EXPECT_FLOAT_EQ(t2(1,2), 3.0);
+  EXPECT_FLOAT_EQ(t2(2,1), 2.0);
+  EXPECT_FLOAT_EQ(t2(2,2), 4.0);
 
   Tensor t3(T3);
   t3.shift(1);
-  ASSERT_FLOAT_EQ(t3(1,1), 7.0);
-  ASSERT_FLOAT_EQ(t3(1,2), 1.0);
-  ASSERT_FLOAT_EQ(t3(1,3), 4.0);
-  ASSERT_FLOAT_EQ(t3(2,1), 8.0);
-  ASSERT_FLOAT_EQ(t3(2,2), 2.0);
-  ASSERT_FLOAT_EQ(t3(2,3), 5.0);
-  ASSERT_FLOAT_EQ(t3(3,1), 9.0);
-  ASSERT_FLOAT_EQ(t3(3,2), 3.0);
-  ASSERT_FLOAT_EQ(t3(3,3), 6.0);
+  EXPECT_FLOAT_EQ(t3(1,1), 7.0);
+  EXPECT_FLOAT_EQ(t3(1,2), 1.0);
+  EXPECT_FLOAT_EQ(t3(1,3), 4.0);
+  EXPECT_FLOAT_EQ(t3(2,1), 8.0);
+  EXPECT_FLOAT_EQ(t3(2,2), 2.0);
+  EXPECT_FLOAT_EQ(t3(2,3), 5.0);
+  EXPECT_FLOAT_EQ(t3(3,1), 9.0);
+  EXPECT_FLOAT_EQ(t3(3,2), 3.0);
+  EXPECT_FLOAT_EQ(t3(3,3), 6.0);
   t3 = T3;
   t3.shift(-1);
-  ASSERT_FLOAT_EQ(t3(1,1), 4.0);
-  ASSERT_FLOAT_EQ(t3(1,2), 7.0);
-  ASSERT_FLOAT_EQ(t3(1,3), 1.0);
-  ASSERT_FLOAT_EQ(t3(2,1), 5.0);
-  ASSERT_FLOAT_EQ(t3(2,2), 8.0);
-  ASSERT_FLOAT_EQ(t3(2,3), 2.0);
-  ASSERT_FLOAT_EQ(t3(3,1), 6.0);
-  ASSERT_FLOAT_EQ(t3(3,2), 9.0);
-  ASSERT_FLOAT_EQ(t3(3,3), 3.0);
+  EXPECT_FLOAT_EQ(t3(1,1), 4.0);
+  EXPECT_FLOAT_EQ(t3(1,2), 7.0);
+  EXPECT_FLOAT_EQ(t3(1,3), 1.0);
+  EXPECT_FLOAT_EQ(t3(2,1), 5.0);
+  EXPECT_FLOAT_EQ(t3(2,2), 8.0);
+  EXPECT_FLOAT_EQ(t3(2,3), 2.0);
+  EXPECT_FLOAT_EQ(t3(3,1), 6.0);
+  EXPECT_FLOAT_EQ(t3(3,2), 9.0);
+  EXPECT_FLOAT_EQ(t3(3,3), 3.0);
   t3 = T3;
   t3.shift(2);
-  ASSERT_FLOAT_EQ(t3(1,1), 4.0);
-  ASSERT_FLOAT_EQ(t3(1,2), 7.0);
-  ASSERT_FLOAT_EQ(t3(1,3), 1.0);
-  ASSERT_FLOAT_EQ(t3(2,1), 5.0);
-  ASSERT_FLOAT_EQ(t3(2,2), 8.0);
-  ASSERT_FLOAT_EQ(t3(2,3), 2.0);
-  ASSERT_FLOAT_EQ(t3(3,1), 6.0);
-  ASSERT_FLOAT_EQ(t3(3,2), 9.0);
-  ASSERT_FLOAT_EQ(t3(3,3), 3.0);
+  EXPECT_FLOAT_EQ(t3(1,1), 4.0);
+  EXPECT_FLOAT_EQ(t3(1,2), 7.0);
+  EXPECT_FLOAT_EQ(t3(1,3), 1.0);
+  EXPECT_FLOAT_EQ(t3(2,1), 5.0);
+  EXPECT_FLOAT_EQ(t3(2,2), 8.0);
+  EXPECT_FLOAT_EQ(t3(2,3), 2.0);
+  EXPECT_FLOAT_EQ(t3(3,1), 6.0);
+  EXPECT_FLOAT_EQ(t3(3,2), 9.0);
+  EXPECT_FLOAT_EQ(t3(3,3), 3.0);
   t3 = T3;
   t3.shift(-2);
-  ASSERT_FLOAT_EQ(t3(1,1), 7.0);
-  ASSERT_FLOAT_EQ(t3(1,2), 1.0);
-  ASSERT_FLOAT_EQ(t3(1,3), 4.0);
-  ASSERT_FLOAT_EQ(t3(2,1), 8.0);
-  ASSERT_FLOAT_EQ(t3(2,2), 2.0);
-  ASSERT_FLOAT_EQ(t3(2,3), 5.0);
-  ASSERT_FLOAT_EQ(t3(3,1), 9.0);
-  ASSERT_FLOAT_EQ(t3(3,2), 3.0);
-  ASSERT_FLOAT_EQ(t3(3,3), 6.0);
+  EXPECT_FLOAT_EQ(t3(1,1), 7.0);
+  EXPECT_FLOAT_EQ(t3(1,2), 1.0);
+  EXPECT_FLOAT_EQ(t3(1,3), 4.0);
+  EXPECT_FLOAT_EQ(t3(2,1), 8.0);
+  EXPECT_FLOAT_EQ(t3(2,2), 2.0);
+  EXPECT_FLOAT_EQ(t3(2,3), 5.0);
+  EXPECT_FLOAT_EQ(t3(3,1), 9.0);
+  EXPECT_FLOAT_EQ(t3(3,2), 3.0);
+  EXPECT_FLOAT_EQ(t3(3,3), 6.0);
 }
 
 
@@ -151,62 +151,109 @@ TEST(TestTensor, Principal)
 
   Vec3 p;
   T1.principal(p);
-  ASSERT_FLOAT_EQ(p.x, 3.0);
-  ASSERT_FLOAT_EQ(p.y, 2.0);
-  ASSERT_FLOAT_EQ(p.z, 1.0);
+  EXPECT_FLOAT_EQ(p.x, 3.0);
+  EXPECT_FLOAT_EQ(p.y, 2.0);
+  EXPECT_FLOAT_EQ(p.z, 1.0);
   T2.principal(p);
-  ASSERT_FLOAT_EQ(p.x, 2.0);
-  ASSERT_FLOAT_EQ(p.y, 1.0);
+  EXPECT_FLOAT_EQ(p.x, 2.0);
+  EXPECT_FLOAT_EQ(p.y, 1.0);
   T3.principal(p);
-  ASSERT_FLOAT_EQ(p.x, 3.0);
-  ASSERT_FLOAT_EQ(p.y, 2.0);
-  ASSERT_FLOAT_EQ(p.z, 1.0);
+  EXPECT_FLOAT_EQ(p.x, 3.0);
+  EXPECT_FLOAT_EQ(p.y, 2.0);
+  EXPECT_FLOAT_EQ(p.z, 1.0);
 
   std::array<Vec3,3> dir;
   T1.principal(p,dir.data());
-  ASSERT_FLOAT_EQ(p.x, 3.0);
-  ASSERT_FLOAT_EQ(p.y, 2.0);
-  ASSERT_FLOAT_EQ(p.z, 1.0);
-  ASSERT_FLOAT_EQ(dir[0].x, 0.0);
-  ASSERT_FLOAT_EQ(dir[0].y, 0.0);
-  ASSERT_FLOAT_EQ(dir[0].z, 1.0);
-  ASSERT_FLOAT_EQ(dir[1].x, Trans2(1,2));
-  ASSERT_FLOAT_EQ(dir[1].y, Trans2(2,2));
-  ASSERT_FLOAT_EQ(dir[1].z, 0.0);
+  EXPECT_FLOAT_EQ(p.x, 3.0);
+  EXPECT_FLOAT_EQ(p.y, 2.0);
+  EXPECT_FLOAT_EQ(p.z, 1.0);
+  EXPECT_FLOAT_EQ(dir[0].x, 0.0);
+  EXPECT_FLOAT_EQ(dir[0].y, 0.0);
+  EXPECT_FLOAT_EQ(dir[0].z, 1.0);
+  EXPECT_FLOAT_EQ(dir[1].x, Trans2(1,2));
+  EXPECT_FLOAT_EQ(dir[1].y, Trans2(2,2));
+  EXPECT_FLOAT_EQ(dir[1].z, 0.0);
   T2.principal(p,dir.data());
-  ASSERT_FLOAT_EQ(p.x, 2.0);
-  ASSERT_FLOAT_EQ(p.y, 1.0);
-  ASSERT_FLOAT_EQ(dir[0].x, Trans2(1,2));
-  ASSERT_FLOAT_EQ(dir[0].y, Trans2(2,2));
-  ASSERT_FLOAT_EQ(dir[0].z, 0.0);
-  ASSERT_FLOAT_EQ(dir[1].x,-Trans2(1,1));
-  ASSERT_FLOAT_EQ(dir[1].y,-Trans2(2,1));
-  ASSERT_FLOAT_EQ(dir[1].z, 0.0);
+  EXPECT_FLOAT_EQ(p.x, 2.0);
+  EXPECT_FLOAT_EQ(p.y, 1.0);
+  EXPECT_FLOAT_EQ(dir[0].x, Trans2(1,2));
+  EXPECT_FLOAT_EQ(dir[0].y, Trans2(2,2));
+  EXPECT_FLOAT_EQ(dir[0].z, 0.0);
+  EXPECT_FLOAT_EQ(dir[1].x,-Trans2(1,1));
+  EXPECT_FLOAT_EQ(dir[1].y,-Trans2(2,1));
+  EXPECT_FLOAT_EQ(dir[1].z, 0.0);
   T3.principal(p,dir.data());
-  ASSERT_FLOAT_EQ(p.x, 3.0);
-  ASSERT_FLOAT_EQ(p.y, 2.0);
-  ASSERT_FLOAT_EQ(p.z, 1.0);
-  ASSERT_NEAR(dir[0].x, Trans3(1,3), 1.0e-15);
-  ASSERT_NEAR(dir[0].y, Trans3(2,3), 1.0e-15);
-  ASSERT_NEAR(dir[0].z, Trans3(3,3), 1.0e-15);
-  ASSERT_NEAR(dir[1].x, Trans3(1,2), 1.0e-15);
-  ASSERT_NEAR(dir[1].y, Trans3(2,2), 1.0e-15);
-  ASSERT_NEAR(dir[1].z, Trans3(3,2), 1.0e-15);
-  ASSERT_NEAR(dir[2].x, Trans3(1,1), 1.0e-15);
-  ASSERT_NEAR(dir[2].y, Trans3(2,1), 1.0e-15);
-  ASSERT_NEAR(dir[2].z, Trans3(3,1), 1.0e-15);
+  EXPECT_FLOAT_EQ(p.x, 3.0);
+  EXPECT_FLOAT_EQ(p.y, 2.0);
+  EXPECT_FLOAT_EQ(p.z, 1.0);
+  EXPECT_NEAR(dir[0].x, Trans3(1,3), 1.0e-15);
+  EXPECT_NEAR(dir[0].y, Trans3(2,3), 1.0e-15);
+  EXPECT_NEAR(dir[0].z, Trans3(3,3), 1.0e-15);
+  EXPECT_NEAR(dir[1].x, Trans3(1,2), 1.0e-15);
+  EXPECT_NEAR(dir[1].y, Trans3(2,2), 1.0e-15);
+  EXPECT_NEAR(dir[1].z, Trans3(3,2), 1.0e-15);
+  EXPECT_NEAR(dir[2].x, Trans3(1,1), 1.0e-15);
+  EXPECT_NEAR(dir[2].y, Trans3(2,1), 1.0e-15);
+  EXPECT_NEAR(dir[2].z, Trans3(3,1), 1.0e-15);
   T3.principal(p,dir.data(),2);
-  ASSERT_FLOAT_EQ(p.x, 3.0);
-  ASSERT_FLOAT_EQ(p.y, 2.0);
-  ASSERT_FLOAT_EQ(p.z, 1.0);
-  ASSERT_NEAR(dir[0].x, Trans3(1,3), 1.0e-15);
-  ASSERT_NEAR(dir[0].y, Trans3(2,3), 1.0e-15);
-  ASSERT_NEAR(dir[0].z, Trans3(3,3), 1.0e-15);
-  ASSERT_NEAR(dir[1].x, Trans3(1,1), 1.0e-15);
-  ASSERT_NEAR(dir[1].y, Trans3(2,1), 1.0e-15);
-  ASSERT_NEAR(dir[1].z, Trans3(3,1), 1.0e-15);
+  EXPECT_FLOAT_EQ(p.x, 3.0);
+  EXPECT_FLOAT_EQ(p.y, 2.0);
+  EXPECT_FLOAT_EQ(p.z, 1.0);
+  EXPECT_NEAR(dir[0].x, Trans3(1,3), 1.0e-15);
+  EXPECT_NEAR(dir[0].y, Trans3(2,3), 1.0e-15);
+  EXPECT_NEAR(dir[0].z, Trans3(3,3), 1.0e-15);
+  EXPECT_NEAR(dir[1].x, Trans3(1,1), 1.0e-15);
+  EXPECT_NEAR(dir[1].y, Trans3(2,1), 1.0e-15);
+  EXPECT_NEAR(dir[1].z, Trans3(3,1), 1.0e-15);
 
-  ASSERT_FLOAT_EQ(T1.vonMises(), sqrt(3.0));
-  ASSERT_FLOAT_EQ(T2.vonMises(), sqrt(3.0));
-  ASSERT_FLOAT_EQ(T3.vonMises(), sqrt(3.0));
+  EXPECT_FLOAT_EQ(T1.vonMises(), sqrt(3.0));
+  EXPECT_FLOAT_EQ(T2.vonMises(), sqrt(3.0));
+  EXPECT_FLOAT_EQ(T3.vonMises(), sqrt(3.0));
+}
+
+
+TEST(TestTensor, Transform)
+{
+  const double data[9] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0 };
+
+  SymmTensor T1(std::vector<double>(data,data+4));
+  SymmTensor T2(std::vector<double>(data,data+3));
+  SymmTensor T3(std::vector<double>(data,data+6));
+  SymmTensor S1(T1), S2(T2), S3(T3);
+
+  double angle = 25.0*M_PI/180.0;
+  Tensor Trans2(2), Trans3(3);
+  Trans2(1,1) = Trans2(2,2) = cos(angle);
+  Trans2(1,2) = -sin(angle);
+  Trans2(2,1) =  sin(angle);
+  Trans3 = Trans2; Trans3(3,3) = 1.0;
+
+  T1.transform(Trans2);
+  T2.transform(Trans2);
+  T3.transform(Trans2);
+  S1.transform(Trans3);
+  S2.transform(Trans3);
+  S3.transform(Trans3);
+
+  size_t i, j;
+  for (i = 1; i <= 3; i++)
+    for (j = i; j <= 3; j++)
+      EXPECT_FLOAT_EQ(T1(i,j),S1(i,j));
+  for (i = 1; i <= 2; i++)
+    for (j = i; j <= 2; j++)
+      EXPECT_FLOAT_EQ(T2(i,j),S2(i,j));
+  for (i = 1; i <= 3; i++)
+    for (j = i; j <= 3; j++)
+      EXPECT_FLOAT_EQ(T3(i,j),S3(i,j));
+}
+
+
+TEST(TestTensor, RotationAngles)
+{
+  Tensor Rot(0.4,1.6,1.1);
+  Vec3 angles = Rot.rotVec();
+
+  EXPECT_FLOAT_EQ(angles.x, 0.4);
+  EXPECT_FLOAT_EQ(angles.y, 1.6);
+  EXPECT_FLOAT_EQ(angles.z, 1.1);
 }


### PR DESCRIPTION
For problems with rotational DOFs, we want to print out the absolute rotation angles for the result points (as in FENRIS).