### PR TITLE
Anasol projection

### DIFF
--- a/scripts/log2reg.sed
+++ b/scripts/log2reg.sed
@@ -1,10 +1,10 @@
 # $Id$
 # Converts a log-file such that it can be used as reference in regression tests.
 # Basically, it deletes lines which are pointless in comparison with references.
-# Remember to manually insert the command-line arguments as the first line.
 
-1,/^ Executing command:/d
-1,15 s/^ *[^ ][^ ]* //
+1,5 d
+6 s/^ *[^ ][^ ]* //
+7,/^ *VTF support/d
 /^ *$/d
 /^ *iter=/d
 /^===============================================================/,$ d

--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -1206,7 +1206,7 @@ bool ASMbase::evaluate (const Field*, RealArray&, int) const
 }
 
 
-bool ASMbase::evaluate (const RealFunc*, RealArray&, int, double) const
+bool ASMbase::evaluate (const FunctionBase*, RealArray&, int, double) const
 {
-  return Aerror("evaluate(const RealFunc*,RealArray&,int,double)");
+  return Aerror("evaluate(const FunctionBase*,RealArray&,int,double)");
 }

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -533,9 +533,16 @@ public:
   //! problems using internal integration point buffers (with history-dependent
   //! data, etc.) and that must be traversed in the same sequence each time.
   //! \note The implementation of this method is placed in GlbL2projector.C
