### PR TITLE
Various norm and VTF related fixes

### DIFF
--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -1186,16 +1186,16 @@ int ASMbase::searchCtrlPt (RealArray::const_iterator cit,
 }
 
 
-bool ASMbase::evalSolution (Matrix&, const Vector&, const int*) const
+bool ASMbase::evalSolution (Matrix&, const Vector&, const int*, int) const
 {
-  return Aerror("evalSolution(Matrix&,const Vector&,const int*)");
+  return Aerror("evalSolution(Matrix&,const Vector&,const int*,int)");
 }
 
 
 bool ASMbase::evalSolution (Matrix&, const Vector&,
-			    const RealArray*, bool, int) const
+                            const RealArray*, bool, int, int) const
 {
-  return Aerror("evalSolution(Matrix&,const Vector&,const RealArray*,bool,int)");
+  return Aerror("evalSolution(Matrix&,const Vector&,const RealArray*,bool,int,int)");
 }
 
 

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -454,8 +454,9 @@ public:
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector local to current patch
   //! \param[in] npe Number of visualization nodes over each knot span
+  //! \param[in] nf If nonzero, mixed evaluates nf fields on first basis
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-			    const int* npe) const;
+                            const int* npe, int nf = 0) const;
 
   //! \brief Evaluates the primary solution field at the given points.
   //! \param[out] sField Solution field
@@ -463,6 +464,7 @@ public:
   //! \param[in] gpar Parameter values of the result sampling points
   //! \param[in] regular Flag indicating how the sampling points are defined
   //! \param[in] deriv Derivative order to return
+  //! \param[in] nf If non-zero mixed evaluates nf fields on first basis
   //!
   //! \details When \a regular is \e true, it is assumed that the parameter
   //! value array \a gpar forms a regular tensor-product point grid of dimension
@@ -471,7 +473,7 @@ public:
   //! directly for each sampling point.
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
                             const RealArray* gpar, bool regular = true,
-                            int deriv = 0) const;
+                            int deriv = 0, int nf = 0) const;
 
   //! \brief Evaluates and interpolates a field over a given geometry.
   //! \param[in] basis The basis of the field to evaluate

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -1134,7 +1134,7 @@ bool ASMs1D::getSolution (Matrix& sField, const Vector& locSol,
 
 
 bool ASMs1D::evalSolution (Matrix& sField, const Vector& locSol,
-			   const int* npe) const
+                           const int* npe, int, int) const
 {
   // Compute parameter values of the result sampling points
   RealArray gpar;
@@ -1147,7 +1147,7 @@ bool ASMs1D::evalSolution (Matrix& sField, const Vector& locSol,
 
 
 bool ASMs1D::evalSolution (Matrix& sField, const Vector& locSol,
-                           const RealArray* gpar, bool, int deriv) const
+                           const RealArray* gpar, bool, int deriv, int) const
 {
   const int p1 = curv->order();
   size_t nComp = locSol.size() / curv->numCoefs();

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -209,7 +209,7 @@ public:
   //! \param[in] locSol Solution vector in DOF-order
   //! \param[in] npe Number of visualization nodes over each knot span
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-			    const int* npe) const;
+                            const int* npe, int = 0, int = 0) const;
 
   //! \brief Evaluates the primary solution field at the given points.
   //! \param[out] sField Solution field
@@ -218,7 +218,7 @@ public:
   //! \param[in] deriv Derivative order to return
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
                             const RealArray* gpar, bool = true,
-                            int deriv = 0) const;
+                            int deriv = 0, int = 0) const;
 
   using ASMbase::evaluate;
   //! \brief Evaluates and interpolates a function over a given geometry.

