### PR TITLE
Lr multipatch refinement alternative

### DIFF
--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -217,7 +217,7 @@ public:
 
   //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
   //! \param[in] lIndex Local index of the boundary face/edge
-  //! \param nodes Array of node numbers
+  //! \param nodes Array of node numbers (1-based)
   //! \param[in] basis Which basis to grab nodes for (0 for all)
   //! \param[in] thick Thickness of connection
   //! \param[in] orient Local orientation of the boundary face/edge

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -190,6 +190,9 @@ public:
                                 int = 0, bool local = false) const;
 
   //! \brief Returns the node index for a given corner.
+  //! \param I     -1 or +1 for either umin or umax corner
+  //! \param J     -1 or +1 for either vmin or vmax corner
+  //! \param basis which basis to consider (only applicable for mixed methods)
   virtual int getCorner(int I, int J, int basis) const;
 
   //! \brief Assigns new global node numbers for all nodes of the patch.

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -206,8 +206,17 @@ public:
                                 int = 0, bool local = false) const;
 
   //! \brief Returns the node index for a given corner.
+  //! \param I     -1 or +1 for either umin or umax corner
+  //! \param J     -1 or +1 for either vmin or vmax corner
+  //! \param K     -1 or +1 for either wmin or wmax corner
+  //! \param basis which basis to consider (only applicable for mixed methods)
   virtual int getCorner(int I, int J, int K, int basis) const;
-  //! \brief Returns the node indices for a given edge.
+
+  //! \brief Returns the (1-indexed) node indices for a given edge.
+  //! \param lEdge  index to local edge (1,2,...12)
+  //! \param open   include end points or not
+  //! \param basis  which basis to consider (only applicable for mixed methods)
+  //! \param orient local orientation of indices, see ASMunstruct::Sort
   virtual std::vector<int> getEdge(int lEdge, bool open, int basis, int = 0) const;
 
   //! \brief Assigns new global node numbers for all nodes of the patch.

--- a/src/ASM/ASMunstruct.h
+++ b/src/ASM/ASMunstruct.h
@@ -142,8 +142,9 @@ public:
 
   //! \brief Return all functions whos support overlap with the input functions
   //! \param nodes List of (0-indexed) patch local node IDs (typically requested by adaptive refinement)
+  //! \param dir   In which parametric direction the basis functions are allowed to have bigger support (-1 for all)
   //! \returns     Node IDs (0-indexed) for functions with overlapping support with the ones in boundary
-  virtual IntVec getOverlappingNodes(const IntVec& nodes) const ;
+  virtual IntVec getOverlappingNodes(const IntVec& nodes, int dir=-1) const ;
 
   //! \brief Remap element wise errors from geometry mesh to refinement mesh.
   //! \param     errors The remapped errors

--- a/src/ASM/ASMunstruct.h
+++ b/src/ASM/ASMunstruct.h
@@ -134,6 +134,12 @@ public:
   static void Sort(int u, int v, int orient,
                    std::vector<LR::Basisfunction*>& functions);
 
+  //! \brief Return all boundary functions that are covered by the given set of input nodes
+  //! \param   nodes List of (0-indexed) patch local node IDs
+  //! \returns       Node IDs (0-indexed) for boundary functions whos support is
+  //                 completely covered by the union of the support in the input array
+  virtual IntVec getBoundaryNodesCovered(const IntVec& nodes) const ;
+
   //! \brief Remap element wise errors from geometry mesh to refinement mesh.
   //! \param     errors The remapped errors
   //! \param[in] origErr The element wise errors on the geometry mesh

--- a/src/ASM/ASMunstruct.h
+++ b/src/ASM/ASMunstruct.h
@@ -135,10 +135,15 @@ public:
                    std::vector<LR::Basisfunction*>& functions);
 
   //! \brief Return all boundary functions that are covered by the given set of input nodes
-  //! \param   nodes List of (0-indexed) patch local node IDs
-  //! \returns       Node IDs (0-indexed) for boundary functions whos support is
-  //                 completely covered by the union of the support in the input array
+  //! \param nodes List of (0-indexed) patch local node IDs (typically requested by adaptive refinement)
+  //! \returns     Node IDs (0-indexed) for boundary functions whos support is
+  //               completely covered by the union of the support in the input array
   virtual IntVec getBoundaryNodesCovered(const IntVec& nodes) const ;
