### PR TITLE
fixed: due to RAII usage in libcereal archive must go out of scope

### DIFF
--- a/Apps/Common/scripts/regtest.sh.in
+++ b/Apps/Common/scripts/regtest.sh.in
@@ -25,7 +25,12 @@ else
 fi
 hdf5=""
 tmplog=`mktemp -t ifemlogXXXXXX`
-test -n "$4" && hdf5="-hdf5 @CMAKE_BINARY_DIR@/Testing/$3"
+if test -n "$4"
+then
+  hdf5="-hdf5 @CMAKE_BINARY_DIR@/Testing/$3"
+  rm -f @CMAKE_BINARY_DIR@/Testing/$3.hdf5
+  rm -f @CMAKE_BINARY_DIR@/Testing/$3_restart.hdf5
+fi
 $mysim $hdf5 $MAPFILE 2>&1 > $tmplog
 if test -n "$4"
 then

--- a/src/SIM/SIMsolution.C
+++ b/src/SIM/SIMsolution.C
@@ -46,9 +46,11 @@ bool SIMsolution::saveSolution (SerializeMap& data,
 {
 #ifdef HAS_CEREAL
   std::ostringstream str;
-  cereal::BinaryOutputArchive archive(str);
-  for (const Vector& sol : this->getSolutions())
-    archive(sol);
+  {
+    cereal::BinaryOutputArchive archive(str);
+    for (const Vector& sol : this->getSolutions())
+      archive(sol);
+  }
   data.insert(std::make_pair(name,str.str()));
   return true;
 #else

--- a/src/SIM/TimeStep.C
+++ b/src/SIM/TimeStep.C
@@ -338,8 +338,10 @@ bool TimeStep::serialize (std::map<std::string,std::string>& data) const
 {
 #ifdef HAS_CEREAL
   std::ostringstream str;
-  cereal::BinaryOutputArchive ar(str);
-  doSerializeOps(ar,*const_cast<TimeStep*>(this));
+  {
+    cereal::BinaryOutputArchive ar(str);
+    doSerializeOps(ar,*const_cast<TimeStep*>(this));
+  }
   data.insert(std::make_pair("TimeStep",str.str()));
   return true;
 #else

--- a/src/Utility/HDF5Writer.C
+++ b/src/Utility/HDF5Writer.C
@@ -110,9 +110,14 @@ void HDF5Writer::openFile(int level, bool restart)
 #endif
   unsigned int flag = restart ? m_restart_flag : m_flag;
   std::string fname = restart ? m_restart_name : m_name;
+  if (flag == H5F_ACC_RDWR) {
+    struct stat buffer;
+    if (stat(fname.c_str(),&buffer) != 0)
+      flag = H5F_ACC_TRUNC;
+  }
 
   if (flag == H5F_ACC_TRUNC)
-    file = H5Fcreate(fname.c_str(),m_flag,H5P_DEFAULT,acc_tpl);
+    file = H5Fcreate(fname.c_str(),flag,H5P_DEFAULT,acc_tpl);
   else {
     // check free disk space - to protect against corrupting files
     // due to out of space condition


### PR DESCRIPTION
if not, the stream is not finished when we read out the data