### PR TITLE
Minor extract/inject patch solution refactor

### DIFF
--- a/Apps/Common/MeshUtils.C
+++ b/Apps/Common/MeshUtils.C
@@ -27,28 +27,25 @@ static bool compute(Vector& result, const SIMbase& model,
 {
   result.resize(model.getNoElms());
 
-  for (int l = 0; l < model.getNoPatches(); l++) {
-    Vector locvec;
-    int loc = model.getLocalPatchIndex(l+1);
-    if (loc == 0)
-      continue;
+  for (int idx = 1; idx <= model.getNoPatches(); idx++) {
+    ASMbase* pch = model.getPatch(idx,true);
+    if (!pch) continue;
 
-    model.extractPatchSolution(displacement,locvec,loc-1);
-    const ASMbase* pch = model.getPatch(loc);
+    Vector locvec;
     if (!displacement.empty()) {
-      model.extractPatchSolution(displacement,locvec,loc-1);
-      const_cast<ASMbase*>(pch)->updateCoords(locvec);
+      model.extractPatchSolution(displacement,locvec,pch);
+      pch->updateCoords(locvec);
     }
 
-   int iel = 0;
-   IntMat::const_iterator elm_it = pch->begin_elm();
-   for (size_t e = 1; elm_it != pch->end_elm(); ++elm_it, ++e)
-     if ((iel = pch->getElmID(e)) > 0)
-       result(iel) = func(*pch,e);
+    int iel = 0;
+    size_t nel = pch->getNoElms(true);
+    for (size_t e = 1; e <= nel; e++)
+      if ((iel = pch->getElmID(e)) > 0)
+        result(iel) = func(*pch,e);
 
     if (!displacement.empty()) {
-      locvec *= -1;
-      const_cast<ASMbase*>(pch)->updateCoords(locvec);
+      locvec *= -1.0;
+      pch->updateCoords(locvec);
     }
   }
 

--- a/Apps/Common/Test/TestMeshUtils.C
+++ b/Apps/Common/Test/TestMeshUtils.C
@@ -10,36 +10,23 @@
 //!
 //==============================================================================
 
-#include "IntegrandBase.h"
 #include "MeshUtils.h"
 #include "SIM2D.h"
 
 #include "gtest/gtest.h"
 
 
-class TestSIM : public SIM2D
-{
-  class DummyIntegrand : public IntegrandBase {};
-
-public:
-  TestSIM() : SIM2D(new DummyIntegrand())
-  {
-    this->createDefaultModel();
-    this->preprocess();
-  }
-  virtual ~TestSIM() {}
-};
-
-
 TEST(TestMeshUtils, Aspect2D)
 {
-  TestSIM model;
+  SIM2D model;
+  ASSERT_TRUE(model.createDefaultModel());
+  ASSERT_TRUE(model.createFEMmodel());
 
   Vector aspect;
   MeshUtils::computeAspectRatios(aspect, model);
   ASSERT_FLOAT_EQ(aspect.front(), 1.0);
 
-  Vector tmp(model.getNoDOFs());
+  Vector tmp(2*model.getNoNodes());
   tmp(2) = -1.0;
   MeshUtils::computeAspectRatios(aspect, model, tmp);
   ASSERT_FLOAT_EQ(aspect.front(), 2.0);
@@ -48,13 +35,15 @@ TEST(TestMeshUtils, Aspect2D)
 
 TEST(TestMeshUtils, Skewness2D)
 {
-  TestSIM model;
+  SIM2D model;
+  ASSERT_TRUE(model.createDefaultModel());
+  ASSERT_TRUE(model.createFEMmodel());
 
   Vector skewness;
   MeshUtils::computeMeshSkewness(skewness, model);
   ASSERT_FLOAT_EQ(skewness.front(), 0.0);
 
-  Vector tmp(model.getNoDOFs());
+  Vector tmp(2*model.getNoNodes());
   tmp(1) = -1.0;
   MeshUtils::computeMeshSkewness(skewness, model, tmp);
   ASSERT_FLOAT_EQ(skewness.front(), 0.5);

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -1361,7 +1361,7 @@ bool SIMbase::solutionNorms (const TimeDomain& time,
             norm->setProjectedFields(f, k);
             projOfs += ndof;
           } else
-            this->extractPatchSolution(ssol[k],norm->getProjection(k),lp-1,nCmp,1);
+            this->extractPatchSolution(ssol[k],norm->getProjection(k),pch,nCmp,1);
 
         if (mySol)
           mySol->initPatch(pch->idx);
@@ -1396,7 +1396,7 @@ bool SIMbase::solutionNorms (const TimeDomain& time,
           norm->setProjectedFields(f, k);
           projOfs += ndof;
         } else
-          this->extractPatchSolution(ssol[k],norm->getProjection(k),i,nCmp,1);
+          this->extractPatchSolution(ssol[k],norm->getProjection(k),myModel[i],nCmp,1);
 
       if (mySol)
         mySol->initPatch(myModel[i]->idx);
@@ -1860,10 +1860,9 @@ bool SIMbase::projectAnaSol (Vector& ssol,
 
 
 size_t SIMbase::extractPatchSolution (const Vector& sol, Vector& vec,
-                                      int pindx, unsigned char nndof,
+                                      const ASMbase* pch, unsigned char nndof,
                                       unsigned char basis) const
 {
-  ASMbase* pch = pindx >= 0 ? this->getPatch(pindx+1) : nullptr;
   if (!pch || sol.empty()) return 0;
 
   if (basis != 0 && nndof != 0 &&
@@ -1881,10 +1880,9 @@ size_t SIMbase::extractPatchSolution (const Vector& sol, Vector& vec,
 
 
 bool SIMbase::injectPatchSolution (Vector& sol, const Vector& vec,
-                                   int pindx, unsigned char nndof,
+                                   const ASMbase* pch, unsigned char nndof,
                                    unsigned char basis) const
 {
-  ASMbase* pch = pindx >= 0 ? this->getPatch(pindx+1) : nullptr;
   if (!pch) return false;
 
   if (basis > 0 && nndof > 0 &&

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -566,21 +566,23 @@ public:
   //! \brief Extracts a local solution vector for a specified patch.
   //! \param[in] sol Global primary solution vector in DOF-order
   //! \param[out] vec Local solution vector associated with specified patch
-  //! \param[in] pindx Local patch index to extract solution vector for
+  //! \param[in] pch The patch to extract solution vector for
   //! \param[in] nndof Number of DOFs per node (optional)
   //! \param[in] basis Basis to extract for (optional)
   //! \return Total number of DOFs in the patch (first basis only if mixed)
-  size_t extractPatchSolution(const Vector& sol, Vector& vec, int pindx,
+  size_t extractPatchSolution(const Vector& sol, Vector& vec,
+                              const ASMbase* pch,
                               unsigned char nndof = 0,
                               unsigned char basis = 0) const;
 
   //! \brief Injects a patch-wise solution vector into the global vector.
   //! \param sol Global primary solution vector in DOF-order
   //! \param[in] vec Local solution vector associated with specified patch
-  //! \param[in] pindx Local patch index to inject solution vector for
+  //! \param[in] pch The patch to inject solution vector for
   //! \param[in] nndof Number of DOFs per node (optional)
   //! \param[in] basis Basis to inject for (optional)
-  bool injectPatchSolution(Vector& sol, const Vector& vec, int pindx,
+  bool injectPatchSolution(Vector& sol, const Vector& vec,
+                           const ASMbase* pch,
                            unsigned char nndof = 0,
                            unsigned char basis = 0) const;
 

--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -544,7 +544,7 @@ int SIMoutput::writeGlvS1 (const Vector& psol, int iStep, int& nBlock,
 
     if (msgLevel > 1)
       IFEM::cout <<"Writing primary solution for patch "
-                 << pch->idx << std::endl;
+                 << pch->idx+1 << std::endl;
 
     // Evaluate primary solution variables
 
@@ -851,25 +851,25 @@ bool SIMoutput::writeGlvP (const Vector& ssol, int iStep, int& nBlock,
 
   Vector::const_iterator ssolIt = ssol.begin();
   int geomID = myGeomID;
-  for (size_t i = 0; i < myModel.size(); i++)
+  for (ASMbase* pch : myModel)
   {
-    if (myModel[i]->empty()) continue; // skip empty patches
+    if (pch->empty()) continue; // skip empty patches
 
     if (msgLevel > 1)
-      IFEM::cout <<"Writing projected solution for patch "<< i+1 << std::endl;
+      IFEM::cout <<"Writing projected solution for patch "
+                 << pch->idx+1 << std::endl;
 
     if (this->fieldProjections())
     {
-      size_t nval = nComp*myModel[i]->getNoProjectionNodes();
-      lovec.resize(nval);
-      std::copy(ssolIt,ssolIt+nval,lovec.begin());
+      size_t nval = nComp*pch->getNoProjectionNodes();
+      lovec = RealArray(ssolIt,ssolIt+nval);
       ssolIt += nval;
     }
     else
-      this->extractPatchSolution(ssol,lovec,i,nComp,1);
+      this->extractPatchSolution(ssol,lovec,pch,nComp,1);
 
     // Evaluate the solution variables at the visualization points
-    if (!myModel[i]->evalProjSolution(field,lovec,opt.nViz,nComp))
+    if (!pch->evalProjSolution(field,lovec,opt.nViz,nComp))
       return false;
 
     size_t j = 1; // Write out to VTF-file as scalar fields

--- a/src/SIM/Test/TestSIM.C
+++ b/src/SIM/Test/TestSIM.C
@@ -131,6 +131,7 @@ TEST(TestSIM3D, ProjectSolutionMixed)
 TEST(TestSIM, InjectPatchSolution)
 {
   TestProjectSIM<SIM2D> sim({1,1});
+  ASMbase* pch = sim.getPatch(1);
 
   Vector sol(2*sim.getNoNodes(1) + sim.getNoNodes(2));
   Vector lsol(2*sim.getNoNodes(1));
@@ -139,7 +140,7 @@ TEST(TestSIM, InjectPatchSolution)
     lsol[2*i] = lsol[2*i+1] = i+1;
 
   ASSERT_TRUE(sim.addMixedMADOF(1, 2));
-  sim.injectPatchSolution(sol, lsol, 0, 2, 1);
+  sim.injectPatchSolution(sol, lsol, pch, 2, 1);
   for (i = ofs = 0; i < sim.getNoNodes(1); i++, ofs += 2) {
     EXPECT_FLOAT_EQ(sol[ofs], i+1);
     EXPECT_FLOAT_EQ(sol[ofs+1], i+1);
@@ -153,7 +154,7 @@ TEST(TestSIM, InjectPatchSolution)
   for (i = 0; i < sim.getNoNodes(2); i++)
     lsol2[2*i] = lsol2[2*i+1] = i+1;
 
-  sim.injectPatchSolution(sol2, lsol2, 0, 2, 2);
+  sim.injectPatchSolution(sol2, lsol2, pch, 2, 2);
   for (i = ofs = 0; i < sim.getNoNodes(1); i++, ofs++)
     EXPECT_FLOAT_EQ(sol2[ofs], 0);
 

--- a/src/Utility/HDF5Writer.h
+++ b/src/Utility/HDF5Writer.h
@@ -31,12 +31,12 @@ class HDF5Writer : public DataWriter
 {
 public:
   //! \brief The constructor opens a named HDF5-file.
-  //! \param[in] name The name (filename without extension) of data file
+  //! \param[in] name The name (without extension) of the data file
   //! \param[in] adm The process administrator
   //! \param[in] append Whether to append to or overwrite an existing file
   //! \param[in] keepopen Whether to always keep the HDF5 open
-  HDF5Writer(const std::string& name, const ProcessAdm& adm, bool append = false,
-             bool keepopen = false);
+  HDF5Writer(const std::string& name, const ProcessAdm& adm,
+             bool append = false, bool keepopen = false);
 
   //! \brief Empty destructor.
   virtual ~HDF5Writer() {}
@@ -46,7 +46,7 @@ public:
 
   //! \brief Opens the file at a given time level.
   //! \param[in] level The requested time level
-  virtual void openFile(int level) { openFile(level, false); }
+  virtual void openFile(int level) { this->openFile(level,false); }
 
   //! \brief Opens the file at a given time level.
   //! \param[in] level The requested time level
@@ -70,7 +70,7 @@ public:
 
   //! \brief Writes data from a SIM to file.
   //! \param[in] level The time level to write the data at
-  //! \param[in] entry The DataEntry describing the vector
+  //! \param[in] entry The DataEntry describing the data to write
   //! \param[in] geometryUpdated Whether or not geometries should be written
   //! \param[in] prefix Field name prefix
   //!
@@ -82,7 +82,7 @@ public:
 
   //! \brief Writes nodal forces to file.
   //! \param[in] level The time level to write the data at
-  //! \param[in] entry The DataEntry describing the vector
+  //! \param[in] entry The DataEntry describing the data to write
   virtual void writeNodalForces(int level, const DataEntry& entry);
 
   //! \brief Writes knot span field to file.
@@ -92,7 +92,7 @@ public:
   virtual void writeKnotspan(int level, const DataEntry& entry,
                              const std::string& prefix);
 
-  //! \brief Write a basis to file
+  //! \brief Writes a basis to file.
   //! \param[in] level The time level to write the basis at
   //! \param[in] entry The DataEntry describing the basis
   //! \param[in] prefix Prefix for basis
@@ -140,26 +140,26 @@ public:
   //! \param[in] basisName Check for a particular basis
   bool hasGeometries(int level, const std::string& basisName = "");
 
-  //! \brief Write restart data.
-  //! \param level Level to write data at
-  //! \param data Data to write
+  //! \brief Writes restart data to file.
+  //! \param[in] level Level to write data at
+  //! \param[in] data Data to write
   bool writeRestartData(int level, const DataExporter::SerializeData& data);
 
-  //! \brief Read restart data from file.
-  //! \param data The map to store data in
-  //! \param level Level to read (-1 to read last level in file)
+  //! \brief Reads restart data from file.
+  //! \param[out] data The map to store data in
+  //! \param[in] level Level to read (-1 to read last level in file)
   //! \returns Negative value on error, else restart level loaded
   int readRestartData(DataExporter::SerializeData& data, int level = -1);
 
-  //! \brief Internal helper function. Reads an array into an array of chars.
+  //! \brief Internal helper function reading into an array of chars.
   //! \param[in] group The HDF5 group to read data from
   //! \param[in] name The name of the array
-  //! \param[in] len The length of the data to read
+  //! \param[out] len The length of the data read
   //! \param[out] data The array to read data into
   void readArray(int group, const std::string& name, int& len, char*& data);
 
 protected:
-  //! \brief Internal helper function. Writes a data array to HDF5 file.
+  //! \brief Internal helper function writing a data array to file.
   //! \param[in] group The HDF5 group to write data into
   //! \param[in] name The name of the array
   //! \param[in] len The length of the array
@@ -168,30 +168,30 @@ protected:
   void writeArray(int group, const std::string& name,
                   int len, const void* data, int type);
 
-  //! \brief Internal helper function. Writes a SIM's basis (geometry) to file.
+  //! \brief Internal helper function writing a SIM's basis (geometry) to file.
   //! \param[in] SIM The SIM we want to write basis for
   //! \param[in] name The name of the basis
   //! \param[in] basis 1/2 Write primary or secondary basis from SIM
   //! \param[in] level The time level to write the basis at
   //! \param[in] redundant Whether or not basis is redundant across processes
-  void writeBasis(SIMbase* SIM, const std::string& name, int basis,
-                  int level, bool redundant=false);
+  void writeBasis(const SIMbase* SIM, const std::string& name,
+                  int basis, int level, bool redundant = false);
 
-  //! \brief Internal helper function. Reads an array into a array of doubles.
+  //! \brief Internal helper function reading into an array of doubles.
   //! \param[in] group The HDF5 group to read data from
   //! \param[in] name The name of the array
-  //! \param[in] len The length of the data to read
+  //! \param[out] len The length of the data read
   //! \param[out] data The array to read data into
   void readArray(int group, const std::string& name, int& len, double*& data);
 
-  //! \brief Internal helper function. Reads an array into a array of integers.
+  //! \brief Internal helper function reading into an array of integers.
   //! \param[in] group The HDF5 group to read data from
   //! \param[in] name The name of the array
-  //! \param[in] len The length of the data to read
+  //! \param[out] len The length of the data read
   //! \param[out] data The array to read data into
   void readArray(int group, const std::string& name, int& len, int*& data);
 
-  //! \brief Internal helper function. Checks if a group exists in the file.
+  //! \brief Internal helper function checking if a group exists in the file.
   //! \param[in] parent The HDF5 group of the parent
   //! \param[in] group The name of the group to check for
   //! \return \e true if group exists, otherwise \e false


### PR DESCRIPTION
Sending in the patch pointer instead of the index, since most uses of these methods are in a loop over patches and not in a random order. Then the search for existing patch is unnecessary.