-  bool L2projection(Matrix& sField,
-                    const IntegrandBase& integrand,
+  bool L2projection(Matrix& sField, IntegrandBase* integrand,
                     const TimeDomain& time);
+
+  //! \brief Projects an explicit function using a continuous global L2-fit.
+  //! \param[out] fVals Control point values of the function
+  //! \param[in] function The function to project
+  //! \param[in] t Current time
+  //!
+  //! \note The implementation of this method is placed in GlbL2projector.C
+  bool L2projection(Matrix& fVals, FunctionBase* function, double t = 0.0);
 
 
   // Methods for result extraction

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -34,6 +34,7 @@ class Integrand;
 class ASMbase;
 class SparseMatrix;
 class StdVector;
+class FunctionBase;
 class RealFunc;
 class VecFunc;
 class Vec3;
@@ -478,7 +479,7 @@ public:
   //! \param[out] vec The obtained coefficients after interpolation
   //! \param[in] basisNum The basis to evaluate for (mixed)
   //! \param[in] time Current time
-  virtual bool evaluate(const RealFunc* f, RealArray& vec,
+  virtual bool evaluate(const FunctionBase* f, RealArray& vec,
                         int basisNum = 1, double time = 0.0) const;
 
   //! \brief Evaluates the secondary solution field at all visualization points.

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -1451,10 +1451,10 @@ bool ASMs1D::getNoStructElms (int& n1, int& n2, int& n3) const
 }
 
 
-bool ASMs1D::evaluate (const RealFunc* func, RealArray& values,
+bool ASMs1D::evaluate (const FunctionBase* func, RealArray& values,
                        int, double time) const
 {
-  Go::SplineCurve* scrv = SplineUtils::project(curv,*func,time);
+  Go::SplineCurve* scrv = SplineUtils::project(curv,*func,func->dim(),time);
   if (!scrv)
   {
     std::cerr <<" *** ASMs1D::evaluate: Projection failure."<< std::endl;

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -226,7 +226,7 @@ public:
   //! \param[out] vec The obtained coefficients after interpolation
   //! \param[in] basis Basis number (mixed)
   //! \param[in] time Current time
-  virtual bool evaluate(const RealFunc* func, RealArray& vec,
+  virtual bool evaluate(const FunctionBase* func, RealArray& vec,
                         int basis, double time) const;
 
   //! \brief Evaluates the secondary solution field at all visualization points.

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -457,7 +457,7 @@ bool ASMs2D::generateFEMTopology ()
 #endif
   // Consistency checks, just to be fool-proof
   if (n1 <  2 || n2 <  2) return false;
-  if (p1 <  1 || p1 <  1) return false;
+  if (p1 <  1 || p2 <  1) return false;
   if (p1 > n1 || p2 > n2) return false;
 
   myMLGE.resize((n1-p1+1)*(n2-p2+1),0);
@@ -1036,7 +1036,7 @@ bool ASMs2D::updateDirichlet (const std::map<int,RealFunc*>& func,
     // Project the function onto the spline curve basis
     Go::SplineCurve* dcrv = 0;
     if ((fit = func.find(dirich[i].code)) != func.end())
-      dcrv = SplineUtils::project(dirich[i].curve,*fit->second,time);
+      dcrv = SplineUtils::project(dirich[i].curve,*fit->second,1,time);
     else if ((vfit = vfunc.find(dirich[i].code)) != vfunc.end())
       dcrv = SplineUtils::project(dirich[i].curve,*vfit->second,nf,time);
     else
@@ -2713,11 +2713,12 @@ short int ASMs2D::InterfaceChecker::hasContribution (int I, int J) const
 }
 
 
-bool ASMs2D::evaluate (const RealFunc* func, RealArray& vec,
+bool ASMs2D::evaluate (const FunctionBase* func, RealArray& vec,
                        int basisNum, double time) const
 {
   Go::SplineSurface* oldSurf = this->getBasis(basisNum);
-  Go::SplineSurface* newSurf = SplineUtils::project(oldSurf,*func,time);
+  Go::SplineSurface* newSurf = SplineUtils::project(oldSurf,*func,
+                                                    func->dim(),time);
   if (!newSurf)
   {
     std::cerr <<" *** ASMs2D::evaluate: Projection failure."<< std::endl;

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -402,7 +402,7 @@ public:
   //! \param[out] vec The obtained coefficients after interpolation
   //! \param[in] basisNum Basis number (mixed)
   //! \param[in] time Current time
-  virtual bool evaluate(const RealFunc* func, RealArray& vec,
+  virtual bool evaluate(const FunctionBase* func, RealArray& vec,
                         int basisNum, double time) const;
 
   //! \brief Evaluates the secondary solution field at all visualization points.

--- a/src/ASM/ASMs2DC1.C
+++ b/src/ASM/ASMs2DC1.C
@@ -54,9 +54,10 @@ bool ASMs2DC1::connectC1 (int edge, ASMs2DC1* neighbor, int nedge, bool revers)
   // Set up the slave node numbers for this surface patch
 
   int n1, n2;
-  if (!this->getSize(n1,n2)) return false;
-  int node = 1, i1 = 0, i2 = 0;
+  if (!this->getSize(n1,n2))
+    return false;
 
+  int node = 1, i1 = 0, i2 = 0;
   switch (edge)
     {
     case 2: // Positive I-direction
@@ -90,9 +91,10 @@ bool ASMs2DC1::connectC1 (int edge, ASMs2DC1* neighbor, int nedge, bool revers)
 
   // Set up the master node numbers for the neighboring surface patch
 
-  if (!neighbor->getSize(n1,n2)) return false;
-  node = 1; i1 = i2 = 0;
+  if (!neighbor->getSize(n1,n2))
+    return false;
 
+  node = 1;
   switch (nedge)
     {
     case 2: // Positive I-direction

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -390,7 +390,7 @@ bool ASMs3D::generateFEMTopology ()
 #endif
   // Consistency checks, just to be fool-proof
   if (n1 <  2 || n2 <  2 || n3 <  2) return false;
-  if (p1 <  1 || p1 <  1 || p3 <  1) return false;
+  if (p1 <  1 || p2 <  1 || p3 <  1) return false;
   if (p1 > n1 || p2 > n2 || p3 > n3) return false;
 
   myMLGE.resize((n1-p1+1)*(n2-p2+1)*(n3-p3+1),0);
@@ -692,7 +692,7 @@ bool ASMs3D::connectBasis (int face, ASMs3D& neighbor, int nface, int norient,
   for (int j = 0; j < n2; j++)
     for (int i = 0; i < n1; i++, ++node)
     {
-      int k = i, l = j;
+      int k, l;
       switch (norient)
 	{
 	case  1: k =    i  ; l = n2-j-1; break;
@@ -1271,7 +1271,7 @@ bool ASMs3D::updateDirichlet (const std::map<int,RealFunc*>& func,
     // Project the function onto the spline surface basis
     Go::SplineSurface* dsurf = nullptr;
     if ((fit = func.find(dirich[i].code)) != func.end())
-      dsurf = SplineUtils::project(dirich[i].surf,*fit->second,time);
+      dsurf = SplineUtils::project(dirich[i].surf,*fit->second,1,time);
     else if ((vfit = vfunc.find(dirich[i].code)) != vfunc.end())
       dsurf = SplineUtils::project(dirich[i].surf,*vfit->second,nf,time);
     else
@@ -3172,11 +3172,12 @@ short int ASMs3D::InterfaceChecker::hasContribution (int I, int J, int K) const
 }
 
 
-bool ASMs3D::evaluate (const RealFunc* func, RealArray& vec,
+bool ASMs3D::evaluate (const FunctionBase* func, RealArray& vec,
                        int basisNum, double time) const
 {
   Go::SplineVolume* oldVol = this->getBasis(basisNum);
-  Go::SplineVolume* newVol = SplineUtils::project(oldVol,*func,time);
+  Go::SplineVolume* newVol = SplineUtils::project(oldVol,*func,
+                                                  func->dim(),time);
   if (!newVol)
   {
     std::cerr <<" *** ASMs3D::evaluate: Projection failure."<< std::endl;

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -468,8 +468,8 @@ public:
   //! \param[out] vec The obtained coefficients after interpolation
   //! \param[in] basisNum Basis number (mixed)
   //! \param[in] time Current time
-  virtual bool evaluate(const RealFunc* func, RealArray& vec,
-                       int basisNum, double time) const;
+  virtual bool evaluate(const FunctionBase* func, RealArray& vec,
+                        int basisNum, double time) const;
 
   //! \brief Evaluates the secondary solution field at all visualization points.
   //! \param[out] sField Solution field

--- a/src/ASM/GlbL2projector.C
+++ b/src/ASM/GlbL2projector.C
@@ -17,6 +17,8 @@
 #include "FiniteElement.h"
 #include "TimeDomain.h"
 #include "ASMbase.h"
+#include "IntegrandBase.h"
+#include "Function.h"
 #include "Profiler.h"
 
 
@@ -39,31 +41,51 @@ public:
 
   GlbL2&         gl2Int;  //!< The global L2-projection integrand
   LocalIntegral* elmData; //!< Element data associated with problem integrand
-  IntVec         mnpc;    //!< Matrix of element nodal correspondance
-  std::vector<size_t> elem_sizes;  //!< Size of each basis on the element
-  std::vector<size_t> basis_sizes; //!< Size of each basis on the patch
+
+  IntVec  mnpc;        //!< Matrix of element nodal correspondance
+  uIntVec elem_sizes;  //!< Size of each basis on the element
+  uIntVec basis_sizes; //!< Size of each basis on the patch
 };
 
 
-GlbL2::GlbL2 (IntegrandBase& p, size_t n) : problem(p), A(SparseMatrix::SUPERLU)
+GlbL2::GlbL2 (IntegrandBase* p, size_t n) : A(SparseMatrix::SUPERLU)
 {
+  problem = p;
+  function = nullptr;
+
   A.redim(n,n);
-  B.redim(n*p.getNoFields(2));
+  B.redim(n*p->getNoFields(2));
+}
+
+
+GlbL2::GlbL2 (FunctionBase* f, size_t n) : A(SparseMatrix::SUPERLU)
+{
+  problem = nullptr;
+  function = f;
+
+  A.redim(n,n);
+  B.redim(n*f->dim());
 }
 
 
 int GlbL2::getIntegrandType () const
 {
-  // Mask off the element interface flag
-  return problem.getIntegrandType() & ~INTERFACE_TERMS;
+  if (problem)
+    // Mask off the element interface flag
+    return problem->getIntegrandType() & ~INTERFACE_TERMS;
+  else
+    return STANDARD;
 }
 
 
 LocalIntegral* GlbL2::getLocalIntegral (size_t nen, size_t iEl,
                                         bool neumann) const
 {
-  return new L2Mats(*const_cast<GlbL2*>(this),
-                    problem.getLocalIntegral(nen,iEl,neumann));
+  if (problem)
+    return new L2Mats(*const_cast<GlbL2*>(this),
+                      problem->getLocalIntegral(nen,iEl,neumann));
+  else
+    return new L2Mats(*const_cast<GlbL2*>(this));
 }
 
 
@@ -74,13 +96,15 @@ bool GlbL2::initElement (const IntVec& MNPC, const FiniteElement& fe,
   L2Mats& gl2 = static_cast<L2Mats&>(elmInt);
 
   gl2.mnpc = MNPC;
-  return problem.initElement(MNPC,fe,Xc,nPt,*gl2.elmData);
+  if (problem && gl2.elmData)
+    return problem->initElement(MNPC,fe,Xc,nPt,*gl2.elmData);
+  else
+    return true;
 }
 
 
 bool GlbL2::initElement (const IntVec& MNPC1,
-                         const std::vector<size_t>& elem_sizes,
-                         const std::vector<size_t>& basis_sizes,
+                         const uIntVec& elem_sizes, const uIntVec& basis_sizes,
                          LocalIntegral& elmInt)
 {
   L2Mats& gl2 = static_cast<L2Mats&>(elmInt);
@@ -88,7 +112,10 @@ bool GlbL2::initElement (const IntVec& MNPC1,
   gl2.mnpc = MNPC1;
   gl2.elem_sizes = elem_sizes;
   gl2.basis_sizes = basis_sizes;
-  return problem.initElement(MNPC1,elem_sizes,basis_sizes,*gl2.elmData);
+  if (problem && gl2.elmData)
+    return problem->initElement(MNPC1,elem_sizes,basis_sizes,*gl2.elmData);
+  else
+    return true;
 }
 
 
@@ -100,24 +127,16 @@ bool GlbL2::evalInt (LocalIntegral& elmInt,
   L2Mats& gl2 = static_cast<L2Mats&>(elmInt);
 
   Vector solPt;
-  if (!problem.evalSol(solPt,fe,X,gl2.mnpc))
-    if (!problem.diverged(fe.iGP+1))
-      return false;
-
-  size_t a, b, nnod = A.dim();
-  for (a = 0; a < fe.N.size(); a++)
+  if (problem)
   {
-    int inod = gl2.mnpc[a]+1;
-    for (b = 0; b < fe.N.size(); b++)
-    {
-      int jnod = gl2.mnpc[b]+1;
-      A(inod,jnod) += fe.N[a]*fe.N[b]*fe.detJxW;
-    }
-    for (b = 0; b < solPt.size(); b++)
-      B(inod+b*nnod) += fe.N[a]*solPt[b]*fe.detJxW;
+    if (!problem->evalSol(solPt,fe,X,gl2.mnpc))
+      if (!problem->diverged(fe.iGP+1))
+        return false;
   }
+  else if (function)
+    solPt = function->getValue(X);
 
-  return true;
+  return this->formL2Mats(gl2.mnpc,solPt,fe,X);
 }
 
 
@@ -129,21 +148,33 @@ bool GlbL2::evalIntMx (LocalIntegral& elmInt,
   L2Mats& gl2 = static_cast<L2Mats&>(elmInt);
 
   Vector solPt;
-  if (!problem.evalSol(solPt,fe,X,gl2.mnpc,gl2.elem_sizes,gl2.basis_sizes))
-    if (!problem.diverged(fe.iGP+1))
-      return false;
-
-  size_t a, b, nnod = A.dim();
-  for (a = 0; a < fe.basis(1).size(); a++)
+  if (problem)
   {
-    int inod = gl2.mnpc[a]+1;
-    for (b = 0; b < fe.basis(1).size(); b++)
+    if (!problem->evalSol(solPt,fe,X,gl2.mnpc,gl2.elem_sizes,gl2.basis_sizes))
+      if (!problem->diverged(fe.iGP+1))
+        return false;
+  }
+  else if (function)
+    solPt = function->getValue(X);
+
+  return this->formL2Mats(gl2.mnpc,solPt,fe,X);
+}
+
+
+bool GlbL2::formL2Mats (const IntVec& mnpc, const Vector& solPt,
+                        const FiniteElement& fe, const Vec3& X) const
+{
+  size_t a, b, nnod = A.dim();
+  for (a = 0; a < fe.N.size(); a++)
+  {
+    int inod = mnpc[a]+1;
+    for (b = 0; b < fe.N.size(); b++)
     {
-      int jnod = gl2.mnpc[b]+1;
-      A(inod,jnod) += fe.basis(1)[a]*fe.basis(1)[b]*fe.detJxW;
+      int jnod = mnpc[b]+1;
+      A(inod,jnod) += fe.N[a]*fe.N[b]*fe.detJxW;
     }
     for (b = 0; b < solPt.size(); b++)
-      B(inod+b*nnod) += fe.basis(1)[a]*solPt[b]*fe.detJxW;
+      B(inod+b*nnod) += fe.N[a]*solPt[b]*fe.detJxW;
   }
 
   return true;
@@ -173,7 +204,11 @@ bool GlbL2::solve (Matrix& sField)
   if (!A.solve(B)) return false;
 
   // Store the nodal values of the projected field
-  size_t j, ncomp = problem.getNoFields(2);
+  size_t j, ncomp = 0;
+  if (problem)
+    ncomp = problem->getNoFields(2);
+  else if (function)
+    ncomp = function->dim();
   sField.resize(ncomp,nnod);
   for (i = 1; i <= nnod; i++)
     for (j = 1; j <= ncomp; j++)
@@ -187,13 +222,26 @@ bool GlbL2::solve (Matrix& sField)
 
 
 bool ASMbase::L2projection (Matrix& sField,
-                            const IntegrandBase& integrand,
+                            IntegrandBase* integrand,
                             const TimeDomain& time)
 {
   PROFILE2("ASMbase::L2projection");
 
-  GlbL2 gl2(const_cast<IntegrandBase&>(integrand),this->getNoNodes(1));
+  GlbL2 gl2(integrand,this->getNoNodes(1));
   GlobalIntegral dummy;
+
+  gl2.preAssemble(MNPC,this->getNoElms(true));
+  return this->integrate(gl2,dummy,time) && gl2.solve(sField);
+}
+
+
+bool ASMbase::L2projection (Matrix& sField, FunctionBase* function, double t)
+{
+  PROFILE2("ASMbase::L2projection");
+
+  GlbL2 gl2(function,this->getNoNodes(1));
+  GlobalIntegral dummy;
+  TimeDomain time; time.t = t;
 
   gl2.preAssemble(MNPC,this->getNoElms(true));
   return this->integrate(gl2,dummy,time) && gl2.solve(sField);

--- a/src/ASM/LR/ASMu2Dmx.h
+++ b/src/ASM/LR/ASMu2Dmx.h
@@ -177,10 +177,11 @@ public:
   //! \param neighbor The neighbor patch
   //! \param[in] nedge Local edge index of neighbor patch, in range [1,4]
   //! \param[in] revers Indicates whether the two edges have opposite directions
+  //! \param[in] basis Which basis to connect
   //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
   //! \param[in] thick Thickness of connection
   virtual bool connectPatch(int edge, ASM2D& neighbor, int nedge, bool revers,
-                            int = 0, bool coordCheck = true, int thick = 1);
+                            int basis, bool coordCheck = true, int thick = 1);
 
 protected:
   //! \brief Assembles L2-projection matrices for the secondary solution.

--- a/src/LinAlg/matrix.h
+++ b/src/LinAlg/matrix.h
@@ -1731,7 +1731,7 @@ namespace utl //! General utility classes and functions.
     else
       s <<"[";
 
-    size_t nsp = 4 + strlen(label);
+    size_t nsp = label ? 4 + strlen(label) : 1;
     for (size_t i = 1; i <= A.rows(); i++)
     {
       if (i > 1)

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -26,8 +26,7 @@
 #include "GlbNorm.h"
 #include "ElmNorm.h"
 #include "AnaSol.h"
-#include "Function.h"
-#include "Vec3.h"
+#include "TensorFunction.h"
 #include "Vec3Oper.h"
 #include "Utilities.h"
 #include "Profiler.h"
@@ -1720,6 +1719,36 @@ bool SIMbase::project (Vector& ssol, const Vector& psol,
     return false;
 
   ssol = stmp;
+  return true;
+}
+
+
+bool SIMbase::projectAnaSol (Vector& ssol,
+                             SIMoptions::ProjectionMethod pMethod) const
+{
+  if (!mySol) return true;
+
+  FunctionBase* f = mySol->getScalarSecSol();
+  if (f)
+  {
+    ssol.resize(f->dim()*mySam->getNoNodes());
+    return this->project(ssol,f,0,0,0,pMethod);
+  }
+
+  f = mySol->getVectorSecSol();
+  if (f)
+  {
+    ssol.resize(f->dim()*mySam->getNoNodes());
+    return this->project(ssol,f,0,0,0,pMethod);
+  }
+
+  f = mySol->getStressSol();
+  if (f)
+  {
+    ssol.resize(f->dim()*mySam->getNoNodes());
+    return this->project(ssol,f,0,0,0,pMethod);
+  }
+
   return true;
 }
 

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -28,6 +28,7 @@ class SAM;
 class AlgEqSystem;
 class LinSolParams;
 class SystemVector;
+class FunctionBase;
 class RealFunc;
 class VecFunc;
 class TractionFunc;
@@ -419,15 +420,17 @@ public:
   bool project(Vector& ssol, const Vector& psol,
                SIMoptions::ProjectionMethod pMethod = SIMoptions::GLOBAL) const;
 
-  //! \brief Projects a scalar function onto the specified basis.
+  //! \brief Projects a function onto the specified basis.
   //! \param[out] values Resulting control point values
   //! \param[in] f The function to evaluate
   //! \param[in] basis Which basis to consider
   //! \param[in] iField Field component offset in values vector
   //! \param[in] nFields Number of field components in values vector
+  //! \param[in] pMethod Projection method to use
   //! \param[in] time Current time
-  bool project(Vector& values, const RealFunc* f,
+  bool project(Vector& values, const FunctionBase* f,
                int basis = 1, int iField = 0, int nFields = 1,
+               SIMoptions::ProjectionMethod pMethod = SIMoptions::GLOBAL,
                double time = 0.0) const;
 
   //! \brief Evaluates the secondary solution field for specified patch.

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -420,6 +420,12 @@ public:
   bool project(Vector& ssol, const Vector& psol,
                SIMoptions::ProjectionMethod pMethod = SIMoptions::GLOBAL) const;
 
+  //! \brief Projects the analytical secondary solution, if any.
+  //! \param[out] ssol Vector of control point values of the secondary solution
+  //! \param[in] pMethod Projection method to use
+  bool projectAnaSol(Vector& ssol,
+                     SIMoptions::ProjectionMethod pMethod) const;
+
   //! \brief Projects a function onto the specified basis.
   //! \param[out] values Resulting control point values
   //! \param[in] f The function to evaluate

--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -345,7 +345,7 @@ bool SIMoutput::writeGlvBC (int& nBlock, int iStep) const
     Matrix bc(nbc,nNodes);
     RealArray flag(3,0.0);
     ASMbase::BCVec::const_iterator bit;
-    for (bit = myModel[i]->begin_BC(); bit != myModel[i]->end_BC(); bit++)
+    for (bit = myModel[i]->begin_BC(); bit != myModel[i]->end_BC(); ++bit)
       if ((n = myModel[i]->getNodeIndex(bit->node,true)) && n <= bc.cols())
       {
         if (!bit->CX && nbc > 0) bc(1,n) = flag[0] = 1.0;
@@ -747,7 +747,7 @@ bool SIMoutput::writeGlvS2 (const Vector& psol, int iStep, int& nBlock,
       const ElementBlock* grid = myVtf->getBlock(geomID);
       Vec3Vec::const_iterator cit = grid->begin_XYZ();
       field.fill(0.0);
-      for (j = 1; cit != grid->end_XYZ() && haveAsol; j++, cit++)
+      for (j = 1; cit != grid->end_XYZ() && haveAsol; j++, ++cit)
       {
         Vec4 Xt(*cit,time);
         if (mySol->hasScalarSol() == 3 || mySol->hasVectorSol() == 3)
@@ -1250,7 +1250,7 @@ bool SIMoutput::dumpResults (const Vector& psol, double time,
     Vec3Vec Xp;
 
     // Find all evaluation points within this patch, if any
-    for (j = 0, p = gPoints.begin(); p != gPoints.end(); j++, p++)
+    for (j = 0, p = gPoints.begin(); p != gPoints.end(); j++, ++p)
       if (this->getLocalPatchIndex(p->patch) == (int)(i+1))
         if (opt.discretization >= ASM::Spline)
         {
@@ -1380,7 +1380,7 @@ bool SIMoutput::dumpVector (const Vector& vsol, const char* fname,
   std::vector<ResPtPair>::const_iterator pit;
   ResPointVec::const_iterator p;
 
-  for (pit = myPoints.begin(); pit != myPoints.end(); ++pit)
+  for (pit = myPoints.begin(); pit != myPoints.end() && ok; ++pit)
   {
     if (fname)
     {
@@ -1399,7 +1399,7 @@ bool SIMoutput::dumpVector (const Vector& vsol, const char* fname,
       continue; // Skip output for this point group
 
     iPoint = 1;
-    for (i = 0; i < myModel.size(); i++)
+    for (i = 0; i < myModel.size() && ok; i++)
     {
       if (myModel[i]->empty()) continue; // skip empty patches
 
@@ -1425,10 +1425,9 @@ bool SIMoutput::dumpVector (const Vector& vsol, const char* fname,
         ok = myModel[i]->evalSolution(sol1,lsol,params.data(),false);
       else
         ok = myModel[i]->ASMbase::getSolution(sol1,lsol,points);
-      if (!ok) return false;
 
       if (fs) // Single-line output to separate file
-        for (j = 0; j < points.size(); j++, iPoint++)
+        for (j = 0; j < points.size() && ok; j++, iPoint++)
         {
           *fs << iPoint;
           for (k = 1; k <= sol1.rows(); k++)
@@ -1437,7 +1436,7 @@ bool SIMoutput::dumpVector (const Vector& vsol, const char* fname,
         }
 
       else // Formatted output to log stream
-        for (j = 0; j < points.size(); j++, iPoint++)
+        for (j = 0; j < points.size() && ok; j++, iPoint++)
         {
           if (points[j] < 0)
             os <<"  Point #"<< -points[j];
@@ -1464,7 +1463,7 @@ bool SIMoutput::dumpVector (const Vector& vsol, const char* fname,
     }
   }
 
-  return true;
+  return ok;
 }
 
 

--- a/src/Utility/ExprFunctions.C
+++ b/src/Utility/ExprFunctions.C
@@ -392,6 +392,8 @@ void TensorFuncExpr::setNoDims ()
     nsd = 2;
   else if (p.size() > 0)
     nsd = 1;
+
+  ncmp = nsd*nsd;
 }
 
 
@@ -446,6 +448,8 @@ void STensorFuncExpr::setNoDims ()
     nsd = 2;
   else if (p.size() > 0)
     nsd = 1;
+
+  ncmp = p.size() == 4 ? 4 : (nsd+1)*nsd/2;
 }
 
 

--- a/src/Utility/ExprFunctions.h
+++ b/src/Utility/ExprFunctions.h
@@ -170,8 +170,8 @@ public:
   virtual Ret dderiv(const Vec3& X, int dir1, int dir2) const;
 
 protected:
-  //! \brief Sets the number of spatial dimenions (default implementation).
-  void setNoDims() { nsd = p.size(); }
+  //! \brief Sets the number of spatial dimensions (default implementation).
+  void setNoDims() { ParentFunc::ncmp = nsd = p.size(); }
 
   //! \brief Evaluates the function expressions.
   virtual Ret evaluate(const Vec3& X) const;

--- a/src/Utility/SplineUtils.h
+++ b/src/Utility/SplineUtils.h
@@ -16,8 +16,7 @@
 
 #include "MatVec.h"
 
-class RealFunc;
-class VecFunc;
+class FunctionBase;
 class Vec4;
 class Vec3;
 
@@ -61,26 +60,20 @@ namespace SplineUtils //! Various utility functions on spline objects.
   void extractBasis(const Go::BasisDerivs2& spline,
                     Vector& N, Matrix& dNdu, Matrix3D& d2Ndu2);
 
-  //! \brief Projects a scalar-valued function onto a spline curve.
+  //! \brief Projects a spatial function onto a spline curve.
   Go::SplineCurve* project(const Go::SplineCurve* curve,
-                           const RealFunc& f, Real time = Real(0));
-  //! \brief Projects a vector-valued function onto a spline curve.
-  Go::SplineCurve* project(const Go::SplineCurve* curve,
-                           const VecFunc& f, int nComp, Real time = Real(0));
+                           const FunctionBase& f,
+                           int nComp = 1, Real time = Real(0));
 
-  //! \brief Projects a scalar-valued function onto a spline surface.
+  //! \brief Projects a spatial function onto a spline surface.
   Go::SplineSurface* project(const Go::SplineSurface* surface,
-                             const RealFunc& f, Real time = Real(0));
-  //! \brief Projects a vector-valued function onto a spline surface.
-  Go::SplineSurface* project(const Go::SplineSurface* surface,
-                             const VecFunc& f, int nComp, Real time = Real(0));
+                             const FunctionBase& f,
+                             int nComp = 1, Real time = Real(0));
 
-  //! \brief Projects a scalar-valued function onto a spline volume.
+  //! \brief Projects a spatial function onto a spline volume.
   Go::SplineVolume* project(const Go::SplineVolume* volume,
-                            const RealFunc& f, Real time = Real(0));
-  //! \brief Projects a vector-valued function onto a spline volume.
-  Go::SplineVolume* project(const Go::SplineVolume* volume,
-                            const VecFunc& f, int nComp, Real time = Real(0));
+                            const FunctionBase& f,
+                            int nComp = 1, Real time = Real(0));
 }
 
 #endif

--- a/src/Utility/TensorFunction.h
+++ b/src/Utility/TensorFunction.h
@@ -22,14 +22,24 @@
   \brief Tensor-valued unary function of a spatial point.
 */
 
-class TensorFunc : public utl::SpatialFunction<Tensor>
+class TensorFunc : public utl::SpatialFunction<Tensor>, public FunctionBase
 {
 protected:
   //! \brief The constructor is protected to allow sub-class instances only.
-  TensorFunc(size_t n = 0) : utl::SpatialFunction<Tensor>(Tensor(n)) {}
+  TensorFunc(size_t n = 0) : utl::SpatialFunction<Tensor>(Tensor(n))
+  {
+    ncmp = zero.size();
+  }
+
 public:
   //! \brief Empty destructor.
   virtual ~TensorFunc() {}
+
+  //! \brief Returns the function value as an array.
+  virtual std::vector<Real> getValue(const Vec3& X) const
+  {
+    return this->evaluate(X);
+  }
 };
 
 
@@ -37,14 +47,26 @@ public:
   \brief Symmetric tensor-valued unary function of a spatial point.
 */
 
-class STensorFunc : public utl::SpatialFunction<SymmTensor>
+class STensorFunc : public utl::SpatialFunction<SymmTensor>,
+                    public FunctionBase
 {
 protected:
   //! \brief The constructor is protected to allow sub-class instances only.
-  STensorFunc(size_t n = 0) : utl::SpatialFunction<SymmTensor>(SymmTensor(n)) {}
+  STensorFunc(size_t n = 0, bool with33 = false)
+    : utl::SpatialFunction<SymmTensor>(SymmTensor(n,with33))
+  {
+    ncmp = zero.size();
+  }
+
 public:
   //! \brief Empty destructor.
   virtual ~STensorFunc() {}
+
+  //! \brief Returns the function value as an array.
+  virtual std::vector<Real> getValue(const Vec3& X) const
+  {
+    return this->evaluate(X);
+  }
 };
 
 #endif

--- a/src/Utility/Test/TestSplineUtils.C
+++ b/src/Utility/Test/TestSplineUtils.C
@@ -6,7 +6,7 @@
 //!
 //! \author Arne Morten Kvarving / SINTEF
 //!
-//! \brief Tests for various utility functions on spline objects - GoTools extensions.
+//! \brief Tests for various utility functions on spline objects.
 //!
 //==============================================================================
 
@@ -18,7 +18,6 @@
 #include "GoTools/geometry/Plane.h"
 #include "GoTools/trivariate/SphereVolume.h"
 #include "GoTools/trivariate/SplineVolume.h"
-#include "Vec3.h"
 #include "ExprFunctions.h"
 #include <fstream>
 
@@ -47,29 +46,26 @@ static Matrix3D readMatrices(size_t r, size_t c, size_t k, const std::string& fi
   return result;
 }
 
-#define CHECK_VECTORS_EQUAL(A,path) \
-  do { \
-  Matrix B = readMatrix(A.size(), 1, path); \
-  for (size_t i=1;i<=A.size();++i) \
-      ASSERT_NEAR(A(i), B(i,1), 1e-13); \
-  } while(0);
+#define CHECK_VECTORS_EQUAL(A,path) { \
+    Matrix B = readMatrix(A.size(), 1, path); \
+    for (size_t i=1;i<=A.size();++i) \
+      EXPECT_NEAR(A(i), B(i,1), 1e-13); \
+  }
 
-#define CHECK_MATRICES_EQUAL(A,path) \
-  do { \
-  Matrix B = readMatrix(A.rows(), A.cols(), path); \
-  for (size_t i=1;i<=A.rows();++i) \
-    for (size_t j=1;j<=A.cols();++j) \
-      ASSERT_NEAR(A(i,j), B(i,j), 1e-13); \
-  } while(0);
+#define CHECK_MATRICES_EQUAL(A,path) { \
+    Matrix B = readMatrix(A.rows(), A.cols(), path); \
+    for (size_t i=1;i<=A.rows();++i) \
+      for (size_t j=1;j<=A.cols();++j) \
+        EXPECT_NEAR(A(i,j), B(i,j), 1e-13); \
+  }
 
-#define CHECK_MATRICES3D_EQUAL(A,path) \
-  do { \
+#define CHECK_MATRICES3D_EQUAL(A,path) { \
     Matrix3D B = readMatrices(A.dim(1), A.dim(2), A.dim(3), path); \
     for (size_t i=1;i<=A.dim(1);++i) \
       for (size_t j=1;j<=A.dim(2);++j) \
         for (size_t k=1;k<=A.dim(3);++k) \
-          ASSERT_NEAR(A(i,j,k), B(i,j,k), 1e-13); \
-  } while(0);
+          EXPECT_NEAR(A(i,j,k), B(i,j,k), 1e-13); \
+  }
 
 TEST(TestSplineUtils, ToVec3)
 {
@@ -77,61 +73,61 @@ TEST(TestSplineUtils, ToVec3)
   Vec3 result1 = SplineUtils::toVec3(X,2);
   Vec3 result2 = SplineUtils::toVec3(X,3);
   Vec3 result3 = SplineUtils::toVec3(X);
-  ASSERT_FLOAT_EQ(result1[0], 1.0);
-  ASSERT_FLOAT_EQ(result1[1], 2.0);
-  ASSERT_FLOAT_EQ(result2[0], 1.0);
-  ASSERT_FLOAT_EQ(result2[1], 2.0);
-  ASSERT_FLOAT_EQ(result3[0], 1.0);
-  ASSERT_FLOAT_EQ(result3[1], 2.0);
-  ASSERT_FLOAT_EQ(result2[2], 3.0);
-  ASSERT_FLOAT_EQ(result3[2], 3.0);
+  EXPECT_FLOAT_EQ(result1.x, 1.0);
+  EXPECT_FLOAT_EQ(result1.y, 2.0);
+  EXPECT_FLOAT_EQ(result2.x, 1.0);
+  EXPECT_FLOAT_EQ(result2.y, 2.0);
+  EXPECT_FLOAT_EQ(result2.z, 3.0);
+  EXPECT_FLOAT_EQ(result3.x, 1.0);
+  EXPECT_FLOAT_EQ(result3.y, 2.0);
+  EXPECT_FLOAT_EQ(result3.z, 3.0);
 }
 
 TEST(TestSplineUtils, ToVec4)
 {
   Go::Point X(1.0, 2.0, 3.0);
-  Vec4 result1 = SplineUtils::toVec4(X,4.0);
-  ASSERT_FLOAT_EQ(result1[0], 1.0);
-  ASSERT_FLOAT_EQ(result1[1], 2.0);
-  ASSERT_FLOAT_EQ(result1[2], 3.0);
-  ASSERT_FLOAT_EQ(result1.t, 4.0);
+  Vec4 result = SplineUtils::toVec4(X,4.0);
+  EXPECT_FLOAT_EQ(result.x, 1.0);
+  EXPECT_FLOAT_EQ(result.y, 2.0);
+  EXPECT_FLOAT_EQ(result.z, 3.0);
+  EXPECT_FLOAT_EQ(result.t, 4.0);
 }
 
 TEST(TestSplineUtils, PointCurve)
 {
-  Vec3 result1;
-
   Go::Line line(Go::Point(0.0, 0.0, 0.0), Go::Point(1.0, 0.0, 0.0));
   Go::SplineCurve* crv = line.createSplineCurve();
-  SplineUtils::point(result1, 0.3, crv);
-  ASSERT_FLOAT_EQ(result1[0], 0.3);
-  ASSERT_FLOAT_EQ(result1[1], 0.0);
-  ASSERT_FLOAT_EQ(result1[2], 0.0);
+
+  Vec3 result;
+  SplineUtils::point(result, 0.3, crv);
+  EXPECT_FLOAT_EQ(result.x, 0.3);
+  EXPECT_FLOAT_EQ(result.y, 0.0);
+  EXPECT_FLOAT_EQ(result.z, 0.0);
 }
 
 TEST(TestSplineUtils, PointSurface)
 {
-  Vec3 result1;
-
   Go::Plane plane(Go::Point(0.0, 0.0, 0.0), Go::Point(1.0, 0.0, 0.0));
   Go::SplineSurface* srf = plane.createSplineSurface();
-  SplineUtils::point(result1, 0.3, 0.3, srf);
-  ASSERT_FLOAT_EQ(result1[0], 0.0);
-  ASSERT_FLOAT_EQ(result1[1], 0.3);
-  ASSERT_FLOAT_EQ(result1[2], 0.3);
+
+  Vec3 result;
+  SplineUtils::point(result, 0.3, 0.3, srf);
+  EXPECT_FLOAT_EQ(result.x, 0.0);
+  EXPECT_FLOAT_EQ(result.y, 0.3);
+  EXPECT_FLOAT_EQ(result.z, 0.3);
 }
 
 TEST(TestSplineUtils, PointVolume)
 {
-  Vec3 result1;
-
   Go::SphereVolume sphere(1.0, Go::Point(0.0, 0.0, 0.0),
                           Go::Point(0.0, 0.0, 1.0), Go::Point(1.0, 0.0, 0.0));
   Go::SplineVolume* vol = sphere.geometryVolume();
-  SplineUtils::point(result1, 0.3, 0.3, 0.3, vol);
-  ASSERT_FLOAT_EQ(result1[0], 0.2392104875250847);
-  ASSERT_FLOAT_EQ(result1[1], 0.1603249784385625);
-  ASSERT_FLOAT_EQ(result1[2], 0.08410852481577462);
+
+  Vec3 result;
+  SplineUtils::point(result, 0.3, 0.3, 0.3, vol);
+  EXPECT_FLOAT_EQ(result.x, 0.2392104875250847);
+  EXPECT_FLOAT_EQ(result.y, 0.1603249784385625);
+  EXPECT_FLOAT_EQ(result.z, 0.08410852481577462);
 }
 
 TEST(TestSplineUtils, ExtractBasisSurface)
@@ -148,6 +144,7 @@ TEST(TestSplineUtils, ExtractBasisSurface)
   srf->computeBasisGrid(gpar,gpar,spline);
   srf->raiseOrder(1,1);
   srf->computeBasisGrid(gpar,gpar,spline2);
+
   Vector N;
   Matrix dNdU;
   Matrix3D d2NdU2;
@@ -172,6 +169,7 @@ TEST(TestSplineUtils, ExtractBasisVolume)
   vol->computeBasisGrid(gpar,gpar,gpar,spline);
   vol->raiseOrder(1,1,1);
   vol->computeBasisGrid(gpar,gpar,gpar,spline2);
+
   Vector N;
   Matrix dNdU;
   Matrix3D d2NdU2;
@@ -190,7 +188,7 @@ TEST(TestSplineUtils, ProjectCurve)
 
   EvalFunction func("sin(x)*t");
   VecFuncExpr func2("sin(x)*t|cos(x)*t");
-  Go::SplineCurve* prjCrv = SplineUtils::project(crv, func, 0.1);
+  Go::SplineCurve* prjCrv  = SplineUtils::project(crv, func , 1, 0.1);
   Go::SplineCurve* prjCrv2 = SplineUtils::project(crv, func2, 2, 0.1);
 
   Vec3 result1, result2, result3, result4;
@@ -199,12 +197,12 @@ TEST(TestSplineUtils, ProjectCurve)
   SplineUtils::point(result3, 0.5, prjCrv2);
   SplineUtils::point(result4, 0.8, prjCrv2);
 
-  ASSERT_FLOAT_EQ(result1[0], -0.0783364);
-  ASSERT_FLOAT_EQ(result2[0], -0.0694399);
-  ASSERT_FLOAT_EQ(result3[0], -0.0783364);
-  ASSERT_FLOAT_EQ(result3[1], -0.0363385);
-  ASSERT_FLOAT_EQ(result4[0], -0.0694399);
-  ASSERT_FLOAT_EQ(result4[1], -0.0363385);
+  EXPECT_FLOAT_EQ(result1.x, -0.0783364);
+  EXPECT_FLOAT_EQ(result2.x, -0.0694399);
+  EXPECT_FLOAT_EQ(result3.x, -0.0783364);
+  EXPECT_FLOAT_EQ(result3.y, -0.0363385);
+  EXPECT_FLOAT_EQ(result4.x, -0.0694399);
+  EXPECT_FLOAT_EQ(result4.y, -0.0363385);
 }
 
 TEST(TestSplineUtils, ProjectSurface)
@@ -217,7 +215,7 @@ TEST(TestSplineUtils, ProjectSurface)
 
   EvalFunction func("sin(x)*sin(y)*t");
   VecFuncExpr func2("sin(x)*sin(y)*t|cos(x)*cos(y)*t");
-  Go::SplineSurface* prjSrf  = SplineUtils::project(srf, func, 0.1);
+  Go::SplineSurface* prjSrf  = SplineUtils::project(srf, func , 1, 0.1);
   Go::SplineSurface* prjSrf2 = SplineUtils::project(srf, func2, 2, 0.1);
 
   Vec3 result1, result2, result3, result4;
@@ -225,10 +223,10 @@ TEST(TestSplineUtils, ProjectSurface)
   SplineUtils::point(result2, 0.8, 0.8, prjSrf);
   SplineUtils::point(result3, 0.5, 0.5, prjSrf2);
   SplineUtils::point(result4, 0.8, 0.8, prjSrf2);
-  ASSERT_FLOAT_EQ(result1[0], 0.02110140763086564);
-  ASSERT_FLOAT_EQ(result2[0], -0.02189938149140131);
-  ASSERT_FLOAT_EQ(result3[0], 0.02110140763086564);
-  ASSERT_FLOAT_EQ(result3[1], 0.07889859236913437);
-  ASSERT_FLOAT_EQ(result4[0], -0.02189938149140131);
-  ASSERT_FLOAT_EQ(result4[1], 0.06514225417205573);
+  EXPECT_FLOAT_EQ(result1.x,  0.02110140763086564);
+  EXPECT_FLOAT_EQ(result2.x, -0.02189938149140131);
+  EXPECT_FLOAT_EQ(result3.x,  0.02110140763086564);
+  EXPECT_FLOAT_EQ(result3.y,  0.07889859236913437);
+  EXPECT_FLOAT_EQ(result4.x, -0.02189938149140131);
+  EXPECT_FLOAT_EQ(result4.y,  0.06514225417205573);
 }


### PR DESCRIPTION
This unifies the projection of scalar and vector functions into one set of methods, and this is now used in a general method for projection of the analytical secondary solution for verification purposes.

Also, the result point/line output is enhanced to also handle recovered solution fields.