### PR TITLE
Norm group facilitation

### DIFF
--- a/Apps/Common/SIMSolverAdap.h
+++ b/Apps/Common/SIMSolverAdap.h
@@ -67,7 +67,6 @@ protected:
     return this->SIMSolver<T1>::parse(elem) && aSim.parse(elem);
   }
 
-private:
   AdaptiveSIM aSim; //!< Adaptive simulation driver
 };
 

--- a/src/SIM/AdaptiveSIM.C
+++ b/src/SIM/AdaptiveSIM.C
@@ -88,7 +88,10 @@ bool AdaptiveSIM::parse (const TiXmlElement* elem)
       IFEM::cout <<"\tRefinement scheme: "<< scheme << std::endl;
     }
     else if ((value = utl::getValue(child,"use_norm")))
+    {
       adaptor = atoi(value);
+      utl::getAttribute(child, "index", adNorm);
+    }
     else if ((value = utl::getValue(child,"use_sub_norm")))
       adNorm = atoi(value);
     else if ((value = utl::getValue(child,"beta"))) {
@@ -152,10 +155,17 @@ bool AdaptiveSIM::parse (char* keyWord, std::istream& is)
 }
 
 
-bool AdaptiveSIM::initAdaptor (size_t indxProj)
+void AdaptiveSIM::setAdaptationNorm (size_t normGroup, size_t normIdx)
 {
-  if (indxProj > 0)
-    adaptor = indxProj; // override value from XML input
+  adaptor = normGroup;
+  adNorm  = normIdx;
+}
+
+
+bool AdaptiveSIM::initAdaptor (size_t normGroup)
+{
+  if (normGroup > 0)
+    adaptor = normGroup; // override value from XML input
 
   SIMoptions::ProjectionMap::const_iterator pit = opt.project.begin();
   for (size_t j = 1; pit != opt.project.end(); ++pit, j++)

--- a/src/SIM/AdaptiveSIM.h
+++ b/src/SIM/AdaptiveSIM.h
@@ -36,9 +36,11 @@ public:
   //! \brief Empty destructor.
   virtual ~AdaptiveSIM() {}
 
-  //! \brief Sets the index to the norm group to base the mesh adaptation on.
-  //! \param[in] indxProj Index to projection method to base mesh adaptation on
-  bool initAdaptor(size_t indxProj = 0);
+  //! \brief Sets the norm group/index of the norm to base mesh adaptation on.
+  void setAdaptationNorm(size_t normGroup, size_t normIdx = 0);
+  //! \brief Initializes the \a projs and \a prefix arrays.
+  //! \param[in] normGroup Index to the norm group to base mesh adaptation on
+  bool initAdaptor(size_t normGroup = 0);
 
   //! \brief Assembles and solves the linear FE equations on current mesh.
   //! \param[in] inputfile File to read model parameters from after refinement

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -1070,31 +1070,6 @@ void SIMbase::printSolutionSummary (const Vector& solution, int printSol,
 }
 
 
-void SIMbase::printNorms (const Vectors& norms, size_t w) const
-{
-  if (norms.empty()) return;
-
-  NormBase* norm = this->getNormIntegrand();
-  const Vector& n = norms.front();
-
-  IFEM::cout <<"Energy norm"
-             << utl::adjustRight(w-11,norm->getName(1,1)) << n(1)
-             <<"\nExternal energy"
-             << utl::adjustRight(w-15,norm->getName(1,2)) << n(2);
-
-  if (mySol)
-    IFEM::cout <<"\nExact norm"
-               << utl::adjustRight(w-10,norm->getName(1,3)) << n(3)
-               <<"\nExact error"
-               << utl::adjustRight(w-11,norm->getName(1,4)) << n(4)
-               <<"\nExact relative error (%) : "
-               << 100.0*n(4)/n(3);
-
-  IFEM::cout << std::endl;
-  delete norm;
-}
-
-
 void SIMbase::getWorstDofs (const Vector& u, const Vector& r,
                             size_t nWorst, double eps, int iteNorm,
                             std::map<std::pair<int,int>,RealArray>& worst) const

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -350,11 +350,6 @@ public:
   bool solutionNorms(const Vectors& psol, Matrix& eNorm, Vectors& gNorm)
   { return this->solutionNorms(TimeDomain(),psol,Vectors(),gNorm,&eNorm); }
 
-  //! \brief Prints integrated solution norms to the log stream.
-  //! \param[in] norms The norm values
-  //! \param[in] w Total number of characters in the norm labels
-  virtual void printNorms(const Vectors& norms, size_t w = 36) const;
-
   //! \brief Prints a summary of the calculated solution to std::cout.
   //! \param[in] solution The solution vector
   //! \param[in] printSol Print solution only if size is less than this value

--- a/src/SIM/SIMoptions.C
+++ b/src/SIM/SIMoptions.C
@@ -177,6 +177,9 @@ bool SIMoptions::parseOutputTag (const TiXmlElement* elem)
     }
   }
 