--- a/src/ASM/ASMs1DLag.C
+++ b/src/ASM/ASMs1DLag.C
@@ -467,14 +467,14 @@ bool ASMs1DLag::tesselate (ElementBlock& grid, const int* npe) const
 
 
 bool ASMs1DLag::evalSolution (Matrix& sField, const Vector& locSol,
-			      const int*) const
+                              const int*, int) const
 {
-  return this->evalSolution(sField,locSol,(const RealArray*)nullptr);
+  return this->evalSolution(sField,locSol,nullptr,false,0,0);
 }
 
 
 bool ASMs1DLag::evalSolution (Matrix& sField, const Vector& locSol,
-                              const RealArray*, bool, int) const
+                              const RealArray*, bool, int, int) const
 {
   size_t nPoints = coord.size();
   size_t nComp = locSol.size() / nPoints;

--- a/src/ASM/ASMs1DLag.h
+++ b/src/ASM/ASMs1DLag.h
@@ -111,13 +111,14 @@ public:
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector in DOF-order
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-                            const int*) const;
+                            const int*, int = 0) const;
 
   //! \brief Evaluates the primary solution field at the nodal points.
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector local to current patch
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-                            const RealArray*, bool = false, int = 0) const;
+                            const RealArray*, bool = false,
+                            int = 0, int = 0) const;
 
   //! \brief Evaluates the secondary solution field at all visualization points.
   //! \details The number of visualization points is the same as the order of

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -2389,7 +2389,7 @@ void ASMs2D::scatterInd (int n1, int n2, int p1, int p2,
 
 
 bool ASMs2D::evalSolution (Matrix& sField, const Vector& locSol,
-			   const int* npe) const
+                           const int* npe, int nf) const
 {
   // Compute parameter values of the result sampling points
   std::array<RealArray,2> gpar;
@@ -2398,12 +2398,13 @@ bool ASMs2D::evalSolution (Matrix& sField, const Vector& locSol,
       return false;
 
   // Evaluate the primary solution at all sampling points
-  return this->evalSolution(sField,locSol,gpar.data());
+  return this->evalSolution(sField,locSol,gpar.data(),true,0,nf);
 }
 
 
 bool ASMs2D::evalSolution (Matrix& sField, const Vector& locSol,
-                           const RealArray* gpar, bool regular, int deriv) const
+                           const RealArray* gpar,
+                           bool regular, int deriv, int) const
 {
   // Evaluate the basis functions at all points
   size_t nPoints = gpar[0].size();
@@ -2558,7 +2559,7 @@ bool ASMs2D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
 
 
 bool ASMs2D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
-			   const RealArray* gpar, bool regular) const
+                           const RealArray* gpar, bool regular) const
 {
   sField.resize(0,0);
 

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -370,8 +370,9 @@ public:
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector in DOF-order
   //! \param[in] npe Number of visualization nodes over each knot span
+  //! \param[in] nf If nonzero, mixed evaluates nf fields on first basis
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-			    const int* npe) const;
+                            const int* npe, int nf = 0) const;
 
   //! \brief Evaluates the primary solution field at the given points.
   //! \param[out] sField Solution field
@@ -387,7 +388,7 @@ public:
   //! directly for each sampling point.
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
                             const RealArray* gpar, bool regular = true,
-                            int deriv = 0) const;
+                            int deriv = 0, int = 0) const;
 
   //! \brief Evaluates and interpolates a field over a given geometry.
   //! \param[in] basis The basis of the field to evaluate

