### PR TITLE
added: support for K-refinement cycles

### DIFF
--- a/Apps/Common/SIMKCyclePC.h
+++ b/Apps/Common/SIMKCyclePC.h
@@ -1,0 +1,302 @@
+//==============================================================================
+//!
+//! \file SIMKCyclePC.h
+//!
+//! \date Nov 28 2012
+//!
+//! \author Arne Morten Kvarving / SINTEF
+//!
+//! \brief Use a simulator as a preconditioner for K-refinement cycles.
+//!
+//==============================================================================
+#ifndef SIM_K_CYCLE_PC_H_
+#define SIM_K_CYCLE_PC_H_
+
+#ifdef HAS_PETSC
+
+#include "AlgEqSystem.h"
+#include "ASMs2D.h"
+#include "ASMs3D.h"
+#include "SAM.h"
+#include <GoTools/geometry/SplineSurface.h>
+#include <GoTools/trivariate/SplineVolume.h>
+
+
+/*!
+ \brief Template for K-cycle preconditioning.
+ \details Currently only single patch models.
+*/
+
+template<class Sim>
+class SIMKCyclePC : public PETScPC
+{
+public:
+  //! \brief Default constructor.
+  //! \param fromSim The model for the solution
+  //! \param pcSim The model for the preconditioner
+  SIMKCyclePC(Sim& fromSim, Sim& pcSim) :
+    S1(pcSim), fSim(fromSim),
+    B(SparseMatrix::SUPERLU), BT(SparseMatrix::SUPERLU)
+  {
+    setup();
+  }
+
+  //! \brief Setup the restriction/prolongation operators.
+  //! \details Operators are constructed through Greville point projection.
+  void setup()
+  {
+    if (fSim.getPatch(1)->getNoSpaceDim() == 2) {
+      const ASMs2D* fpch = dynamic_cast<const ASMs2D*>(fSim.getPatch(1));
+      const ASMs2D* pch = dynamic_cast<const ASMs2D*>(S1.getPatch(1));
+      std::array<RealArray,2> gPrm;
+      fpch->getGrevilleParameters(gPrm[0], 0);
+      fpch->getGrevilleParameters(gPrm[1], 1);
+      N.resize(gPrm[0].size()*gPrm[1].size(), S1.getNoDOFs());
+      NT.resize(S1.getNoDOFs(), gPrm[0].size()*gPrm[1].size());
+      std::vector<Go::BasisDerivsSf> spline;
+      pch->getBasis(1)->computeBasisGrid(gPrm[0], gPrm[1], spline);
+      int p1 = pch->getBasis(1)->order_u();
+      int p2 = pch->getBasis(1)->order_v();
+      int n1 = pch->getBasis(1)->numCoefs_u();
+      int n2 = pch->getBasis(1)->numCoefs_v();
+      for (size_t ip = 0; ip < gPrm[0].size()*gPrm[1].size(); ++ip) {
+        IntVec idx;
+        ASMs2D::scatterInd(n1,n2,p1,p2,spline[ip].left_idx,idx);
+        for (size_t k = 0; k < spline[ip].basisValues.size(); ++k) {
+          N(ip+1, idx[k]+1) += spline[ip].basisValues[k];
+          NT(idx[k]+1, ip+1) += spline[ip].basisValues[k];
+        }
+      }
+      fpch->getBasis(1)->computeBasisGrid(gPrm[0], gPrm[1], spline);
+      p1 = fpch->getBasis(1)->order_u();
+      p2 = fpch->getBasis(1)->order_v();
+      n1 = fpch->getBasis(1)->numCoefs_u();
+      n2 = fpch->getBasis(1)->numCoefs_v();
+      B.resize(fSim.getNoDOFs(), fSim.getNoDOFs());
+      BT.resize(fSim.getNoDOFs(), fSim.getNoDOFs());
+
+      for (size_t ip = 0; ip < gPrm[0].size()*gPrm[1].size(); ++ip) {
+        IntVec idx;
+        ASMs2D::scatterInd(n1,n2,p1,p2,spline[ip].left_idx,idx);
+        for (size_t k = 0; k < spline[ip].basisValues.size(); ++k) {
+          B(ip+1, idx[k]+1) += spline[ip].basisValues[k];
+          BT(idx[k]+1, ip+1) += spline[ip].basisValues[k];
+        }
+      }
+    } else {
+      const ASMs3D* fpch = dynamic_cast<const ASMs3D*>(fSim.getPatch(1));
+      const ASMs3D* pch = dynamic_cast<const ASMs3D*>(S1.getPatch(1));
+      std::array<RealArray,3> gPrm;
+      fpch->getGrevilleParameters(gPrm[0], 0);
+      fpch->getGrevilleParameters(gPrm[1], 1);
+      fpch->getGrevilleParameters(gPrm[2], 2);
+      N.resize(gPrm[0].size()*gPrm[1].size()*gPrm[2].size(), S1.getNoDOFs());
+      NT.resize(S1.getNoDOFs(), gPrm[0].size()*gPrm[1].size()*gPrm[2].size());
+      std::vector<Go::BasisDerivs> spline;
+      pch->getBasis(1)->computeBasisGrid(gPrm[0], gPrm[1], gPrm[2], spline);
+      int p1 = pch->getBasis(1)->order(0);
+      int p2 = pch->getBasis(1)->order(1);
+      int p3 = pch->getBasis(1)->order(2);
+      int n1 = pch->getBasis(1)->numCoefs(0);
+      int n2 = pch->getBasis(1)->numCoefs(1);
+      int n3 = pch->getBasis(1)->numCoefs(2);
+      for (size_t ip = 0; ip < gPrm[0].size()*gPrm[1].size()*gPrm[2].size(); ++ip) {
+        IntVec idx;
+        ASMs3D::scatterInd(n1,n2,n3,p1,p2,p3,spline[ip].left_idx,idx);
+        for (size_t k = 0; k < spline[ip].basisValues.size(); ++k) {
+          N(ip+1, idx[k]+1) += spline[ip].basisValues[k];
+          NT(idx[k]+1, ip+1) += spline[ip].basisValues[k];
+        }
+      }
+      fpch->getBasis(1)->computeBasisGrid(gPrm[0], gPrm[1], gPrm[2], spline);
+      p1 = fpch->getBasis(1)->order(0);
+      p2 = fpch->getBasis(1)->order(1);
+      p3 = fpch->getBasis(1)->order(2);
+      n1 = fpch->getBasis(1)->numCoefs(0);
+      n2 = fpch->getBasis(1)->numCoefs(1);
+      n3 = fpch->getBasis(1)->numCoefs(2);
+      B.resize(fSim.getNoDOFs(), fSim.getNoDOFs());
+      BT.resize(fSim.getNoDOFs(), fSim.getNoDOFs());
+
+      for (size_t ip = 0; ip < gPrm[0].size()*gPrm[1].size()*gPrm[2].size(); ++ip) {
+        IntVec idx;
+        ASMs3D::scatterInd(n1,n2,n3,p1,p2,p3,spline[ip].left_idx,idx);
+        for (size_t k = 0; k < spline[ip].basisValues.size(); ++k) {
+          B(ip+1, idx[k]+1) += spline[ip].basisValues[k];
+          BT(idx[k]+1, ip+1) += spline[ip].basisValues[k];
+        }
+      }
+    }
+  }
+
+  //! \brief Evaluate preconditioner.
+  bool eval(Vec& x, Vec& y) override
+  {
+    // copy vector into a standard vector for expansion
+    int len;
+    VecGetSize(x, &len);
+    StdVector X(len);
+    std::vector<PetscInt> idx(len);
+    std::iota(idx.begin(), idx.end(), 0);
+    VecGetValues(x, len, idx.data(), X.getPtr());
+
+    // Expand solution vector x to DOF vector
+    StdVector dofSol(fSim.getNoDOFs());
+    fSim.getSAM()->expandSolution(X, dofSol);
+
+    // Evaluate restriction - N^T * (B^T)^-1 * dofSol
+    BT.solve(dofSol);
+    StdVector restrict(NT.rows());
+    NT.multiply(dofSol, restrict);
+
+    // copy to solution vector
+    StdVector* eqsVec = S1.getVector();
+    eqsVec->init();
+    vectorToSolVec(S1, *eqsVec, restrict);
+    eqsVec->beginAssembly();
+    eqsVec->endAssembly();
+
+    // Perform inner solve, store in restrict
+    double cond;
+    int oldLev = this->S1.msgLevel;
+    this->S1.msgLevel = 0;
+    if (!this->S1.solveSystem(restrict, 0, &cond, "displacement", false))
+      return false;
+    this->S1.msgLevel = oldLev;
+
+    // Evaluate prolonged solution - dofSol = B^-1 * N * restrict
+    N.multiply(restrict, dofSol);
+    B.solve(dofSol);
+
+    // Inject into solution vector y
+    const int* meqn = fSim.getSAM()->getMEQN();
+    for (size_t i = 1; i <= fSim.getPatch(1)->getNoNodes(); ++i) {
+      int eq = meqn[i-1];
+      if (eq > 0)
+        VecSetValue(y, eq-1, dofSol(i), INSERT_VALUES);
+    }
+
+    return true;
+  }
+
+  //! \brief Evaluate the right-hand-side system - the prolongiation of the coarse system solution.
+  //! \param rhs The resulting vector
+  void evalRHS(PETScVector& rhs)
+  {
+    // Solve coarse system, store in solCoarse
+    StdVector solCoarse(S1.getNoDOFs());
+    S1.solveSystem(solCoarse);
+
+    // Evaluate prolongiation - rhs = B^-1 * N * solCoarse
+    StdVector prolong(N.rows());
+    N.multiply(solCoarse, prolong);
+    B.solve(prolong);
+    vectorToSolVec(fSim, rhs, prolong);
+
+    rhs.beginAssembly();
+    rhs.endAssembly();
+  }
+
+  //! \brief Returns name of this preconditioner.
+  const char* getName() const override { return "K-cycle preconditioner"; }
+
+protected:
+  //! \brief Helper template for copying a equation vector to a DOF vector.
+  //! \param sim The simulator to use
+  //! \param V1 The resulting DOF vector
+  //! \param V2 The initial equation vecto
+  template <class V1, class V2>
+  void vectorToSolVec(Sim& sim, V1& dof, const V2& eqn)
+  {
+    const int* meqn = sim.getSAM()->getMEQN();
+    for (size_t i = 1; i <= sim.getPatch(1)->getNoNodes(); ++i) {
+      int eq = meqn[i-1];
+      if (eq > 0)
+        dof(eq) = eqn(i);
+    }
+  }
+
+  Sim& S1;   //!< Preconditioner simulator
+  Sim& fSim; //!< Solution model
+  SparseMatrix B, BT; //!< Greville mass matrix for fSim
+  SparseMatrix N; //!< Basis functions of S1 in greville of fSim
+  SparseMatrix NT; //!< Stupid no-transpose multiply
+};
+
+
+/*!
+  \brief Driver class for K-refined NURBS-based FEM analysis of linear problems.
+*/
+
+template<class T1>
+class SIMKRefWrap : public T1
+{
+public:
+  //! \brief Default constructor.
+  explicit SIMKRefWrap(const typename T1::SetupProps& props) : T1(props) {}
+
+  //! \brief Clears out patches, FE model and linear system.
+  void clearModel()
+  {
+    this->clearProperties();
+    delete this->mySam;
+    this->mySam=nullptr;
+    for (ASMbase* patch : this->myModel)
+      delete patch;
+    this->myModel.clear();
+    delete this->myEqSys;
+    this->myEqSys = nullptr;
+  }
+
+  //! \brief Set a linear solver parameter.
+  //! \param key Parameter to set
+  //! \param value Value for parameter
+  //! \param old If non-null, previous value is stored here
+  void setLinSolParam(const std::string& key, const std::string& value, std::string* old = nullptr)
+  {
+    if (!this->mySolParams)
+      this->mySolParams = new LinSolParams;
+
+    if (old)
+      *old = this->mySolParams->getStringValue(key);
+
+    this->mySolParams->addValue(key, value);
+  }
+
+  //! \brief Remove shell matrix-vector product.
+  //! \param oldSolver Solver used before it was overridden with PETSc for shell solver
+  //! \param oldRtol Old relative tolerance before it was overridden with shell solver tolerance
+  void clearMxV(int oldSolver, const std::string& oldRtol)
+  {
+    this->mySolParams->addValue("matrixfree", "0");
+    this->mySolParams->addValue("rtol", oldRtol);
+    this->getMatrix()->clearMxV();
+
+    // We have to flag that we want to solve using sparse direct solver for preconditioner.
+    // We have assembled into a PETSc matrix previously.
+    if (oldSolver != SystemMatrix::PETSC)
+      static_cast<PETScMatrix*>(this->myEqSys->getMatrix(0))->setSolveSparse(true);
+  }
+
+  //! \brief Obtain a pointer to current PETSc system matrix.
+  PETScMatrix* getMatrix()
+  {
+    return dynamic_cast<PETScMatrix*>(this->myEqSys->getMatrix(0));
+  }
+
+  //! \brief Obtain a pointer to current system vector.
+  StdVector* getVector()
+  {
+    return dynamic_cast<StdVector*>(this->myEqSys->getVector(0));
+  }
+
+  //! \brief Assemble system.
+  bool assembleStep()
+  {
+    return this->assembleSystem();
+  }
+};
+
+#endif
+
+#endif

