### PR TITLE
Move patch-only dependent code from SIMinput to ASM-scope

### DIFF
--- a/src/ASM/ASMunstruct.h
+++ b/src/ASM/ASMunstruct.h
@@ -33,13 +33,12 @@ namespace LR //! Utilities for LR-splines.
     options[0] is the beta percentage of elements to refine,
     options[1] is the knotline multiplicity (default 1),
     options[2] is the refinement scheme (default 0),
-    (FULLSPAN=0, MINSPAN=1, ISOTROPIC ELEMENTS=2, ISOTROPIC FUNCTIONS=3),
-    options[3] is the symmetry, i.e., always refine a multiple of this value,
-    options[4] is nonzero if testing for linear independence at all iterations,
-    options[5] is the maximum number of T-joints allowed in the model,
-    options[6] is the maximum allowed parametric aspect ratio of an element,
-    options[7] is one if all "gaps" are to be closed,
-    options[8] is one if using true beta.
+    (FULLSPAN=0, MINSPAN=1, ISOTROPIC_ELEMENTS=2, ISOTROPIC_FUNCTIONS=3),
+    options[3] is nonzero if testing for linear independence at all iterations,
+    options[4] is the maximum number of T-joints allowed in the model,
+    options[5] is the maximum allowed parametric aspect ratio of an element,
+    options[6] is one if all "gaps" are to be closed,
+    options[7] is one if using "true beta".
   */
   struct RefineData
   {
@@ -172,36 +171,42 @@ public:
   virtual void remapErrors(RealArray& errors, const RealArray& orig,
                            bool elemErrors = false) const = 0;
 
+  //! \brief Extends the refinement domain with information for neighbors.
+  //! \param refineIndices List of basis functions to refine
+  //! \param neighborIndices Basis functions to refine from neighbor patches
+  virtual void extendRefinementDomain(IntSet& refineIndices,
+                                      const IntSet& neighborIndices) const = 0;
+
   //! \brief Transfers Gauss point variables from old basis to this patch.
   //! \param[in] oldBasis The LR-spline basis to transfer from
-  //! \param[in] oldVars Gauss point variables associated with \a oldBasis
-  //! \param[out] newVars Gauss point variables associated with this patch.
+  //! \param[in] oldVar Gauss point variables associated with \a oldBasis
+  //! \param[out] newVar Gauss point variables associated with this patch
   //! \param[in] nGauss Number of Gauss points along a knot-span
   virtual bool transferGaussPtVars(const LR::LRSpline* oldBasis,
-                                   const RealArray& oldVars, RealArray& newVars,
+                                   const RealArray& oldVar, RealArray& newVar,
                                    int nGauss) const = 0;
   //! \brief Transfers Gauss point variables from old basis to this patch.
   //! \param[in] oldBasis The LR-spline basis to transfer from
-  //! \param[in] oldVars Gauss point variables associated with \a oldBasis
-  //! \param[out] newVars Gauss point variables associated with this patch.
+  //! \param[in] oldVar Gauss point variables associated with \a oldBasis
+  //! \param[out] newVar Gauss point variables associated with this patch
   //! \param[in] nGauss Number of Gauss points along a knot-span
   virtual bool transferGaussPtVarsN(const LR::LRSpline* oldBasis,
-                                    const RealArray& oldVars, RealArray& newVars,
+                                    const RealArray& oldVar, RealArray& newVar,
                                     int nGauss) const = 0;
   //! \brief Transfers control point variables from old basis to this patch.
   //! \param[in] oldBasis The LR-spline basis to transfer from
-  //! \param[out] newVars Gauss point variables associated with this patch.
+  //! \param[out] newVar Gauss point variables associated with this patch
   //! \param[in] nGauss Number of Gauss points along a knot-span
   virtual bool transferCntrlPtVars(const LR::LRSpline* oldBasis,
-                                   RealArray& newVars, int nGauss) const = 0;
+                                   RealArray& newVar, int nGauss) const = 0;
   //! \brief Transfers control point variables from old basis to this patch.
   //! \param[in] oldBasis The LR-spline basis to transfer from