--- a/src/ASM/ASMs2DLag.C
+++ b/src/ASM/ASMs2DLag.C
@@ -667,14 +667,14 @@ bool ASMs2DLag::tesselate (ElementBlock& grid, const int* npe) const
 
 
 bool ASMs2DLag::evalSolution (Matrix& sField, const Vector& locSol,
-			      const int*) const
+                              const int*, int nf) const
 {
-  return this->evalSolution(sField,locSol,(const RealArray*)nullptr);
+  return this->evalSolution(sField,locSol,nullptr,true,0,nf);
 }
 
 
 bool ASMs2DLag::evalSolution (Matrix& sField, const Vector& locSol,
-                              const RealArray*, bool, int) const
+                              const RealArray*, bool, int, int) const
 {
   size_t nPoints = coord.size();
   size_t nNodes = this->getNoNodes(-1);

--- a/src/ASM/ASMs2DLag.h
+++ b/src/ASM/ASMs2DLag.h
@@ -125,14 +125,16 @@ public:
   //! the Lagrange elements by default.
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector in DOF-order
+  //! \param[in] nf If nonzero, mixed evaluates nf fields on first basis
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-                            const int*) const;
+                            const int*, int nf) const;
 
   //! \brief Evaluates the primary solution field at the nodal points.
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector local to current patch
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-                            const RealArray*, bool = false, int = 0) const;
+                            const RealArray* gpar, bool = false,
+                            int = 0, int = 0) const;
 
   using ASMs2D::evalSolution;
   //! \brief Evaluates the secondary solution field at all visualization points.

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -845,7 +845,7 @@ int ASMs2Dmx::evalPoint (const double* xi, double* param, Vec3& X) const
 
 
 bool ASMs2Dmx::evalSolution (Matrix& sField, const Vector& locSol,
-                             const RealArray* gpar, bool regular, int) const
+                             const RealArray* gpar, bool regular, int, int nf) const
 {
   // Evaluate the basis functions at all points
   std::vector<std::vector<Go::BasisPtsSf>> splinex(m_basis.size());
@@ -865,14 +865,12 @@ bool ASMs2Dmx::evalSolution (Matrix& sField, const Vector& locSol,
   else
     return false;
 
-  std::vector<size_t> nc(nfx.size());
-  std::copy(nfx.begin(), nfx.end(), nc.begin());
+  std::vector<size_t> nc(nfx.size(), 0);
+  if (nf)
+    nc[0] = nf;
+  else
+    std::copy(nfx.begin(), nfx.end(), nc.begin());
 
-  // assume first basis only
-  if (locSol.size() < std::inner_product(nb.begin(), nb.end(), nfx.begin(), 0u)) {
-    std::fill(nc.begin(), nc.end(), 0);
-    nc[0] = nfx[0];
-  }
 
   if (std::inner_product(nb.begin(), nb.end(), nc.begin(), 0u) != locSol.size())
     return false;

--- a/src/ASM/ASMs2Dmx.h
+++ b/src/ASM/ASMs2Dmx.h
@@ -157,6 +157,7 @@ public:
   //! \param[in] gpar Parameter values of the result sampling points
   //! \param[in] regular Flag indicating how the sampling points are defined
   //! \param[in] deriv Derivative order to return
+  //! \param[in] nf If nonzero, evaluate nf fields on first basis
   //!
   //! \details When \a regular is \e true, it is assumed that the parameter
   //! value array \a gpar forms a regular tensor-product point grid of dimension
@@ -165,7 +166,7 @@ public:
   //! directly for each sampling point.
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
                             const RealArray* gpar, bool regular = true,
-                            int deriv = 0) const;
+                            int deriv = 0, int nf = 0) const;
 
   //! \brief Evaluates the secondary solution field at the given points.
   //! \param[out] sField Solution field

