### PR TITLE
Changed: Undo of 02d84c07e2dc79d3adeec067a47c5fe8d878f3ce

### DIFF
--- a/Apps/Common/SIMCoupled.h
+++ b/Apps/Common/SIMCoupled.h
@@ -53,13 +53,7 @@ public:
   }
 
   //! \brief Computes the solution for the current time step.
-  virtual bool solveStep(TimeStep& tp)
-  {
-    return this->solveStep(tp, true);
-  }
-
-  //! \brief Computes the solution for the current time step.
-  virtual bool solveStep(TimeStep& tp, bool firstS1)
+  virtual bool solveStep(TimeStep& tp, bool firstS1 = true)
   {
     if (firstS1)
       return S1.solveStep(tp) && S2.solveStep(tp);

--- a/Apps/Common/SIMCoupledSI.h
+++ b/Apps/Common/SIMCoupledSI.h
@@ -32,8 +32,7 @@ public:
   virtual ~SIMCoupledSI() {}
 
   //! \brief Computes the solution for the current time step.
-  using SIMCoupled<T1,T2>::solveStep;
-  virtual bool solveStep(TimeStep& tp, bool firstS1)
+  virtual bool solveStep(TimeStep& tp, bool firstS1 = true)
   {
     if (maxIter <= 0)
       maxIter = std::min(this->S1.getMaxit(),this->S2.getMaxit());


### PR DESCRIPTION
It feels unnecessary and confusing with two versions of solveStep
and the need for the using statement when one of them is overridden?

I think the reason for the May 5th commit on this is that it was forgotten up update the overridden solveStep method in the one and only downstream application that did override it (SIMKEpsilonBase).
I believe it is much better(?) to update that signature also such that we don't need to overload this method, and consequently can skip the annoying need for using-statements.