### PR TITLE
Separate projection basis for 1D

### DIFF
--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -620,6 +620,11 @@ public:
   virtual Fields* getProjectedFields(const Vector&, size_t) const
   { return nullptr; }
 
+  //! \brief Creates a separate projection basis for this patch.
+  virtual bool createProjectionBasis(bool) { return false; }
+  //! \brief Checks if a separate projection basis is used for this patch.
+  virtual bool separateProjectionBasis() const { return false; }
+
 
   // Methods for result extraction
   // =============================
@@ -752,7 +757,7 @@ public:
   //! \param[in] dirs Which local DOFs to constrain (1, 2, 3, 12, 23, 123)
   //! \return Invalid local DOFs
   int fix(size_t inod, int dirs = 123);
-  //! \brief Checks whether given DOFs are fixed or not.
+  //! \brief Checks if the given DOFs are fixed.
   //! \param[in] node Global node number of the DOF to check
   //! \param[in] dof Local indices of the DOFs to check
   //! \param[in] all Returns \e true only if all DOFs are fixed

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -256,6 +256,9 @@ bool ASMs1D::raiseOrder (int ru)
   the subsequent refine and raiseOrder operations will apply to the projection
   basis and not on the geometry basis.
   In the second call, the pointers are swapped back.
+
+  The method can also be invoked twice with \a init = \e false in case the
+  projection basis is to be read from a file.
 */
 
 bool ASMs1D::createProjectionBasis (bool init)
@@ -264,9 +267,8 @@ bool ASMs1D::createProjectionBasis (bool init)
     return false;
   else if (init && !proj)
     projB = proj = curv->clone();
-  else if (init || !proj)
-    return false;
 
+  std::swap(geomB,projB);
   std::swap(curv,proj);
   return true;
 }

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -91,7 +91,7 @@ bool ASMs1D::read (std::istream& is)
     nsd = curv->dimension();
   }
 
-  geo = curv;
+  geomB = curv;
   return true;
 }
 
@@ -113,7 +113,7 @@ void ASMs1D::clear (bool retainGeometry)
   {
     // Erase spline data
     if (curv && !shareFE) delete curv;
-    geo = curv = nullptr;
+    geomB = curv = nullptr;
   }
 
   // Erase the FE data

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -24,6 +24,7 @@
 #include "CoordinateMapping.h"
 #include "GaussQuadrature.h"
 #include "SparseMatrix.h"
+#include "SplineFields1D.h"
 #include "ElementBlock.h"
 #include "SplineUtils.h"
 #include "Utilities.h"
@@ -1701,4 +1702,13 @@ bool ASMs1D::evaluate (const FunctionBase* func, RealArray& values,
   delete scrv;
 
   return true;
+}
+
+
+Fields* ASMs1D::getProjectedFields (const Vector& coefs, size_t nf) const
+{
+  if (proj == curv)
+    return nullptr;
+
+  return new SplineFields1D(proj,coefs,nf);
 }

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -248,6 +248,13 @@ public:
                             const RealArray* gpar, bool = true,
                             int deriv = 0, int = 0) const;
 
+  //! \brief Evaluates the projected solution field at all visualization points.
+  //! \param[out] sField Solution field
+  //! \param[in] locSol Solution vector local to current patch
+  //! \param[in] npe Number of visualization nodes over each knot span
+  virtual bool evalProjSolution(Matrix& sField, const Vector& locSol,
+                                const int* npe, int) const;
+
   using ASMbase::evaluate;
   //! \brief Evaluates and interpolates a function over a given geometry.
   //! \param[in] func The function to evaluate
@@ -282,8 +289,7 @@ public:
 
   //! \brief Returns a field using the projection basis.
   //! \param[in] coefs The coefficients for the field
-  //! \param[in] nf Number of components
-  virtual Fields* getProjectedFields(const Vector& coefs, size_t nf) const;
+  virtual Fields* getProjectedFields(const Vector& coefs, size_t = 0) const;
 
   //! \brief Evaluates the secondary solution field at the given points.
   //! \param[out] sField Solution field

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -280,6 +280,11 @@ public:
   //! \param[in] integrand Object with problem-specific data and methods
   virtual Go::GeomObject* evalSolution(const IntegrandBase& integrand) const;
 
