### PR TITLE
Fix 2D gauss point transfer and add 3D implementation

### DIFF
--- a/src/ASM/ASMunstruct.h
+++ b/src/ASM/ASMunstruct.h
@@ -203,6 +203,11 @@ public:
                            const RealArray& oldVars, RealArray& newVars,
                            int nGauss, int nf = 1) const;
 
+  //! \brief Refines the parametrization based on a mesh density function.
+  //! \param[in] refC Mesh refinement criteria function
+  //! \param[in] refTol Mesh refinement threshold
+  virtual bool refine(const RealFunc& refC, double refTol) = 0;
+
 protected:
   LR::LRSpline* geo; //!< Pointer to the actual spline geometry object
 

--- a/src/ASM/ASMunstruct.h
+++ b/src/ASM/ASMunstruct.h
@@ -172,6 +172,37 @@ public:
   virtual void remapErrors(RealArray& errors, const RealArray& orig,
                            bool elemErrors = false) const = 0;
 
+  //! \brief Transfers Gauss point variables from old basis to this patch.
+  //! \param[in] oldBasis The LR-spline basis to transfer from
+  //! \param[in] oldVars Gauss point variables associated with \a oldBasis
+  //! \param[out] newVars Gauss point variables associated with this patch.
+  //! \param[in] nGauss Number of Gauss points along a knot-span
+  virtual bool transferGaussPtVars(const LR::LRSpline* oldBasis,
+                                   const RealArray& oldVars, RealArray& newVars,
+                                   int nGauss) const = 0;
+  //! \brief Transfers Gauss point variables from old basis to this patch.
+  //! \param[in] oldBasis The LR-spline basis to transfer from
+  //! \param[in] oldVars Gauss point variables associated with \a oldBasis
+  //! \param[out] newVars Gauss point variables associated with this patch.
+  //! \param[in] nGauss Number of Gauss points along a knot-span
+  virtual bool transferGaussPtVarsN(const LR::LRSpline* oldBasis,
+                                    const RealArray& oldVars, RealArray& newVars,
+                                    int nGauss) const = 0;
+  //! \brief Transfers control point variables from old basis to this patch.
+  //! \param[in] oldBasis The LR-spline basis to transfer from
+  //! \param[out] newVars Gauss point variables associated with this patch.
+  //! \param[in] nGauss Number of Gauss points along a knot-span
+  virtual bool transferCntrlPtVars(const LR::LRSpline* oldBasis,
+                                   RealArray& newVars, int nGauss) const = 0;
+  //! \brief Transfers control point variables from old basis to this patch.
+  //! \param[in] oldBasis The LR-spline basis to transfer from
+  //! \param[in] oldVars Control point variables associated with \a oldBasis
+  //! \param[out] newVars Gauss point variables associated with this patch.
+  //! \param[in] nGauss Number of Gauss points along a knot-span
+  bool transferCntrlPtVars(LR::LRSpline* oldBasis,
+                           const RealArray& oldVars, RealArray& newVars,
+                           int nGauss, int nf = 1) const;
+
 protected:
   LR::LRSpline* geo; //!< Pointer to the actual spline geometry object
 

--- a/src/ASM/LR/ASMLRSpline.C
+++ b/src/ASM/LR/ASMLRSpline.C
@@ -384,3 +384,13 @@ void ASMunstruct::Sort(int u, int v, int orient,
               return false;
             });
 }
+
+
+bool ASMunstruct::transferCntrlPtVars (LR::LRSpline* oldBasis,
+                                       const RealArray& oldVars, RealArray& newVars,
+                                       int nGauss, int nf) const
+{
+  oldBasis->rebuildDimension(nf);
+  oldBasis->setControlPoints(const_cast<RealArray&>(oldVars));
+  return this->transferCntrlPtVars(oldBasis,newVars,nGauss);
+}

