### PR TITLE
Interpolation of initial condition for ASMu[23]D

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,3 @@
-*.log
-*.vtfx
-*.vtf
 *~
-*.eps
-Apps/AdvectionDiffusion
-Apps/Elasticity
-Apps/FSI
-Apps/NavierStokes
-Apps/Poisson
-Apps/PoroElasticity
-Apps/Stokes
 Release
 Debug


### PR DESCRIPTION
This was missing, I think, so overrriding the ASMbase::evaluate method and invoking the L2-projection for both 2D and 3D.

The other changes in this PR are pure cleanup issues (needs testing though).