+  //! \brief Returns a field using the projection basis.
+  //! \param[in] coefs The coefficients for the field
+  //! \param[in] nf Number of components
+  virtual Fields* getProjectedFields(const Vector& coefs, size_t nf) const;
+
   //! \brief Evaluates the secondary solution field at the given points.
   //! \param[out] sField Solution field
   //! \param[in] integrand Object with problem-specific data and methods

--- a/src/ASM/ASMs1DLag.C
+++ b/src/ASM/ASMs1DLag.C
@@ -63,6 +63,7 @@ void ASMs1DLag::clear (bool retainGeometry)
 bool ASMs1DLag::generateOrientedFEModel (const Vec3& Zaxis)
 {
   if (!curv) return false;
+  if (!proj) proj = curv;
 
   // Order of the basis
   p1 = curv->order();

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -125,7 +125,7 @@ bool ASMs2D::read (std::istream& is)
   {
     std::cerr <<" *** ASMs2D::read: Failure reading spline data"<< std::endl;
     delete surf;
-    surf = 0;
+    surf = nullptr;
     return false;
   }
   else if (surf->dimension() < 2)
@@ -133,7 +133,7 @@ bool ASMs2D::read (std::istream& is)
     std::cerr <<" *** ASMs2D::read: Invalid spline surface patch, dim="
 	      << surf->dimension() << std::endl;
     delete surf;
-    surf = 0;
+    surf = nullptr;
     return false;
   }
   else if (surf->dimension() < nsd)
@@ -145,7 +145,7 @@ bool ASMs2D::read (std::istream& is)
     nsd = surf->dimension();
   }
 
-  geo = surf;
+  geomB = surf;
   return true;
 }
 
@@ -167,8 +167,7 @@ void ASMs2D::clear (bool retainGeometry)
   {
     // Erase spline data
     if (surf && !shareFE) delete surf;
-    surf = 0;
-    geo = 0;
+    geomB = surf = nullptr;
   }
 
   // Erase the FE data

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -22,8 +22,8 @@
 #include "IntegrandBase.h"
 #include "CoordinateMapping.h"
 #include "GaussQuadrature.h"
-#include "SplineUtils.h"
 #include "SplineFields2D.h"
+#include "SplineUtils.h"
 #include "Utilities.h"
 #include "Profiler.h"
 #include "Vec3Oper.h"
@@ -85,14 +85,11 @@ bool ASMs2Dmx::write (std::ostream& os, int basis) const
 
 void ASMs2Dmx::clear (bool retainGeometry)
 {
-  // Erase the spline data
-  if (!retainGeometry)
-    delete surf, surf = 0;
-
+  // Erase the solution field bases
   for (auto& it : m_basis)
     it.reset();
 
-  // Erase the FE data
+  // Erase the FE data and the geometry basis
   this->ASMs2D::clear(retainGeometry);
 }
 
@@ -133,6 +130,7 @@ char ASMs2Dmx::getNodeType (size_t inod) const
 {
   if (this->isLMn(inod))
     return 'L';
+
   size_t nbc=nb.front();
   if (inod <= nbc)
     return 'D';
@@ -188,7 +186,7 @@ bool ASMs2Dmx::generateFEMTopology ()
       projBasis = m_basis.front();
   }
   delete surf;
-  geo = surf = m_basis[geoBasis-1]->clone();
+  geomB = surf = m_basis[geoBasis-1]->clone();
 
   nb.clear();
   nb.reserve(m_basis.size());
@@ -353,7 +351,6 @@ bool ASMs2Dmx::getElementCoordinates (Matrix& X, int iel) const
 
   size_t nenod = surf->order_u()*surf->order_v();
   size_t lnod0 = 0;
-
   for (int i = 1; i < geoBasis; ++i)
     lnod0 += m_basis[i-1]->order_u()*m_basis[i-1]->order_v();
 

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -38,7 +38,7 @@
 
 
 ASMs3D::ASMs3D (unsigned char n_f)
-  : ASMstruct(3,3,n_f), svol(0), nodeInd(myNodeInd)
+  : ASMstruct(3,3,n_f), svol(nullptr), nodeInd(myNodeInd)
 {
   swapW = false;
 }
@@ -107,7 +107,7 @@ bool ASMs3D::read (std::istream& is)
   {
     std::cerr <<" *** ASMs3D::read: Failure reading spline data"<< std::endl;
     delete svol;
-    svol = 0;
+    svol = nullptr;
     return false;
   }
   else if (svol->dimension() < 3)