--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -2095,9 +2095,13 @@ bool ASMu2D::transferGaussPtVarsN (const LR::LRSplineSurface* oldBasis,
         double v = vmin + dv * (xi[j] + 1.0);
         double dist = 1.0e16;
         size_t near = 0;
-        for (size_t k = 0; k < nGP; ++k)
-          if (hypot(oGP[k].u-u,oGP[k].v-v) < dist)
+        for (size_t k = 0; k < nGP; ++k) {
+          double nd = hypot(oGP[k].u-u,oGP[k].v-v);
+          if (nd < dist) {
             near = k;
+            dist = nd;
+          }
+        }
         newVars.push_back(oldVars[iOld*nGP+near]);
       }
   }

--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -1992,11 +1992,12 @@ size_t ASMu2D::getNoNodes (int) const
 }
 
 
-bool ASMu2D::transferGaussPtVars (const LR::LRSplineSurface* oldBasis,
+bool ASMu2D::transferGaussPtVars (const LR::LRSpline* old_basis,
                                   const RealArray& oldVars, RealArray& newVars,
                                   int nGauss) const
 {
   const LR::LRSplineSurface* newBasis = this->getBasis();
+  const LR::LRSplineSurface* oldBasis = static_cast<const LR::LRSplineSurface*>(old_basis);
 
   size_t nGp = nGauss*nGauss;
   newVars.resize(newBasis->nElements()*nGp);
@@ -2044,11 +2045,12 @@ bool ASMu2D::transferGaussPtVars (const LR::LRSplineSurface* oldBasis,
 }
 
 
-bool ASMu2D::transferGaussPtVarsN (const LR::LRSplineSurface* oldBasis,
+bool ASMu2D::transferGaussPtVarsN (const LR::LRSpline* old_basis,
                                    const RealArray& oldVars, RealArray& newVars,
                                    int nGauss) const
 {
   const LR::LRSplineSurface* newBasis = this->getBasis();
+  const LR::LRSplineSurface* oldBasis = static_cast<const LR::LRSplineSurface*>(old_basis);
 
   size_t nGP = nGauss*nGauss;
   newVars.clear();
@@ -2110,20 +2112,11 @@ bool ASMu2D::transferGaussPtVarsN (const LR::LRSplineSurface* oldBasis,
 }
 
 
-bool ASMu2D::transferCntrlPtVars (LR::LRSplineSurface* oldBasis,
-                                  const RealArray& oldVars, RealArray& newVars,
-                                  int nGauss) const
-{
-  oldBasis->rebuildDimension(1);
-  oldBasis->setControlPoints(const_cast<RealArray&>(oldVars));
-  return this->transferCntrlPtVars(oldBasis,newVars,nGauss);
-}
-
-
-bool ASMu2D::transferCntrlPtVars (const LR::LRSplineSurface* oldBasis,
+bool ASMu2D::transferCntrlPtVars (const LR::LRSpline* old_basis,
                                   RealArray& newVars, int nGauss) const
 {
   const LR::LRSplineSurface* newBasis = this->getBasis();
+  const LR::LRSplineSurface* oldBasis = static_cast<const LR::LRSplineSurface*>(old_basis);
 
   newVars.clear();
   newVars.reserve(newBasis->nElements()*nGauss*nGauss*oldBasis->dimension());

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -424,35 +424,29 @@ public:
                          double time) const;
 
   //! \brief Transfers Gauss point variables from old basis to this patch.
-  //! \param[in] oldBasis The LR-spline basis to transfer from
+  //! \param[in] old_basis The LR-spline basis to transfer from
   //! \param[in] oldVars Gauss point variables associated with \a oldBasis
   //! \param[out] newVars Gauss point variables associated with this patch.
   //! \param[in] nGauss Number of Gauss points along a knot-span
-  bool transferGaussPtVars(const LR::LRSplineSurface* oldBasis,
-                           const RealArray& oldVars, RealArray& newVars,
-                           int nGauss) const;
+  virtual bool transferGaussPtVars(const LR::LRSpline* old_basis,
+                                   const RealArray& oldVars, RealArray& newVars,
+                                   int nGauss) const;
   //! \brief Transfers Gauss point variables from old basis to this patch.
-  //! \param[in] oldBasis The LR-spline basis to transfer from
+  //! \param[in] old_basis The LR-spline basis to transfer from
   //! \param[in] oldVars Gauss point variables associated with \a oldBasis
   //! \param[out] newVars Gauss point variables associated with this patch.
   //! \param[in] nGauss Number of Gauss points along a knot-span
-  bool transferGaussPtVarsN(const LR::LRSplineSurface* oldBasis,
-                            const RealArray& oldVars, RealArray& newVars,
-                            int nGauss) const;
+  virtual bool transferGaussPtVarsN(const LR::LRSpline* old_basis,
+                                    const RealArray& oldVars, RealArray& newVars,
+                                    int nGauss) const;
+
+  using ASMunstruct::transferCntrlPtVars;
   //! \brief Transfers control point variables from old basis to this patch.
-  //! \param[in] oldBasis The LR-spline basis to transfer from
-  //! \param[in] oldVars Control point variables associated with \a oldBasis
+  //! \param[in] old_basis The LR-spline basis to transfer from
   //! \param[out] newVars Gauss point variables associated with this patch.
   //! \param[in] nGauss Number of Gauss points along a knot-span
-  bool transferCntrlPtVars(LR::LRSplineSurface* oldBasis,
-                           const RealArray& oldVars, RealArray& newVars,
-                           int nGauss) const;
-  //! \brief Transfers control point variables from old basis to this patch.
-  //! \param[in] oldBasis The LR-spline basis to transfer from
-  //! \param[out] newVars Gauss point variables associated with this patch.
-  //! \param[in] nGauss Number of Gauss points along a knot-span
-  bool transferCntrlPtVars(const LR::LRSplineSurface* oldBasis,
-                           RealArray& newVars, int nGauss) const;
+  virtual bool transferCntrlPtVars(const LR::LRSpline* old_basis,
+                                   RealArray& newVars, int nGauss) const;
 
 protected:
 

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -2409,3 +2409,31 @@ bool ASMu3D::transferCntrlPtVars (const LR::LRSpline* old_basis,
 
   return true;
 }
+
+
+/*!
+  Refines all elements for which refC(X0) < refTol,
+  where X0 is the element center.
+*/
+
+bool ASMu3D::refine (const RealFunc& refC, double refTol)
+{
+  Go::Point X0;
+  std::vector<int> elements;
+  std::vector<LR::Element*>::const_iterator eit = lrspline->elementBegin();
+  for (int iel = 0; eit != lrspline->elementEnd(); iel++, ++eit)
+  {
+    double u0 = 0.5*((*eit)->umin() + (*eit)->umax());
+    double v0 = 0.5*((*eit)->vmin() + (*eit)->vmax());
+    double w0 = 0.5*((*eit)->wmin() + (*eit)->wmax());
+    lrspline->point(X0,u0,v0,w0);
+    if (refC(SplineUtils::toVec3(X0,nsd)) < refTol)
+      elements.push_back(iel);
+  }
+
+  Vectors dummySol;
+  LR::RefineData prm(true);
+  prm.options = { 10, 1, 2 };
+  prm.elements = this->getFunctionsForElements(elements);
+  return this->refine(prm,dummySol);
+}

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -139,6 +139,14 @@ public:
   //! \param[in] rw Number of times to raise the order in w-direction
   virtual bool raiseOrder(int ru, int rv, int rw);
 
+  //! \brief Defines the minimum element volume for adaptive refinement.
+  //! \param[in] nrefinements Maximum number of adaptive refinement levels
+  virtual double getMinimumSize(int nrefinements) const;
+  //! \brief Checks if the specified element is larger than the minimum size.
+  //! \param[in] elmId Global/patch-local element index
+  //! \param[in] globalNum If \e true, \a elmId is global otherwise patch-local
+  virtual bool checkElementSize(int elmId, bool globalNum = true) const;
+
 
   // Various methods for preprocessing of boundary conditions and patch topology
   // ===========================================================================
@@ -547,6 +555,7 @@ protected:
   Matrices      myBezierExtract; //!< Bezier extraction matrices
 
   ThreadGroups threadGroups; //!< Element groups for multi-threaded assembly
+  mutable double vMin; //!< Minimum element volume for adaptive refinement
 };
 
 #endif

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -339,6 +339,30 @@ public:
   virtual bool evalSolution(Matrix& sField, const IntegrandBase& integrand,
                             const int* npe, char project = '\0') const;
 
+  //! \brief Transfers Gauss point variables from old basis to this patch.
+  //! \param[in] old_basis The LR-spline basis to transfer from
+  //! \param[in] oldVars Gauss point variables associated with \a oldBasis
+  //! \param[out] newVars Gauss point variables associated with this patch.
+  //! \param[in] nGauss Number of Gauss points along a knot-span
+  virtual bool transferGaussPtVars(const LR::LRSpline* old_basis,
+                                   const RealArray& oldVars, RealArray& newVars,
+                                   int nGauss) const;
+  //! \brief Transfers Gauss point variables from old basis to this patch.
+  //! \param[in] old_basis The LR-spline basis to transfer from
+  //! \param[in] oldVars Gauss point variables associated with \a oldBasis
+  //! \param[out] newVars Gauss point variables associated with this patch.
+  //! \param[in] nGauss Number of Gauss points along a knot-span
+  virtual bool transferGaussPtVarsN(const LR::LRSpline* old_basis,
+                                    const RealArray& oldVars, RealArray& newVars,
+                                    int nGauss) const;
+  using ASMunstruct::transferCntrlPtVars;
+  //! \brief Transfers control point variables from old basis to this patch.
+  //! \param[in] old_basis The LR-spline basis to transfer from
+  //! \param[out] newVars Gauss point variables associated with this patch.
+  //! \param[in] nGauss Number of Gauss points along a knot-span
+  virtual bool transferCntrlPtVars(const LR::LRSpline* old_basis,
+                                   RealArray& newVars, int nGauss) const;
+
 private:
   //! \brief Struct representing an inhomogeneous Dirichlet boundary condition.
   struct DirichletFace

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -363,6 +363,11 @@ public:
   virtual bool transferCntrlPtVars(const LR::LRSpline* old_basis,
                                    RealArray& newVars, int nGauss) const;
 
+  //! \brief Refines the parametrization based on a mesh density function.
+  //! \param[in] refC Mesh refinement criteria function
+  //! \param[in] refTol Mesh refinement threshold
+  virtual bool refine(const RealFunc& refC, double refTol);
+
 private:
   //! \brief Struct representing an inhomogeneous Dirichlet boundary condition.
   struct DirichletFace

--- a/src/ASM/LR/Test/TestASMu2D.C
+++ b/src/ASM/LR/Test/TestASMu2D.C
@@ -11,6 +11,7 @@
 //==============================================================================
 
 #include "ASMu2D.h"
+#include "GaussQuadrature.h"
 #include "SIM2D.h"
 #include "LRSpline/LRSplineSurface.h"
 
@@ -143,4 +144,58 @@ TEST(TestASMu2D, InterfaceChecker)
       }
     }
   }
+}
+
+
+TEST(TestASMu2D, TransferGaussPtVars)
+{
+  SIM2D sim(1);
+  sim.opt.discretization = ASM::LRSpline;
+  sim.createDefaultModel();
+  ASMu2D* pch = static_cast<ASMu2D*>(sim.getPatch(1));
+  RealArray oldAr(9), newAr;
+  const double* xi = GaussQuadrature::getCoord(3);
+  size_t id[2];
+  for (size_t idx = 0; idx < 2; ++idx) {
+    SIM2D simNew(1);
+    simNew.opt.discretization = ASM::LRSpline;
+    simNew.createDefaultModel();
+    ASMu2D* pchNew = static_cast<ASMu2D*>(simNew.getPatch(1));
+    pchNew->uniformRefine(idx, 1);
+    for (id[1] = 0; id[1] < 3; ++id[1])
+      for (id[0] = 0; id[0] < 3; ++id[0])
+        oldAr[id[0]+id[1]*3] = (1.0 + xi[id[idx]]) / 2.0;
+    pchNew->transferGaussPtVars(pch->getSurface(), oldAr, newAr, 3);
+    size_t k = 0;
+    for (size_t iEl = 0; iEl < 2; ++iEl) {
+      for (id[1] = 0; id[1] < 3; ++id[1])
+        for (id[0] = 0; id[0] < 3; ++id[0], ++k)
+          EXPECT_FLOAT_EQ(newAr[k], 0.5*iEl + 0.5*(xi[id[idx]] + 1.0) / 2.0);
+    }
+  }
+}
+
+
+TEST(TestASMu2D, TransferGaussPtVarsN)
+{
+  SIM2D sim(1), sim2(1);
+  sim.opt.discretization = sim2.opt.discretization = ASM::LRSpline;
+  sim.createDefaultModel();
+  sim2.createDefaultModel();
+  ASMu2D* pch = static_cast<ASMu2D*>(sim.getPatch(1));
+  ASMu2D* pchNew = static_cast<ASMu2D*>(sim2.getPatch(1));
+  pchNew->uniformRefine(0, 1);
+  RealArray oldAr(9), newAr;
+  std::iota(oldAr.begin(), oldAr.end(), 1);
+
+  pchNew->transferGaussPtVarsN(pch->getSurface(), oldAr, newAr, 3);
+  static RealArray refAr = {{1.0, 1.0, 2.0,
+                             4.0, 4.0, 5.0,
+                             7.0, 7.0, 8.0,
+                             2.0, 3.0, 3.0,
+                             5.0, 6.0, 6.0,
+                             8.0, 9.0, 9.0}};
+  EXPECT_EQ(refAr.size(), newAr.size());
+  for (size_t i = 0; i < refAr.size(); ++i)
+    EXPECT_FLOAT_EQ(refAr[i], newAr[i]);
 }