--- a/src/ASM/ASMs2DmxLag.C
+++ b/src/ASM/ASMs2DmxLag.C
@@ -467,9 +467,9 @@ bool ASMs2DmxLag::integrate (Integrand& integrand, int lIndex,
 
 
 bool ASMs2DmxLag::evalSolution (Matrix& sField, const Vector& locSol,
-                                const RealArray*, bool, int) const
+                                const RealArray*, bool, int, int nf) const
 {
-  size_t nc1 = nfx[0];
+  size_t nc1 = nf ? nf : nfx[0];
   size_t nc2 = 0;
   if (nc1*nb[0] < locSol.size())
     nc2 = (locSol.size() - nc1*nb[0])/nb[1];

--- a/src/ASM/ASMs2DmxLag.h
+++ b/src/ASM/ASMs2DmxLag.h
@@ -114,8 +114,10 @@ public:
   //! \brief Evaluates the primary solution field at the given points.
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector local to current patch
+  //! \param[in] nf If nonzero, evaluates nf fields on first basis
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-                            const RealArray*, bool, int) const;
+                            const RealArray*, bool,
+                            int, int nf = 0) const;
 
   //! \brief Evaluates the secondary solution field at the given points.
   //! \param[out] sField Solution field

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -2702,7 +2702,7 @@ void ASMs3D::scatterInd (int n1, int n2, int n3, int p1, int p2, int p3,
 
 
 bool ASMs3D::evalSolution (Matrix& sField, const Vector& locSol,
-			   const int* npe) const
+                           const int* npe, int nf) const
 {
   // Compute parameter values of the result sampling points
   std::array<RealArray,3> gpar;
@@ -2711,12 +2711,13 @@ bool ASMs3D::evalSolution (Matrix& sField, const Vector& locSol,
       return false;
 
   // Evaluate the primary solution at all sampling points
-  return this->evalSolution(sField,locSol,gpar.data());
+  return this->evalSolution(sField,locSol,gpar.data(),true,0,nf);
 }
 
 
 bool ASMs3D::evalSolution (Matrix& sField, const Vector& locSol,
-                           const RealArray* gpar, bool regular, int deriv) const
+                           const RealArray* gpar,
+                           bool regular, int deriv, int) const
 {
   sField.resize(0,0);
 

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -430,8 +430,9 @@ public:
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector in DOF-order
   //! \param[in] npe Number of visualization nodes over each knot span
+  //! \param[in] nf If nonzero, mixed evaluates nf fields on first basis
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-			    const int* npe) const;
+                            const int* npe, int nf) const;
 
   //! \brief Evaluates the primary solution field at the given points.
   //! \param[out] sField Solution field
@@ -447,7 +448,7 @@ public:
   //! directly for each sampling point.
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
                             const RealArray* gpar, bool regular = true,
-                            int deriv = 0) const;
+                            int deriv = 0, int = 0) const;
 
   //! \brief Evaluates and interpolates a field over a given geometry.
   //! \param[in] basis The basis of the field to evaluate

--- a/src/ASM/ASMs3DLag.C
+++ b/src/ASM/ASMs3DLag.C
@@ -897,14 +897,14 @@ bool ASMs3DLag::tesselate (ElementBlock& grid, const int* npe) const
 
 
 bool ASMs3DLag::evalSolution (Matrix& sField, const Vector& locSol,
-			      const int*) const
+                              const int*, int nf) const
 {
-  return this->evalSolution(sField,locSol,(const RealArray*)nullptr);
+  return this->evalSolution(sField,locSol,nullptr,true,0,nf);
 }
 
 
 bool ASMs3DLag::evalSolution (Matrix& sField, const Vector& locSol,
-                              const RealArray*, bool, int) const
+                              const RealArray*, bool, int, int) const
 {
   size_t nPoints = coord.size();
   size_t nNodes = this->getNoNodes(-1);
@@ -922,14 +922,14 @@ bool ASMs3DLag::evalSolution (Matrix& sField, const Vector& locSol,
 
 
 bool ASMs3DLag::evalSolution (Matrix& sField, const IntegrandBase& integrand,
-			      const int*, char) const
+                              const int*, char) const
 {
   return this->evalSolution(sField,integrand,(const RealArray*)nullptr);
 }
 
 
 bool ASMs3DLag::evalSolution (Matrix& sField, const IntegrandBase& integrand,
-			      const RealArray*, bool) const
+                              const RealArray*, bool) const
 {
   sField.resize(0,0);
 

--- a/src/ASM/ASMs3DLag.h
+++ b/src/ASM/ASMs3DLag.h
@@ -127,14 +127,16 @@ public:
   //! the Lagrange elements by default.
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector in DOF-order
+  //! \param[in] nf If nonzero, mixed evaluates nf fields on first basis
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-                            const int*) const;
+                            const int*, int nf = 0) const;
 
   //! \brief Evaluates the primary solution field at the nodal points.
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector local to current patch
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-                            const RealArray*, bool = false, int = 0) const;
+                            const RealArray*, bool = false,
+                            int = 0, int = 0) const;
 
   //! \brief Evaluates the secondary solution field at all visualization points.
   //! \details The number of visualization points is the same as the order of

