### PR TITLE
fixed: this should not be virtual

### DIFF
--- a/src/LinAlg/ProcessAdm.h
+++ b/src/LinAlg/ProcessAdm.h
@@ -108,7 +108,7 @@ public:
   //! \brief Blocking receive of a double
   //! \param[out] value  Received value
   //! \param[in]  source Process id for source
-  virtual void receive(double& value, int source) const;
+  void receive(double& value, int source) const;
   //! \brief Blocking receive of a double vector
   //! \param[out] rvec   Double vector to receive
   //! \param[in]  source Process id for source


### PR DESCRIPTION
quells warnings about deleting object with virtual members and
non-virtual destructor