-  //! \param[in] oldVars Control point variables associated with \a oldBasis
-  //! \param[out] newVars Gauss point variables associated with this patch.
+  //! \param[in] oldVar Control point variables associated with \a oldBasis
+  //! \param[out] newVar Gauss point variables associated with this patch
   //! \param[in] nGauss Number of Gauss points along a knot-span
-  //! \param[in] nf Number of fields to transfer
+  //! \param[in] nf Number of field components
   bool transferCntrlPtVars(LR::LRSpline* oldBasis,
-                           const RealArray& oldVars, RealArray& newVars,
+                           const RealArray& oldVar, RealArray& newVar,
                            int nGauss, int nf = 1) const;
 
   //! \brief Refines the parametrization based on a mesh density function.

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -56,20 +56,21 @@ public:
     //! \brief Get intersections for a given element edge.
     //! \param iel Element index (1-based)
     //! \param edge Edge to get intersections for (1..4)
-    //! \param cont If not nullpt, intersection continuity is given here
-    std::vector<double> getIntersections(int iel, int edge, int* cont=nullptr) const;
+    //! \param cont If not null, the intersection continuity is given here
+    RealArray getIntersections(int iel, int edge, int* cont=nullptr) const;
   protected:
     const ASMu2D& myPatch; //!< Reference to the patch being integrated
 
     //! \brief Struct describing an intersection of mesh lines.
     struct Intersection {
-      int continuity; //!< Continuity across intersection
+      int continuity = 0; //!< Continuity across intersection
       std::vector<double> pts; //!< Intersection points
     };
 
-    //! \brief Intersections for elements. Key: element << 4 + edge (1..4)
+    //! Intersections for elements. Key: element << 4 + edge (1..4).
     std::map<int,Intersection> intersections;
   };
+
   //! \brief Default constructor.
   ASMu2D(unsigned char n_s = 2, unsigned char n_f = 2);
   //! \brief Copy constructor.
@@ -427,28 +428,28 @@ public:
 
   //! \brief Transfers Gauss point variables from old basis to this patch.
   //! \param[in] old_basis The LR-spline basis to transfer from
-  //! \param[in] oldVars Gauss point variables associated with \a oldBasis
-  //! \param[out] newVars Gauss point variables associated with this patch.
+  //! \param[in] oldVar Gauss point variables associated with \a oldBasis
+  //! \param[out] newVar Gauss point variables associated with this patch
   //! \param[in] nGauss Number of Gauss points along a knot-span
   virtual bool transferGaussPtVars(const LR::LRSpline* old_basis,
-                                   const RealArray& oldVars, RealArray& newVars,
+                                   const RealArray& oldVar, RealArray& newVar,
                                    int nGauss) const;
   //! \brief Transfers Gauss point variables from old basis to this patch.
   //! \param[in] old_basis The LR-spline basis to transfer from
-  //! \param[in] oldVars Gauss point variables associated with \a oldBasis
-  //! \param[out] newVars Gauss point variables associated with this patch.
+  //! \param[in] oldVar Gauss point variables associated with \a oldBasis
+  //! \param[out] newVar Gauss point variables associated with this patch
   //! \param[in] nGauss Number of Gauss points along a knot-span
   virtual bool transferGaussPtVarsN(const LR::LRSpline* old_basis,
-                                    const RealArray& oldVars, RealArray& newVars,
+                                    const RealArray& oldVar, RealArray& newVar,
                                     int nGauss) const;
 
   using ASMunstruct::transferCntrlPtVars;
   //! \brief Transfers control point variables from old basis to this patch.
   //! \param[in] old_basis The LR-spline basis to transfer from
-  //! \param[out] newVars Gauss point variables associated with this patch.
+  //! \param[out] newVar Gauss point variables associated with this patch
   //! \param[in] nGauss Number of Gauss points along a knot-span
   virtual bool transferCntrlPtVars(const LR::LRSpline* old_basis,
-                                   RealArray& newVars, int nGauss) const;
+                                   RealArray& newVar, int nGauss) const;
 
 protected:
 