--- a/src/ASM/ASMs3Dmx.C
+++ b/src/ASM/ASMs3Dmx.C
@@ -843,7 +843,8 @@ int ASMs3Dmx::evalPoint (const double* xi, double* param, Vec3& X) const
 
 
 bool ASMs3Dmx::evalSolution (Matrix& sField, const Vector& locSol,
-                             const RealArray* gpar, bool regular, int) const
+                             const RealArray* gpar,
+                             bool regular, int, int nf) const
 {
   if (m_basis.empty()) return false;
 
@@ -865,14 +866,11 @@ bool ASMs3Dmx::evalSolution (Matrix& sField, const Vector& locSol,
   else
     return false;
 
-  std::vector<size_t> nc(nfx.size());
-  std::copy(nfx.begin(), nfx.end(), nc.begin());
-
-  // assume first basis only
-  if (locSol.size() < std::inner_product(nb.begin(), nb.end(), nfx.begin(), 0u)) {
-    std::fill(nc.begin(), nc.end(), 0);
-    nc[0] = nfx[0];
-  }
+  std::vector<size_t> nc(nfx.size(), 0);
+  if (nf)
+    nc[0] = nf;
+  else
+    std::copy(nfx.begin(), nfx.end(), nc.begin());
 
   if (std::inner_product(nb.begin(), nb.end(), nc.begin(), 0u) != locSol.size())
     return false;

--- a/src/ASM/ASMs3Dmx.h
+++ b/src/ASM/ASMs3Dmx.h
@@ -150,6 +150,7 @@ public:
   //! \param[in] gpar Parameter values of the result sampling points
   //! \param[in] regular Flag indicating how the sampling points are defined
   //! \param[in] deriv Derivative order to return
+  //! \param[in] nf If non-zero evaluates nf fields on first basis
   //!
   //! \details When \a regular is \e true, it is assumed that the parameter
   //! value array \a gpar forms a regular tensor-product point grid of dimension
@@ -158,7 +159,7 @@ public:
   //! directly for each sampling point.
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
                             const RealArray* gpar, bool regular = true,
-                            int deriv = 0) const;
+                            int deriv = 0, int nf = 0) const;
 
   //! \brief Evaluates the secondary solution field at the given points.
   //! \param[out] sField Solution field

--- a/src/ASM/ASMs3DmxLag.C
+++ b/src/ASM/ASMs3DmxLag.C
@@ -534,9 +534,9 @@ bool ASMs3DmxLag::integrate (Integrand& integrand, int lIndex,
 
 
 bool ASMs3DmxLag::evalSolution (Matrix& sField, const Vector& locSol,
-                                const RealArray*, bool, int) const
+                                const RealArray*, bool, int, int nf) const
 {
-  size_t nc1 = nfx[0];
+  size_t nc1 = nf ? nf : nfx[0];
   size_t nc2 = 0;
   if (nc1*nb[0] < locSol.size())
     nc2 = (locSol.size() - nc1*nb[0])/nb[1];

--- a/src/ASM/ASMs3DmxLag.h
+++ b/src/ASM/ASMs3DmxLag.h
@@ -114,8 +114,10 @@ public:
   //! \brief Evaluates the primary solution field at the given points.
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector local to current patch
+  //! \param[in] nf If non-zero evaluates nf fields on first basis
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-                            const RealArray*, bool, int) const;
+                            const RealArray*, bool = true,
+                            int = 0, int nf = 0) const;
 
   //! \brief Evaluates the secondary solution field at the given points.
   //! \param[out] sField Solution field

--- a/src/ASM/IntegrandBase.h
+++ b/src/ASM/IntegrandBase.h
@@ -366,6 +366,9 @@ public:
   virtual bool reducedInt(LocalIntegral& elmInt,
                           const FiniteElement& fe, const Vec3& X) const;
 
+  //! \brief Returns whether projections are fed through external means.
+  virtual bool hasExternalProjections() const { return false; }
+
 protected:
   //! \brief Initializes the projected fields for current element.
   bool initProjection(const std::vector<int>& MNPC, LocalIntegral& elmInt);