--- a/Apps/Common/SIMMxV.h
+++ b/Apps/Common/SIMMxV.h
@@ -1,0 +1,69 @@
+//==============================================================================
+//!
+//! \file SIMMxV.h
+//!
+//! \date Nov 28 2012
+//!
+//! \author Arne Morten Kvarving / SINTEF
+//!
+//! \brief Use a simulator as a matrix-vector product for iterative solvers.
+//!
+//==============================================================================
+#ifndef SIM_MXV_H_
+#define SIM_MXV_H_
+
+#ifdef HAS_PETSC
+
+#include "PETScMatrix.h"
+
+
+/*!
+ \brief Template for applying the matrix assembled in a simulator to a vector
+        for use in iterative solvers.
+*/
+
+template<class Sim>
+class SIMMxV : public PETScMxV {
+public:
+  //! \brief Default constructor.
+  //! \param sim The simulator to wrap
+  SIMMxV(Sim& sim) : S1(sim)
+  {
+    S1.getMatrix()->setMxV(this,true);
+  }
+
+  //! \brief Evaluate the matrix-vector product y = A*y
+  bool evalMxV(Vec& x, Vec& y) override
+  {
+    MatMult(S1.getMatrix()->getBlockMatrices()[0], x, y);
+    return true;
+  }
+
+  //! \brief Set a matrix-free preconditioner.
+  void setPC(PETScPC* pc)
+  {
+    S1.getMatrix()->setPC(pc);
+  }
+
+  //! \brief Solve at time level.
+  bool solveStep()
+  {
+    TimeStep tp;
+    return S1.solveStep(tp);
+  }
+
+  //! \brief The matrix used for building the preconditioner.
+  //! \details Defaults to the system matrix
+  bool evalPC(Mat& P) override
+  {
+    MatDuplicate(S1.getMatrix()->getMatrix(), MAT_COPY_VALUES, &P);
+    return true;
+  }
+
+protected:
+  Sim& S1; //!< Reference to wrapped simulator
+};
+
+#endif
+
+#endif