@@ -115,11 +115,11 @@ bool ASMs3D::read (std::istream& is)
     std::cerr <<" *** ASMs3D::read: Invalid spline volume patch, dim="
               << svol->dimension() << std::endl;
     delete svol;
-    svol = 0;
+    svol = nullptr;
     return false;
   }
 
-  geo = svol;
+  geomB = svol;
   return true;
 }
 
@@ -141,8 +141,7 @@ void ASMs3D::clear (bool retainGeometry)
   {
     // Erase spline data
     if (svol && !shareFE) delete svol;
-    svol = 0;
-    geo = 0;
+    geomB = svol = nullptr;
   }
 
   // Erase the FE data

--- a/src/ASM/ASMstruct.C
+++ b/src/ASM/ASMstruct.C
@@ -23,20 +23,31 @@
 ASMstruct::ASMstruct (unsigned char n_p, unsigned char n_s, unsigned char n_f)
   : ASMbase(n_p,n_s,n_f)
 {
-  geo = nullptr;
+  geomB = projB = nullptr;
 }
 
 
 ASMstruct::ASMstruct (const ASMstruct& patch, unsigned char n_f)
   : ASMbase(patch,n_f)
 {
-  geo = patch.geo;
+  geomB = patch.geomB;
+  projB = patch.projB;
 }
 
 
 ASMstruct::~ASMstruct ()
 {
-  if (geo && !shareFE) delete geo;
+  if (projB && projB != geomB)
+    delete projB;
+
+  if (geomB && !shareFE)
+    delete geomB;
+}
+
+
+bool ASMstruct::separateProjectionBasis () const
+{
+  return projB && projB != geomB;
 }
 
 
@@ -48,7 +59,7 @@ bool ASMstruct::addXNodes (unsigned short int dim, size_t nXn, IntVec& nodes)
               <<", only "<< (int)ndim-1 <<" is allowed."<< std::endl;
     return false;
   }
-  else if (!geo || shareFE == 'F')
+  else if (!geomB || shareFE == 'F')
     return false; // logic error
 
   else if (MNPC.size() == nel && MLGE.size() == nel)

--- a/src/ASM/ASMstruct.h
+++ b/src/ASM/ASMstruct.h
@@ -39,11 +39,11 @@ protected:
   ASMstruct(const ASMstruct& patch, unsigned char n_f);
 
 public:
-  //! \brief The destructor frees the dynamically allocated spline object.
+  //! \brief The destructor frees the dynamically allocated spline objects.
   virtual ~ASMstruct();
 
   //! \brief Checks if the patch is empty.
-  virtual bool empty() const { return geo == nullptr; }
+  virtual bool empty() const { return geomB == nullptr; }
 
   //! \brief Returns the number of nodal points in each parameter direction.
   //! \param[out] n1 Number of nodes in first (u) direction
@@ -78,6 +78,9 @@ public:
   virtual bool diracPoint(Integrand& integr, GlobalIntegral& glInt,
                           const double* u, const Vec3& pval);
 
+  //! \brief Checks if a separate projection basis is used for this patch.
+  virtual bool separateProjectionBasis() const;
+
 protected:
   //! \brief Adds extraordinary nodes associated with a patch boundary.
   //! \param[in] dim Dimension of the boundary
@@ -104,7 +107,8 @@ protected:
   virtual void getElementBorders(int iel, double* u) const = 0;
 
 protected:
-  Go::GeomObject* geo; //!< Pointer to the actual spline geometry object
+  Go::GeomObject* geomB; //!< Pointer to spline object of the geometry basis
+  Go::GeomObject* projB; //!< Pointer to spline object of the projection basis
 };
 
 #endif

--- a/src/ASM/Fields.C
+++ b/src/ASM/Fields.C
@@ -69,3 +69,14 @@ Fields* Fields::create (const ASMbase* pch, const RealArray& v,
 
   return nullptr;
 }
+
+
+bool Fields::valueNode (size_t node, Vector& vals) const
+{
+  if (node < 1 || node > nno)
+    return false;
+
+  vals.resize(nf);
+  vals.fill(values.ptr()+(node-1)*nf);
+  return true;
+}