--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -1614,10 +1614,10 @@ bool ASMu2D::tesselate (ElementBlock& grid, const int* npe) const
 
 
 bool ASMu2D::evalSolution (Matrix& sField, const Vector& locSol,
-                           const int* npe) const
+                           const int* npe, int nf) const
 {
 #ifdef SP_DEBUG
-  std::cout <<"ASMu2D::evalSolution(Matrix&,const Vector&,const int*)\n";
+  std::cout <<"ASMu2D::evalSolution(Matrix&,const Vector&,const int*,int)\n";
 #endif
   // Compute parameter values of the result sampling points
   std::array<RealArray,2> gpar;
@@ -1626,12 +1626,12 @@ bool ASMu2D::evalSolution (Matrix& sField, const Vector& locSol,
       return false;
 
   // Evaluate the primary solution at all sampling points
-  return this->evalSolution(sField,locSol,gpar.data());
+  return this->evalSolution(sField,locSol,gpar.data(),false,0,nf);
 }
 
 
 bool ASMu2D::evalSolution (Matrix& sField, const Vector& locSol,
-                           const RealArray* gpar, bool, int deriv) const
+                           const RealArray* gpar, bool, int deriv, int) const
 {
 #ifdef SP_DEBUG
   std::cout <<"ASMu2D::evalSolution(Matrix&,const Vector&,const RealArray*,"

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -284,8 +284,9 @@ public:
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector in DOF-order
   //! \param[in] npe Number of visualization nodes over each knot span
+  //! \param[in] nf If nonzero, mixed evaluates nf fields on first basis
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-                            const int* npe) const;
+                            const int* npe, int nf = 0) const;
 
   //! \brief Evaluates the primary solution field at the given points.
   //! \param[out] sField Solution field
@@ -294,7 +295,7 @@ public:
   //! \param[in] deriv Derivative order to return
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
                             const RealArray* gpar, bool = false,
-                            int deriv = 0) const;
+                            int deriv = 0, int = 0) const;
 
   //! \brief Evaluates and interpolates a function over a given geometry.
   //! \param[in] func The function to evaluate

--- a/src/ASM/LR/ASMu2Dmx.h
+++ b/src/ASM/LR/ASMu2Dmx.h
@@ -114,8 +114,8 @@ public:
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector local to current patch
   //! \param[in] gpar Parameter values of the result sampling points
-  //! \param[in] regular Flag indicating how the sampling points are defined
   //! \param[in] deriv Derivative order to return
+  //! \param[in] nf If nonzero, evaluate nf fields on first basis
   //!
   //! \details When \a regular is \e true, it is assumed that the parameter
   //! value array \a gpar forms a regular tensor-product point grid of dimension
@@ -123,14 +123,13 @@ public:
   //! Otherwise, we assume that it contains the \a u and \a v parameters
   //! directly for each sampling point.
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-                            const RealArray* gpar, bool regular = true,
-                            int deriv = 0) const;
+                            const RealArray* gpar, bool = false,
+                            int deriv = 0, int nf = 0) const;
 
   //! \brief Evaluates the secondary solution field at the given points.
   //! \param[out] sField Solution field
   //! \param[in] integrand Object with problem-specific data and methods
   //! \param[in] gpar Parameter values of the result sampling points
-  //! \param[in] regular Flag indicating how the sampling points are defined
   //!
   //! \details The secondary solution is derived from the primary solution,
   //! which is assumed to be stored within the \a integrand for current patch.
