### PR TITLE
fixed: lower-dimension connections is not an error

### DIFF
--- a/src/SIM/SIM2D.C
+++ b/src/SIM/SIM2D.C
@@ -82,7 +82,7 @@ bool SIM2D::addConnection (int master, int slave, int mIdx,
   int lslave = this->getLocalPatchIndex(slave);
   if (lmaster > 0 && lslave > 0)
   {
-    if (dim < 1) return false;
+    if (dim < 1) return true; // ignored in serial
 
     IFEM::cout <<"\tConnecting P"<< slave <<" E"<< sIdx
                <<" to P"<< master <<" E"<< mIdx

--- a/src/SIM/SIM3D.C
+++ b/src/SIM/SIM3D.C
@@ -60,7 +60,7 @@ bool SIM3D::addConnection (int master, int slave, int mIdx,
   int lslave = this->getLocalPatchIndex(slave);
   if (lmaster > 0 && lslave > 0)
   {
-    if (dim < 2) return false;
+    if (dim < 2) return true; // ignored in serial
 
     IFEM::cout <<"\tConnecting P"<< slave <<" F"<< sIdx
                <<" to P"<< master <<" F"<< mIdx


### PR DESCRIPTION
they are necessary in parallel, and depending on how the model is partitioned, they may be process-local. we should just ignore them.