+
+  //! \brief Return all functions whos support overlap with the input functions
+  //! \param nodes List of (0-indexed) patch local node IDs (typically requested by adaptive refinement)
+  //! \returns     Node IDs (0-indexed) for functions with overlapping support with the ones in boundary
+  virtual IntVec getOverlappingNodes(const IntVec& nodes) const ;
 
   //! \brief Remap element wise errors from geometry mesh to refinement mesh.
   //! \param     errors The remapped errors

--- a/src/ASM/ASMunstruct.h
+++ b/src/ASM/ASMunstruct.h
@@ -142,9 +142,17 @@ public:
 
   //! \brief Return all functions whos support overlap with the input functions
   //! \param nodes List of (0-indexed) patch local node IDs (typically requested by adaptive refinement)
-  //! \param dir   In which parametric direction the basis functions are allowed to have bigger support (-1 for all)
+  //! \param dir   3bit binary mask for which parametri directions are allowed to grow; i.e. bin(011)=dec(3) 
+  //               allows u-direction and v-direction to grow, default is bin(111)=dec(7) all directions
   //! \returns     Node IDs (0-indexed) for functions with overlapping support with the ones in boundary
-  virtual IntVec getOverlappingNodes(const IntVec& nodes, int dir=-1) const ;
+  virtual IntVec getOverlappingNodes(const IntVec& nodes, int dir=7) const ;
+
+  //! \brief Return all functions whos support overlap with the input functions
+  //! \param nodes List of (0-indexed) patch local node IDs (typically requested by adaptive refinement)
+  //! \param dir   3bit binary mask for which parametri directions are allowed to grow; i.e. bin(011)=dec(3) 
+  //               allows u-direction and v-direction to grow, default is bin(111)=dec(7) all directions
+  //! \returns     Node IDs (0-indexed) for functions with overlapping support with the ones in boundary
+  virtual IntVec getOverlappingNodes(int node, int dir=7) const { return getOverlappingNodes(IntVec(1, node), dir); }
 
   //! \brief Remap element wise errors from geometry mesh to refinement mesh.
   //! \param     errors The remapped errors

--- a/src/ASM/LR/ASMLRSpline.C
+++ b/src/ASM/LR/ASMLRSpline.C
@@ -307,6 +307,26 @@ IntVec ASMunstruct::getFunctionsForElements (const IntVec& elements)
   return result;
 }
 
+IntVec ASMunstruct::getBoundaryNodesCovered (const IntVec& nodes) const
+{
+  geo->generateIDs();
+  IntVec oneBoundary, result;
+  int numbEdges = (getNoParamDim() == 2) ? 4 : 6;
+  for(int edge=1; edge<=numbEdges;  edge++)
+  {
+    getBoundaryNodes(edge, oneBoundary); // this returns a 1-indexed list
+    for(const int i : nodes)
+      for(const int j : oneBoundary)
+        if(geo->getBasisfunction(i)->contains(*geo->getBasisfunction(j-1)))
+          result.push_back(j-1);
+  }
+  // remove duplicate indices
+  std::sort(result.begin(), result.end());
+  auto last = std::unique(result.begin(), result.end());
+  result.erase(last, result.end());
+  return result;
+}
+
 
 void ASMunstruct::Sort(int u, int v, int orient,
                        std::vector<LR::Basisfunction*>& functions)

--- a/src/ASM/LR/ASMLRSpline.C
+++ b/src/ASM/LR/ASMLRSpline.C
@@ -337,25 +337,18 @@ IntVec ASMunstruct::getOverlappingNodes (const IntVec& nodes, int dir) const
     {
       for(auto basis : el->support()) // for all functions on this element
       {
-        if(dir == -1)
+        bool support_only_bigger_in_allowed_direction = true;
+        for(int j=0; j<b->nVariate(); j++)
         {
-          result.push_back(basis->getId());
-        }
-        else
-        {
-          bool support_only_bigger_in_dir_direction = true;
-          for(int j=0; j<b->nVariate(); j++)
+          if((1<<j) & dir ) continue; // the function is allowed to grow in the direction j
+          if(b->getParmin(j) > basis->getParmin(j) ||
+             b->getParmax(j) < basis->getParmax(j))
           {
-            if(j==dir) continue;
-            if(b->getParmin(j) > basis->getParmin(j) ||
-               b->getParmax(j) < basis->getParmax(j))
-            {
-              support_only_bigger_in_dir_direction = false;
-            }
+            support_only_bigger_in_allowed_direction = false;
           }
-          if(support_only_bigger_in_dir_direction)
-            result.push_back(basis->getId());
         }
+        if(support_only_bigger_in_allowed_direction)
+          result.push_back(basis->getId());
       }
     }
   }