--- a/src/ASM/Fields.h
+++ b/src/ASM/Fields.h
@@ -36,7 +36,7 @@ class Fields
 protected:
   //! \brief The constructor sets the field name.
   //! \param[in] name Name of field
-  explicit Fields(const char* name = 0) : nf(0), nelm(0), nno(0)
+  explicit Fields(const char* name = nullptr) : nf(0), nelm(0), nno(0)
   { if (name) fname = name; }
 
 public:
@@ -67,36 +67,36 @@ public:
   // Methods to evaluate the field
   //==============================
 
-  //! \brief Computes the value in a given node/control point.
-  //! \param[in] node Node number
-  //! \param[out] vals Node values
-  virtual bool valueNode(size_t node, Vector& vals) const = 0;
+  //! \brief Computes the value at a given node/control point.
+  //! \param[in] node 1-based node/control point index
+  //! \param[out] vals Values at given node/control point
+  virtual bool valueNode(size_t node, Vector& vals) const;
 
-  //! \brief Computes the value at a given local coordinate.
+  //! \brief Computes the value for a given local coordinate.
   //! \param[in] fe Finite element definition
-  //! \param[out] vals Values in local point in given element
+  //! \param[out] vals Values at local point in given element
   virtual bool valueFE(const FiniteElement& fe, Vector& vals) const = 0;
 
-  //! \brief Computes the value at a given global coordinate.
-  //! \param[in] x Global/physical coordinate for point
-  //! \param[out] vals Values in given physical coordinate
+  //! \brief Computes the value for a given global coordinate.
+  //! \param[in] x Global coordinate of evaluation point
+  //! \param[out] vals Values at given global coordinate
   virtual bool valueCoor(const Vec4& x, Vector& vals) const { return false; }
 
   //! \brief Computes the gradient for a given local coordinate.
-  //! \param[in] fe Finite element
-  //! \param[out] grad Gradient of solution in a given local coordinate
+  //! \param[in] fe Finite element definition
+  //! \param[out] grad Gradient at local point in given element
   virtual bool gradFE(const FiniteElement& fe, Matrix& grad) const = 0;
 
-  //! \brief Computes the hessian for a given local coordinate.
-  //! \param[in] fe Finite element
-  //! \param[out] d2UdX2 Hessian of solution in a given local coordinate
-  virtual bool hessianFE(const FiniteElement& fe, Matrix3D& d2UdX2) const
-  { return false; }
-
-  //! \brief Computes the gradient for a given global/physical coordinate.
-  //! \param[in] x Global coordinate
-  //! \param[out] grad Gradient of solution in a given global coordinate
+  //! \brief Computes the gradient for a given global coordinate.
+  //! \param[in] x Global coordinate of evaluation point
+  //! \param[out] grad Gradient at given global coordinate
   virtual bool gradCoor(const Vec4& x, Matrix& grad) const { return false; }
+
+  //! \brief Computes the hessian for a given local coordinate.
+  //! \param[in] fe Finite element definition
+  //! \param[out] H Hessian at local point in given element
+  virtual bool hessianFE(const FiniteElement& fe, Matrix3D& H) const
+  { return false; }
 
 protected:
   unsigned char nf;  //!< Number of field components

--- a/src/ASM/IntegrandBase.C
+++ b/src/ASM/IntegrandBase.C
@@ -264,6 +264,20 @@ std::string IntegrandBase::getField2Name (size_t idx, const char* prefix) const
 }
 
 
+NormBase::~NormBase ()
+{
+  for (Fields* f : prjFld)
+    delete f;
+}
+
+
+void NormBase::initProjection (size_t nproj)
+{
+  prjFld.resize(nproj,nullptr);
+  prjsol.resize(nproj);
+}
+
+
 Vector& NormBase::getProjection (size_t i)
 {
   if (i < prjsol.size())
@@ -271,6 +285,16 @@ Vector& NormBase::getProjection (size_t i)
 
   static Vector dummy;
   return dummy;
+}
+
+
+void NormBase::setProjectedFields (Fields* f, size_t idx)
+{
+  if (idx < prjFld.size())
+  {
+    std::swap(f,prjFld[idx]);
+    delete f;
+  }
 }
 
 

--- a/src/ASM/IntegrandBase.h
+++ b/src/ASM/IntegrandBase.h
@@ -302,13 +302,13 @@ protected:
                                         lints(nullptr), finalOp(ASM::SQRT) {}
 
 public:
