### PR TITLE
fixed: iterate over basis functions instead of getting by ID

### DIFF
--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -1804,8 +1804,8 @@ bool ASMu2D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
   {
     // Extract control point values from the spline object
     sField.resize(s->dimension(),s->nBasisFunctions());
-    for (int i = 0; i < s->nBasisFunctions(); i++)
-      sField.fillColumn(i+1,&(*s->getBasisfunction(i)->cp()));
+    for (auto it = s->basisBegin(); it != s->basisEnd(); ++it)
+      sField.fillColumn((*it)->getId()+1,&(*(*it)->cp()));
     delete s;
     return true;
   }


### PR DESCRIPTION
the data structure is O(n) for access (and O(1) insert). 

@kmokstad should fix observed inefficiencies in openfrac + hdf5 export.