@@ -140,7 +139,7 @@ public:
   //! Otherwise, we assume that it contains the \a u and \a v parameters
   //! directly for each sampling point.
   virtual bool evalSolution(Matrix& sField, const IntegrandBase& integrand,
-                            const RealArray* gpar, bool regular = true) const;
+                            const RealArray* gpar, bool = true) const;
 
   //! \brief Extracts nodal results for this patch from the global vector.
   //! \param[in] globVec Global solution vector in DOF-order

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -1795,7 +1795,7 @@ bool ASMu3D::tesselate (ElementBlock& grid, const int* npe) const
 
 
 bool ASMu3D::evalSolution (Matrix& sField, const Vector& locSol,
-                           const int* npe) const
+                           const int* npe, int nf) const
 {
   // Compute parameter values of the result sampling points
   std::array<RealArray,3> gpar;
@@ -1804,12 +1804,12 @@ bool ASMu3D::evalSolution (Matrix& sField, const Vector& locSol,
       return false;
 
   // Evaluate the primary solution at all sampling points
-  return this->evalSolution(sField,locSol,gpar.data());
+  return this->evalSolution(sField,locSol,gpar.data(),false,0,nf);
 }
 
 
 bool ASMu3D::evalSolution (Matrix& sField, const Vector& locSol,
-                           const RealArray* gpar, bool, int deriv) const
+                           const RealArray* gpar, bool, int deriv, int) const
 {
   size_t nComp = locSol.size() / this->getNoNodes();
   if (nComp*this->getNoNodes() != locSol.size())

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -293,8 +293,9 @@ public:
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector in DOF-order
   //! \param[in] npe Number of visualization nodes over each knot span
+  //! \param[in] nf If nonzero, mixed evaluates nf fields on first basis
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-                            const int* npe) const;
+                            const int* npe, int nf) const;
 
   //! \brief Evaluates the primary solution field at the given points.
   //! \param[out] sField Solution field
@@ -303,7 +304,7 @@ public:
   //! \param[in] deriv Derivative order to return
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
                             const RealArray* gpar, bool = false,
-                            int deriv = 0) const;
+                            int deriv = 0, int = 0) const;
 
   //! \brief Evaluates and interpolates a function over a given geometry.
   //! \param[in] func The function to evaluate

--- a/src/ASM/LR/ASMu3Dmx.C
+++ b/src/ASM/LR/ASMu3Dmx.C
@@ -729,19 +729,19 @@ bool ASMu3Dmx::integrate (Integrand& integrand, int lIndex,
 
 
 bool ASMu3Dmx::evalSolution (Matrix& sField, const Vector& locSol,
-                             const RealArray* gpar, bool regular,
-                             int deriv) const
+                             const RealArray* gpar, bool,
+                             int deriv, int nf) const
 {
   return false;
 }
 
 
 bool ASMu3Dmx::evalSolution (Matrix& sField, const IntegrandBase& integrand,
-                             const RealArray* gpar, bool regular) const
+                             const RealArray* gpar, bool) const
 {
   return evalSolution(sField,
                      const_cast<IntegrandBase&>(integrand).getSolution(0),
-                     gpar, regular, 0);
+                     gpar, false, 0);
 }
 
 

--- a/src/ASM/LR/ASMu3Dmx.h
+++ b/src/ASM/LR/ASMu3Dmx.h
@@ -114,8 +114,8 @@ public:
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector local to current patch
   //! \param[in] gpar Parameter values of the result sampling points
-  //! \param[in] regular Flag indicating how the sampling points are defined
   //! \param[in] deriv Derivative order to return
+  //! \param[in] nf If nonzero, evaluates nf fields on first basis
   //!
   //! \details When \a regular is \e true, it is assumed that the parameter
   //! value array \a gpar forms a regular tensor-product point grid of dimension
@@ -123,14 +123,13 @@ public:
   //! Otherwise, we assume that it contains the \a u and \a v parameters
   //! directly for each sampling point.
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-                            const RealArray* gpar, bool regular = true,
-                            int deriv = 0) const;
+                            const RealArray* gpar, bool = false,
+                            int deriv = 0, int nf = 0) const;
 
   //! \brief Evaluates the secondary solution field at the given points.
   //! \param[out] sField Solution field
   //! \param[in] integrand Object with problem-specific data and methods
   //! \param[in] gpar Parameter values of the result sampling points
-  //! \param[in] regular Flag indicating how the sampling points are defined
   //!
   //! \details The secondary solution is derived from the primary solution,
   //! which is assumed to be stored within the \a integrand for current patch.
