### PR TITLE
added: allow using PETSc solvers with CGL2 version 2

### DIFF
--- a/src/ASM/GlbL2projector.h
+++ b/src/ASM/GlbL2projector.h
@@ -20,6 +20,7 @@
 class IntegrandBase;
 class FunctionBase;
 class LinSolParams;
+class ProcessAdm;
 
 typedef std::vector<size_t> uIntVec; //!< General unsigned integer vector
 
@@ -42,8 +43,8 @@ public:
   //! \param[in] f The function to to L2-projection on
   //! \param[in] n Dimension of the L2-projection matrices (number of nodes)
   GlbL2(FunctionBase* f, size_t n);
-  //! \brief Empty destructor.
-  virtual ~GlbL2() {}
+  //! \brief The destructor frees the system matrix and system vector.
+  virtual ~GlbL2();
 
   //! \brief Defines which FE quantities are needed by the integrand.
   virtual int getIntegrandType() const;
@@ -120,8 +121,11 @@ public:
 private:
   IntegrandBase* problem; //!< The main problem integrand
   FunctionBase* function; //!< Explicit function to L2-project
-  mutable SparseMatrix A; //!< Left-hand-side matrix of the L2-projection
-  mutable StdVector    B; //!< Right-hand-side vectors of the L2-projection
+  mutable SparseMatrix* pA; //!< Left-hand-side matrix of the L2-projection
+  mutable StdVector*    pB; //!< Right-hand-side vectors of the L2-projection
+#ifdef HAS_PETSC
+  ProcessAdm*         adm; //!< Process administrator for PETSc
+#endif
 };
 
 #endif

--- a/src/ASM/GlbL2projector.h
+++ b/src/ASM/GlbL2projector.h
@@ -109,6 +109,9 @@ public:
   //! \param[out] sField Nodal/control-point values of the projected results.
   bool solve(Matrix& sField);
 
+  mutable SparseMatrix* pA; //!< Left-hand-side matrix of the L2-projection
+  mutable StdVector*    pB; //!< Right-hand-side vectors of the L2-projection
+
  protected:
   //! \brief Integrates the L2-projection matrices.
   //! \param[in] mnpc Matrix of nodal point correspondance
@@ -121,8 +124,6 @@ public:
 private:
   IntegrandBase* problem; //!< The main problem integrand
   FunctionBase* function; //!< Explicit function to L2-project
-  mutable SparseMatrix* pA; //!< Left-hand-side matrix of the L2-projection
-  mutable StdVector*    pB; //!< Right-hand-side vectors of the L2-projection
 #ifdef HAS_PETSC
   ProcessAdm*         adm; //!< Process administrator for PETSc
 #endif

--- a/src/LinAlg/PETScMatrix.h
+++ b/src/LinAlg/PETScMatrix.h
@@ -108,9 +108,6 @@ public:
   //! \brief Returns the matrix type.
   virtual Type getType() const { return PETSC; }
 
-  //! \brief Returns the dimension of the system matrix.
-  virtual size_t dim(int = 1) const { return 0; }
-
   //! \brief Initializes the element assembly process.
   //! \details Must be called once before the element assembly loop.
   //! The PETSc data structures are initialized and the all symbolic operations

--- a/src/LinAlg/ProcessAdm.h
+++ b/src/LinAlg/ProcessAdm.h
@@ -58,7 +58,7 @@ public:
 #endif
 
   //! \brief The destructor releases the process administrator.
-  ~ProcessAdm();
+  virtual ~ProcessAdm();
 
   //! \brief Return process id
   int getProcId() const  { return myPid; }


### PR DESCRIPTION
Motivation:

ASMu3D integrate is optimized using Bezier-extraction, while the other version is not. This becomes a severe bottleneck for larger simulations;
```
===============================================================
===   Profiling results for /home/akva/kode/IFEM/Apps/IFEM-Poisson/r/bin/Poisson
=================================================================
                      |       CPU time     |      Wall time     |
Task                  |  Total(s)  Mean(s) |  Total(s)  Mean(s) | calls
----------------------+--------------------+--------------------+------
ASMbase::globalL2     |  17936.70   498.24 |  17937.97   498.28 |    36
ASMu3D::integrate(I)  |   1483.96    20.61 |   1484.10    20.61 |    72
ASMunstruct::refine() |    718.38    22.45 |    718.41    22.45 |    32
BeSpline evaluation   |    624.38     0.00 |    658.13     0.00 |78744600
Bezier extraction     |    114.91     0.00 |    114.58     0.00 |393723
Element assembly      |    809.82    89.98 |    809.87    89.99 |     9
Equation solving      |    517.88    57.54 |    517.95    57.55 |     9
Norm integration      |    686.48    76.28 |    686.56    76.28 |     9
Solution projection   |  17936.73  1992.97 |  17937.99  1993.11 |     9
global L2 assembly    |  16695.62   463.77 |  16696.79   463.80 |    36
Other                 |   3596.85          |   3595.42          |
----------------------+--------------------+--------------------+------
Total time            |  24409.38          |  24410.39          |
=================================================================
```
which is reduced to
```
===============================================================
===   Profiling results for ../../../../r/bin/Poisson
=================================================================
                      |       CPU time     |      Wall time     |
Task                  |  Total(s)  Mean(s) |  Total(s)  Mean(s) | calls
----------------------+--------------------+--------------------+------
ASMbase::L2projection |  11977.87   332.72 |  11978.81   332.74 |    36
ASMu3D::integrate(I)  |  12581.71   116.50 |  12582.72   116.51 |   108
ASMunstruct::refine() |    705.17    22.04 |    705.26    22.04 |    32
BeSpline evaluation   |    735.65     0.00 |    775.50     0.00 |78744600
Bezier extraction     |    117.43     0.00 |    117.37     0.00 |393723
Element assembly      |    798.03    88.67 |    798.12    88.68 |     9
Equation solving      |    481.88    53.54 |    481.98    53.55 |     9
Initialization        |      0.01          |      0.00          |
Norm integration      |    694.32    77.15 |    694.35    77.15 |     9
Solution projection   |  11977.88  1330.88 |  11978.82  1330.98 |     9
Other                 |   3527.83          |   3526.12          |
----------------------+--------------------+--------------------+------
Total time            |  18330.93          |  18331.69          |
=================================================================
```
by using version 2.

Further, by not assembling directly into the sparse matrix, we can restore sanity
```
===============================================================
===   Profiling results for ../../../../r/bin/Poisson
=================================================================
                      |       CPU time     |      Wall time     |
Task                  |  Total(s)  Mean(s) |  Total(s)  Mean(s) | calls
----------------------+--------------------+--------------------+------
ASMbase::L2projection |   1555.07    43.20 |   1556.26    43.23 |    36
ASMu3D::integrate(I)  |   2169.17    20.08 |   2172.74    20.12 |   108
ASMunstruct::refine() |    774.24    24.20 |    777.74    24.30 |    32
BeSpline evaluation   |    643.03     0.00 |    680.33     0.00 |78744600
Bezier extraction     |    117.12     0.00 |    117.20     0.00 |393723
Element assembly      |    823.65    91.52 |    825.27    91.70 |     9
Equation solving      |    505.38    56.15 |    507.11    56.35 |     9
Norm integration      |    701.28    77.92 |    703.12    78.12 |     9
Solution projection   |   1555.08   172.79 |   1556.28   172.92 |     9
Other                 |   3765.09          |   3767.80          |
----------------------+--------------------+--------------------+------
Total time            |   8272.06          |   8286.00          |
=================================================================
```
we are now dominated by VTF output (and refinement). VTF should probably be attacked next.