-  //! \brief Empty destructor.
-  virtual ~NormBase() {}
+  //! \brief The destructor deletes the projected secondary solution fields.
+  virtual ~NormBase();
 
   //! \brief Initializes the integrand with the number of integration points.
   virtual void initIntegration(size_t, size_t) {}
   //! \brief Sets the number of projected solutions.
-  void initProjection(size_t nproj) { prjsol.resize(nproj); }
+  void initProjection(size_t nproj);
   //! \brief Sets a vector of LocalIntegrals to be used during norm integration.
   void setLocalIntegrals(LintegralVec* elementNorms) { lints = elementNorms; }
 
@@ -382,10 +382,10 @@ public:
   //! \brief Returns whether projections are fed through external means.
   virtual bool hasExternalProjections() const { return false; }
 
-  //! \brief Set projected quantities as fields.
-  //! \param[in] f The field with the info
+  //! \brief Sets a projected secondary solution as a field quantity.
+  //! \param[in] f The field defining the projected secondary solution
   //! \param[in] idx Projection index
-  virtual void setProjectedFields(Fields* f, size_t idx) {}
+  virtual void setProjectedFields(Fields* f, size_t idx);
 
 protected:
   //! \brief Initializes the projected fields for current element.
@@ -395,6 +395,8 @@ protected:
   double applyFinalOp(double value) const;
 
   IntegrandBase& myProblem; //!< The problem-specific data
+
+  std::vector<Fields*> prjFld; //!< Projected secondary solution fields
 
   Vectors prjsol; //!< Projected secondary solution vectors for current patch
   bool   projBou; //!< If \e true, the boundary integrand needs prjsol too