@@ -140,7 +139,7 @@ public:
   //! Otherwise, we assume that it contains the \a u and \a v parameters
   //! directly for each sampling point.
   virtual bool evalSolution(Matrix& sField, const IntegrandBase& integrand,
-                            const RealArray* gpar, bool regular = true) const;
+                            const RealArray* gpar, bool = false) const;
 
   //! \brief Extracts nodal results for this patch from the global vector.
   //! \param[in] globVec Global solution vector in DOF-order

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -1282,12 +1282,23 @@ bool SIMbase::solutionNorms (const TimeDomain& time,
   // Initialize norm integral classes
   gNorm.resize(norm->getNoFields(0));
   size_t nNorms = 0;
+  auto prj_idx = opt.project.begin();
+  // count norms if they are:
+  // 1) associated with the primary solution
+  // 2) associated with a projected secondary solution
+  // 3) associated with a residual secondary solution
+  // 4) associated with a secondary solution provided through external means
+  // 5) associated with an additional group defined in the integrand
   for (i = 0; i < gNorm.size(); i++)
-    if (i == 0 || i > ssol.size() || !ssol[i-1].empty())
+    if (i == 0 || i > ssol.size() || (!ssol[i-1].empty() ||
+                                      prj_idx->first == SIMoptions::NONE ||
+                                      norm->hasExternalProjections()))
     {
       size_t nNrm = norm->getNoFields(1+i);
       gNorm[i].resize(nNrm,true);
       nNorms += nNrm;
+      if (i != 0 && i <= ssol.size())
+        ++prj_idx;
     }
 
   GlbNorm globalNorm(gNorm,norm->getFinalOperation());

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -1398,6 +1398,9 @@ bool SIMbase::solutionNorms (const TimeDomain& time,
   for (k = 0; k < gNorm.size(); k++)
     adm.allReduceAsSum(gNorm[k]);
 
+  if (ok)
+    ok = this->postProcessNorms(gNorm, eNorm);
+
   return ok;
 }
 

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -352,6 +352,11 @@ public:
   bool solutionNorms(const Vectors& psol, Matrix& eNorm, Vectors& gNorm)
   { return this->solutionNorms(TimeDomain(),psol,Vectors(),gNorm,&eNorm); }
 
+  //! \brief Apply app-specific post-processing to element norms.
+  //! \param gNorm Vector with global norms
+  //! \param eNorm Matrix with element norms
+  virtual bool postProcessNorms(Vectors& gNorm, Matrix* eNorm) { return true; }
+
   //! \brief Prints a summary of the calculated solution to std::cout.
   //! \param[in] solution The solution vector
   //! \param[in] printSol Print solution only if size is less than this value

--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -359,7 +359,7 @@ bool SIMoutput::writeGlvBC (int& nBlock, int iStep) const
     if (msgLevel > 1)
       IFEM::cout <<"Writing boundary conditions for patch "<< i+1 << std::endl;
 
-    if (!myModel[i]->evalSolution(field,bc,opt.nViz))
+    if (!myModel[i]->evalSolution(field,bc,opt.nViz,nbc))
       return false;
 
     // The BC fields should either be 0.0 or 1.0

--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -1009,7 +1009,7 @@ bool SIMoutput::writeGlvN (const Matrix& norms, int iStep, int& nBlock,
   NormBase* norm = myProblem->getNormIntegrand(mySol);
 
   Matrix field;
-  std::array<IntVec,20> sID;
+  std::array<IntVec,30> sID;
   const size_t maxN = sID.size();
 
   size_t i, j, k, l, m;


### PR DESCRIPTION
This is a collection of norm and/or VTF related fixes found while doing adaptive stokes.

- increase max number of norms from 20 to 30
- make sure to count norms from empty secondary solutions (this is for residual based estimators)
- add a hook for postprocessing norms. necessary due to shenanigans required in stokes code
- fix output of secondary solutions to VTF for mixed
- fix output for anasol - number of components there does not necessarily correspond to number of primary/secondary solutions