@@ -524,6 +525,12 @@ protected:
   //! \param[in] elemErrors If true, map to elements instead of basis functions
   virtual void remapErrors(RealArray& errors,
                            const RealArray& origErr, bool elemErrors) const;
+
+  //! \brief Extends the refinement domain with information for neighbors.
+  //! \param refineIndices List of basis functions to refine
+  //! \param neighborIndices Basis functions to refine from neighbor patches
+  virtual void extendRefinementDomain(IntSet& refineIndices,
+                                      const IntSet& neighborIndices) const;
 
 public:
   //! \brief Returns the number of elements on a boundary.

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -32,6 +32,7 @@
 #include "SplineUtils.h"
 #include "Utilities.h"
 #include "Profiler.h"
+#include "Function.h"
 #include "Vec3Oper.h"
 #include <array>
 
@@ -502,7 +503,7 @@ size_t ASMu3D::constrainFaceLocal(int dir, bool open, int dof, int code, bool pr
 }
 
 
-std::vector<int> ASMu3D::getEdge(int lEdge, bool open, int basis, int orient) const
+IntVec ASMu3D::getEdge (int lEdge, bool open, int basis, int orient) const
 {
   // lEdge = 1-4, running index is u (vmin,wmin), (vmax,wmin), (vmin,wmax), (vmax,wmax)
   // lEdge = 5-8, running index is v (umin,wmin), (umax,wmin), (umin,wmax), (umax,wmax)
@@ -549,7 +550,7 @@ std::vector<int> ASMu3D::getEdge(int lEdge, bool open, int basis, int orient) co
     ASMunstruct::Sort(u, v, orient, thisEdge);
   }
 
-  std::vector<int> result;
+  IntVec result;
   for (LR::Basisfunction* b : thisEdge)
     result.push_back(b->getId()+ofs);
 
@@ -2043,7 +2044,7 @@ bool ASMu3D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
 }
 
 
-std::vector<int> ASMu3D::getFaceNodes (int face, int basis, int orient) const
+IntVec ASMu3D::getFaceNodes (int face, int basis, int orient) const
 {
   size_t ofs = 1;
   for (int i = 1; i < basis; i++)
@@ -2057,7 +2058,7 @@ std::vector<int> ASMu3D::getFaceNodes (int face, int basis, int orient) const
   case 4: edge = LR::NORTH; break;
   case 5: edge = LR::BOTTOM; break;
   case 6: edge = LR::TOP; break;
-  default: return std::vector<int>();
+  default: return IntVec();
   }
 
   std::vector<LR::Basisfunction*> edgeFunctions;
@@ -2069,7 +2070,7 @@ std::vector<int> ASMu3D::getFaceNodes (int face, int basis, int orient) const
     ASMunstruct::Sort(u, v, orient, edgeFunctions);
   }
 
-  std::vector<int> result(edgeFunctions.size());
+  IntVec result(edgeFunctions.size());
   std::transform(edgeFunctions.begin(), edgeFunctions.end(), result.begin(),
                  [ofs](LR::Basisfunction* a) { return a->getId()+ofs; });
 
@@ -2467,4 +2468,75 @@ bool ASMu3D::checkElementSize (int elmId, bool globalNum) const
     return lrspline->getElement(elmId)->volume() > vMin+1.0e-12;
   else
     return false;
