### PR TITLE
add support for solving global L2 systems using PETSc solvers

### DIFF
--- a/src/ASM/GlbL2projector.h
+++ b/src/ASM/GlbL2projector.h
@@ -19,6 +19,7 @@
 
 class IntegrandBase;
 class FunctionBase;
+class LinSolParams;
 
 typedef std::vector<size_t> uIntVec; //!< General unsigned integer vector
 
@@ -30,6 +31,9 @@ typedef std::vector<size_t> uIntVec; //!< General unsigned integer vector
 class GlbL2 : public Integrand
 {
 public:
+  static SystemMatrix::Type MatrixType; //!< Matrix type for projection
+  static LinSolParams* SolverParams; //!< Linear solver params projection
+
   //! \brief The constructor initializes the projection matrices.
   //! \param[in] p The main problem integrand
   //! \param[in] n Dimension of the L2-projection matrices (number of nodes)

--- a/src/LinAlg/PETScMatrix.h
+++ b/src/LinAlg/PETScMatrix.h
@@ -179,6 +179,12 @@ protected:
   //! \brief Solve a linear system
   bool solve(const Vec& b, Vec& x, bool newLHS, bool knoll);
 
+  //! \brief Solve system stored in the elem map.
+  //! \details Create matrix from elem table, and solve for (possibly) multiple
+  //!          right-hand-side vectors in B.
+  //! \param B Vector with right-hand-sides to solve for
+  bool solveDirect(PETScVector& B);
+
   //! \brief Disabled copy constructor.
   PETScMatrix(const PETScMatrix& A) = delete;
 
@@ -188,6 +194,7 @@ protected:
   const ProcessAdm&   adm;             //!< Process administrator
   PETScSolParams      solParams;       //!< Linear solver parameters
   bool                setParams;       //!< If linear solver parameters are set
+  std::string         forcedKSPType;   //!< Force a KSP type ignoring the parameters
   PetscInt            ISsize;          //!< Number of index sets/elements
   PetscRealVec        coords;          //!< Coordinates of local nodes (x0,y0,z0,x1,y1,...)
   ISMat               dirIndexSet;     //!< Direction ordering

--- a/src/SIM/SIMinput.C
+++ b/src/SIM/SIMinput.C
@@ -16,6 +16,7 @@
 #include "ModelGenerator.h"
 #include "ASMstruct.h"
 #include "ASMunstruct.h"
+#include "GlbL2projector.h"
 #include "LinSolParams.h"
 #include "Functions.h"
 #include "Utilities.h"
@@ -495,6 +496,9 @@ bool SIMinput::parse (const TiXmlElement* elem)
     std::string solver;
     if (utl::getAttribute(elem,"class",solver,true))
       opt.setLinearSolver(solver);
+    if (utl::getAttribute(elem,"l2class",solver,true))
+      if (solver == "petsc")
+        GlbL2::MatrixType = SystemMatrix::PETSC;
   }
   else if (!strcasecmp(elem->Value(),"eigensolver"))
     utl::getAttribute(elem,"mode",opt.eig);
@@ -532,6 +536,9 @@ bool SIMinput::parse (const TiXmlElement* elem)
     if (!mySolParams)
       mySolParams = new LinSolParams();
     result &= mySolParams->read(elem);
+    // for now use same solver parameters for l2
+    if (GlbL2::MatrixType == SystemMatrix::PETSC)
+      GlbL2::SolverParams = mySolParams;
   }
 
   const TiXmlElement* child = elem->FirstChildElement();


### PR DESCRIPTION
This adds support for using PETSc solvers for global L2 projections and the necessary functionality in the PETSc code (solve system directly built using elem map from SparseMatrix).