### PR TITLE
Changed: The bool argument of SIMbase::getNoNodes is removed.

### DIFF
--- a/Apps/Common/SIMSemi3D.h
+++ b/Apps/Common/SIMSemi3D.h
@@ -114,7 +114,7 @@ public:
   {
     planeNodes.resize(this->getNoPlanes());
     for (size_t i=0;i<m_planes.size();++i)
-      planeNodes[startCtx+i] = m_planes[i]->getNoNodes(true);
+      planeNodes[startCtx+i] = m_planes[i]->getNoNodes();
 
 #ifdef HAVE_MPI
     std::vector<int> send(planeNodes);

--- a/src/SIM/HHTSIM.C
+++ b/src/SIM/HHTSIM.C
@@ -163,11 +163,11 @@ bool HHTSIM::predictStep (TimeStep& param)
   {
     // Initalize the total angular rotations for this time step
     Vector& psol = solution.front();
-    if (psol.size() != 6*model.getNoNodes(true))
+    if (psol.size() != 6*model.getNoNodes(1))
     {
       std::cerr <<" *** HHTSIM::predictStep: Invalid dimension on"
                 <<" the displacement vector "<< psol.size()
-                <<" != "<< 6*model.getNoNodes(true) << std::endl;
+                <<" != "<< 6*model.getNoNodes(1) << std::endl;
       return false;
     }
     for (size_t i = 3; i < psol.size(); i += 6)

--- a/src/SIM/NewmarkNLSIM.C
+++ b/src/SIM/NewmarkNLSIM.C
@@ -128,11 +128,11 @@ bool NewmarkNLSIM::predictStep (TimeStep& param)
   {
     // Initalize the total angular rotations for this time step
     Vector& psol = solution.front();
-    if (psol.size() != 6*model.getNoNodes(true))
+    if (psol.size() != 6*model.getNoNodes(1))
     {
       std::cerr <<" *** NewmarkNLSIM::predictStep: Invalid dimension on"
                 <<" the displacement vector "<< psol.size()
-                <<" != "<< 6*model.getNoNodes(true) << std::endl;
+                <<" != "<< 6*model.getNoNodes(1) << std::endl;
       return false;
     }
     for (size_t i = 3; i < psol.size(); i += 6)

--- a/src/SIM/NewmarkSIM.C
+++ b/src/SIM/NewmarkSIM.C
@@ -199,11 +199,11 @@ bool NewmarkSIM::predictStep (TimeStep& param)
   {
     // Initalize the total angular rotations for this time step
     Vector& psol = solution.front();
-    if (psol.size() != 6*model.getNoNodes(true))
+    if (psol.size() != 6*model.getNoNodes(1))
     {
       std::cerr <<" *** NewmarkSIM::predictStep: Invalid dimension on"
                 <<" the displacement vector "<< psol.size()
-                <<" != "<< 6*model.getNoNodes(true) << std::endl;
+                <<" != "<< 6*model.getNoNodes(1) << std::endl;
       return false;
     }
     for (size_t i = 3; i < psol.size(); i += 6)

--- a/src/SIM/NonLinSIM.C
+++ b/src/SIM/NonLinSIM.C
@@ -524,11 +524,11 @@ bool NonLinSIM::updateConfiguration (TimeStep& time)
     {
       // Initalize the total angular rotations for this load increment
       Vector& psol = solution.front();
-      if (psol.size() != 6*model.getNoNodes(true))
+      if (psol.size() != 6*model.getNoNodes(1))
       {
         std::cerr <<" *** NonLinSIM::updateConfiguration: Invalid dimension on"
                   <<" the displacement vector "<< psol.size()
-                  <<" != "<< 6*model.getNoNodes(true) << std::endl;
+                  <<" != "<< 6*model.getNoNodes(1) << std::endl;
         return false;
       }
       for (size_t i = 3; i < psol.size(); i += 6)

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -150,8 +150,9 @@ public:
   size_t getNoFields(int basis = 0) const;
   //! \brief Returns the model size in terms of number of DOFs.
   size_t getNoDOFs() const;
-  //! \brief Returns the model size in terms of number of (unique) nodes.
-  size_t getNoNodes(bool unique = false, int basis = 0) const;
+  //! \brief Returns the model size in terms of number of unique nodes.
+  //! \param[in] basis Which basis to return the number of nodes for (0 = all)
+  size_t getNoNodes(int basis = 0) const;
   //! \brief Returns the model size in terms of number of elements.
   //! \param[in] includeXElms If \e true, include any extra-ordinary elements
   size_t getNoElms(bool includeXElms = false) const;

--- a/src/SIM/Test/TestSIM.C
+++ b/src/SIM/Test/TestSIM.C
@@ -80,7 +80,7 @@ TEST(TestSIM2D, ProjectSolution)
   size_t n = 1;
   for (size_t j = 0; j < 2; ++j)
     for (size_t i = 0; i < 2; ++i)
-      ASSERT_FLOAT_EQ(ssol(1, n++), i + j);
+      EXPECT_FLOAT_EQ(ssol(1, n++), i + j);
 }
 
 
@@ -94,7 +94,7 @@ TEST(TestSIM2D, ProjectSolutionMixed)
   size_t n = 1;
   for (size_t j = 0; j < 3; ++j)
     for (size_t i = 0; i < 3; ++i)
-      ASSERT_FLOAT_EQ(ssol(1, n++), i/2.0 + j/2.0);
+      EXPECT_FLOAT_EQ(ssol(1, n++), i/2.0 + j/2.0);
 }
 
 
@@ -109,7 +109,7 @@ TEST(TestSIM3D, ProjectSolution)
   for (size_t k = 0; k < 2; ++k)
     for (size_t j = 0; j < 2; ++j)
       for (size_t i = 0; i < 2; ++i)
-        ASSERT_FLOAT_EQ(ssol(1, n++), i + j + k);
+        EXPECT_FLOAT_EQ(ssol(1, n++), i + j + k);
 }
 
 
@@ -124,7 +124,7 @@ TEST(TestSIM3D, ProjectSolutionMixed)
   for (size_t k = 0; k < 3; ++k)
     for (size_t j = 0; j < 3; ++j)
       for (size_t i = 0; i < 3; ++i)
-        ASSERT_FLOAT_EQ(ssol(1, n++), i/2.0 + j/2.0 + k/2.0);
+        EXPECT_FLOAT_EQ(ssol(1, n++), i/2.0 + j/2.0 + k/2.0);
 }
 
 
@@ -132,33 +132,33 @@ TEST(TestSIM, InjectPatchSolution)
 {
   TestProjectSIM<SIM2D> sim({1,1});
 
-  Vector sol(2*sim.getNoNodes(true, 1) + sim.getNoNodes(true, 2));
-  Vector lsol(2*sim.getNoNodes(true, 1));
+  Vector sol(2*sim.getNoNodes(1) + sim.getNoNodes(2));
+  Vector lsol(2*sim.getNoNodes(1));
   size_t i, ofs;
-  for (i = 0; i < sim.getNoNodes(true,1); i++)
+  for (i = 0; i < sim.getNoNodes(1); i++)
     lsol[2*i] = lsol[2*i+1] = i+1;
 
   ASSERT_TRUE(sim.addMixedMADOF(1, 2));
   sim.injectPatchSolution(sol, lsol, 0, 2, 1);
-  for (i = ofs = 0; i < sim.getNoNodes(true,1); i++, ofs += 2) {
-    ASSERT_FLOAT_EQ(sol[ofs], i+1);
-    ASSERT_FLOAT_EQ(sol[ofs+1], i+1);
+  for (i = ofs = 0; i < sim.getNoNodes(1); i++, ofs += 2) {
+    EXPECT_FLOAT_EQ(sol[ofs], i+1);
+    EXPECT_FLOAT_EQ(sol[ofs+1], i+1);
   }
-  for (i = 0; i < sim.getNoNodes(true,2); i++, ofs++)
-    ASSERT_FLOAT_EQ(sol[ofs], 0);
+  for (i = 0; i < sim.getNoNodes(2); i++, ofs++)
+    EXPECT_FLOAT_EQ(sol[ofs], 0);
 
   ASSERT_TRUE(sim.addMixedMADOF(2, 2));
-  Vector sol2(sim.getNoNodes(true, 1) + 2*sim.getNoNodes(true, 2));
-  Vector lsol2(2*sim.getNoNodes(true, 2));
-  for (i = 0; i < sim.getNoNodes(true,2); i++)
+  Vector sol2(sim.getNoNodes(1) + 2*sim.getNoNodes(2));
+  Vector lsol2(2*sim.getNoNodes(2));
+  for (i = 0; i < sim.getNoNodes(2); i++)
     lsol2[2*i] = lsol2[2*i+1] = i+1;
 
   sim.injectPatchSolution(sol2, lsol2, 0, 2, 2);
-  for (i = ofs = 0; i < sim.getNoNodes(true,1); i++, ofs++)
-    ASSERT_FLOAT_EQ(sol2[ofs], 0);
+  for (i = ofs = 0; i < sim.getNoNodes(1); i++, ofs++)
+    EXPECT_FLOAT_EQ(sol2[ofs], 0);
 
-  for (i = 0; i < sim.getNoNodes(true,2); i++, ofs += 2) {
-    ASSERT_FLOAT_EQ(sol2[ofs], i+1);
-    ASSERT_FLOAT_EQ(sol2[ofs+1], i+1);
+  for (i = 0; i < sim.getNoNodes(2); i++, ofs += 2) {
+    EXPECT_FLOAT_EQ(sol2[ofs], i+1);
+    EXPECT_FLOAT_EQ(sol2[ofs+1], i+1);
   }
 }


### PR DESCRIPTION
Its default value (false) was not used in practice and it was
thus only a potential source of confusion.
Fixed: Also include the 'X'-nodes (if any) when counting the nodes
associated with the first basis. That means, we assume that only
the first basis can have Dirichlet boundary conditions defined in
local coordinate axes.

If you pull this one before #175, the unresolved problem mentioned there regarding the local coordinate system nodes should be fixed, I think. At least, this is a proposed solution to it.