+  else if (!strcasecmp(elem->Value(),"residual"))
+    project[NONE] = "Pure residuals";
+
   return true;
 }
 
@@ -332,6 +335,8 @@ bool SIMoptions::parseProjectionMethod (const char* ptype, int version)
     project[QUASI] = "Quasi-interpolated";
   else if (!strcasecmp(ptype,"lsq"))
     project[LEASTSQ] = "Least-square projected";
+  else if (!strncasecmp(ptype,"residual",8))
+    project[NONE] = "Pure residuals";
   else
     return false;
 
@@ -375,11 +380,18 @@ utl::LogStream& SIMoptions::print (utl::LogStream& os, bool addBlankLine) const
   default: break;
   }
 
-  if (!project.empty()) {
+  std::vector<std::string> projections;
+  for (const auto& prj : project)
+    if (prj.first == NONE)
+      os <<"\nPure residual error estimates enabled";
+    else
+      projections.push_back(prj.second);
+
+  if (!projections.empty()) {
     ProjectionMap::const_iterator it = project.begin();
-    os <<"\nEnabled projection(s): "<< it->second;
-    for (++it; it != project.end(); ++it)
-      os <<"\n                       "<< it->second;
+    os <<"\nEnabled projection(s): "<< projections.front();
+    for (size_t i = 1; i < projections.size(); i++)
+      os <<"\n                       "<< projections[i];
   }
 
   if (format >= 0) {

--- a/src/SIM/SIMoutput.h
+++ b/src/SIM/SIMoutput.h
@@ -269,6 +269,17 @@ public:
   //! \brief Checks whether point result files have been defined or not.
   bool hasPointResultFile() const;
 
+  //! \brief Prints integrated solution norms to the log stream.
+  //! \param[in] norms The norm values
+  //! \param[in] w Total number of characters in the norm labels
+  virtual void printNorms(const Vectors& norms, size_t w = 36) const;
+  //! \brief Prints a norm group to the log stream (app-specific).
+  virtual void printNormGroup(const Vector&, const Vector&,
+                              const std::string&) const {}
+
+  //! \brief Returns the reference norm to base mesh adaptation upon.
+  virtual double getReferenceNorm(const Vectors& gNorm, size_t adaptor) const;
+
   //! \brief Serialization support.
   virtual bool serialize(std::map<std::string,std::string>&) { return false; }
 


### PR DESCRIPTION
@akva2 se om du evt. kan få til det du trenger på toppen av dette. Her har jeg forsøkt å ta høyde for at norm gruppe 1 (som da inneholder eksakt feil når de finnes, kan inneholde noen flere størrelser og man kan velge mer fritt (via adNorm variabelen, `<use_sub_norm>` i input-filen) hvilken som skal brukes for adaptering. Dessuten en virtuell metode getRefereneNorm som returner normen det skal normaliseres med. Denne må da overlagres i din sub-klasse når det avvikes fra default implementasjon.

Så er det innført konseptet med at projection-metode NONE kan brukes til å angi en norm-gruppe som ikke har noen tilhørende projeksjon, men bare pure residuals. Angi `<residual\>`i input-filen (evt. kommand-linje opsjon `-residual` for å aktivere. Da tror jeg resten skal gå av seg selv, gitt at de nødvendige tilbassninger i norm-integranden er gjort. SIMbase::project blir da ikke kallt for denne, men solutionNorms vil/skal fungere likevel med et tomt ssol-array.

This also fixes #15 (probably).