--- a/src/ASM/SplineFields1D.C
+++ b/src/ASM/SplineFields1D.C
@@ -1,0 +1,148 @@
+// $Id$
+//==============================================================================
+//!
+//! \file SplineFields1D.C
+//!
+//! \date Nov 23 2018
+//!
+//! \author Arne Morten Kvarving / SINTEF
+//!
+//! \brief Class for spline-based finite element vector fields in 1D.
+//!
+//==============================================================================
+
+#include "GoTools/geometry/SplineCurve.h"
+
+#include "SplineFields1D.h"
+#include "FiniteElement.h"
+#include "CoordinateMapping.h"
+#include "Utilities.h"
+#include <numeric>
+
+
+SplineFields1D::SplineFields1D (const Go::SplineCurve* crv,
+                                const RealArray& v, int ncmp, const char* name)
+  : Fields(name), curv(crv)
+{
+  nsd = 1; // That is, this constructor can not be used for curved beams (nsd>1)
+  nf = ncmp;
+  values = v;
+}
+
+
+bool SplineFields1D::valueFE (const FiniteElement& fe, Vector& vals) const
+{
+  if (!curv) return false;
+
+  // Find nodal indices of element containing given point
+  int first, last;
+  curv->basis().coefsAffectingParam(fe.u,first,last);
+  if (first == last)
+  {
+    // We are at an interpolatory point (with C^0 continuity)
+    vals.resize(nf);
+    vals.fill(values.data()+nf*first,nf);
+    return true;
+  }
+
+  // Find nodal field values around this point
+  std::vector<int> ip(last-first+1);
+  Matrix Vnod;
+  std::iota(ip.begin(),ip.end(),first);
+  utl::gather(ip,nf,values,Vnod);
+
+  // Evaluate the basis functions at the given point
+  RealArray basisVal, basisDerivs;
+#pragma omp critical
+  curv->computeBasis(fe.u,basisVal,basisDerivs);
+
+  // Evaluate the field at the given point.
+  // Notice we don't just do a matrix-vector multiplication here,
+  // to account for that the basisVal array may be longer that ip.
+  // This seems to happen when we have repeated knots in the affected element.
+  vals.resize(nf,true);
+  size_t inod = 0;
+  for (double N : basisVal)
+    if (N > 0.0 && inod < Vnod.cols())
+      vals.add(Vnod.getColumn(++inod),N);
+
+  return true;
+}
+
+
+bool SplineFields1D::gradFE (const FiniteElement& fe, Matrix& grad) const
+{
+  if (!curv) return false;
+
+  // Evaluate the basis functions at the given point
+  RealArray basisVal, basisDerivs;
+#pragma omp critical
+  curv->computeBasis(fe.u,basisVal,basisDerivs);
+  Matrix Jac, dNdX, dNdu(basisDerivs.size(),1);
+  dNdu.fillColumn(1,basisDerivs);
+
+  // Find nodal indices of element containing the given point
+  int first, last;
+  curv->basis().coefsAffectingParam(fe.u,first,last);
+  std::vector<int> ip(last-first+1);
+  std::iota(ip.begin(),ip.end(),first);
+
+  // Find nodal coordinates of element containing the given point
+  Matrix Velm, Xelm(nsd,ip.size());
+  RealArray::const_iterator cit = curv->coefs_begin();
+  for (int inod = first; inod <= last; inod++)
+  {
+    int ip = inod*curv->dimension();
+    for (size_t i = 0; i < nsd; i++)
+      Xelm(i+1,inod-first+1) = *(cit+(ip+i));
+  }
+
+  // Evaluate the field gradient at the given point
+  utl::gather(ip,nf,values,Velm);
+  if (!utl::Jacobian(Jac,dNdX,Xelm,dNdu))
+    return false;
+  return !grad.multiply(Velm,dNdX).empty(); // grad = Xelm * dNdX
+}
+
+
+bool SplineFields1D::hessianFE (const FiniteElement& fe, Matrix3D& H) const
+{
+  if (!curv)  return false;
+
+  // Evaluate the basis functions at the given point
+  RealArray basisVal, basisDerivs1, basisDerivs2;
+  // TODO: It does not make sense that we here need to const_cast
+  // when it is not needed in the first derivatives version used above.
+  // Can this be fixed in GoTools?
+  Go::SplineCurve* ccrv = const_cast<Go::SplineCurve*>(curv);
+#pragma omp critical
+  ccrv->computeBasis(fe.u,basisVal,basisDerivs1,basisDerivs2);
+  Matrix Jac, dNdX, dNdu(basisDerivs1.size(),1);
+  dNdu.fillColumn(1,basisDerivs1);
+  Matrix3D Hess, d2NdX2, d2Ndu2(basisDerivs2.size(),1,1);
+  d2Ndu2.fillColumn(1,1,basisDerivs2);
+
+  // Find nodal indices of element containing the given point
+  int first, last;
+  curv->basis().coefsAffectingParam(fe.u,first,last);
+  std::vector<int> ip(last-first+1);;
+  std::iota(ip.begin(),ip.end(),first);
+
+  // Find nodal coordinates of element containing the given point
+  Matrix Velm, Xelm(nsd,ip.size());
+  RealArray::const_iterator cit = curv->coefs_begin();
+  for (int inod = first; inod <= last; inod++)
+  {
+    int ip = inod*curv->dimension();
+    for (size_t i = 0; i < nsd; i++)
+      Xelm(i+1,inod-first+1) = *(cit+(ip+i));
+  }
+
+  // Evaluate the field hessian at the given point
+  utl::gather(ip,nf,values,Velm);
+  if (!utl::Jacobian(Jac,dNdX,Xelm,dNdu))
+    return false;
+  if (!utl::Hessian(Hess,d2NdX2,Jac,Xelm,d2Ndu2,dNdX))
+    return false;
+  return H.multiply(Velm,d2NdX2); // H = Xelm * d2NdX2
+}

