### PR TITLE
Add support for jump terms in norm integrands

### DIFF
--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -39,6 +39,7 @@ class FunctionBase;
 class RealFunc;
 class VecFunc;
 class Vec3;
+namespace ASM { class InterfaceChecker; }
 
 typedef std::vector<ASMbase*> ASMVec; //!< Spline patch container
 
@@ -427,6 +428,14 @@ public:
  			     GlobalIntegral& glbInt,
 			     const TimeDomain& time) { return false; }
 
+  //! \brief Evaluates an integral over element interfaces in the patch.
+  //! \param integrand Object with problem-specific data and methods
+  //! \param glbInt The integrated quantity
+  //! \param[in] time Parameters for nonlinear/time-dependent simulations
+  //! \param[in] iChk Object checking if an element interface has contributions
+  virtual bool integrate(Integrand& integrand, GlobalIntegral& glbInt,
+                         const TimeDomain& time,
+                         const ASM::InterfaceChecker& iChk) { return true; }
 
   // Post-processing methods
   // =======================

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -245,7 +245,7 @@ bool ASMs2D::addXElms (short int dim, short int item, size_t nXn, IntVec& nodes)
 }
 
 
-bool ASMs2D::addInterfaceElms (const InterfaceChecker& iChk)
+bool ASMs2D::addInterfaceElms (const ASM::InterfaceChecker& iChk)
 {
   if (!surf || shareFE == 'F') return false;
 
@@ -270,7 +270,7 @@ bool ASMs2D::addInterfaceElms (const InterfaceChecker& iChk)
       if (MLGE[iel] < 1) continue; // Skip zero-area element
 
       // Loop over the (north and east only) element edges with contributions
-      short int status = iChk.hasContribution(i1,i2);
+      short int status = iChk.hasContribution(iel,i1,i2);
       for (int iedge = 1; iedge <= 4 && status > 0; iedge++, status /= 2)
         if (iedge%2 == 0 && status%2 == 1)
         {
@@ -1945,7 +1945,7 @@ bool ASMs2D::integrate (Integrand& integrand,
 bool ASMs2D::integrate (Integrand& integrand,
                         GlobalIntegral& glInt,
                         const TimeDomain& time,
-                        const InterfaceChecker& iChk)
+                        const ASM::InterfaceChecker& iChk)
 {
   if (!surf) return true; // silently ignore empty patches
   if (!(integrand.getIntegrandType() & Integrand::INTERFACE_TERMS)) return true;
@@ -1983,7 +1983,7 @@ bool ASMs2D::integrate (Integrand& integrand,
       fe.iel = abs(MLGE[jel]);
       if (fe.iel < 1) continue; // zero-area element
 
-      short int status = iChk.hasContribution(i1,i2);
+      short int status = iChk.hasContribution(iel,i1,i2);
       if (!status) continue; // no interface contributions for this element
 
 #if SP_DEBUG > 3
@@ -2758,7 +2758,7 @@ void ASMs2D::extractBasis (double u, double v, int dir, int p,
 }
 
 
-short int ASMs2D::InterfaceChecker::hasContribution (int I, int J) const
+short int ASMs2D::InterfaceChecker::hasContribution (int, int I, int J, int) const
 {
   bool neighbor[4];
   neighbor[0] = I > myPatch.surf->order_u();    // West neighbor

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -328,6 +328,14 @@ public:
   virtual bool integrate(Integrand& integrand, int lIndex,
                          GlobalIntegral& glbInt, const TimeDomain& time);
 
+  //! \brief Evaluates an integral over element interfaces in the patch.
+  //! \param integrand Object with problem-specific data and methods
+  //! \param glbInt The integrated quantity
+  //! \param[in] time Parameters for nonlinear/time-dependent simulations
+  //! \param[in] iChk Object checking if an element interface has contributions
+  virtual bool integrate(Integrand& integrand, GlobalIntegral& glbInt,
+                         const TimeDomain& time, const ASM::InterfaceChecker& iChk);
+
 protected:
   //! \brief Evaluates an integral over the interior patch domain.
   //! \param integrand Object with problem-specific data and methods
@@ -336,14 +344,6 @@ protected:
   //! \param[in] itgPts Parameters and weights of the integration points
   bool integrate(Integrand& integrand, GlobalIntegral& glbInt,
                  const TimeDomain& time, const Real3DMat& itgPts);
-
-  //! \brief Evaluates an integral over element interfaces in the patch.
-  //! \param integrand Object with problem-specific data and methods
-  //! \param glbInt The integrated quantity
-  //! \param[in] time Parameters for nonlinear/time-dependent simulations
-  //! \param[in] iChk Object checking if an element interface has contributions
-  bool integrate(Integrand& integrand, GlobalIntegral& glbInt,
-                 const TimeDomain& time, const ASM::InterfaceChecker& iChk);
 
 public:
 

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -16,6 +16,7 @@
 
 #include "ASMstruct.h"
 #include "ASM2D.h"
+#include "Interface.h"
 #include "ThreadGroups.h"
 
 namespace Go {
@@ -84,10 +85,11 @@ private:
     : curve(sc), dof(d), code(c) {}
   };
 
-protected:
+public:
   //! \brief Base class that checks if an element has interface contributions.
-  class InterfaceChecker
+  class InterfaceChecker : public ASM::InterfaceChecker
   {
+  protected:
     const ASMs2D& myPatch; //!< Reference to the patch being integrated
   public:
     //! \brief The constructor initialises the reference to current patch.
@@ -97,10 +99,9 @@ protected:
     //! \brief Returns non-zero if the specified element have contributions.
     //! \param[in] I Index in first parameter direction of the element
     //! \param[in] J Index in second parameter direction of the element
-    virtual short int hasContribution(int I, int J) const;
+    virtual short int hasContribution(int, int I, int J, int = -1) const;
   };
 
-public:
   //! \brief Default constructor.
   ASMs2D(unsigned char n_s = 2, unsigned char n_f = 2);
   //! \brief Special copy constructor for sharing of FE data.
@@ -148,7 +149,7 @@ public:
 
   //! \brief Adds interface elements with coupling to all element DOFs.
   //! \param[in] iChk Object checking if an element interface has contributions
-  bool addInterfaceElms(const InterfaceChecker& iChk);
+  bool addInterfaceElms(const ASM::InterfaceChecker& iChk);
 
   //! \brief Returns local 1-based index of the node with given global number.
   //! \details If the given node number is not present, 0 is returned.
@@ -342,7 +343,7 @@ protected:
   //! \param[in] time Parameters for nonlinear/time-dependent simulations
   //! \param[in] iChk Object checking if an element interface has contributions
   bool integrate(Integrand& integrand, GlobalIntegral& glbInt,
-                 const TimeDomain& time, const InterfaceChecker& iChk);
+                 const TimeDomain& time, const ASM::InterfaceChecker& iChk);
 
 public:
 

--- a/src/ASM/ASMs2DIB.C
+++ b/src/ASM/ASMs2DIB.C
@@ -228,15 +228,17 @@ bool ASMs2DIB::generateFEMTopology ()
 }
 
 
-short int ASMs2DIB::Intersected::hasContribution (int I, int J) const
+short int ASMs2DIB::Intersected::hasContribution (int, int I, int J, int) const
 {
-  const int n1 = myPatch.surf->numCoefs_u();
-  const int n2 = myPatch.surf->numCoefs_v();
-  const int p1 = myPatch.surf->order_u();
-  const int p2 = myPatch.surf->order_v();
+  const ASMs2DIB& patch = static_cast<const ASMs2DIB&>(myPatch);
+
+  const int n1 = patch.surf->numCoefs_u();
+  const int n2 = patch.surf->numCoefs_v();
+  const int p1 = patch.surf->order_u();
+  const int p2 = patch.surf->order_v();
 
   int iel = I-p1 + (n1-p1+1)*(J-p2); // Zero-based index of this element
-  if (myPatch.quadPoints[iel].empty())
+  if (patch.quadPoints[iel].empty())
     return 0; // This element is completely outside the domain
 
   int jel[4];
@@ -246,14 +248,14 @@ short int ASMs2DIB::Intersected::hasContribution (int I, int J) const
   jel[3] = J < n2 ? iel + (n1-p1+1) : 0; // North neighbor
 
   // Check if the element itself is intersected
-  bool isCut = myAll || myPatch.isIntersected(iel);
+  bool isCut = myAll || patch.isIntersected(iel);
 
   // Check if any of the neighboring elements are intersected, or if
   // this element is intersected, only check if the neighbor is in the domain
   short int status = 0, s = 1;
   for (short int i = 0; i < 4; i++, s *= 2)
     if (alsoSW || i%2 == 1)
-      if (jel[i] && myPatch.isIntersected(jel[i],isCut))
+      if (jel[i] && patch.isIntersected(jel[i],isCut))
         status += s;
 
   return status;

--- a/src/ASM/ASMs2DIB.h
+++ b/src/ASM/ASMs2DIB.h
@@ -31,21 +31,20 @@ class ASMs2DIB : public ASMs2D
     element is intersected by the immersed boundary, or if it is neighbor to
     an element that is intersected.
   */
-  class Intersected : public InterfaceChecker
+  class Intersected : public ASMs2D::InterfaceChecker
   {
-    const ASMs2DIB& myPatch; //!< Reference to the patch being integrated
     bool            myAll;   //!< If \e true, consider all element interfaces
     bool            alsoSW;  //!< If \e true, consider south/west neighbors too
   public:
     //! \brief The constructor initialises the reference to current patch.
     Intersected(const ASMs2DIB& pch, bool all = false, bool sw = false)
-      : InterfaceChecker(pch), myPatch(pch), myAll(all), alsoSW(sw) {}
+      : InterfaceChecker(pch), myAll(all), alsoSW(sw) {}
     //! \brief Empty destructor.
     virtual ~Intersected() {}
     //! \brief Returns non-zero if the specified element have contributions.
     //! \param[in] I Index in first parameter direction of the element
     //! \param[in] J Index in second parameter direction of the element
-    virtual short int hasContribution(int I, int J) const;
+    virtual short int hasContribution(int, int I, int J, int = -1) const;
   };
 
 public:

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -991,6 +991,10 @@ bool ASMs2Dmx::integrate (Integrand& integrand,
           }
         }
 
+      // Finalize the element quantities
+      if (ok && !integrand.finalizeElement(*A,time,0))
+        ok = false;
+
       // Assembly of global system integral
       if (ok && !glInt.assemble(A->ref(),fe.iel))
         ok = false;

--- a/src/ASM/ASMs2Dmx.h
+++ b/src/ASM/ASMs2Dmx.h
@@ -131,6 +131,14 @@ public:
   virtual bool integrate(Integrand& integrand, int lIndex,
 			 GlobalIntegral& glbInt, const TimeDomain& time);
 
+  //! \brief Evaluates an integral over element interfaces in the patch.
+  //! \param integrand Object with problem-specific data and methods
+  //! \param glbInt The integrated quantity
+  //! \param[in] time Parameters for nonlinear/time-dependent simulations
+  //! \param[in] iChk Object checking if an element interface has contributions
+  virtual bool integrate(Integrand& integrand, GlobalIntegral& glbInt,
+                         const TimeDomain& time, const ASM::InterfaceChecker& iChk);
+
 
   // Post-processing methods
   // =======================

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -2151,7 +2151,7 @@ bool ASMs3D::integrate (Integrand& integrand,
 bool ASMs3D::integrate (Integrand& integrand,
                         GlobalIntegral& glInt,
                         const TimeDomain& time,
-                        const InterfaceChecker& iChk)
+                        const ASM::InterfaceChecker& iChk)
 {
   if (!svol) return true; // silently ignore empty patches
   if (!(integrand.getIntegrandType() & Integrand::INTERFACE_TERMS)) return true;
@@ -3157,7 +3157,7 @@ void ASMs3D::extractBasis (double u, double v, double w, int dir, int p,
 }
 
 
-short int ASMs3D::InterfaceChecker::hasContribution (int I, int J, int K) const
+short int ASMs3D::InterfaceChecker::hasContribution (int, int I, int J, int K) const
 {
   bool neighbor[6];
   neighbor[0] = I > myPatch.svol->order(0);    // West neighbor

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -16,6 +16,7 @@
 
 #include "ASMstruct.h"
 #include "ASM3D.h"
+#include "Interface.h"
 #include "ThreadGroups.h"
 
 namespace Go {
@@ -88,6 +89,23 @@ public:
     int next();
   };
 
+  //! \brief Base class that checks if an element has interface contributions.
+  class InterfaceChecker : public ASM::InterfaceChecker
+  {
+  protected:
+    const ASMs3D& myPatch; //!< Reference to the patch being integrated
+  public:
+    //! \brief The constructor initialises the reference to current patch.
+    explicit InterfaceChecker(const ASMs3D& pch) : myPatch(pch) {}
+    //! \brief Empty destructor.
+    virtual ~InterfaceChecker() {}
+    //! \brief Returns non-zero if the specified element have contributions.
+    //! \param[in] I Index in first parameter direction of the element
+    //! \param[in] J Index in second parameter direction of the element
+    //! \param[in] K Index in third parameter direction of the element
+    virtual short int hasContribution(int, int I, int J, int K) const;
+  };
+
 private:
   typedef std::pair<int,int> Ipair; //!< Convenience type
 
@@ -101,23 +119,6 @@ private:
     //! \brief Default constructor.
     DirichletFace(Go::SplineSurface* ss = nullptr, int d = 0, int c = 0)
     : surf(ss), dof(d), code(c) {}
-  };
-
-protected:
-  //! \brief Base class that checks if an element has interface contributions.
-  class InterfaceChecker
-  {
-    const ASMs3D& myPatch; //!< Reference to the patch being integrated
-  public:
-    //! \brief The constructor initialises the reference to current patch.
-    explicit InterfaceChecker(const ASMs3D& pch) : myPatch(pch) {}
-    //! \brief Empty destructor.
-    virtual ~InterfaceChecker() {}
-    //! \brief Returns non-zero if the specified element have contributions.
-    //! \param[in] I Index in first parameter direction of the element
-    //! \param[in] J Index in second parameter direction of the element
-    //! \param[in] K Index in third parameter direction of the element
-    virtual short int hasContribution(int I, int J, int K) const;
   };
 
 public:
@@ -407,7 +408,7 @@ protected:
   //! \param[in] time Parameters for nonlinear/time-dependent simulations
   //! \param[in] iChk Object checking if an element interface has contributions
   bool integrate(Integrand& integrand, GlobalIntegral& glbInt,
-                 const TimeDomain& time, const InterfaceChecker& iChk);
+                 const TimeDomain& time, const ASM::InterfaceChecker& iChk);
 
 public:
 

--- a/src/ASM/ASMs3Dmx.C
+++ b/src/ASM/ASMs3Dmx.C
@@ -1037,6 +1037,10 @@ bool ASMs3Dmx::integrate (Integrand& integrand,
             }
           }
 
+        // Finalize the element quantities
+        if (ok && !integrand.finalizeElement(*A,time,0))
+          ok = false;
+
         // Assembly of global system integral
         if (ok && !glInt.assemble(A->ref(),fe.iel))
           ok = false;

--- a/src/ASM/ASMs3Dmx.h
+++ b/src/ASM/ASMs3Dmx.h
@@ -124,6 +124,13 @@ public:
   virtual bool integrate(Integrand& integrand, int lIndex,
 			 GlobalIntegral& glbInt, const TimeDomain& time);
 
+  //! \brief Evaluates an integral over element interfaces in the patch.
+  //! \param integrand Object with problem-specific data and methods
+  //! \param glbInt The integrated quantity
+  //! \param[in] time Parameters for nonlinear/time-dependent simulations
+  //! \param[in] iChk Object checking if an element interface has contributions
+  virtual bool integrate(Integrand& integrand, GlobalIntegral& glbInt,
+                         const TimeDomain& time, const ASM::InterfaceChecker& iChk);
 
   // Post-processing methods
   // =======================

--- a/src/ASM/FiniteElement.h
+++ b/src/ASM/FiniteElement.h
@@ -38,6 +38,9 @@ public:
   //! \brief Returns a reference to the basis function values.
   virtual Vector& basis(char) { return N; }
 
+  //! \brief Returns number of bases
+  virtual size_t getNoBasis() const { return 1; }
+
   //! \brief Returns a const reference to the basis function derivatives.
   virtual const Matrix& grad(char) const { return dNdX; }
   //! \brief Returns a reference to the basis function derivatives.
@@ -102,6 +105,9 @@ public:
   virtual const Vector& basis(char b) const { return b == 1 ? N : Nx[b-2]; }
   //! \brief Returns a reference to the basis function values.
   virtual Vector& basis(char b) { return b == 1 ? N : Nx[b-2]; }
+
+  //! \brief Returns number of bases
+  virtual size_t getNoBasis() const { return 1+Nx.size(); }
 
   //! \brief Returns a const reference to the basis function derivatives.
   virtual const Matrix& grad(char b) const { return b == 1 ? dNdX : dNxdX[b-2]; }

--- a/src/ASM/Integrand.h
+++ b/src/ASM/Integrand.h
@@ -222,6 +222,22 @@ public:
     return this->evalInt(elmInt,fe,X,normal);
   }
 
+  //! \brief Evaluates the integrand at an element interface point.
+  //! \param elmInt The local integral object to receive the contributions
+  //! \param[in] fe Finite element data of current integration point
+  //! \param[in] time Parameters for nonlinear and time-dependent simulations
+  //! \param[in] X Cartesian coordinates of current integration point
+  //! \param[in] normal Interface normal vector at current integration point
+  //!
+  //! \details The default implementation forwards to the stationary version.
+  //! Reimplement this method for time-dependent or non-linear problems.
+  virtual bool evalIntMx(LocalIntegral& elmInt, const MxFiniteElement& fe,
+                         const TimeDomain& time,
+                         const Vec3& X, const Vec3& normal) const
+  {
+    return this->evalIntMx(elmInt,fe,X,normal);
+  }
+
   //! \brief Finalizes the element quantities after the numerical integration.
   //! \param elmInt The local integral object to receive the contributions
   //! \param[in] fe Nodal and integration point data for current element
@@ -315,6 +331,9 @@ protected:
   //! \brief Evaluates the integrand at interface points for stationary problems.
   virtual bool evalInt(LocalIntegral&, const FiniteElement& fe,
                        const Vec3&, const Vec3&) const { return false; }
+  //! \brief Evaluates the integrand at interface points for stationary problems.
+  virtual bool evalIntMx(LocalIntegral&, const MxFiniteElement& fe,
+                         const Vec3&, const Vec3&) const { return false; }
 
   //! \brief Evaluates the integrand at boundary points for stationary problems.
   virtual bool evalBou(LocalIntegral&, const FiniteElement&,

--- a/src/ASM/Interface.h
+++ b/src/ASM/Interface.h
@@ -17,7 +17,6 @@
 
 namespace ASM
 {
-
   /*!
     \brief Struct for representing a domain interface.
   */
@@ -33,6 +32,23 @@ namespace ASM
     int thick;  //!< Thickness of connection.
   };
 
+
+  /*!
+    \brief Base class for checking for internal boundary integrand contributions.
+  */
+
+  class InterfaceChecker
+  {
+  public:
+    virtual ~InterfaceChecker () = default;
+    //! \brief Returns non-zero if the specified element have contributions.
+    //! \param[in] iel Element number
+    //! \param[in] I Index in first parameter direction of the element
+    //! \param[in] J Index in second parameter direction of the element
+    //! \param[in] K Index in third parameter direction of the element
+    virtual short int hasContribution(int iel, int I,
+                                      int J, int K = -1) const = 0;
+  };
 }
 
 #endif

--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -2199,3 +2199,101 @@ bool ASMu2D::evaluate (const FunctionBase* func, RealArray& vec,
   vec = ctrlPvals;
   return ok;
 }
+
+
+ASMu2D::InterfaceChecker::InterfaceChecker(const ASMu2D& pch) : myPatch(pch)
+{
+  const LR::LRSplineSurface* lr = myPatch.getBasis(1);
+
+  for (auto m : lr->getAllMeshlines()) {
+    std::vector<double> isectpts(1);
+
+    for (auto m2 : lr->getAllMeshlines())
+      if (m->intersects(m2, &isectpts.back()))
+        isectpts.push_back(0);
+
+    isectpts.pop_back();
+    std::sort(isectpts.begin(), isectpts.end());
+    auto end = std::unique(isectpts.begin(), isectpts.end());
+    isectpts.erase(end,isectpts.end());
+
+    // find elements where this intersection lives
+    std::vector<double> parval_left(2);
+    std::vector<double> parval_right(2);
+    double epsilon = 1e-6;
+    for(size_t i=0; i < isectpts.size()-1; i++) {
+      if (m->is_spanning_u()) {
+#if SP_DEBUG > 2
+        std::cout << "Line piece from ("<< isectpts[i] << ", " << m->const_par_ << ") to ("
+             << isectpts[i+1] << ", " << m->const_par_ << ")" << std::endl;
+#endif
+        parval_left[0]  = (isectpts[i]+isectpts[i+1])/2.0;
+        parval_right[0] = (isectpts[i]+isectpts[i+1])/2.0;
+        parval_left[1]  = m->const_par_ - epsilon;
+        parval_right[1] = m->const_par_ + epsilon;
+      } else {
+#if SP_DEBUG > 2
+        std::cout << "Line piece from ("<< m->const_par_ << ", " << isectpts[i] << ") to ("
+                  << m->const_par_ << ", " << isectpts[i+1] << ")" << std::endl;
+#endif
+        parval_left[0]  = m->const_par_ - epsilon;
+        parval_right[0] = m->const_par_ + epsilon;
+        parval_left[1]  = (isectpts[i]+isectpts[i+1])/2.0;
+        parval_right[1] = (isectpts[i]+isectpts[i+1])/2.0;
+      }
+      int el1 = lr->getElementContaining(parval_left);
+      int el2 = lr->getElementContaining(parval_right);
+#if SP_DEBUG > 2
+      std::cout << "\t elem1 " << el1 << " elem2 " << el2 << std::endl;
+#endif
+      if (m->is_spanning_u()) {
+        if (el1 > -1 && el2 > -1) {
+          intersections[el2*16 + 3].pts.push_back(isectpts[i+1]);
+          intersections[el1*16 + 4].pts.push_back(isectpts[i+1]);
+        }
+      } else {
+        if (el1 > -1 && el2 > -1) {
+          intersections[el2*16 + 1].pts.push_back(isectpts[i+1]);
+          intersections[el1*16 + 2].pts.push_back(isectpts[i+1]);
+        }
+      }
+    }
+  }
+  for (auto& it : intersections) {
+    std::sort(it.second.pts.begin(), it.second.pts.end());
+    auto end = std::unique(it.second.pts.begin(), it.second.pts.end());
+    it.second.pts.erase(end,it.second.pts.end());
+  }
+}
+
+
+short int ASMu2D::InterfaceChecker::hasContribution (int iel, int, int, int) const
+{
+  const LR::Element* el = myPatch.geo->getElement(iel-1);
+  bool neighbor[4];
+  neighbor[0] = el->getParmin(0) != myPatch.geo->startparam(0); // West neighbor
+  neighbor[1] = el->getParmax(0) != myPatch.geo->endparam(0); // East neighbor
+  neighbor[2] = el->getParmin(1) != myPatch.geo->startparam(1); // South neighbor
+  neighbor[3] = el->getParmax(1) != myPatch.geo->endparam(1); // North neighbor
+
+  // Check for existing neighbors
+  short int status = 0, s = 1;
+  for (short int i = 0; i < 4; i++, s *= 2)
+    if (neighbor[i]) status += s;
+
+  return status;
+}
+
+
+std::vector<double> ASMu2D::InterfaceChecker::getIntersections(int iel, int edge,
+                                                               int* cont) const
+{
+  auto it = intersections.find((iel-1)*16 + edge);
+  if (it != intersections.end()) {
+    if (cont)
+      *cont = it->second.continuity;
+    return it->second.pts;
+  }
+
+  return std::vector<double>();
+}

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -16,6 +16,7 @@
 
 #include "ASMunstruct.h"
 #include "ASM2D.h"
+#include "Interface.h"
 #include "LRSpline/LRSpline.h"
 #include "ThreadGroups.h"
 #include <memory>
@@ -40,6 +41,34 @@ namespace LR {
 class ASMu2D : public ASMunstruct, public ASM2D
 {
 public:
+  //! \brief Base class that checks if an element has interface contributions.
+  class InterfaceChecker : public ASM::InterfaceChecker
+  {
+  public:
+    //! \brief The constructor initialises the reference to current patch.
+    explicit InterfaceChecker(const ASMu2D& pch);
+    //! \brief Empty destructor.
+    virtual ~InterfaceChecker() {}
+    //! \brief Returns non-zero if the specified element have contributions.
+    //! \param[in] iel Element number
+    virtual short int hasContribution(int iel, int = -1,
+                                      int = -1, int = -1) const;
+    //! \brief Get intersections for a given element edge.
+    //! \param iel Element index (1-based)
+    //! \param edge Edge to get intersections for (1..4)
+    //! \param cont If not nullpt, intersection continuity is given here
+    std::vector<double> getIntersections(int iel, int edge, int* cont=nullptr) const;
+  protected:
+    const ASMu2D& myPatch; //!< Reference to the patch being integrated
+
+    struct Intersection {
+      int continuity;
+      std::vector<double> pts;
+    };
+
+    //! \brief Intersections for elements. Key: element << 4 + edge (1..4)
+    std::map<int,Intersection> intersections;
+  };
   //! \brief Default constructor.
   ASMu2D(unsigned char n_s = 2, unsigned char n_f = 2);
   //! \brief Copy constructor.

--- a/src/ASM/LR/ASMu2Dmx.C
+++ b/src/ASM/LR/ASMu2Dmx.C
@@ -280,7 +280,7 @@ bool ASMu2Dmx::integrate (Integrand& integrand,
       std::vector<size_t> elem_sizes;
       for (size_t i=0; i < m_basis.size(); ++i) {
         els.push_back(m_basis[i]->getElementContaining(uh, vh)+1);
-        elem_sizes.push_back((*(m_basis[i]->elementBegin()+els.back()-1))->nBasisFunctions());
+        elem_sizes.push_back(m_basis[i]->getElement(els.back()-1)->nBasisFunctions());
       }
 
       int geoEl = els[geoBasis-1];
@@ -479,7 +479,7 @@ bool ASMu2Dmx::integrate (Integrand& integrand, int lIndex,
     std::vector<size_t> elem_sizes;
     for (size_t i=0; i < m_basis.size(); ++i) {
       els.push_back(m_basis[i]->getElementContaining(uh, vh)+1);
-      elem_sizes.push_back((*(m_basis[i]->elementBegin()+els.back()-1))->nBasisFunctions());
+      elem_sizes.push_back((*(m_basis[i]->elementBegin()+(els.back()-1)))->nBasisFunctions());
     }
     int geoEl = els[geoBasis-1];
 
@@ -556,6 +556,206 @@ bool ASMu2Dmx::integrate (Integrand& integrand, int lIndex,
 
     // Assembly of global system integral
     if (!glInt.assemble(A,fe.iel))
+      return false;
+
+    A->destruct();
+  }
+
+  return true;
+}
+
+
+bool ASMu2Dmx::integrate (Integrand& integrand,
+                          GlobalIntegral& glInt,
+                          const TimeDomain& time,
+                          const ASM::InterfaceChecker& iChkgen)
+{
+  if (!geo) return true; // silently ignore empty patches
+  if (!(integrand.getIntegrandType() & Integrand::INTERFACE_TERMS)) return true;
+
+  PROFILE2("ASMu2Dmx::integrate(J)");
+
+  const ASMu2D::InterfaceChecker& iChk =
+                          static_cast<const ASMu2D::InterfaceChecker&>(iChkgen);
+
+  // Get Gaussian quadrature points and weights
+  int nGP = integrand.getBouIntegrationPoints(nGauss);
+  const double* xg = GaussQuadrature::getCoord(nGP);
+  const double* wg = GaussQuadrature::getWeight(nGP);
+  if (!xg || !wg) return false;
+
+  Matrix   Xnod, Jac;
+  Vec4     X;
+  Vec3     normal;
+
+  std::vector<LR::Element*>::iterator el1 = m_basis[0]->elementBegin();
+  for (int iel = 1; el1 != m_basis[0]->elementEnd(); ++el1, ++iel) {
+    short int status = iChk.hasContribution(iel);
+    if (!status) continue; // no interface contributions for this element
+    // first push the hosting elements
+    std::vector<size_t> els(1,iel);
+    std::vector<size_t> elem_sizes(1,(*el1)->nBasisFunctions());
+
+    double uh = ((*el1)->umin()+(*el1)->umax())/2.0;
+    double vh = ((*el1)->vmin()+(*el1)->vmax())/2.0;
+
+    for (size_t i=1; i < m_basis.size(); ++i) {
+      els.push_back(m_basis[i]->getElementContaining(uh, vh)+1);
+      elem_sizes.push_back(m_basis[i]->getElement(els.back()-1)->nBasisFunctions());
+    }
+
+    // Set up control point coordinates for current element
+    if (!this->getElementCoordinates(Xnod,els[geoBasis-1]))
+      return false;
+
+    LocalIntegral* A = integrand.getLocalIntegral(elem_sizes, iel);
+    integrand.initElement(MNPC[els[geoBasis-1]-1],elem_sizes,nb,*A);
+    size_t origSize = A->vec.size();
+
+    int bit = 8;
+    for (int iedge = 4; iedge > 0 && status > 0; iedge--, bit /= 2) {
+      if (status & bit) {
+        const int edgeDir = (iedge+1)/(iedge%2 ? -2 : 2);
+        const int t1 = abs(edgeDir);   // Tangent direction normal to the edge
+        const int t2 = 3-abs(edgeDir); // Tangent direction along the edge
+
+        // Set up parameters
+        double u1 = iedge != 2 ? (*el1)->umin() : (*el1)->umax();
+        double v1 = iedge < 4 ? (*el1)->vmin() : (*el1)->vmax();
+        double u2(u1);
+        double v2(v1);
+        const double epsilon = 1e-8;
+        double epsu = 0.0, epsv = 0.0;
+        if (iedge == 1)
+          epsu = epsilon;
+        if (iedge == 2)
+          epsu = -epsilon;
+        if (iedge == 3)
+          epsv = epsilon;
+        if (iedge == 4)
+          epsv = -epsilon;
+
+        std::vector<double> intersections = iChk.getIntersections(iel, iedge);
+        for (size_t i = 0; i < intersections.size(); ++i) {
+          std::vector<double> parval(2);
+          parval[0] = u1-epsu;
+          parval[1] = v1-epsv;
+
+          if (iedge == 1 || iedge == 2)
+            v2 = intersections[i];
+          else
+            u2 = intersections[i];
+
+          int el_neigh = this->getBasis(1)->getElementContaining(parval)+1;
+          const LR::Element* el2 = m_basis[0]->getElement(el_neigh-1);
+          uh = (el2->umin()+el2->umax())/2.0;
+          vh = (el2->vmin()+el2->vmax())/2.0;
+
+          std::vector<size_t> els2(1,el_neigh);
+          std::vector<size_t> elem_sizes2(1,el2->nBasisFunctions());
+          for (size_t i=1; i < m_basis.size(); ++i) {
+            els2.push_back(m_basis[i]->getElementContaining(uh, vh)+1);
+            elem_sizes2.push_back(m_basis[i]->getElement(els2.back()-1)->nBasisFunctions());
+          }
+
+          LocalIntegral* A_neigh = integrand.getLocalIntegral(elem_sizes2, el_neigh);
+          integrand.initElement(MNPC[els2[geoBasis-1]-1],elem_sizes2,nb,*A_neigh);
+
+          // Element sizes for both elements
+          std::vector<size_t> elem_sizes3(elem_sizes);
+          std::copy(elem_sizes2.begin(), elem_sizes2.end(),
+                    std::back_inserter(elem_sizes3));
+
+          MxFiniteElement fe(elem_sizes3);
+          fe.h = this->getElementCorners(els2[geoBasis-1], fe.XC);
+
+          if (!A_neigh->vec.empty()) {
+            A->vec.resize(origSize+A_neigh->vec.size());
+            std::copy(A_neigh->vec.begin(), A_neigh->vec.end(),
+                      A->vec.begin()+origSize);
+          }
+          A_neigh->destruct();
+
+          double dS = (iedge == 1 || iedge == 2) ? v2 - v1 : u2 - u1;
+
+          std::array<Vector,2> gpar;
+          if (iedge == 1 || iedge == 2) {
+            gpar[0].resize(nGauss);
+            gpar[0].fill(u1);
+            gpar[1].resize(nGauss);
+            for (int i = 0; i < nGauss; ++i)
+              gpar[1][i] = 0.5*((v2-v1)*xg[i] + v2 + v1);
+          } else {
+            gpar[0].resize(nGauss);
+            for (int i = 0; i < nGauss; ++i)
+              gpar[0][i] = 0.5*((u2-u1)*xg[i] + u2 + u1);
+            gpar[1].resize(nGauss);
+            gpar[1].fill(v1);
+          }
+          Matrix Xnod2, Jac2;
+          if (!this->getElementCoordinates(Xnod2,els2[geoBasis-1]))
+            return false;
+
+          for (int g = 0; g < nGP; g++, ++fe.iGP)
+          {
+            // Local element coordinates and parameter values
+            // of current integration point
+            fe.xi = xg[g];
+            fe.eta = xg[g];
+            fe.u = gpar[0][g];
+            fe.v = gpar[1][g];
+
+            // Evaluate basis function derivatives at current integration points
+            std::vector<Matrix> dNxdu(m_basis.size()*2);
+            for (size_t b=0; b < m_basis.size(); ++b) {
+              Go::BasisDerivsSf spline;
+              m_basis[b]->computeBasis(fe.u+epsu, fe.v+epsv, spline, els[b]-1);
+              SplineUtils::extractBasis(spline,fe.basis(b+1),dNxdu[b]);
+              m_basis[b]->computeBasis(fe.u-epsu, fe.v-epsv, spline, els2[b]-1);
+              SplineUtils::extractBasis(spline,fe.basis(b+1+m_basis.size()),
+                                        dNxdu[b+m_basis.size()]);
+            }
+
+            // Compute Jacobian inverse of the coordinate mapping and
+            // basis function derivatives w.r.t. Cartesian coordinates
+            fe.detJxW = utl::Jacobian(Jac2, normal,
+                                      fe.grad(geoBasis+m_basis.size()),
+                                      Xnod2,dNxdu[geoBasis-1+m_basis.size()],t1,t2);
+            fe.detJxW = utl::Jacobian(Jac, normal,
+                                      fe.grad(geoBasis),Xnod,dNxdu[geoBasis-1],t1,t2);
+            if (fe.detJxW == 0.0) continue; // skip singular points
+            for (size_t b = 0; b < m_basis.size(); ++b)
+              if (b != (size_t)geoBasis-1) {
+                fe.grad(b+1).multiply(dNxdu[b],Jac);
+                fe.grad(b+1+m_basis.size()).multiply(dNxdu[b+m_basis.size()],Jac);
+              }
+
+            if (edgeDir < 0)
+              normal *= -1.0;
+
+            // Cartesian coordinates of current integration point
+            X = Xnod * fe.basis(geoBasis);
+            X.t = time.t;
+
+            // Evaluate the integrand and accumulate element contributions
+            fe.detJxW *= 0.5*dS*wg[g];
+            if (!integrand.evalIntMx(*A,fe,time,X,normal))
+              return false;
+          }
+
+          if (iedge == 1 || iedge == 2)
+            v1 = v2;
+          else
+            u1 = u2;
+        }
+      }
+    }
+    // Finalize the element quantities
+    if (!integrand.finalizeElement(*A,time,0))
+      return false;
+
+    // Assembly of global system integral
+    if (!glInt.assemble(A,els[geoBasis-1]))
       return false;
 
     A->destruct();
@@ -834,7 +1034,7 @@ bool ASMu2Dmx::refine (const LR::RefineData& prm,
   std::cout <<"Refined mesh: ";
   for (const auto& it : m_basis)
     std::cout << it->nElements() <<" ";
-  std::cout <<"elements";
+  std::cout <<"elements ";
   for (const auto& it : m_basis)
     std::cout << it->nBasisFunctions() <<" ";
   std::cout <<"nodes."<< std::endl;

--- a/src/ASM/LR/ASMu2Dmx.h
+++ b/src/ASM/LR/ASMu2Dmx.h
@@ -98,6 +98,14 @@ public:
   virtual bool integrate(Integrand& integrand, int lIndex,
                          GlobalIntegral& glbInt, const TimeDomain& time);
 
+  //! \brief Evaluates an integral over element interfaces in the patch.
+  //! \param integrand Object with problem-specific data and methods
+  //! \param glbInt The integrated quantity
+  //! \param[in] time Parameters for nonlinear/time-dependent simulations
+  //! \param[in] iChk Object checking if an element interface has contributions
+  virtual bool integrate(Integrand& integrand, GlobalIntegral& glbInt,
+                         const TimeDomain& time, const ASM::InterfaceChecker& iChk);
+
 
   // Post-processing methods
   // =======================

--- a/src/ASM/LR/Test/TestASMu2D.C
+++ b/src/ASM/LR/Test/TestASMu2D.C
@@ -12,6 +12,7 @@
 
 #include "ASMu2D.h"
 #include "SIM2D.h"
+#include "LRSpline/LRSplineSurface.h"
 
 #include "gtest/gtest.h"
 
@@ -74,10 +75,72 @@ TEST_P(TestASMu2D, ConstrainEdgeOpen)
 
 static const std::vector<EdgeTest> edgeTestData =
         {{{1, -1, {-1, -1}, {-1 , 1}},
-         {2,  1, { 1, -1}, { 1 , 1}},
-         {3, -2, {-1, -1}, { 1, -1}},
-         {4,  2, {-1,  1}, { 1,  1}}}};
+          {2,  1, { 1, -1}, { 1 , 1}},
+          {3, -2, {-1, -1}, { 1, -1}},
+          {4,  2, {-1,  1}, { 1,  1}}}};
 
 
 INSTANTIATE_TEST_CASE_P(TestASMu2D, TestASMu2D,
                         testing::ValuesIn(edgeTestData));
+
+
+TEST(TestASMu2D, InterfaceChecker)
+{
+  SIM2D sim(1);
+  sim.opt.discretization = ASM::LRSpline;
+  sim.createDefaultModel();
+  ASMu2D* pch = static_cast<ASMu2D*>(sim.getPatch(1));
+  pch->raiseOrder(1,1);
+  pch->uniformRefine(0, 3);
+  pch->uniformRefine(1, 3);
+  LR::LRSplineSurface* lr = pch->getSurface();
+  lr->insert_const_u_edge(0.5,   0, 1, 2);
+  lr->insert_const_v_edge(0.125, 0.5, 1, 2);
+  lr->insert_const_v_edge(0.25,  0.5, 1, 2);
+  lr->insert_const_v_edge(0.875, 0.5, 1, 1);
+  EXPECT_TRUE(sim.createFEMmodel());
+
+  static std::vector<int> elem_flags = {{10, 11, 11,  9,
+                                         14, 15, 15, 13,
+                                         14, 15, 15, 13,
+                                          6,  7, 15, 13,
+                                         15, 13,
+                                          7,  5}};
+
+  static std::vector<std::array<std::vector<double>,4>> elem_pts =
+  {{{{    {},        {0.25},     {}, {0.25}}},
+   {{ {0.25}, {0.125, 0.25},     {},  {0.5}}},
+   {{{0.125},       {0.125},     {}, {0.75}}},
+   {{{0.125},            {},     {},  {1.0}}},
+   {{     {},         {0.5}, {0.25}, {0.25}}},
+   {{  {0.5},         {0.5},  {0.5},  {0.5}}},
+   {{  {0.5},         {0.5}, {0.75}, {0.75}}},
+   {{  {0.5},         {0.5},  {1.0},  {1.0}}},
+   {{     {},        {0.75}, {0.25}, {0.25}}},
+   {{ {0.75},        {0.75},  {0.5},  {0.5}}},
+   {{ {0.75},        {0.75}, {0.75}, {0.75}}},
+   {{ {0.75},            {},  {1.0},  {1.0}}},
+   {{     {},         {1.0}, {0.25},     {}}},
+   {{  {1.0},  {0.875, 1.0},  {0.5},  {0.5}}},
+   {{{0.875},       {0.875}, {0.75}, {0.75}}},
+   {{{0.875},            {},  {1.0},  {1.0}}},
+   {{ {0.25},        {0.25}, {0.75}, {0.75}}},
+   {{ {0.25},            {},  {1.0},  {1.0}}},
+   {{  {1.0},         {1.0}, {0.75},     {}}},
+   {{  {1.0},            {},  {1.0},     {}}}}};
+
+  EXPECT_EQ(elem_flags.size(), pch->getNoElms());
+  EXPECT_EQ(elem_pts.size(), pch->getNoElms());
+  ASMu2D::InterfaceChecker iChk(*pch);
+  for (size_t i = 0; i < pch->getNoElms(); ++i) {
+    EXPECT_EQ(iChk.hasContribution(i+1), elem_flags[i]);
+    for (size_t edge = 1; edge <= 4; ++edge) {
+      if (elem_flags[i] & (1 << (edge-1))) {
+        auto val = iChk.getIntersections(i+1, edge);
+        EXPECT_EQ(val.size(), elem_pts[i][edge-1].size());
+        for (size_t j = 0; j < val.size(); ++j)
+          EXPECT_FLOAT_EQ(val[j], elem_pts[i][edge-1][j]);
+      }
+    }
+  }
+}

--- a/src/SIM/AdaptiveSIM.C
+++ b/src/SIM/AdaptiveSIM.C
@@ -469,15 +469,15 @@ void AdaptiveSIM::printNorms (size_t w) const
   {
     NormBase* norm = model.getNormIntegrand();
 
-    const Vector& fNorm = gNorm.front();
     const Vector& aNorm = gNorm[adaptor];
     IFEM::cout <<"\nError estimate"
                << utl::adjustRight(w-14,norm->getName(adaptor+1,adNorm))
                << aNorm(adNorm)
                <<"\nRelative error (%) : "
                << 100.0*aNorm(adNorm)/model.getReferenceNorm(gNorm,adaptor);
-    if (model.haveAnaSol() && fNorm.size() > 3 && adNorm == 2)
-      IFEM::cout <<"\nEffectivity index  : "<< aNorm(2)/fNorm(4);
+    if (model.haveAnaSol() && adaptor != 0)
+      IFEM::cout <<"\nEffectivity index  : "
+                 << model.getEffectivityIndex(gNorm,adaptor,adNorm);
     IFEM::cout <<"\n"<< std::endl;
 
     // Calculate the row-index for the corresponding element norms

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -1348,6 +1348,13 @@ bool SIMbase::solutionNorms (const TimeDomain& time,
         if (mySol)
           mySol->initPatch(pch->idx);
 	ok &= pch->integrate(*norm,globalNorm,time);
+        if (norm->getIntegrandType() & IntegrandBase::INTERFACE_TERMS) {
+          ASM::InterfaceChecker* iChk = this->getInterfaceChecker(pch->idx);
+          if (iChk) {
+            ok &= !pch->integrate(*norm,globalNorm,time,*iChk);
+            delete iChk;
+          }
+        }
       }
       else
 	ok = false;
@@ -1366,6 +1373,13 @@ bool SIMbase::solutionNorms (const TimeDomain& time,
       if (mySol)
         mySol->initPatch(myModel[i]->idx);
       ok &= myModel[i]->integrate(*norm,globalNorm,time);
+      if (norm->getIntegrandType() & IntegrandBase::INTERFACE_TERMS) {
+        ASM::InterfaceChecker* iChk = this->getInterfaceChecker(myModel[i]->idx);
+        if (iChk) {
+          ok &= myModel[i]->integrate(*norm,globalNorm,time,*iChk);
+          delete iChk;
+        }
+      }
       lp = i+1;
     }
 

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -126,6 +126,10 @@ public:
   //! \brief Returns a pointer to the problem-specific data object.
   const IntegrandBase* getProblem() const { return myProblem; }
 
+  //! \brief Returns interface checker type for model.
+  virtual ASM::InterfaceChecker* getInterfaceChecker(size_t) const
+  { return nullptr; }
+
   //! \brief Clears the reference to the problem-specific data object.
   //! \details This method is used when the same IntegrandBase object is shared
   //! by several SIMbase objects, to avoid that it is deleted more than once.

--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -1651,3 +1651,10 @@ double SIMoutput::getReferenceNorm (const Vectors& gNorm, size_t adaptor) const
   // |u|_ref = sqrt( |u^h|^2 + |e^*|^2 )
   return hypot(fNorm(1),gNorm[adaptor](2));
 }
+
+
+double SIMoutput::getEffectivityIndex (const Vectors& gNorm,
+                                       size_t idx, size_t inorm) const
+{
+  return gNorm[idx](inorm) / gNorm.front()(4);
+}

--- a/src/SIM/SIMoutput.h
+++ b/src/SIM/SIMoutput.h
@@ -289,6 +289,10 @@ public:
   //! \brief Returns the reference norm to base mesh adaptation upon.
   virtual double getReferenceNorm(const Vectors& gNorm, size_t adaptor) const;
 
+  //! \brief Returns the global effectivity index.
+  virtual double getEffectivityIndex(const Vectors& gNorm,
+                                     size_t idx, size_t inorm) const;
+
   //! \brief Serialization support.
   virtual bool serialize(std::map<std::string,std::string>&) { return false; }
 


### PR DESCRIPTION
This generalizes some concepts from Immersed Boundary calculations and use these to allow for jump terms in norm integrands.

See https://github.com/sintefmath/IFEM-Stokes/pull/75 for user side.