### PR TITLE
Collapse degenerated edges into a single node

### DIFF
--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -286,6 +286,11 @@ public:
   //! \param[in] master 1-based index of the first master node in this basis
   virtual void closeEdges(int dir, int basis = 0, int master = 1);
 
+  //! \brief Collapses a degenereated edge into a single node.
+  //! \param[in] dir Parameter direction defining the edge to collapse
+  //! \param[in] basis Which basis to connect (mixed methods), 0 means both
+  virtual bool collapseEdge(int dir, int basis = 0);
+
   //! \brief Sets the global node numbers for this patch.
   //! \param[in] nodes Vector of global node numbers (zero-based)
   virtual void setNodeNumbers(const std::vector<int>& nodes);


### PR DESCRIPTION
This adds the input-file tag `<collapse>` for 2D patches, which can be used when you have a polar parametrization where one of the edges collapse into a point. This then automatically assigns a common node number of all the collocated control points (replaces functionality formerly found in the getGNO utility). The extension to 3D (face to point and face to edge) is not there yet (but can be added).

I did this for the quarter-circular patch, which I ended up not using now after all, but...