### PR TITLE
Trace operator for matrix and matrix3D

### DIFF
--- a/src/LinAlg/Test/TestMatrix.C
+++ b/src/LinAlg/Test/TestMatrix.C
@@ -72,7 +72,19 @@ TEST(TestMatrix, Norm)
   EXPECT_FLOAT_EQ(a.sum(),210.0);
   EXPECT_FLOAT_EQ(a.sum(5),34.0);
   EXPECT_FLOAT_EQ(a.asum(5),34.0);
+  EXPECT_FLOAT_EQ(a.trace(),34.0);
   EXPECT_NEAR(a.norm2(5),sqrt(414.0),1.0e-15);
+}
+
+
+TEST(TestMatrix3D, Trace)
+{
+  utl::matrix3d<double> a(4,3,3);
+  std::iota(a.begin(),a.end(),1.0);
+  std::cout <<"A:"<< a;
+
+  for (size_t i = 1; i <= 4; i++)
+    EXPECT_FLOAT_EQ(a.trace(i),3.0*i+48.0);
 }
 
 
@@ -98,10 +110,9 @@ TEST(TestMatrix3D, GetColumn)
 
 TEST(TestMatrix3D, DumpRead)
 {
+  int i = 0;
   utl::matrix3d<double> A(2,3,4);
-  double i = 0.0;
-  for (auto p = A.begin(); p != A.end(); ++p, ++i)
-    *p = 3.14159*i*i;
+  for (double& v : A) v = 3.14159*(++i);
 
   const char* fname = "/tmp/testMatrix3D.dat";
   std::ofstream os(fname);

--- a/src/LinAlg/matrix.h
+++ b/src/LinAlg/matrix.h
@@ -555,6 +555,9 @@ namespace utl //! General utility classes and functions.
       return *this;
     }
 
+    //! \brief Return the trace of the matrix (sum of its diagonal elements).
+    T trace() const { return this->elem.sum(0,nrow+1); }
+
 #define THIS(i,j) this->operator()(i,j)
 
     //! \brief Compute the determinant of a square matrix.
@@ -914,6 +917,13 @@ namespace utl //! General utility classes and functions.
       vector<T> col(this->n[0]);
       memcpy(col.ptr(),this->ptr(i2-1+this->n[1]*(i3-1)),col.size()*sizeof(T));
       return col;
+    }
+
+    //! \brief Return the trace of the \a i1'th sub-matrix.
+    T trace(size_t i1) const
+    {
+      CHECK_INDEX("matrix3d::trace(): Index ",i1,this->n[0]);
+      return this->elem.sum(i1-1,this->n[0]*(this->n[1]+1));
     }
 
     //! \brief Add the given matrix \b X to \a *this.

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -1763,13 +1763,17 @@ bool SIMbase::extractPatchSolution (IntegrandBase* problem,
 
 
 bool SIMbase::project (Vector& ssol, const Vector& psol,
-		       SIMoptions::ProjectionMethod pMethod) const
+		       SIMoptions::ProjectionMethod pMethod, size_t iComp) const
 {
   Matrix stmp;
   if (!this->project(stmp,psol,pMethod))
     return false;
 
-  ssol = stmp;
+  if (iComp > 0)
+    ssol = stmp.getRow(iComp);
+  else
+    ssol = stmp;
+
   return true;
 }
 

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -445,10 +445,12 @@ public:
   //! \param[out] ssol Vector of control point values of the secondary solution
   //! \param[in] psol Vector of control point values of the primary solution
   //! \param[in] pMethod Projection method to use
+  //! \param[in] iComp One-based index of the component to return (0 = all)
   //!
   //! \details Convenience overload, for stationary problems only.
   bool project(Vector& ssol, const Vector& psol,
-               SIMoptions::ProjectionMethod pMethod = SIMoptions::GLOBAL) const;
+               SIMoptions::ProjectionMethod pMethod = SIMoptions::GLOBAL,
+               size_t iComp = 0) const;
 
   //! \brief Projects the analytical secondary solution, if any.
   //! \param[out] ssol Vector of control point values of the secondary solution

--- a/src/SIM/SIMoptions.h
+++ b/src/SIM/SIMoptions.h
@@ -65,7 +65,6 @@ public:
   //! \brief Prints out the simulation options to the given stream.
   utl::LogStream& print(utl::LogStream& os, bool addBlankLine = false) const;
 
-private:
   //! \brief Parses a projection method XML-tag.
   bool parseProjectionMethod(const char* ptype, int version = 1);
 


### PR DESCRIPTION
Just some convenience methods. Also (first commit) an extra argument for the SIMbase::project method such that it can be used when we only want a specified component.