--- a/Apps/Common/SIMSolverKRef.h
+++ b/Apps/Common/SIMSolverKRef.h
@@ -1,0 +1,164 @@
+// $Id$
+//==============================================================================
+//!
+//! \file SIMSolverKRef.h
+//!
+//! \date Feb 2 2016
+//!
+//! \author Arne Morten Kvarving / SINTEF
+//!
+//! \brief Stationary solver class template for K-refinement.
+//!
+//==============================================================================
+
+#ifndef _SIM_SOLVER_KREF_H_
+#define _SIM_SOLVER_KREF_H_
+
+#include "SIMSolver.h"
+#include "SIMenums.h"
+#include "SIMMxV.h"
+#include "SIMKCyclePC.h"
+#include "Utilities.h"
+
+
+/*!
+  \brief Template class for stationary K-refinement simulator drivers.
+  \details This template can be instanciated over any type implementing the
+  ISolver interface. It provides a solver loop with data output.
+*/
+
+template<class T1> class SIMSolverKRef : public SIMSolverStat<SIMKRefWrap<T1>>
+{
+public:
+  //! \brief The constructor forwards to the parent class constructor.
+  SIMSolverKRef(SIMKRefWrap<T1>& s1, SIMKRefWrap<T1>& s2) :
+    SIMSolverStat<SIMKRefWrap<T1>>(s1), S2(s2)
+  {
+  }
+
+  //! \brief Empty destructor.
+  virtual ~SIMSolverKRef() = default;
+
+  //! \brief Read k-refinement settings.
+  bool read(const char* infile) override { return this->SIMadmin::read(infile); }
+
+  //! \brief Solves the problem (all k-refinement cycles).
+  int solveProblem(char* infile,
+                   const char* heading = nullptr, bool = false) override
+  {
+    int geoBlk=0, nBlock=0;
+
+    this->printHeading(heading);
+
+    this->S1.getProcessAdm().cout <<"\nK-refinement cycle 1" << std::endl;
+
+    TimeStep tp;
+    if (!this->initSystem(infile, this->S2, false))
+      return 1;
+
+    SIMKRefWrap<T1>* s1 = &this->S1;
+    SIMKRefWrap<T1>* s2 = &this->S2;
+
+    // First assemble first preconditioner system.
+    s2->initDirichlet();
+    s2->assembleStep();
+
+    for (tp.iter = 1; tp.iter <= cycles; ++tp.iter) {
+      if (tp.iter != 1)
+        this->S1.getProcessAdm().cout <<"\nK-refinement cycle "<< tp.iter << std::endl;
+
+      // Reload main simulator
+      s1->increaseAdditionalRefinement();
+      if (!this->initSystem(infile,*s1))
+        return 3;
+
+      SIMMxV<SIMKRefWrap<T1>> mxv(*s1);
+      SIMKCyclePC<SIMKRefWrap<T1>> pc(*s1,*s2);
+      mxv.setPC(&pc);
+
+      // First RHS is solution of coarse system prolonged onto fine mesh.
+      PETScVector rhs(s1->getProcessAdm(),
+                      s1->getSAM()->getNoEquations());
+      s2->initDirichlet();
+      pc.evalRHS(rhs);
+      s1->getMatrix()->setInitialGuess(&rhs);
+      s2->updateDirichlet(0.0);
+
+      s1->initDirichlet();
+      if (!mxv.solveStep())
+        return 1;
+
+      if (!s1->saveModel(tp.iter == 1 ? infile : nullptr, geoBlk, nBlock))
+        return 2;
+      else if (!s1->saveStep(tp, nBlock))
+        return 2;
+
+      // Reset linear solver parameters
+      s1->clearMxV(oldSolver, oldRtol);
+
+      // Increase additional refinement for s2 (s1 in next step) and clear out model.
+      s2->increaseAdditionalRefinement();
+      s2->clearModel();
+      s2->setVTF(s1->getVTF());
+
+      // Main solver will be preconditioner in next cycle
+      std::swap(s1, s2);
+    }
+
+    this->S2.setVTF(nullptr);
+
+    return 0;
+  }
+
+  //! \brief Load and initialize a simulator.
+  //! \param infile Input file to use
+  //! \param sim The simulator to initialize
+  //! \param setPetsc \e true to force a petsc solver
+  int initSystem(const char* infile, SIMKRefWrap<T1>& sim, bool setPetsc=true)
+  {
+    if (!sim.read(infile))
+      return 1;
+
+    if (setPetsc)
+      sim.opt.solver = SystemMatrix::PETSC;
+    else
+      oldSolver = sim.opt.solver;
+
+    if (!sim.preprocess())
+      return 2;
+
+    sim.setQuadratureRule(sim.opt.nGauss[0],true);
+    if (setPetsc) {
+      sim.setLinSolParam("matrixfree", "1");
+      std::stringstream str;
+      str << rtol;
+      sim.setLinSolParam("rtol", str.str(), &oldRtol);
+    }
+
+    sim.setMode(SIM::STATIC);
+    return sim.initSystem(sim.opt.solver,1,1,0,true);
+  }
+
+protected:
+  //! \brief Parses a data section from an XML element.
+  bool parse(const TiXmlElement* elem) override
+  {
+    if (strcasecmp(elem->Value(),"krefinement"))
+      return this->SIMSolverStat<SIMKRefWrap<T1>>::parse(elem);
+
+    if (utl::getAttribute(elem,"cycles",cycles))
+      IFEM::cout << "\tDoing " << cycles << " k-refinement cycles." << std::endl;
+    if (utl::getAttribute(elem,"rtol",rtol))
+      IFEM::cout << "\tK-solver tolerance " << rtol << std::endl;
+
+    return true;
+  }
+
+  int cycles = 1;      //!< Number of k-refinement cycles
+  double rtol = 1e-6;  //!< Relative tolerance in outer petsc solver
+  int oldSolver = -1;  //!< Old matrix type before we overwrote with PETSc for k-refinement
+  std::string oldRtol; //!< Old relative tolerance before we overwrite with k-refinement tolerance
+  SIMKRefWrap<T1>& S2; //!< Reference to second simulator
+};
+
+#endif

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -482,6 +482,12 @@ public:
   virtual bool evalSolution(Matrix& sField, const IntegrandBase& integrand,
 			    const RealArray* gpar, bool regular = true) const;
 
