### PR TITLE
External energy fix and SIMNodalConstraint simplification

### DIFF
--- a/src/ASM/IntegrandBase.C
+++ b/src/ASM/IntegrandBase.C
@@ -266,6 +266,36 @@ LocalIntegral* NormBase::getLocalIntegral (size_t, size_t iEl, bool) const
 }
 
 
+double NormBase::applyFinalOp (double value) const
+{
+  switch (finalOp)
+    {
+    case ASM::ABS:
+      return fabs(value);
+    case ASM::SQRT:
+      return value < 0.0 ? -sqrt(-value) : sqrt(value);
+    default:
+      return value;
+    }
+}
+
+
+void NormBase::addBoundaryTerms (Vectors& gNorm, double energy) const
+{
+  if (gNorm.empty() || gNorm.front().size() < 2 || energy == 0.0) return;
+
+  double& extEnergy = gNorm.front()[1];
+#ifdef SP_DEBUG
+  if (extEnergy != 0.0)
+    std::cout <<"External energy contribution from interior terms: "
+              << this->applyFinalOp(extEnergy) << std::endl;
+  std::cout <<"External energy contribution from boundary terms: "
+            << this->applyFinalOp(energy) << std::endl;
+#endif
+  extEnergy += energy;
+}
+
+
 size_t NormBase::getNoFields (int group) const
 {
   return group > 0 ? 0 : 1 + prjsol.size();

--- a/src/ASM/IntegrandBase.h
+++ b/src/ASM/IntegrandBase.h
@@ -328,7 +328,9 @@ public:
   virtual bool hasBoundaryTerms() const { return false; }
 
   //! \brief Adds external energy terms to relevant norms.
-  virtual void addBoundaryTerms(Vectors&, double) const {}
+  //! \param gNorm Global norm quantities
+  //! \param[in] energy Global external energy
+  void addBoundaryTerms(Vectors& gNorm, double energy) const;
 
   //! \brief Returns the number of norm groups or size of a specified group.
   //! \details If \a group is zero, the number of norm groups is returned.
@@ -367,6 +369,9 @@ public:
 protected:
   //! \brief Initializes the projected fields for current element.
   bool initProjection(const std::vector<int>& MNPC, LocalIntegral& elmInt);
+
+  //! \brief Applies the operation \a finalOp on the given \a value.
+  double applyFinalOp(double value) const;
 
   IntegrandBase& myProblem; //!< The problem-specific data
 

--- a/src/LinAlg/SAM.C
+++ b/src/LinAlg/SAM.C
@@ -503,7 +503,7 @@ bool SAM::assembleSystem (SystemVector& sysRHS,
   }
 
   sysRHS.restore(sysrhsPtr);
-  if (!eS.empty())
+  if (reactionForces && !eS.empty())
     this->assembleReactions(*reactionForces,eS,iel);
 
   return true;
@@ -898,8 +898,16 @@ Real SAM::normReact (const Vector& u, const Vector& rf) const
   Real retVal = Real(0);
 
   for (int i = 0; i < ndof; i++)
-    if (msc[i] < 0 && -msc[i] <= (int)rf.size())
-      retVal += u[i]*rf(-msc[i]);
+    if (meqn[i] < 0 && msc[i] < 0 && -msc[i] <= (int)rf.size())
+      if (mpmceq[-meqn[i]] - mpmceq[-meqn[i]-1] == 1) // Only prescribed DOFs
+      {
+        retVal += u[i]*rf(-msc[i]);
+#if SP_DEBUG > 1
+        std::cout <<"SAM::normReact: idof="<< i+1 <<" SC="<< msc[i]
+                  <<" u="<< u[i] <<" RF="<< rf(-msc[i]) <<" --> "
+                  << 0.5*retVal << std::endl;
+#endif
+      }
 
   return 0.5*retVal;
 }

--- a/src/SIM/AdaptiveSIM.C
+++ b/src/SIM/AdaptiveSIM.C
@@ -189,7 +189,7 @@ bool AdaptiveSIM::initAdaptor (size_t indxProj)
 }
 
 
