### PR TITLE
Fixed: Partly undo of commit 89faa82c6f972e01029f2ec4e11f1f0e4865bdb2

### DIFF
--- a/src/SIM/NewmarkSIM.C
+++ b/src/SIM/NewmarkSIM.C
@@ -444,13 +444,12 @@ SIM::ConvStatus NewmarkSIM::checkConvergence (TimeStep& param)
   model.iterationNorms(linsol,residual,norms[0],norms[1],norms[2]);
   double norm = norms[cNorm];
 
-  bool checkAllIt = (subiter & FIRST) && (refNopt == ALL);
   if (param.iter == 0)
   {
     if (norms[2] == 0.0)
       return SIM::CONVERGED; // No load on this step
 
-    if (checkAllIt || fabs(norm) > refNorm)
+    if ((subiter&FIRST && refNopt == ALL) || fabs(norm) > refNorm)
       refNorm = fabs(norm);
 
     if (refNorm*rTol > aTol) {
@@ -485,7 +484,7 @@ SIM::ConvStatus NewmarkSIM::checkConvergence (TimeStep& param)
 
   // Check for convergence or divergence
   SIM::ConvStatus status = SIM::OK;
-  if (fabs(norm) < convTol && (param.iter > 0 || checkAllIt))
+  if (fabs(norm) < convTol && (param.iter > 0 || refNopt == ALL))
     status = SIM::CONVERGED;
   else if (std::isnan(norms[2]))
     status = SIM::DIVERGED;

--- a/src/SIM/NonLinSIM.C
+++ b/src/SIM/NonLinSIM.C
@@ -416,13 +416,12 @@ ConvStatus NonLinSIM::checkConvergence (TimeStep& param)
   double norm = iteNorm == ENERGY ? enorm : resNorm;
   if (iteNorm == L2SOL) norm = linsolNorm;
 
-  bool checkAllIt = (subiter & FIRST) && (refNopt == ALL);
   if (param.iter == 0)
   {
     if (linsolNorm == 0.0)
       return CONVERGED; // No load on this step
 
-    if (checkAllIt || fabs(norm) > refNorm)
+    if ((subiter&FIRST && refNopt == ALL) || fabs(norm) > refNorm)
       refNorm = fabs(norm);
 
     if (refNorm*rTol > aTol) {
@@ -498,7 +497,7 @@ ConvStatus NonLinSIM::checkConvergence (TimeStep& param)
   }
 
   // Check for convergence or divergence
-  if (fabs(norm) < convTol && (param.iter > 0 || checkAllIt))
+  if (fabs(norm) < convTol && (param.iter > 0 || refNopt == ALL))
     status = CONVERGED;
   else if (std::isnan(linsolNorm))
     status = DIVERGED;


### PR DESCRIPTION
Do only one iteration if the first iteration already satisfies the
convergence tolerance when refNopt=ALL. No check on subiter&FIRST here.

This only removes some unnecessary iterations in cases with sub-iterations, and may affect tests on apps using that feature (but hopefully only to the better).