### PR TITLE
changed: move Interface class out of DomainDecomposition

### DIFF
--- a/src/ASM/DomainDecomposition.h
+++ b/src/ASM/DomainDecomposition.h
@@ -14,6 +14,7 @@
 #ifndef _DOMAIN_DECOMPOSITION_H
 #define _DOMAIN_DECOMPOSITION_H
 
+#include "Interface.h"
 #include <map>
 #include <set>
 #include <vector>
@@ -32,18 +33,6 @@ class SIMbase;
 class DomainDecomposition
 {
 public:
-  //! \brief Struct defining a domain interface.
-  struct Interface {
-    int master; //!< Master patch (global number).
-    int slave;  //!< Slave patch (global number).
-    int midx;   //!< Index of boundary on master.
-    int sidx;   //!< Index of boundary on slave.
-    int orient; //!< Orientation.
-    int dim;    //!< Dimension of boundary.
-    int basis;  //!< Basis of boundary.
-    int thick;  //!< Thickness of connection.
-  };
-
   //! \brief Functor to order ghost connections.
   class SlaveOrder {
     public:
@@ -52,7 +41,7 @@ public:
       //! \brief Hide ill-formed default assignment operator.
       SlaveOrder& operator=(const SlaveOrder&) { return *this; }
       //! \brief Compare interfaces.
-      bool operator()(const Interface& A, const Interface& B) const
+      bool operator()(const ASM::Interface& A, const ASM::Interface& B) const
       {
         // order by master owner id first
         if (dd.getPatchOwner(A.master) != dd.getPatchOwner(B.master))
@@ -81,7 +70,7 @@ public:
       const DomainDecomposition& dd;
   };
 
-  std::set<Interface, SlaveOrder> ghostConnections; //!< Connections to other processes.
+  std::set<ASM::Interface, SlaveOrder> ghostConnections; //!< Connections to other processes.
 
   //! \brief Default constructor.
   DomainDecomposition() : ghostConnections(SlaveOrder(*this)), blocks(1) {}

--- a/src/ASM/Interface.h
+++ b/src/ASM/Interface.h
@@ -1,0 +1,38 @@
+// $Id$
+//==============================================================================
+//!
+//! \file Interface.h
+//!
+//! \date Aug 28 2017
+//!
+//! \author Arne Morten Kvarving / SINTEF
+//!
+//! \brief Representation of domain interfaces.
+//!
+//==============================================================================
+
+#ifndef _INTERFACE_H
+#define _INTERFACE_H
+
+
+namespace ASM
+{
+
+  /*!
+    \brief Struct for representing a domain interface.
+  */
+
+  struct Interface {
+    int master; //!< Master patch (global number).
+    int slave;  //!< Slave patch (global number).
+    int midx;   //!< Index of boundary on master.
+    int sidx;   //!< Index of boundary on slave.
+    int orient; //!< Orientation.
+    int dim;    //!< Dimension of boundary.
+    int basis;  //!< Basis of boundary.
+    int thick;  //!< Thickness of connection.
+  };
+
+}
+
+#endif

--- a/src/SIM/SIM1D.C
+++ b/src/SIM/SIM1D.C
@@ -78,9 +78,9 @@ bool SIM1D::addConnection (int master, int slave, int mIdx, int sIdx,
       return false;
   }
   else
-    adm.dd.ghostConnections.insert(DomainDecomposition::Interface{master, slave,
-                                                                  mIdx, sIdx, 0,
-                                                                  dim, basis, thick});
+    adm.dd.ghostConnections.insert(ASM::Interface{master, slave,
+                                                  mIdx, sIdx, 0,
+                                                  dim, basis, thick});
 
   return true;
 }

--- a/src/SIM/SIM2D.C
+++ b/src/SIM/SIM2D.C
@@ -103,9 +103,9 @@ bool SIM2D::addConnection (int master, int slave, int mIdx,
         return false;
   }
   else
-    adm.dd.ghostConnections.insert(DomainDecomposition::Interface{master, slave,
-                                                                  mIdx, sIdx, orient,
-                                                                  dim, basis, thick});
+    adm.dd.ghostConnections.insert(ASM::Interface{master, slave,
+                                                  mIdx, sIdx, orient,
+                                                  dim, basis, thick});
 
   return true;
 }

--- a/src/SIM/SIM3D.C
+++ b/src/SIM/SIM3D.C
@@ -81,9 +81,9 @@ bool SIM3D::addConnection (int master, int slave, int mIdx,
         return false;
   }
   else
-    adm.dd.ghostConnections.insert(DomainDecomposition::Interface{master, slave,
-                                                                  mIdx, sIdx, orient,
-                                                                  dim, basis, thick});
+    adm.dd.ghostConnections.insert(ASM::Interface{master, slave,
+                                                  mIdx, sIdx, orient,
+                                                  dim, basis, thick});
 
   return true;
 }


### PR DESCRIPTION
will be reused for intra-process connection representations