### PR TITLE
Fixed: Copy the norm prefixes to avoid valgrind complaint

### DIFF
--- a/src/SIM/AdaptiveSIM.h
+++ b/src/SIM/AdaptiveSIM.h
@@ -33,8 +33,8 @@ public:
   //! \param sim The FE model
   //! \param sa If \e true, this is a stand-alone driver
   AdaptiveSIM(SIMoutput& sim, bool sa = true);
-  //! \brief Empty destructor.
-  virtual ~AdaptiveSIM() {}
+  //! \brief The destructor frees the norm prefices.
+  virtual ~AdaptiveSIM();
 
   //! \brief Sets the norm group/index of the norm to base mesh adaptation on.
   void setAdaptationNorm(size_t normGroup, size_t normIdx = 0);


### PR DESCRIPTION
This resolves the memory issue http://afem:8000/job/IFEM-memtest/1010/

The problem is that AdaptiveSIM keeps an array of C-pointers to the norm prefices to use, but when the mesh is refined and the input-file is parsed again for the new mesh, these pointers are invalidated (at least when run through valgrind). Now I make a copy of those strings instead and the problem vanishes. Maybe not the most elegant, but works.