+  //! \brief Calculates parameter values for the Greville points.
+  //! \param[out] prm Parameter values in given direction for all points
+  //! \param[in] dir Parameter direction (0,1)
+  //! \param[in] basis Basis number (mixed)
+  bool getGrevilleParameters(RealArray& prm, int dir, int basis=1) const;
+
 protected:
 
   // Internal utility methods
@@ -518,12 +524,6 @@ protected:
   //! \return The parameter value matrix casted into a one-dimensional vector
   const Vector& getGaussPointParameters(Matrix& uGP, int dir, int nGauss,
 					const double* xi) const;
-
-  //! \brief Calculates parameter values for the Greville points.
-  //! \param[out] prm Parameter values in given direction for all points
-  //! \param[in] dir Parameter direction (0,1)
-  //! \param[in] basis Basis number (mixed)
-  bool getGrevilleParameters(RealArray& prm, int dir, int basis=1) const;
 
   //! \brief Calculates parameter values for the Quasi-Interpolation points.
   //! \param[out] prm Parameter values in given direction for all points

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -544,6 +544,12 @@ public:
   virtual bool evalSolution(Matrix& sField, const IntegrandBase& integrand,
 			    const RealArray* gpar, bool regular = true) const;
 
+  //! \brief Calculates parameter values for the Greville points.
+  //! \param[out] prm Parameter values in given direction for all points
+  //! \param[in] dir Parameter direction (0,1,2)
+  //! \param[in] basis Basis number (mixed)
+  bool getGrevilleParameters(RealArray& prm, int dir, int basis=1) const;
+
 protected:
 
   // Internal utility methods