+}
+
+
+void ASMu3D::extendRefinementDomain (IntSet& refineIndices,
+                                     const IntSet& neighborIndices) const
+{
+  const int nedge = 12;
+  const int nface =  6;
+
+  IntVec bndry0;
+  for (int K = -1; K < 2; K += 2)
+    for (int J = -1; J < 2; J += 2)
+      for (int I = -1; I < 2; I += 2)
+        bndry0.push_back(this->getCorner(I,J,K,1));
+
+  std::vector<IntVec> bndry1;
+  for (int j = 1; j <= nedge; j++)
+    bndry1.push_back(this->getEdge(j, true, 1, 0));
+
+  std::vector<IntVec> bndry2(nface);
+  for (int j = 1; j <= nface; j++)
+    this->getBoundaryNodes(j, bndry2[j-1], 1, 1, 0, true);
+
+  // Add refinement from neighbors
+  for (int j : neighborIndices)
+  {
+    bool done_with_this_node = false;
+
+    // Check if node is a corner node,
+    // compute large extended domain (all directions)
+    for (int edgeNode : bndry0)
+      if (edgeNode-1 == j)
+      {
+        IntVec secondary = this->getOverlappingNodes(j);
+        refineIndices.insert(secondary.begin(),secondary.end());
+        done_with_this_node = true;
+        break;
+      }
+
+    // Check if node is an edge node,
+    // compute moderate extended domain (2 directions)
+    int allowedDir;
+    for (int edge = 0; edge < nedge && !done_with_this_node; edge++)
+      for (int edgeNode : bndry1[edge])
+        if (edgeNode-1 == j)
+        {
+          if (edge < 4)
+            allowedDir = 6; // bin(110), allowed to grow in v- and w-direction
+          else if (edge < 8)
+            allowedDir = 5; // bin(101), allowed to grow in u- and w-direction
+          else
+            allowedDir = 3; // bin(011), allowed to grow in u- and v-direction
+          IntVec secondary = this->getOverlappingNodes(j,allowedDir);
+          refineIndices.insert(secondary.begin(),secondary.end());
+          done_with_this_node = true;
+          break;
+        }
+
+    // Check if node is a face node,
+    // compute small extended domain (1 direction)
+    for (int face = 0; face < nface && !done_with_this_node; face++)
+      for (int edgeNode : bndry2[face])
+        if (edgeNode-1 == j)
+        {
+          allowedDir = 1 << face/2;
+          IntVec secondary = this->getOverlappingNodes(j,allowedDir);
+          refineIndices.insert(secondary.begin(),secondary.end());
+          done_with_this_node = true;
+          break;
+        }
+  }
 }

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -349,27 +349,27 @@ public:
 
   //! \brief Transfers Gauss point variables from old basis to this patch.
   //! \param[in] old_basis The LR-spline basis to transfer from
-  //! \param[in] oldVars Gauss point variables associated with \a oldBasis
-  //! \param[out] newVars Gauss point variables associated with this patch.
+  //! \param[in] oldVar Gauss point variables associated with \a oldBasis
+  //! \param[out] newVar Gauss point variables associated with this patch
   //! \param[in] nGauss Number of Gauss points along a knot-span
   virtual bool transferGaussPtVars(const LR::LRSpline* old_basis,
-                                   const RealArray& oldVars, RealArray& newVars,
+                                   const RealArray& oldVar, RealArray& newVar,
                                    int nGauss) const;
   //! \brief Transfers Gauss point variables from old basis to this patch.
   //! \param[in] old_basis The LR-spline basis to transfer from
-  //! \param[in] oldVars Gauss point variables associated with \a oldBasis
-  //! \param[out] newVars Gauss point variables associated with this patch.
+  //! \param[in] oldVar Gauss point variables associated with \a oldBasis
+  //! \param[out] newVar Gauss point variables associated with this patch
   //! \param[in] nGauss Number of Gauss points along a knot-span
   virtual bool transferGaussPtVarsN(const LR::LRSpline* old_basis,
-                                    const RealArray& oldVars, RealArray& newVars,
+                                    const RealArray& oldVar, RealArray& newVar,
                                     int nGauss) const;
   using ASMunstruct::transferCntrlPtVars;
   //! \brief Transfers control point variables from old basis to this patch.
   //! \param[in] old_basis The LR-spline basis to transfer from