--- a/src/ASM/SplineFields1D.h
+++ b/src/ASM/SplineFields1D.h
@@ -1,0 +1,70 @@
+// $Id$
+//==============================================================================
+//!
+//! \file SplineFields1D.h
+//!
+//! \date Nov 23 2018
+//!
+//! \author Arne Morten Kvarving / SINTEF
+//!
+//! \brief Class for spline-based finite element vector fields in 1D.
+//!
+//==============================================================================
+
+#ifndef _SPLINE_FIELDS_1D_H
+#define _SPLINE_FIELDS_1D_H
+
+#include "Fields.h"
+
+namespace Go {
+  class SplineCurve;
+}
+
+
+/*!
+  \brief Class for spline-based finite element vector fields in 1D.
+
+  \details This class implements the methods required to evaluate a 1D
+  spline vector field at a given point in parametrical or physical coordinates.
+*/
+
+class SplineFields1D : public Fields
+{
+public:
+  //! \brief Construct directly from curve.
+  //! \param[in] crv The spline curve to use
+  //! \param[in] v Array of control point field values
+  //! \param[in] ncmp Number of field components
+  //! \param[in] name Name of spline field
+  SplineFields1D(const Go::SplineCurve* crv, const RealArray& v, int ncmp,
+                 const char* name = nullptr);
+
+  //! \brief Empty destructor.
+  virtual ~SplineFields1D() {}
+
+  // Methods to evaluate the field
+  //==============================
+
+  //! \brief Computes the value for a given local coordinate.
+  //! \param[in] fe Finite element definition
+  //! \param[out] vals Values at local point in given element
+  virtual bool valueFE(const FiniteElement& fe, Vector& vals) const;
+
+  //! \brief Computes the gradient for a given local coordinate.
+  //! \param[in] fe Finite element definition
+  //! \param[out] grad Gradient at local point in given element
+  virtual bool gradFE(const FiniteElement& fe, Matrix& grad) const;
+
+  //! \brief Computes the hessian for a given local coordinate.
+  //! \param[in] fe Finite element definition
+  //! \param[out] H Hessian at local point in given element
+  virtual bool hessianFE(const FiniteElement& fe, Matrix3D& H) const;
+
+protected:
+  const Go::SplineCurve* curv; //!< Spline geometry description
+
+private:
+  unsigned char nsd; //!< Number of space dimensions
+};
+
+#endif

--- a/src/SIM/SIM1D.C
+++ b/src/SIM/SIM1D.C
@@ -206,6 +206,24 @@ bool SIM1D::parseGeometryTag (const TiXmlElement* elem)
     IFEM::cout <<"\tZ-direction vector: "<< XZp << std::endl;
   }
 
+  else if (!strcasecmp(elem->Value(),"projection") && !isRefined)
+  {
+    // Generate separate projection basis from current geometry basis
+    for (ASMbase* pch : myModel)
+      pch->createProjectionBasis(true);
+
+    // Apply refine and/raise-order commands to define the projection basis
+    const TiXmlElement* child = elem->FirstChildElement();
+    for (; child; child = child->NextSiblingElement())
+      if (!strcasecmp(child->Value(),"refine") ||
+          !strcasecmp(child->Value(),"raiseorder"))
+        if (!this->parseGeometryTag(child))
+          return false;
+
+    for (ASMbase* pch : myModel)
+      pch->createProjectionBasis(false);
+  }
+
   return true;
 }
 

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -1777,6 +1777,15 @@ bool SIMbase::project (Vector& values, const FunctionBase* f,
     case SIMoptions::CGL2:
     case SIMoptions::CGL2_INT:
       // Continuous global L2-projection
+      if (myModel[j]->separateProjectionBasis())
+      {
+        // Not implemented yet, silently ignore unless debug build
+#ifdef SP_DEBUG
+        std::cerr <<"  ** L2 projection of explicit functions onto a"
+                  <<" separate basis is not available."<< std::endl;
+#endif
+        return false;
+      }
       ok = myModel[j]->L2projection(f_values,const_cast<FunctionBase*>(f),time);
       loc_values = f_values;
       break;
@@ -1919,6 +1928,16 @@ bool SIMbase::evalSecondarySolution (Matrix& field, int pindx) const
 
   const_cast<SIMbase*>(this)->setPatchMaterial(pindx+1);
   return pch->evalSolution(field,*myProblem);
+}
+
+
+bool SIMbase::fieldProjections () const
+{
+  for (const ASMbase* pch : myModel)
+    if (pch->separateProjectionBasis())
+      return true;
+
+  return false;
 }
 
 

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -496,8 +496,8 @@ public:
   //! the spline basis to obtain the control point values.
   bool evalSecondarySolution(Matrix& field, int pindx) const;
 
-  //! \brief Returns whether or not projections are handled through fields.
-  virtual bool fieldProjections() const { return false; }
+  //! \brief Returns whether projections must be handled through fields or not.
+  virtual bool fieldProjections() const;
 
   //! \brief Returns whether an analytical solution is available or not.
   virtual bool haveAnaSol() const { return mySol ? true : false; }


### PR DESCRIPTION
Revised part of #316 concerning 1D models.

The input is here handled in a slightly different way. Instead of an extra attribute on the refine/raiseorder tags, a separate `<projection>`-tag within the `<geometry>`scope is introduced, where commands that should apply to the projection basis are specified.