### PR TITLE
fixed: ASMbase needs the maximum number of components

### DIFF
--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -37,7 +37,7 @@
 
 ASMs2Dmx::ASMs2Dmx (unsigned char n_s,
 		    const std::vector<unsigned char>& n_f)
-  : ASMs2D(n_s), ASMmxBase(n_f)
+  : ASMs2D(n_s, *std::max_element(n_f.begin(),n_f.end())), ASMmxBase(n_f)
 {
 }
 

--- a/src/ASM/LR/ASMu2Dmx.C
+++ b/src/ASM/LR/ASMu2Dmx.C
@@ -41,7 +41,7 @@
 
 
 ASMu2Dmx::ASMu2Dmx (unsigned char n_s, const CharVec& n_f)
-  : ASMu2D(n_s), ASMmxBase(n_f)
+  : ASMu2D(n_s, *std::max_element(n_f.begin(),n_f.end())), ASMmxBase(n_f)
 {
   threadBasis = nullptr;
 }


### PR DESCRIPTION
if not, we cannot apply boundary conditions for simulators where
number of fields > nsd. fixes boussinesq application.