### PR TITLE
Nodeset fix

### DIFF
--- a/Apps/Common/SIMCoupled.h
+++ b/Apps/Common/SIMCoupled.h
@@ -53,13 +53,7 @@ public:
   }
 
   //! \brief Computes the solution for the current time step.
-  virtual bool solveStep(TimeStep& tp)
-  {
-    return this->solveStep(tp, true);
-  }
-
-  //! \brief Computes the solution for the current time step.
-  virtual bool solveStep(TimeStep& tp, bool firstS1)
+  virtual bool solveStep(TimeStep& tp, bool firstS1 = true)
   {
     if (firstS1)
       return S1.solveStep(tp) && S2.solveStep(tp);

--- a/Apps/Common/SIMCoupledSI.h
+++ b/Apps/Common/SIMCoupledSI.h
@@ -32,8 +32,7 @@ public:
   virtual ~SIMCoupledSI() {}
 
   //! \brief Computes the solution for the current time step.
-  using SIMCoupled<T1,T2>::solveStep;
-  virtual bool solveStep(TimeStep& tp, bool firstS1)
+  virtual bool solveStep(TimeStep& tp, bool firstS1 = true)
   {
     if (maxIter <= 0)
       maxIter = std::min(this->S1.getMaxit(),this->S2.getMaxit());

--- a/src/ASM/ASMu2DLag.C
+++ b/src/ASM/ASMu2DLag.C
@@ -142,7 +142,7 @@ bool ASMu2DLag::readMatlab (std::istream& is)
           cline.erase(i,1);
 
         int node;
-        IntVec& nodes = nodeSets[setname];
+        IntVec nodes;
         std::istringstream selem(cline);
         selem >> node;
         while (selem)
@@ -156,6 +156,7 @@ bool ASMu2DLag::readMatlab (std::istream& is)
         std::cout << std::endl;
 #endif
         std::getline(is,cline);
+        nodeSets.push_back(std::make_pair(setname,nodes));
       }
     }
 
@@ -214,6 +215,17 @@ const IntVec& ASMu2DLag::getNodeSet (int idx) const
       return it.second;
 
   return this->ASMbase::getNodeSet(idx);
+}
+
+
+IntVec& ASMu2DLag::getNodeSet (const std::string& setName)
+{
+  for (NodeSet& it : nodeSets)
+    if (it.first == setName)
+      return it.second;
+
+  nodeSets.push_back(std::make_pair(setName,IntVec()));
+  return nodeSets.back().second;
 }
 
 

--- a/src/ASM/ASMu2DLag.h
+++ b/src/ASM/ASMu2DLag.h
@@ -15,7 +15,6 @@
 #define _ASM_S2D_MATLAB_H
 
 #include "ASMs2DLag.h"
-#include <unordered_map>
 
 
 /*!
@@ -57,7 +56,7 @@ public:
   //! \brief Returns an indexed pre-defined node set.
   virtual const IntVec& getNodeSet(int idx) const;
   //! \brief Returns a named node set for update.
-  virtual IntVec& getNodeSet(const std::string& name) { return nodeSets[name]; }
+  virtual IntVec& getNodeSet(const std::string& setName);
 
   using ASMs2DLag::generateThreadGroups;
   //! \brief Generates element groups for multi-threading of interior integrals.
@@ -73,8 +72,8 @@ public:
 
 private:
   char fileType; //!< Mesh file format
-  //! Pre-defined node sets for Dirichlet BCs
-  std::unordered_map<std::string,IntVec> nodeSets;
+  typedef std::pair<std::string,IntVec> NodeSet; //!< Named node set container
+  std::vector<NodeSet> nodeSets; //!< Pre-defined node sets for Dirichlet BCs
 };
 
 #endif

--- a/src/ASM/Test/TestMatlabPatch.C
+++ b/src/ASM/Test/TestMatlabPatch.C
@@ -82,15 +82,26 @@ TEST(TestMatlabPatch, IO)
   ASMbase* pch2 = sim2.getPatch(1);
   ASSERT_TRUE(pch1 != nullptr);
   ASSERT_TRUE(pch2 != nullptr);
-  IntVec b1, b2 = pch2->getNodeSet(pch2->getNodeSetIdx("Boundary"));
+  int idx1 = pch2->getNodeSetIdx("Boundary");
+  int idx2 = pch2->getNodeSetIdx("Edge2");
+  pch2->getNodeSet("ACorner").push_back(1);
+  int idx3 = pch2->getNodeSetIdx("ACorner");
+  EXPECT_EQ(idx1,1);
+  EXPECT_EQ(idx2,2);
+  EXPECT_EQ(idx3,3);
+
+  IntVec b1, b2 = pch2->getNodeSet(idx1);
   for (int edge = 1; edge <= 4; edge++)
     pch1->getBoundaryNodes(edge,b1);
   std::set<int> b1set;
   for (int n : b1) b1set.insert(n);
   EXPECT_EQ(b1set.size(),b2.size());
   EXPECT_TRUE(IntVec(b1set.begin(),b1set.end()) == b2);
-  IntVec e1, e2 = pch2->getNodeSet(pch2->getNodeSetIdx("Edge2"));
+  IntVec e1, e2 = pch2->getNodeSet(idx2);
   pch1->getBoundaryNodes(2,e1);
   EXPECT_EQ(e1.size(),e2.size());
   EXPECT_TRUE(e1 == e2);
+  IntVec corner = pch2->getNodeSet(idx3);
+  ASSERT_EQ(corner.size(),1U);
+  EXPECT_EQ(corner.front(),1);
 }


### PR DESCRIPTION
It seems like the unordered_map class does not work as I anticipated. It do sorts on the key which makes the unit test on Matlab input fail (first commit). In the second commit I replaced by a vector of pairs instead which works better.

Is this a bug in STL or is it supposed to work like this?