### PR TITLE
 Fixed: Pass global (not local) element number to the SAM assembly methods

### DIFF
--- a/src/ASM/ASMstruct.C
+++ b/src/ASM/ASMstruct.C
@@ -122,9 +122,8 @@ bool ASMstruct::checkThreadGroups (const std::vector<std::set<int>>& nodes,
 bool ASMstruct::diracPoint (Integrand& integr, GlobalIntegral& glInt,
                             const double* u, const Vec3& pval)
 {
-  FiniteElement fe;
-  fe.iel = this->findElementContaining(u);
-  if (fe.iel < 1 || fe.iel > (int)nel)
+  int iel = this->findElementContaining(u);
+  if (iel < 1 || iel > (int)nel)
   {
     std::cerr <<" *** ASMstruct::diracPoint: The point";
     for (unsigned char i = 0; i < ndim; i++) std::cerr <<" "<< u[i];
@@ -134,14 +133,14 @@ bool ASMstruct::diracPoint (Integrand& integr, GlobalIntegral& glInt,
 
 #ifdef INDEX_CHECK
   double uElm[6];
-  this->getElementBorders(fe.iel,uElm);
+  this->getElementBorders(iel,uElm);
   for (unsigned char i = 0; i < ndim; i++)
     if (u[i] < uElm[2*i] || u[i] > uElm[2*i+1])
     {
       unsigned char d;
       std::cerr <<" *** ASMstruct::diracPoint: The point";
       for (d = 0; d < ndim; d++) std::cerr <<" "<< u[d];
-      std::cerr <<" is not within the domain of the found element "<< fe.iel
+      std::cerr <<" is not within the domain of the found element "<< iel
                 <<" which is";
       for (d = 0; d < ndim; d++)
         std::cerr <<(d ? "x[":" [") << uElm[2*d] <<","<< uElm[2*d+1] <<"]";
@@ -154,7 +153,7 @@ bool ASMstruct::diracPoint (Integrand& integr, GlobalIntegral& glInt,
       unsigned char d;
       std::cerr <<"   * The point";
       for (d = 0; d < ndim; d++) std::cerr <<" "<< u[d];
-      std::cerr <<" is within the domain of element "<< fe.iel <<" which is";
+      std::cerr <<" is within the domain of element "<< iel <<" which is";
       for (d = 0; d < ndim; d++)
         std::cerr << (d ? "x[":" [") << uElm[2*d] <<","<< uElm[2*d+1] <<"]";
       std::cerr << std::endl;
@@ -162,12 +161,14 @@ bool ASMstruct::diracPoint (Integrand& integr, GlobalIntegral& glInt,
 #endif
 #endif
 
+  FiniteElement fe;
+  fe.iel = MLGE[iel-1];
   if (ndim > 0) fe.u = u[0];
   if (ndim > 1) fe.v = u[1];
   if (ndim > 2) fe.w = u[2];
   this->evaluateBasis(fe.u,fe.v,fe.w,fe.N);
 
-  LocalIntegral* A = integr.getLocalIntegral(MNPC[fe.iel-1].size(),fe.iel,true);
+  LocalIntegral* A = integr.getLocalIntegral(MNPC[iel-1].size(),fe.iel,true);
   bool ok = integr.evalPoint(*A,fe,pval) && glInt.assemble(A,fe.iel);
   A->destruct();
 

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -274,10 +274,10 @@ public:
   //! \brief Integrates a spatial dirac-delta function over a patch.
   //! \param integrand Object with problem-specific data and methods
   //! \param glbInt The integrated quantity
-  //! \param[in] u Parameters of the non-zero point of the dirac-delta function
+  //! \param[in] param Parameters of the non-zero point of dirac-delta function
   //! \param[in] pval Function value at the specified point
   virtual bool diracPoint(Integrand& integrand, GlobalIntegral& glbInt,
-                          const double* u, const Vec3& pval);
+                          const double* param, const Vec3& pval);
 
   //! \brief Updates the time-dependent in-homogeneous Dirichlet coefficients.
   //! \param[in] func Scalar property fields
@@ -525,9 +525,11 @@ protected:
   //! \return Characteristic element size
   double getElementCorners(int iel, std::vector<Vec3>& XC) const;
 
-  //! \brief Evaluates the basis functions and derivatives of order \a derivs
-  //! of an element.
-  bool evaluateBasis(FiniteElement& el, int derivs = 0) const;
+  //! \brief Evaluates the basis functions and derivatives of an element.
+  //! \param[in] iel 0-based element index
+  //! \param fe Integration point data for current element
+  //! \param[in] derivs Derivative order of the basis functions
+  bool evaluateBasis(int iel, FiniteElement& fe, int derivs = 0) const;
 
   using ASMunstruct::generateThreadGroups;
   //! \brief Generates element groups for multi-threading of interior integrals.

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -277,10 +277,10 @@ public:
   //! \brief Integrates a spatial dirac-delta function over a patch.
   //! \param integrand Object with problem-specific data and methods
   //! \param glbInt The integrated quantity
-  //! \param[in] u Parameters of the non-zero point of the dirac-delta function
+  //! \param[in] param Parameters of the non-zero point of dirac-delta function
   //! \param[in] pval Function value at the specified point
   virtual bool diracPoint(Integrand& integrand, GlobalIntegral& glbInt,
-                          const double* u, const Vec3& pval);
+                          const double* param, const Vec3& pval);
 
   //! \brief Updates the time-dependent in-homogeneous Dirichlet coefficients.
   //! \param[in] func Scalar property fields
@@ -522,21 +522,24 @@ protected:
   double getElementCorners(int iel, std::vector<Vec3>& XC) const;
 
   //! \brief Evaluate all basis functions and first derivatives on one element
-  void evaluateBasis(int iel, double u, double v, double w,
-                     Vector& N, Matrix& dNdu, int basis) const;
+  void evaluateBasis(int iel, int basis, double u, double v, double w,
+                     Vector& N, Matrix& dNdu) const;
 
   //! \brief Evaluate all basis functions and \a derivs number of derivatives on one element
-  void evaluateBasis(FiniteElement &el, int derivs, int basis = 1) const;
+  void evaluateBasis(int iel, FiniteElement& fe,
+                     int derivs = 0, int basis = 1) const;
 
   //! \brief Evaluate all basis functions and first derivatives on one element
-  void evaluateBasis(FiniteElement &el, Matrix &dNdu,
-                     const Matrix &C, const Matrix &B, int basis = 1) const;
+  void evaluateBasis(FiniteElement& fe, Matrix& dNdu,
+                     const Matrix& C, const Matrix& B, int basis = 1) const;
 
   //! \brief Evaluate all basis functions and first derivatives on one element
-  void evaluateBasis(FiniteElement &el, Matrix &dNdu, int basis = 1) const;
+  void evaluateBasis(int iel, FiniteElement& fe, Matrix& dNdu,
+                     int basis = 1) const;
 
   //! \brief Evaluate all basis functions and second order derivatives on one element
-  void evaluateBasis(FiniteElement &el, Matrix &dNdu, Matrix3D& d2Ndu2, int basis = 1) const;
+  void evaluateBasis(int iel, FiniteElement& fe, Matrix& dNdu, Matrix3D& d2Ndu2,
+                     int basis = 1) const;
 
   using ASMunstruct::generateThreadGroups;
   //! \brief Generates element groups for multi-threading of interior integrals.

--- a/src/ASM/LR/ASMu3Dmx.C
+++ b/src/ASM/LR/ASMu3Dmx.C
@@ -376,7 +376,7 @@ bool ASMu3Dmx::integrate (Integrand& integrand,
     }
     int iEl = el->getId();
     MxFiniteElement fe(elem_sizes);
-    fe.iel = iEl+1;
+    fe.iel = MLGE[iEl];
 
     std::vector<Matrix> dNxdu(m_basis.size());
     Matrix   Xnod, Jac;
@@ -435,7 +435,7 @@ bool ASMu3Dmx::integrate (Integrand& integrand,
           {
             // Fetch basis function derivatives at current integration point
             for (size_t b = 1; b <= m_basis.size(); ++b)
-              evaluateBasis(fe, dNxdu[b-1], b);
+              this->evaluateBasis(iEl, fe, dNxdu[b-1], b);
 
             // Compute Jacobian determinant of coordinate mapping
             // and multiply by weight of current integration point
@@ -507,13 +507,11 @@ bool ASMu3Dmx::integrate (Integrand& integrand,
             B.fillColumn(4, BdNdw[b].getColumn(ig)*2.0/dw);
 
             // Fetch basis function derivatives at current integration point
-            fe.iel = els[b]; // evaluateBasis use elem number from fe
             if (integrand.getIntegrandType() & Integrand::SECOND_DERIVATIVES)
-              evaluateBasis(fe, dNxdu[b], d2Nxdu2[b], b+1);
+              this->evaluateBasis(els[b]-1, fe, dNxdu[b], d2Nxdu2[b], b+1);
             else
-              evaluateBasis(fe, dNxdu[b], bezierExtractmx[b][els[b]-1], B, b+1) ;
+              this->evaluateBasis(fe, dNxdu[b], bezierExtractmx[b][els[b]-1], B, b+1);
           }
-          fe.iel = iEl+1;
 
           // Compute Jacobian inverse of coordinate mapping and derivatives
           fe.detJxW = utl::Jacobian(Jac,fe.grad(geoBasis),Xnod,dNxdu[geoBasis-1]);
@@ -616,7 +614,7 @@ bool ASMu3Dmx::integrate (Integrand& integrand, int lIndex,
     }
     int iEl = el->getId();
     MxFiniteElement fe(elem_sizes);
-    fe.iel = iEl+1;
+    fe.iel = MLGE[iEl];
 
     // Compute parameter values of the Gauss points over the whole element
     std::array<Vector,3> gpar;
@@ -716,7 +714,7 @@ bool ASMu3Dmx::integrate (Integrand& integrand, int lIndex,
 
         // Fetch basis function derivatives at current integration point
         for (size_t b = 1; b <= m_basis.size(); ++b)
-          evaluateBasis(fe, dNxdu[b-1], b);
+          this->evaluateBasis(iEl, fe, dNxdu[b-1], b);
 
         // Compute basis function derivatives and the face normal
         fe.detJxW = utl::Jacobian(Jac, normal, fe.grad(geoBasis), Xnod,

--- a/src/ASM/LR/ASMu3Drecovery.C
+++ b/src/ASM/LR/ASMu3Drecovery.C
@@ -544,7 +544,7 @@ bool ASMu3D::faceL2projection (const DirichletFace& face,
         if (gpar[2].size() > 1) w = gpar[2](k3+1);
 
         // Evaluate basis function derivatives at integration points
-        this->evaluateBasis(iel-1, u, v, w, N, dNdu, myGeoBasis);
+        this->evaluateBasis(iel-1, myGeoBasis, u, v, w, N, dNdu);
 
         // Compute basis function derivatives
         double dJxW = dA*wg[i]*wg[j]*utl::Jacobian(Jac,X,dNdX,Xnod,dNdu,t1,t2);


### PR DESCRIPTION
This fixes #301 because the assembly methods require the global element numbers, where the findElementContining methods returns local patch-wise element indices (including the 0-elements).

The other commit here is some LR cleanups from April.