### PR TITLE
Added: Separate array dof_type to assign type flags on the DOF-level.

### DIFF
--- a/src/ASM/IntegrandBase.h
+++ b/src/ASM/IntegrandBase.h
@@ -273,6 +273,9 @@ public:
   //! \param[in] vec Vector to inject field into
   void registerVector(const std::string& name, Vector* vec);
 
+  //! \brief Returns nodal DOF flags for monolithic coupled integrands.
+  virtual void getNodalDofTypes(std::vector<char>&) const {}
+
 private:
   std::map<std::string,Vector*> myFields; //!< Named fields of this integrand
 

--- a/src/ASM/SAMpatch.h
+++ b/src/ASM/SAMpatch.h
@@ -37,7 +37,9 @@ public:
   //! \brief Allocates the dynamic arrays and populates them with data.
   //! \param[in] model All spline patches in the model
   //! \param[in] numNod Total number of unique nodes in the model
-  virtual bool init(const std::vector<ASMbase*>& model, int numNod = 0);
+  //! \param[in] dTypes Nodal DOF type flags
+  virtual bool init(const std::vector<ASMbase*>& model, int numNod,
+                    const std::vector<char>& dTypes);
 
   //! \brief Updates the multi-point constraint array \a TTCC.
   //! \param[in] model All spline patches in the model
@@ -54,7 +56,8 @@ public:
 
 protected:
   //! \brief Initializes the nodal arrays \a MINEX, \a MADOF and \a MSC.
-  bool initNodeDofs(const std::vector<ASMbase*>& model);
+  bool initNodeDofs(const std::vector<ASMbase*>& model,
+                    const std::vector<char>& dTypes);
   //! \brief Initializes the element topology arrays \a MPMNPC and \a MMNPC.
   bool initElementConn(const std::vector<ASMbase*>& model);
   //! \brief Initializes the multi-point constraint arrays.

--- a/src/LinAlg/SAM.h
+++ b/src/LinAlg/SAM.h
@@ -54,10 +54,10 @@ public:
   int getNoDOFs() const { return ndof; }
   //! \brief Returns the number of equations (free DOFs) in the model.
   virtual int getNoEquations() const { return neq; }
-  //! \brief Returns the equations numbers for a given dofType.
-  //! \param nodeType Type of node
-  //! \param dof DOFs in nodes (0 = all)
-  IntSet getEquations(char nodeType, int dof=0) const;
+  //! \brief Returns the equations numbers for a given DOF type.
+  //! \param[in] dType The DOF type to consider
+  //! \param[in] dof The local DOF in each node to consider (0 = all)
+  IntSet getEquations(char dType, int dof = 0) const;
   //! \brief Returns the Matrix of Accumulated DOFs.
   const int* getMADOF() const { return madof; }
   //! \brief Returns the Matrix of EQuation Numbers.
@@ -247,21 +247,21 @@ public:
   //! \brief Computes the dot-product of two vectors of length NDOF.
   //! \param[in] x The first vector of the dot-product
   //! \param[in] y The second vector of the dot-product
-  //! \param[in] dofType Only consider nodes of this type (for mixed methods)
+  //! \param[in] dofType Only consider DOFs of this type
   virtual Real dot(const Vector& x, const Vector& y, char dofType = 'D') const;
   //! \brief Computes the l2-norm of a vector of length NDOF.
   //! \param[in] x The vector to compute the norm of
-  //! \param[in] dofType Only consider nodes of this type (for mixed methods)
+  //! \param[in] dofType Only consider DOFs of this type
   Real norm2(const Vector& x, char dofType = 'D') const
   { return sqrt(this->dot(x,x,dofType)); }
   //! \brief Computes the L2-norm of a vector of length NDOF.
   //! \param[in] x The vector to compute the norm of
-  //! \param[in] dofType Only consider nodes of this type (for mixed methods)
+  //! \param[in] dofType Only consider DOFs of this type
   virtual Real normL2(const Vector& x, char dofType = 'D') const;
   //! \brief Computes the L_infinity-norm of a vector of length NDOF.
   //! \param[in] x The vector to compute the norm of
   //! \param comp Local nodal DOF on input, index of the largest value on output
-  //! \param[in] dofType Only consider nodes of this type (for mixed methods)
+  //! \param[in] dofType Only consider DOFs of this type
   virtual Real normInf(const Vector& x, size_t& comp, char dofType = 'D') const;
 
   //! \brief Computes the energy norm contributions from nodal reaction forces.
@@ -335,6 +335,7 @@ protected:
   int*  meqn;   //!< Matrix of equation numbers
 
   std::vector<char> nodeType; //!< Nodal DOF classification
+  std::vector<char> dof_type; //!< Individual DOF classification
 
   friend class DenseMatrix;
   friend class SPRMatrix;

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -302,8 +302,8 @@ public:
   //! \param[out] eNorm Energy norm of solution increment
   //! \param[out] rNorm Residual norm of solution increment
   //! \param[out] dNorm Displacement norm of solution increment
-  void iterationNorms(const Vector& x, const Vector& r,
-                      double& eNorm, double& rNorm, double& dNorm) const;
+  virtual void iterationNorms(const Vector& x, const Vector& r, double& eNorm,
+                              double& rNorm, double& dNorm) const;
 
   //! \brief Evaluates some norms of the primary solution vector
   //! \param[in] x Global primary solution vector


### PR DESCRIPTION
To be used in norm calculations, etc. for monolithic coupled solvers.

As discussed before lunch today. Here is my suggestion on how to solve the norm calculation issue in case of non-mixed coupled simulators, through the introduction of the `dof_type` array in SAM (similar as `nodeType`, but size `ndof` instead of `nnod`). Not totally finished. Think there are some issues regarding the `SAM::normInf` method.