### PR TITLE
Changed: Check app return code in regtest.sh

### DIFF
--- a/Apps/Common/scripts/regtest.sh.in
+++ b/Apps/Common/scripts/regtest.sh.in
@@ -27,6 +27,13 @@ hdf5=""
 tmplog=`mktemp -t ifemlogXXXXXX`
 test -n "$4" && hdf5="-hdf5 @CMAKE_BINARY_DIR@/Testing/$3"
 $mysim $hdf5 $MAPFILE 2>&1 > $tmplog
+retcode=$?
+if test $retcode -ne 0
+then
+  echo Application returned error code: $retcode >> @CMAKE_BINARY_DIR@/failed.log
+  echo Application returned error code: $retcode >> /dev/stderr
+  exit 1
+fi
 if test -n "$4"
 then
   $mysim $MAPFILE -restart @CMAKE_BINARY_DIR@/Testing/$3_restart.hdf5 $4 2>&1 > $tmplog


### PR DESCRIPTION
There seems to be at least three regtests in apps (OpenFrac specifically) that produce the correct output but crash after that point.