### PR TITLE
Interface integration in SIMbase::assembleSystem

### DIFF
--- a/src/ASM/Interface.h
+++ b/src/ASM/Interface.h
@@ -34,20 +34,34 @@ namespace ASM
 
 
   /*!
-    \brief Base class for checking for internal boundary integrand contributions.
+    \brief Base class to check for internal boundary integrand contributions.
   */
 
   class InterfaceChecker
   {
   public:
-    virtual ~InterfaceChecker () = default;
-    //! \brief Returns non-zero if the specified element have contributions.
+    //! \brief Default destructor.
+    virtual ~InterfaceChecker() = default;
+    //! \brief Returns non-zero if the specified element has contributions.
     //! \param[in] iel Element number
     //! \param[in] I Index in first parameter direction of the element
     //! \param[in] J Index in second parameter direction of the element
     //! \param[in] K Index in third parameter direction of the element
-    virtual short int hasContribution(int iel, int I,
-                                      int J, int K = -1) const = 0;
+    virtual short int hasContribution(int iel,
+                                      int I, int J, int K = -1) const = 0;
+    //! \brief Returns a status mask based on the element boundary parameters.
+    //! \param[in] u0 Parameter value of the west element boundary
+    //! \param[in] u1 Parameter value of the east element boundary
+    //! \param[in] v0 Parameter value of the south element boundary
+    //! \param[in] v1 Parameter value of the north element boundary
+    //! \param[in] w0 Parameter value of the back element boundary
+    //! \param[in] w1 Parameter value of the front element boundary
+    virtual short int elmBorderMask(double u0, double u1,
+                                    double v0, double v1,
+                                    double w0 = 0.0, double w1 = 1.0) const
+    {
+      return 63; // = 1+2+4+8+16+32 (i.e., don't mask off any boundary)
+    }
   };
 }
 

--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -1721,6 +1721,10 @@ bool ASMu2D::integrate (Integrand& integrand,
     short int status = iChk.hasContribution(++iel);
     if (!status) continue; // no interface contributions for this element
 
+    status &= iChk.elmBorderMask(elm->umin(),elm->umax(),
+                                 elm->vmin(),elm->vmax());
+    if (!status) continue; // no interface contributions for this element
+
 #if SP_DEBUG > 3
     std::cout <<"\n\nIntegrating interface terms for element "<< fe.iel
               << std::endl;

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -26,10 +26,10 @@ class FiniteElement;
 namespace Go {
   class SplineCurve;
   class SplineSurface;
-  class BasisPtsSf;
-  class BasisDerivsSf;
-  class BasisDerivsSf2;
-  class BasisDerivsSf3;
+  struct BasisPtsSf;
+  struct BasisDerivsSf;
+  struct BasisDerivsSf2;
+  struct BasisDerivsSf3;
 }
 
 namespace LR {
@@ -58,17 +58,19 @@ public:
     virtual short int hasContribution(int iel, int = -1,
                                       int = -1, int = -1) const;
     //! \brief Get intersections for a given element edge.
-    //! \param iel Element index (1-based)
-    //! \param edge Edge to get intersections for (1..4)
-    //! \param cont If not null, the intersection continuity is given here
-    RealArray getIntersections(int iel, int edge, int* cont=nullptr) const;
+    //! \param[in] iel Element index (1-based)
+    //! \param[in] edge Edge to get intersections for (1..4)
+    //! \param[out] cont If not null, the intersection continuity is given here
+    const RealArray& getIntersections(int iel, int edge,
+                                      int* cont = nullptr) const;
+
   protected:
     const ASMu2D& myPatch; //!< Reference to the patch being integrated
 
     //! \brief Struct describing an intersection of mesh lines.
     struct Intersection {
       int continuity = 0; //!< Continuity across intersection
-      std::vector<double> pts; //!< Intersection points
+      RealArray pts;      //!< Intersection points
     };
 
     //! Intersections for elements. Key: element << 4 + edge (1..4).
@@ -285,6 +287,15 @@ public:
   //! \param[in] time Parameters for nonlinear/time-dependent simulations
   virtual bool integrate(Integrand& integrand, int lIndex,
                          GlobalIntegral& glbInt, const TimeDomain& time);
+
+  //! \brief Evaluates an integral over element interfaces in the patch.
+  //! \param integrand Object with problem-specific data and methods
+  //! \param glbInt The integrated quantity
+  //! \param[in] time Parameters for nonlinear/time-dependent simulations
+  //! \param[in] iChk Object checking if an element interface has contributions
+  virtual bool integrate(Integrand& integrand, GlobalIntegral& glbInt,
+                         const TimeDomain& time,
+                         const ASM::InterfaceChecker& iChk);
 
   //! \brief Integrates a spatial dirac-delta function over a patch.
   //! \param integrand Object with problem-specific data and methods


### PR DESCRIPTION
This adds the interface integration functionality also in assembleSystem (currently it is invoked for solutionNorms only). The motivation is to use this for right-hand-side calculation due to line loads along interior mesh edges for plate and shell problems.

Does not work yet, and time is running up before NSCM-31 next week. Just creating this PR for picking up at a later point. Remaining issues:

* Currently, many of the LinEl tests fails with nodes out of range during norm integration. Think it is due to the lambda functions, but not sure why.
* Check the interface-integration methods for ASMs2D, ASMu2Dmx and now ASMu2D. They look too different.
* Add an ASM::InterfaceChecker sub-class in SIMLinElKL to actually represent the line load.