-bool AdaptiveSIM::solveStep (const char* inputfile, int iStep)
+bool AdaptiveSIM::solveStep (const char* inputfile, int iStep, bool withRF)
 {
   model.getProcessAdm().cout <<"\nAdaptive step "<< iStep << std::endl;
   if (iStep > 1)
@@ -210,7 +210,7 @@ bool AdaptiveSIM::solveStep (const char* inputfile, int iStep)
 
   // Assemble the linear FE equation system
   model.setMode(SIM::STATIC,true);
-  model.initSystem(opt.solver,1,model.getNoRHS(),0,true);
+  model.initSystem(opt.solver,1,model.getNoRHS(),0,withRF);
   model.setQuadratureRule(opt.nGauss[0],true);
   if (!model.assembleSystem())
     return false;

--- a/src/SIM/AdaptiveSIM.h
+++ b/src/SIM/AdaptiveSIM.h
@@ -43,7 +43,8 @@ public:
   //! \brief Assembles and solves the linear FE equations on current mesh.
   //! \param[in] inputfile File to read model parameters from after refinement
   //! \param[in] iStep Refinement step counter
-  bool solveStep(const char* inputfile, int iStep);
+  //! \param[in] withRF Whether nodal reaction forces should be computed or not
+  bool solveStep(const char* inputfile, int iStep, bool withRF = false);
 
   //! \brief Refines the current mesh based on the element norms.
   //! \param[in] iStep Refinement step counter

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -54,6 +54,7 @@ SIMbase::SIMbase (IntegrandBase* itg) : g2l(&myGlb2Loc)
   nGlPatches = 0;
   nIntGP = nBouGP = 0;
   lagMTOK = false;
+  extEnergy = 0.0;
 
   MPCLess::compareSlaveDofOnly = true; // to avoid multiple slave definitions
 }
@@ -1386,10 +1387,12 @@ double SIMbase::externalEnergy (const Vectors& psol) const
   if (psol.size() == 1)
     return mySam->normReact(psol.front(),*reactionForces);
 
-  static double extEnergy = 0.0;
-  static Vector prevForces(reactionForces->size());
-  extEnergy += mySam->normReact(psol[0]-psol[1],*reactionForces+prevForces);
+  if (prevForces.empty())
+    extEnergy += mySam->normReact(psol[0]-psol[1],*reactionForces);
+  else
+    extEnergy += mySam->normReact(psol[0]-psol[1],*reactionForces+prevForces);
   prevForces = *reactionForces;
+
   return extEnergy;
 }
 

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -34,9 +34,6 @@ class TractionFunc;
 class Vec4;
 class Vec3;
 
-//! Property code to integrand map
-typedef std::multimap<int,IntegrandBase*> IntegrandMap;
-
 
 /*!
   \brief Struct for storage of data associated with one mode shape.
@@ -612,8 +609,6 @@ public:
   static bool ignoreDirichlet; //!< Set to \e true for free vibration analysis
   static bool preserveNOrder;  //!< Set to \e true to preserve node ordering
 
-  typedef std::vector<unsigned char> CharVec; //!< Convenience declaration
-
 protected:
   //! \brief Scalar field container
   typedef std::map<int,RealFunc*>     SclFuncMap;
@@ -621,6 +616,9 @@ protected:
   typedef std::map<int,VecFunc*>      VecFuncMap;
   //! \brief Traction field container
   typedef std::map<int,TractionFunc*> TracFuncMap;
+
+  //! Property code to integrand map
+  typedef std::multimap<int,IntegrandBase*> IntegrandMap;
 
   // Model attributes
   bool           isRefined; //!< Indicates if the model is adaptively refined
@@ -670,6 +668,9 @@ private:
 
   //! Additional MADOF arrays for mixed problems (extraordinary DOF counts)
   std::map<int, std::vector<int> > mixedMADOFs;
+
+  mutable double extEnergy;  //!< Path integral of external forces
+  mutable Vector prevForces; //!< Reaction forces of previous time step
 };
 
 #endif

--- a/src/SIM/SIMinput.h
+++ b/src/SIM/SIMinput.h
@@ -51,7 +51,8 @@ public:
                                    basis(1), component(0),
                                    sim_field(f), file_field(f) {}
   };
-  typedef std::vector<ICInfo> InitialCondVec; //!< Initial condition container
+  typedef std::vector<ICInfo> InitialCondVec; //!< Convenience declaration
+  typedef std::vector<unsigned char> CharVec; //!< Convenience declaration
 
 protected:
   //! \brief The constructor just forwards to the base class constructor.

--- a/src/SIM/Test/TestSIM.C
+++ b/src/SIM/Test/TestSIM.C
@@ -21,7 +21,7 @@
 template<class Dim> class TestProjectSIM : public Dim
 {
 public:
-  TestProjectSIM(const SIMbase::CharVec& nf) : Dim(nf)
+  TestProjectSIM(const SIMinput::CharVec& nf) : Dim(nf)
   {
     Dim::myProblem = new TestProjectIntegrand(Dim::dimension);
     EXPECT_TRUE(this->createDefaultModel());


### PR DESCRIPTION
Only the first commit might be controversial, but I think the simplification is OK? Did not see any practical reason why not the apply method could not me a member of SIMNodalConstraint (but please bear with me if there are some template magic here I don't see). At least the unit tests still passes.

The other fix only affects models containing multi-point constraints (master-slave couplings) and calculates reaction forces, essentially only the C1-plate problems, as far as I know.