@@ -580,12 +586,6 @@ protected:
   //! \return The parameter value matrix casted into a one-dimensional vector
   const Vector& getGaussPointParameters(Matrix& uGP, int dir, int nGauss,
 					const double* xi) const;
-
-  //! \brief Calculates parameter values for the Greville points.
-  //! \param[out] prm Parameter values in given direction for all points
-  //! \param[in] dir Parameter direction (0,1,2)
-  //! \param[in] basis Basis number (mixed)
-  bool getGrevilleParameters(RealArray& prm, int dir, int basis=1) const;
 
   //! \brief Calculates parameter values for the Quasi-Interpolation points.
   //! \param[out] prm Parameter values in given direction for all points

--- a/src/ASM/SAMpatchPETSc.C
+++ b/src/ASM/SAMpatchPETSc.C
@@ -178,7 +178,7 @@ bool SAMpatchPETSc::expandSolution(const SystemVector& solVec,
 {
   PETScVector* Bptr = const_cast<PETScVector*>(dynamic_cast<const PETScVector*>(&solVec));
   if (!Bptr)
-    return false;
+    return this->SAMpatch::expandSolution(solVec, dofVec, scaleSD);
 
 #ifdef HAVE_MPI
   if (adm.isParallel()) {

--- a/src/LinAlg/LinSolParams.C
+++ b/src/LinAlg/LinSolParams.C
@@ -182,6 +182,8 @@ bool LinSolParams::read (const TiXmlElement* elem)
       addValue("dtol", value);
     else if ((value = utl::getValue(child,"maxits")))
       addValue("maxits", value);
+    else if (!strcasecmp(child->Value(),"matrixfree"))
+      addValue("matrixfree", "1");
   }
 
   if (parseblock == 0)

--- a/src/LinAlg/PETScSolParams.C
+++ b/src/LinAlg/PETScSolParams.C
@@ -384,6 +384,7 @@ void PETScSolParams::setupAdditiveSchwarz(PC& pc, size_t block,
   }
 }
 
+
 void PETScSolParams::setupSchurComplement(const std::vector<Mat>& matvec)
 {
   PetscInt m1, n1;
@@ -396,6 +397,7 @@ void PETScSolParams::setupSchurComplement(const std::vector<Mat>& matvec)
 
   // TODO: non-SIMPLE schur preconditioners
   MatGetDiagonal(matvec[0],diagA00);
+  // TODO: Lumping
   VecReciprocal(diagA00);
   SPsetup = true;
 
@@ -409,4 +411,26 @@ void PETScSolParams::setupSchurComplement(const std::vector<Mat>& matvec)
   MatAXPY(Sp,-1.0,tmp2,DIFFERENT_NONZERO_PATTERN);
   MatDestroy(&tmp);
   MatDestroy(&tmp2);
+}
+
+
+extern "C" {
+
+PetscErrorCode PETScSIMMxV(Mat A, Vec x, Vec y)
+{
+  void* p;
+  MatShellGetContext(A, &p);
+  PETScMxV* sim = static_cast<PETScMxV*>(p);
+  return sim->evalMxV(x,y) ? 0 : 1;
+}
+
+
+PetscErrorCode PETScSIMPC(PC pc, Vec x, Vec y)
+{
+  void* p;
+  PCShellGetContext(pc, &p);
+  PETScPC* sim = static_cast<PETScPC*>(p);
+  return sim->eval(x,y) ? 0 : 1;
+}
+
 }

--- a/src/LinAlg/PETScSolParams.h
+++ b/src/LinAlg/PETScSolParams.h
@@ -40,6 +40,41 @@ typedef std::vector<ISVec>       ISMat;        //!< Index set matrix
 enum SchurPrec { SIMPLE, MSIMPLER, PCD };
 
 
+/*! \brief Interface to use a simulator as a matrix-vector product.
+*/
+
+class PETScMxV {
+public:
+  //! \brief Obtain the matrix to use as preconditioner.
+  virtual bool evalPC(Mat& P) = 0;
+
+  //! \brief Evaluate the matrix-vector product y=A*x.
+  virtual bool evalMxV(Vec& x, Vec& y) = 0;
+};
+
+
+/*! \brief Interface to use a simulator as a preconditioner.
+*/
+
+class PETScPC {
+public:
+  //! \brief Evaluate y = P^-1*x
+  virtual bool eval(Vec& x, Vec& y) = 0;
+
+  //! \brief Get the name of the preconditioner.
+  virtual const char* getName() const { return "SimPC"; }
+};
+
+
+extern "C" {
+  //! \brief Evaluate the matrix-vector product y=A*x
+  PetscErrorCode PETScSIMMxV(Mat A, Vec x, Vec y);
+
+  //! \brief Evaluate the preconditioner y=P^-1*x
+  PetscErrorCode PETScSIMPC(PC pc, Vec x, Vec y);
+}
+
+
 /*!
   \brief Class for PETSc solver parameters.
   \details It contains information about solver method, preconditioner

--- a/src/SIM/SIM2D.C
+++ b/src/SIM/SIM2D.C
@@ -168,6 +168,7 @@ bool SIM2D::parseGeometryTag (const TiXmlElement* elem)
     int addu = 0, addv = 0;
     utl::getAttribute(elem,"u",addu);
     utl::getAttribute(elem,"v",addv);
+    addu += addRef, addv += addRef;
     for (int j : patches) {
       ASM2D* pch;
       if ((pch = dynamic_cast<ASM2D*>(this->getPatch(j,true))))

--- a/src/SIM/SIM3D.C
+++ b/src/SIM/SIM3D.C
@@ -148,6 +148,7 @@ bool SIM3D::parseGeometryTag (const TiXmlElement* elem)
     utl::getAttribute(elem,"u",addu);
     utl::getAttribute(elem,"v",addv);
     utl::getAttribute(elem,"w",addw);
+    addu += addRef, addv += addRef, addw += addRef;
     for (int j : patches) {
       ASM3D* pch;
       if ((pch = dynamic_cast<ASM3D*>(this->getPatch(j,true))))

--- a/src/SIM/SIMinput.h
+++ b/src/SIM/SIMinput.h
@@ -99,6 +99,9 @@ public:
   bool setTracProperty(int code, Property::Type ptype,
                        TractionFunc* field = nullptr);
 
+  //! \brief Increase additional refinement.
+  void increaseAdditionalRefinement() { ++addRef; }
+
 private:
   //! \brief Parses a subelement of the \a geometry XML-tag.
   bool parseGeometryTag(const TiXmlElement* elem);
@@ -242,6 +245,8 @@ private:
                            const InitialCondVec& info);
 
 protected:
+  int addRef = 0; //!< Additional refinement to perform
+
   ModelGenerator* myGen; //!< Model generator
 
   TopologySet myEntitys; //!< Set of named topological entities


### PR DESCRIPTION
This requires extending PETSc support to allow simulators as matrix-vector products and preconditioners.