### PR TITLE
changed: introduce a SIMoutput::getEfficiencyNorm

### DIFF
--- a/src/SIM/AdaptiveSIM.C
+++ b/src/SIM/AdaptiveSIM.C
@@ -469,15 +469,15 @@ void AdaptiveSIM::printNorms (size_t w) const
   {
     NormBase* norm = model.getNormIntegrand();
 
-    const Vector& fNorm = gNorm.front();
     const Vector& aNorm = gNorm[adaptor];
     IFEM::cout <<"\nError estimate"
                << utl::adjustRight(w-14,norm->getName(adaptor+1,adNorm))
                << aNorm(adNorm)
                <<"\nRelative error (%) : "
                << 100.0*aNorm(adNorm)/model.getReferenceNorm(gNorm,adaptor);
-    if (model.haveAnaSol() && fNorm.size() > 3 && adNorm == 2)
-      IFEM::cout <<"\nEffectivity index  : "<< aNorm(2)/fNorm(4);
+    if (model.haveAnaSol() && adaptor != 0)
+      IFEM::cout <<"\nEffectivity index  : "
+                 << aNorm(adNorm)/model.getEfficiencyNorm(gNorm,adaptor);
     IFEM::cout <<"\n"<< std::endl;
 
     // Calculate the row-index for the corresponding element norms

--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -1650,3 +1650,9 @@ double SIMoutput::getReferenceNorm (const Vectors& gNorm, size_t adaptor) const
   // |u|_ref = sqrt( |u^h|^2 + |e^*|^2 )
   return hypot(fNorm(1),gNorm[adaptor](2));
 }
+
+
+double SIMoutput::getEfficiencyNorm (const Vectors& gNorm, size_t adaptor) const
+{
+  return gNorm[0](4);
+}

--- a/src/SIM/SIMoutput.h
+++ b/src/SIM/SIMoutput.h
@@ -289,6 +289,9 @@ public:
   //! \brief Returns the reference norm to base mesh adaptation upon.
   virtual double getReferenceNorm(const Vectors& gNorm, size_t adaptor) const;
 
+  //! \brief Returns the reference norm for effectivity index.
+  virtual double getEfficiencyNorm(const Vectors& gNorm, size_t adaptor) const;
+
   //! \brief Serialization support.
   virtual bool serialize(std::map<std::string,std::string>&) { return false; }
 


### PR DESCRIPTION
returns the norm to base global effectivity index calculations on