--- a/src/ASM/LR/ASMLRSpline.C
+++ b/src/ASM/LR/ASMLRSpline.C
@@ -327,15 +327,37 @@ IntVec ASMunstruct::getBoundaryNodesCovered (const IntVec& nodes) const
   return result;
 }
 
-IntVec ASMunstruct::getOverlappingNodes (const IntVec& nodes) const
+IntVec ASMunstruct::getOverlappingNodes (const IntVec& nodes, int dir) const
 {
   IntVec result;
   for(const int i : nodes)
   {
     LR::Basisfunction *b = geo->getBasisfunction(i);
     for(auto el : b->support()) // for all elements where *b has support
+    {
       for(auto basis : el->support()) // for all functions on this element
-        result.push_back(basis->getId());
+      {
+        if(dir == -1)
+        {
+          result.push_back(basis->getId());
+        }
+        else
+        {
+          bool support_only_bigger_in_dir_direction = true;
+          for(int j=0; j<b->nVariate(); j++)
+          {
+            if(j==dir) continue;
+            if(b->getParmin(j) > basis->getParmin(j) ||
+               b->getParmax(j) < basis->getParmax(j))
+            {
+              support_only_bigger_in_dir_direction = false;
+            }
+          }
+          if(support_only_bigger_in_dir_direction)
+            result.push_back(basis->getId());
+        }
+      }
+    }
   }
 
   // remove duplicate indices

--- a/src/ASM/LR/ASMLRSpline.C
+++ b/src/ASM/LR/ASMLRSpline.C
@@ -106,22 +106,22 @@ void LR::generateThreadGroups (ThreadGroups& threadGroups, const LR::LRSpline* l
     int nColors       = 0;
     while(fixedElements < nElement) {
       // reset un-assigned element tags
-      for(int i=0; i<nElement; i++)
-        if(status[i]<0)
+      for (int i=0; i<nElement; i++)
+        if (status[i]<0)
           status[i] = 0;
       std::vector<int> thisColor;
 
       // look for available elements
-      for(auto e : lr->getAllElements() ) {
+      for (auto e : lr->getAllElements() ) {
         int i = e->getId();
-        if(status[i] == 0) {
+        if (status[i] == 0) {
           status[i] = nColors+1;
           thisColor.push_back(i);
           fixedElements++;
-          for(auto b : e->support()) // for all basisfunctions with support here
-            for(auto el2 : b->support()) {// for all element this function supports
+          for (auto b : e->support()) // for all basisfunctions with support here
+            for (auto el2 : b->support()) {// for all element this function supports
               int j = el2->getId();
-              if(status[j] == 0)  // if not assigned a color yet
+              if (status[j] == 0)  // if not assigned a color yet
                 status[j] = -1; // set as unavailable (with current color)
             }
         }
@@ -307,17 +307,18 @@ IntVec ASMunstruct::getFunctionsForElements (const IntVec& elements)
   return result;
 }
 
+
 IntVec ASMunstruct::getBoundaryNodesCovered (const IntVec& nodes) const
 {
   IntVec result;
   int numbEdges = (getNoParamDim() == 2) ? 4 : 6;
-  for(int edge=1; edge<=numbEdges;  edge++)
+  for (int edge=1; edge<=numbEdges;  edge++)
   {
     IntVec oneBoundary;
     this->getBoundaryNodes(edge, oneBoundary, 1, 1, 0, true); // this returns a 1-indexed list
-    for(const int i : nodes)
-      for(const int j : oneBoundary)
-        if(geo->getBasisfunction(i)->contains(*geo->getBasisfunction(j-1)))
+    for (const int i : nodes)
+      for (const int j : oneBoundary)
+        if (geo->getBasisfunction(i)->contains(*geo->getBasisfunction(j-1)))
           result.push_back(j-1);
   }
   // remove duplicate indices
@@ -327,27 +328,28 @@ IntVec ASMunstruct::getBoundaryNodesCovered (const IntVec& nodes) const
   return result;
 }
 
+
 IntVec ASMunstruct::getOverlappingNodes (const IntVec& nodes, int dir) const
 {
   IntVec result;
-  for(const int i : nodes)
+  for (const int i : nodes)
   {
     LR::Basisfunction *b = geo->getBasisfunction(i);
-    for(auto el : b->support()) // for all elements where *b has support
+    for (auto el : b->support()) // for all elements where *b has support
     {
-      for(auto basis : el->support()) // for all functions on this element
+      for (auto basis : el->support()) // for all functions on this element
       {
         bool support_only_bigger_in_allowed_direction = true;
-        for(int j=0; j<b->nVariate(); j++)
+        for (int j=0; j<b->nVariate(); j++)
         {
-          if((1<<j) & dir ) continue; // the function is allowed to grow in the direction j
-          if(b->getParmin(j) > basis->getParmin(j) ||
+          if ((1<<j) & dir ) continue; // the function is allowed to grow in the direction j
+          if (b->getParmin(j) > basis->getParmin(j) ||
              b->getParmax(j) < basis->getParmax(j))
           {
             support_only_bigger_in_allowed_direction = false;
           }
         }
-        if(support_only_bigger_in_allowed_direction)
+        if (support_only_bigger_in_allowed_direction)
           result.push_back(basis->getId());
       }
     }
@@ -377,7 +379,7 @@ void ASMunstruct::Sort(int u, int v, int orient,
                 if ((*a)[idx1][i] != (*b)[idx1][i])
                   return orient & 2 ? (*a)[idx1][i] > (*b)[idx1][i]
                                     : (*a)[idx1][i] < (*b)[idx1][i];
-              for(int i = 0; i < 1 + (orient < 4 ? p1 : p2); ++i)
+              for (int i = 0; i < 1 + (orient < 4 ? p1 : p2); ++i)
                 if ((*a)[idx2][i] != (*b)[idx2][i])
                   return orient & 1 ? (*a)[idx2][i] > (*b)[idx2][i]
                                     : (*a)[idx2][i] < (*b)[idx2][i];

--- a/src/ASM/LR/ASMLRSpline.C
+++ b/src/ASM/LR/ASMLRSpline.C
@@ -310,7 +310,7 @@ IntVec ASMunstruct::getFunctionsForElements (const IntVec& elements)
 
 IntVec ASMunstruct::getBoundaryNodesCovered (const IntVec& nodes) const
 {
-  IntVec result;
+  std::set<int> result;
   int numbEdges = (getNoParamDim() == 2) ? 4 : 6;
   for (int edge=1; edge<=numbEdges;  edge++)
   {
@@ -319,19 +319,15 @@ IntVec ASMunstruct::getBoundaryNodesCovered (const IntVec& nodes) const
     for (const int i : nodes)
       for (const int j : oneBoundary)
         if (geo->getBasisfunction(i)->contains(*geo->getBasisfunction(j-1)))
-          result.push_back(j-1);
+          result.insert(j-1);
   }
-  // remove duplicate indices
-  std::sort(result.begin(), result.end());
-  auto last = std::unique(result.begin(), result.end());
-  result.erase(last, result.end());
-  return result;
+  return IntVec(result.begin(), result.end());
 }
 
 
 IntVec ASMunstruct::getOverlappingNodes (const IntVec& nodes, int dir) const
 {
-  IntVec result;
+  std::set<int> result;
   for (const int i : nodes)
   {
     LR::Basisfunction *b = geo->getBasisfunction(i);
@@ -350,16 +346,12 @@ IntVec ASMunstruct::getOverlappingNodes (const IntVec& nodes, int dir) const
           }
         }
         if (support_only_bigger_in_allowed_direction)
-          result.push_back(basis->getId());
+          result.insert(basis->getId());
       }
     }
   }
 
-  // remove duplicate indices
-  std::sort(result.begin(), result.end());
-  auto last = std::unique(result.begin(), result.end());
-  result.erase(last, result.end());
-  return result;
+  return IntVec(result.begin(), result.end());
 }
 
 

--- a/src/ASM/LR/ASMLRSpline.C
+++ b/src/ASM/LR/ASMLRSpline.C
@@ -309,17 +309,35 @@ IntVec ASMunstruct::getFunctionsForElements (const IntVec& elements)
 
 IntVec ASMunstruct::getBoundaryNodesCovered (const IntVec& nodes) const
 {
-  geo->generateIDs();
-  IntVec oneBoundary, result;
+  IntVec result;
   int numbEdges = (getNoParamDim() == 2) ? 4 : 6;
   for(int edge=1; edge<=numbEdges;  edge++)
   {
-    getBoundaryNodes(edge, oneBoundary); // this returns a 1-indexed list
+    IntVec oneBoundary;
+    this->getBoundaryNodes(edge, oneBoundary, 1, 1, 0, true); // this returns a 1-indexed list
     for(const int i : nodes)
       for(const int j : oneBoundary)
         if(geo->getBasisfunction(i)->contains(*geo->getBasisfunction(j-1)))
           result.push_back(j-1);
   }
+  // remove duplicate indices
+  std::sort(result.begin(), result.end());
+  auto last = std::unique(result.begin(), result.end());
+  result.erase(last, result.end());
+  return result;
+}
+
+IntVec ASMunstruct::getOverlappingNodes (const IntVec& nodes) const
+{
+  IntVec result;
+  for(const int i : nodes)
+  {
+    LR::Basisfunction *b = geo->getBasisfunction(i);
+    for(auto el : b->support()) // for all elements where *b has support
+      for(auto basis : el->support()) // for all functions on this element
+        result.push_back(basis->getId());
+  }
+
   // remove duplicate indices
   std::sort(result.begin(), result.end());
   auto last = std::unique(result.begin(), result.end());

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -241,6 +241,9 @@ public:
                                const std::map<int,int>* g2l = nullptr);
 
   //! \brief Returns the node index for a given corner.
+  //! \param I     -1 or +1 for either umin or umax corner
+  //! \param J     -1 or +1 for either vmin or vmax corner
+  //! \param basis which basis to consider (only applicable for mixed methods)
   virtual int getCorner(int I, int J, int basis) const;
 
   //! \brief Returns the node indices for a given edge.

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -105,8 +105,17 @@ public:
                                 int, int orient, bool local = false) const;
 
   //! \brief Returns the node index for a given corner.
+  //! \param I     -1 or +1 for either umin or umax corner
+  //! \param J     -1 or +1 for either vmin or vmax corner
+  //! \param K     -1 or +1 for either wmin or wmax corner
+  //! \param basis which basis to consider (only applicable for mixed methods)
   virtual int getCorner(int I, int J, int K, int basis) const;
-  //! \brief Returns the node indices for a given edge.
+
+  //! \brief Returns the (1-indexed) node indices for a given edge.
+  //! \param lEdge  index to local edge (1,2,...12)
+  //! \param open   include end points or not
+  //! \param basis  which basis to consider (only applicable for mixed methods)
+  //! \param orient local orientation of indices, see ASMunstruct::Sort
   virtual std::vector<int> getEdge(int lEdge, bool open, int basis, int orient) const;
 
   //! \brief Returns the polynomial order in each parameter direction.

--- a/src/SIM/SIMinput.C
+++ b/src/SIM/SIMinput.C
@@ -1089,9 +1089,9 @@ bool SIMinput::refine (const LR::RefineData& prm,
   }
 
   // single patch models only pass refinement call to the ASM level
-  if(myModel.size() == 1)
+  if (myModel.size() == 1)
   {
-    if( !pch->refine(prm, sol, fName))
+    if ( !pch->refine(prm, sol, fName))
     {
       return false;
     }
@@ -1118,7 +1118,7 @@ bool SIMinput::refine (const LR::RefineData& prm,
     pch = dynamic_cast<ASMunstruct*>(myModel[i]);
     for (int it : prm.elements) {
       int node = myModel[i]->getNodeIndex(it+1);
-      if(node > 0)
+      if (node > 0)
         refineIndices[i].push_back(node-1);
     }
     // fetch all boundary nodes covered (may need to pass this to other patches)
@@ -1139,17 +1139,21 @@ bool SIMinput::refine (const LR::RefineData& prm,
     // for all boundary nodes, check if these appear on other patches
     for (const int k : bndry_nodes)
     {
-      conformingIndicies[i].push_back(k);
+      bool appears_elsewhere = false;
       int globId = pch->getNodeID(k+1);
       for (size_t j = 0; j < myModel.size(); j++)
       {
-        if( i == j) continue;
+        if ( i == j) continue;
         pch2 = dynamic_cast<ASMunstruct*>(myModel[j]);
         int locId = pch2->getNodeIndex(globId);
-        if(locId > 0) {
+        if (locId > 0)
+        {
           conformingIndicies[j].push_back(locId-1);
+          appears_elsewhere = true;
         }
       }
+      if (appears_elsewhere)
+        conformingIndicies[i].push_back(k);
     }
   }
 
@@ -1166,40 +1170,40 @@ bool SIMinput::refine (const LR::RefineData& prm,
     // for it like we do here. pch->getBoundaryNodes() above seem to compute this,
     // but it is only for the sending patch boundary index, not the recieving patch boundary
     // index.
-    if(pch->getNoParamDim() == 2) {
+    if (pch->getNoParamDim() == 2) {
       ASMu2D* lr = dynamic_cast<ASMu2D*>(myModel[i]);
       int nedg0d = 4;
       int nedg1d = 4;
       IntVec              bndry0;
       std::vector<IntVec> bndry1(nedg1d);
-      for(int j =0 ; j<nedg0d; j++)
+      for (int j =0 ; j<nedg0d; j++)
         bndry0.push_back(lr->getCorner((j%2)*2-1, (j/2)*2-1, 1));
-      for(int j =1 ; j<=nedg1d; j++)
+      for (int j =1 ; j<=nedg1d; j++)
         lr->getBoundaryNodes(j, bndry1[j-1], 1, 1, 0, true);
-      for(int j : conformingIndicies[i]) // add refinement from neighbours
+      for (int j : conformingIndicies[i]) // add refinement from neighbours
       {
         bool done_with_this_node = false;
         // check if node is a corner node, compute large extended domain (all directions)
-        for(int edgeNode : bndry0)
+        for (int edgeNode : bndry0)
         {
-          if(edgeNode-1 == j)
+          if (edgeNode-1 == j)
           {
             IntVec secondary = lr->getOverlappingNodes(j);
-            for(int k : secondary)
+            for (int k : secondary)
               refineIndices[i].push_back(k);
             done_with_this_node = true;
             break;
           }
         }
         // check if node is an edge node, compute small extended domain (one direction)
-        for(int edge1d=0;  edge1d<nedg1d && !done_with_this_node; edge1d++)
+        for (int edge1d=0;  edge1d<nedg1d && !done_with_this_node; edge1d++)
         {
-          for(int edgeNode : bndry1[edge1d])
+          for (int edgeNode : bndry1[edge1d])
           {
-            if(edgeNode-1 == j)
+            if (edgeNode-1 == j)
             {
               IntVec secondary = lr->getOverlappingNodes(j, edge1d/2+1);
-              for(int k : secondary)
+              for (int k : secondary)
                 refineIndices[i].push_back(k);
               done_with_this_node = true;
               break;
@@ -1216,45 +1220,45 @@ bool SIMinput::refine (const LR::RefineData& prm,
       IntVec              bndry0;
       std::vector<IntVec> bndry1;
       std::vector<IntVec> bndry2(nedg2d);
-      for(int K=-1; K<2; K+=2)
-        for(int J=-1; J<2; J+=2)
-          for(int I=-1; I<2; I+=2)
+      for (int K=-1; K<2; K+=2)
+        for (int J=-1; J<2; J+=2)
+          for (int I=-1; I<2; I+=2)
             bndry0.push_back(lr->getCorner(I,J,K, 1));
-      for(int j =1 ; j<=nedg1d; j++)
+      for (int j =1 ; j<=nedg1d; j++)
         bndry1.push_back(lr->getEdge(j, true, 1, 0));
-      for(int j =1 ; j<=nedg2d; j++)
+      for (int j =1 ; j<=nedg2d; j++)
         lr->getBoundaryNodes(j, bndry2[j-1], 1, 1, 0, true);
-      for(int j : conformingIndicies[i]) // add refinement from neighbours
+      for (int j : conformingIndicies[i]) // add refinement from neighbours
       {
         bool done_with_this_node = false;
         // check if node is a corner node, compute large extended domain (all directions)
-        for(int edgeNode : bndry0)
+        for (int edgeNode : bndry0)
         {
-          if(edgeNode-1 == j)
+          if (edgeNode-1 == j)
           {
             IntVec secondary = lr->getOverlappingNodes(j);
-            for(int k : secondary)
+            for (int k : secondary)
               refineIndices[i].push_back(k);
             done_with_this_node = true;
             break;
           }
         }
         // check if node is an edge node, compute moderate extended domain (2 directions)
-        for(int edge1d=0;  edge1d<nedg1d && !done_with_this_node; edge1d++)
+        for (int edge1d=0;  edge1d<nedg1d && !done_with_this_node; edge1d++)
         {
-          for(int edgeNode : bndry1[edge1d])
+          for (int edgeNode : bndry1[edge1d])
           {
-            if(edgeNode-1 == j)
+            if (edgeNode-1 == j)
             {
               int allowed_direction;
-              if(edge1d < 4)
+              if (edge1d < 4)
                 allowed_direction = 6; // bin(110), allowed to grow in v- and w-direction
-              else if(edge1d < 8)
+              else if (edge1d < 8)
                 allowed_direction = 5; // bin(101), allowed to grow in u- and w-direction
               else
                 allowed_direction = 3; // bin(011), allowed to grow in u- and v-direction
               IntVec secondary = lr->getOverlappingNodes(j, allowed_direction);
-              for(int k : secondary)
+              for (int k : secondary)
                 refineIndices[i].push_back(k);
               done_with_this_node = true;
               break;
@@ -1262,14 +1266,14 @@ bool SIMinput::refine (const LR::RefineData& prm,
           }
         }
         // check if node is a face node, compute small extended domain (1 direction)
-        for(int edge2d=0;  edge2d<nedg2d && !done_with_this_node; edge2d++)
+        for (int edge2d=0;  edge2d<nedg2d && !done_with_this_node; edge2d++)
         {
-          for(int edgeNode : bndry2[edge2d])
+          for (int edgeNode : bndry2[edge2d])
           {
-            if(edgeNode-1 == j)
+            if (edgeNode-1 == j)
             {
               IntVec secondary = lr->getOverlappingNodes(j, (1<<edge2d/2));
-              for(int k : secondary)
+              for (int k : secondary)
                 refineIndices[i].push_back(k);
               done_with_this_node = true;
               break;
@@ -1296,11 +1300,13 @@ bool SIMinput::refine (const LR::RefineData& prm,
     LR::RefineData prmloc(prm);
     prmloc.elements = refineIndices[i];
     char patchName[256];
-    sprintf(patchName, "%d_%s", (int) i, fName);
+    if (fName != nullptr)
+      sprintf(patchName, "%d_%s", (int) i, fName);
+
     Vectors lsol(sol.size());
     for (size_t j = 0; j < sol.size(); ++j)
       pch->extractNodeVec(sol[j], lsol[j], sol[j].size()/this->getNoNodes(1));
-    if (!pch->refine(prmloc,lsol,patchName))
+    if (!pch->refine(prmloc,lsol,(fName) ? patchName : fName))
       return false;
     for (size_t j = 0; j < sol.size(); ++j)
       lsols[k++] = lsol[j];


### PR DESCRIPTION
Fixes LR multipatch refinement in two steps:

-  by using existing MLGN arrays to pass boundary functions to neighbouring patches (with the additional logic of finding boundary functions completely covered by requested refinement indices)
-  interior refinement is done by picking all overlapping functions of all boundary functions on both sides of the boundary. This is needed since LR meshes requires the mesh *inside* the patch to match near the boundary.