### PR TITLE
fixed: make sure we have a row to store anasol component in

### DIFF
--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -596,7 +596,7 @@ int SIMoutput::writeGlvS1 (const Vector& psol, int iStep, int& nBlock,
         {
           const RealFunc* psSol;
           size_t r = pSol.dim() + 1;
-          for (size_t k = 0; (psSol = mySol->getScalarSol(k)); k++, r++)
+          for (size_t k = 0; (psSol = mySol->getScalarSol(k)) && r <= field.rows(); k++, r++)
           {
             cit = grid->begin_XYZ();
             const RealFunc& sSol = *psSol;


### PR DESCRIPTION
This is necessary with Chorin. Due to the split nature of things, we do not have a pressure in the primary field when storing the VTF (it's written by the pressure correction SIM).

This causes problems, as the anasol still holds the pressure (necessary for norm calculations) and this sanity check comes to the rescue. Should only add sanity in any case so i think it's an acceptable solution.