--- a/src/ASM/LR/Test/TestASMu3D.C
+++ b/src/ASM/LR/Test/TestASMu3D.C
@@ -11,7 +11,9 @@
 //==============================================================================
 
 #include "ASMu3D.h"
+#include "GaussQuadrature.h"
 #include "SIM3D.h"
+#include "LRSpline/LRSplineVolume.h"
 
 #include "gtest/gtest.h"
 
@@ -59,3 +61,72 @@ const std::vector<int> tests = {1,2,3,4,5,6};
 INSTANTIATE_TEST_CASE_P(TestASMu3D,
                         TestASMu3D,
                         testing::ValuesIn(tests));
+
+
+TEST(TestASMu3D, TransferGaussPtVars)
+{
+  SIM3D sim(1);
+  sim.opt.discretization = ASM::LRSpline;
+  sim.createDefaultModel();
+  ASMu3D* pch = static_cast<ASMu3D*>(sim.getPatch(1));
+  size_t id[3];
+  const double* xi = GaussQuadrature::getCoord(3);
+  RealArray oldAr(3*3*3), newAr;
+  for (size_t idx = 0; idx < 3; ++idx) {
+    SIM3D simNew(1);
+    simNew.opt.discretization = ASM::LRSpline;
+    simNew.createDefaultModel();
+    ASMu3D* pchNew = static_cast<ASMu3D*>(simNew.getPatch(1));
+    pchNew->uniformRefine(idx, 1);
+
+    for (id[2] = 0; id[2] < 3; ++id[2])
+      for (id[1] = 0; id[1] < 3; ++id[1])
+        for (id[0] = 0; id[0] < 3; ++id[0])
+          oldAr[id[0]+(id[1]+id[2]*3)*3] = (1.0 + xi[id[idx]]) / 2.0;
+
+    pchNew->transferGaussPtVars(pch->getVolume(), oldAr, newAr, 3);
+    size_t k = 0;
+    for (size_t iEl = 0; iEl < 2; ++iEl)
+    for (id[2] = 0; id[2] < 3; ++id[2])
+      for (id[1] = 0; id[1] < 3; ++id[1])
+        for (id[0] = 0; id[0] < 3; ++id[0], ++k)
+            EXPECT_FLOAT_EQ(newAr[k], 0.5*iEl + 0.5*(xi[id[idx]] + 1.0) / 2.0);
+  }
+}
+
+
+TEST(TestASMu3D, TransferGaussPtVarsN)
+{
+  SIM3D sim(1), sim2(1);
+  sim.opt.discretization = sim2.opt.discretization = ASM::LRSpline;
+  sim.createDefaultModel();
+  sim2.createDefaultModel();
+  ASMu3D* pch = static_cast<ASMu3D*>(sim.getPatch(1));
+  ASMu3D* pchNew = static_cast<ASMu3D*>(sim2.getPatch(1));
+  pchNew->uniformRefine(0, 1);
+  RealArray oldAr(3*3*3), newAr;
+  std::iota(oldAr.begin(), oldAr.end(), 1);
+
+  pchNew->transferGaussPtVarsN(pch->getVolume(), oldAr, newAr, 3);
+  static RealArray refAr = {{ 1.0,  1.0,  2.0,
+                              4.0,  4.0,  5.0,
+                              7.0,  7.0,  8.0,
+                             10.0, 10.0, 11.0,
+                             13.0, 13.0, 14.0,
+                             16.0, 16.0, 17.0,
+                             19.0, 19.0, 20.0,
+                             22.0, 22.0, 23.0,
+                             25.0, 25.0, 26.0,
+                              2.0,  3.0,  3.0,
+                              5.0,  6.0,  6.0,
+                              8.0,  9.0,  9.0,
+                             11.0, 12.0, 12.0,
+                             14.0, 15.0, 15.0,
+                             17.0, 18.0, 18.0,
+                             20.0, 21.0, 21.0,
+                             23.0, 24.0, 24.0,
+                             26.0, 27.0, 27.0}};
+  EXPECT_EQ(refAr.size(), newAr.size());
+  for (size_t i = 0; i < refAr.size(); ++i)
+    EXPECT_FLOAT_EQ(refAr[i], newAr[i]);
+}

--- a/src/Utility/LagrangeInterpolator.C
+++ b/src/Utility/LagrangeInterpolator.C
@@ -26,10 +26,10 @@ double LagrangeInterpolator::evaluate(double x,
 
 Matrix LagrangeInterpolator::get(const std::vector<double>& new_grid)
 {
-  Matrix result(grid.size(), new_grid.size());
+  Matrix result(new_grid.size(), grid.size());
   for (size_t i = 0; i < grid.size(); ++i)
     for (size_t j = 0; j < new_grid.size(); ++j)
-      result(i+1, j+1) =  Lagrange(new_grid[j], i, grid);
+      result(j+1, i+1) =  Lagrange(new_grid[j], i, grid);
 
   return result;
 }


### PR DESCRIPTION
- Found some issues while writing tests (included).
- virtualize various methods on ASMunstruct level and implement for 3D LR

with this, only minor adjustments in IFEM-OpenFrac (use through virtual interfaces) will allow for running adaptive 3D.