-  //! \param[out] newVars Gauss point variables associated with this patch.
+  //! \param[out] newVar Gauss point variables associated with this patch
   //! \param[in] nGauss Number of Gauss points along a knot-span
   virtual bool transferCntrlPtVars(const LR::LRSpline* old_basis,
-                                   RealArray& newVars, int nGauss) const;
+                                   RealArray& newVar, int nGauss) const;
 
   //! \brief Refines the parametrization based on a mesh density function.
   //! \param[in] refC Mesh refinement criteria function
@@ -533,6 +533,12 @@ protected:
   //! \param[in] elemErrors If true, map to elements instead of basis functions
   virtual void remapErrors(RealArray& errors,
                            const RealArray& origErr, bool elemErrors) const;
+
+  //! \brief Extends the refinement domain with information for neighbors.
+  //! \param refineIndices List of basis functions to refine
+  //! \param neighborIndices Basis functions to refine from neighbor patches
+  virtual void extendRefinementDomain(IntSet& refineIndices,
+                                      const IntSet& neighborIndices) const;
 
 public:
   //! \brief Returns the number of elements on a boundary.

--- a/src/SIM/SIM3D.C
+++ b/src/SIM/SIM3D.C
@@ -822,6 +822,21 @@ bool SIM3D::readNodes (std::istream& isn, int pchInd, int basis, bool oneBased)
 }
 
 
+void SIM3D::clonePatches (const PatchVec& patches,
+                          const std::map<int,int>& glb2locN)
+{
+  ASM3D* pch = nullptr;
+  for (size_t i = 0; i < patches.size(); i++)
+    if ((pch = dynamic_cast<ASM3D*>(patches[i])))
+      myModel.push_back(pch->clone(nf));
+
+  g2l = &glb2locN;
+
+  if (nGlPatches == 0)
+    nGlPatches = myModel.size();
+}
+
+
 ModelGenerator* SIM3D::getModelGenerator (const TiXmlElement* geo) const
 {
   return new DefaultGeometry3D(geo);

--- a/src/SIM/SIM3D.h
+++ b/src/SIM/SIM3D.h
@@ -51,6 +51,12 @@ public:
   //! \brief Returns the number of parameter dimensions in the model.
   virtual unsigned short int getNoParamDim() const { return 3; }
 
+  //! \brief Creates the FE model by copying the given patches.
+  //! \param[in] patches List of patches to borrow the grid from
+  //! \param[in] g2ln Global-to-local node number mapping for the borrowed grid
+  virtual void clonePatches(const PatchVec& patches,
+                            const std::map<int,int>& g2ln);
+
   //! \brief Reads a patch from given input stream.
   //! \param[in] isp The input stream to read from
   //! \param[in] pchInd 0-based index of the patch to read

--- a/src/Utility/NodeVecFunc.C
+++ b/src/Utility/NodeVecFunc.C
@@ -14,7 +14,7 @@
 #include "NodeVecFunc.h"
 #include "SIMbase.h"
 #include "ASMbase.h"
-#include "Vec3.h"
+#include "Vec3Oper.h"
 
 
 bool NodeVecFunc::isZero () const

--- a/src/Utility/NodeVecFunc.h
+++ b/src/Utility/NodeVecFunc.h
@@ -15,7 +15,6 @@
 #define _NODE_VEC_FUNC_H
 
 #include "Function.h"
-#include "Vec3Oper.h"
 #include <map>
 
 class SIMbase;


### PR DESCRIPTION
Some refactoring to make SIMinput cleaner.

There are two issues with this one that need some attention before this can be merged.

1. In ASMu2D::InterfaceChecker::Intersection (which I now changed into a std::pair, was done before the doxy arrived), I cannot see that the continuity flag (now the first member) is ever set or used. It is referred in the Stokes-app (the JumpCheckeru2D class), but where is it defined?

2. The second commit (SIM3D::clonePatches was missing) causes the 3D FSI tests to fail, due to the results are slightly off. Need to check whether it is the new or the old results that are the "correct" ones, and either update the tests for find the source of the error.