### PR TITLE
Anasol fields, now also with time histories

### DIFF
--- a/src/Utility/HDF5Writer.C
+++ b/src/Utility/HDF5Writer.C
@@ -723,7 +723,13 @@ bool HDF5Writer::hasGeometries(int level, const std::string& basisName)
   str << '/' << level << "/basis";
   if (!basisName.empty())
     str << '/' << basisName;
-  return checkGroupExistence(m_file,str.str().c_str());
+
+  bool notOpen = m_file == 0;
+  if (notOpen) this->openFile(level);
+  bool result = this->checkGroupExistence(m_file,str.str().c_str());
+  if (notOpen) this->closeFile(level);
+
+  return result;
 }
 
 


### PR DESCRIPTION
Kun siste commit, de andre er inkludert i #219 og #226.

Har utvidet funksjonaliteten i FieldFunction klassene til også ta høyde for tiden `t`, slik at riktig datasett leses inn når `t` endres i evaluerings-kallet. Ser ut til å fungere, men jeg fikk ikke til å ta høyde for adapterte grid, dvs. den antar nå at basisen er lik for alle t. Prøvde å bruke `HDF5Writer::hasGeometries` men den returnerte alltid false. Dette er derfor kommentert ut.