### PR TITLE
Boundary conditions in local axis directions for 1D

### DIFF
--- a/src/ASM/ASM1D.h
+++ b/src/ASM/ASM1D.h
@@ -72,7 +72,6 @@ public:
   //! \param[in] xi Parameter value along the curve
   //! \param[in] dof Which DOFs to constrain at the node
   //! \param[in] code Inhomogeneous dirichlet condition code
-  //! \param[in] basis Basis to constrain node for
   //! \return 1-based index of the constrained node
   //!
   //! \details The parameter value has to be in the domain [0.0,1.0], where
@@ -80,8 +79,12 @@ public:
   //! in between, the actual index is taken as the integer value closest to
   //! \a r*n, where \a r denotes the given relative parameter value,
   //! and \a n is the number of nodes along that parameter direction.
-  virtual int constrainNode(double xi, int dof,
-                            int code = 0, char basis = 1) = 0;
+  virtual int constrainNode(double xi, int dof, int code = 0) = 0;
+  //! \brief Constrains all DOFs in local directions at a given end point.
+  //! \param[in] dir Parameter direction defining the end to constrain
+  //! \param[in] dof Which local DOFs to constrain at the end point
+  //! \param[in] code Inhomogeneous dirichlet condition code
+  virtual size_t constrainEndLocal(int dir, int dof, int code = 0) = 0;
 
   //! \brief Calculates parameter values for visualization nodal points.
   //! \param[out] prm Parameter values for all points

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -40,6 +40,7 @@ class FunctionBase;
 class RealFunc;
 class VecFunc;
 class Vec3;
+class Tensor;
 namespace ASM { class InterfaceChecker; }
 
 typedef std::vector<ASMbase*> ASMVec; //!< Spline patch container
@@ -684,6 +685,11 @@ protected:
   // Internal methods for preprocessing of boundary conditions
   // =========================================================
 
+  //! \brief Creates constraint equations coupling global DOFs to local DOFs.
+  //! \param[in] iSlave 0-based local index of node with global DOFs
+  //! \param[in] master Global node number of node with local DOFs
+  //! \param[in] Tlg Local-to-global transformation matrix
+  void addLocal2GlobalCpl(int iSlave, int master, const Tensor& Tlg);
   //! \brief Creates and adds a three-point constraint to this patch.
   //! \param[in] slave Global node number of the node to constrain
   //! \param[in] dir Which local DOF to constrain (1, 2, 3)
@@ -764,6 +770,9 @@ public:
   bool isFixed(int node, int dof, bool all = false) const;
 
 protected:
+  //! \brief Returns \e true if \a dirs constains all local DOFs in the patch.
+  bool allDofs(int dirs) const;
+
   //! \brief Calculated the deformed configuration for current element.
   //! \param[in] Xnod Array of nodal point coordinates for current element
   //! \param eVec Current element solution vectors

--- a/src/ASM/ASMs1DC1.h
+++ b/src/ASM/ASMs1DC1.h
@@ -50,7 +50,6 @@ public:
   //! \param[in] xi Parameter value along the curve
   //! \param[in] dof Which DOFs to constrain at the node
   //! \param[in] code Inhomogeneous dirichlet condition code
-  //! \param[in] basis The basis to constrain node for
   //! \return 1-based index of the constrained node
   //!
   //! \details The parameter value has to be in the domain [0.0,1.0], where
@@ -58,7 +57,12 @@ public:
   //! in between, the actual index is taken as the integer value closest to
   //! \a r*n, where \a r denotes the given relative parameter value,
   //! and \a n is the number of nodes along that parameter direction.
-  virtual int constrainNode(double xi, int dof, int code, char basis);
+  virtual int constrainNode(double xi, int dof, int code);
+  //! \brief Constrains all DOFs in local directions at a given end point.
+  //! \param[in] dir Parameter direction defining the end to constrain
+  //! \param[in] dof Which local DOFs to constrain at the end point
+  //! \param[in] code Inhomogeneous dirichlet condition code
+  virtual size_t constrainEndLocal(int dir, int dof, int code);
 };
 
 #endif

--- a/src/ASM/ASMstruct.C
+++ b/src/ASM/ASMstruct.C
@@ -12,6 +12,7 @@
 //==============================================================================
 
 #include "ASMstruct.h"
+#include "TimeDomain.h"
 #include "FiniteElement.h"
 #include "GlobalIntegral.h"
 #include "LocalIntegral.h"
@@ -167,7 +168,9 @@ bool ASMstruct::diracPoint (Integrand& integr, GlobalIntegral& glInt,
   this->evaluateBasis(fe.u,fe.v,fe.w,fe.N);
 
   LocalIntegral* A = integr.getLocalIntegral(MNPC[iel-1].size(),fe.iel,true);
-  bool ok = integr.evalPoint(*A,fe,pval) && glInt.assemble(A,fe.iel);
+  bool ok = (integr.evalPoint(*A,fe,pval) &&
+             integr.finalizeElement(*A,fe,TimeDomain(),0) &&
+             glInt.assemble(A,fe.iel));
   A->destruct();
 
   return ok;

--- a/src/ASM/NewmarkMats.C
+++ b/src/ASM/NewmarkMats.C
@@ -60,29 +60,29 @@ const Matrix& NewmarkMats::getNewtonMatrix () const
 
 const Vector& NewmarkMats::getRHSVector () const
 {
-  if (!A.empty() && vec.size() > 2)
-  {
-    Vector& dF = const_cast<Vector&>(b.front());
+  Vector& dF = const_cast<Vector&>(b.front());
 
-    int ia = vec.size() - 1; // index to element acceleration vector (a)
-    int iv = vec.size() - 2; // index to element velocity vector (v)
+  int ia = vec.size() - 1; // index to element acceleration vector (a)
+  int iv = vec.size() - 2; // index to element velocity vector (v)
+
 #if SP_DEBUG > 2
-    std::cout <<"\nf_ext - f_s"<< dF;
+  std::cout <<"\nf_ext - f_s"<< dF;
+  if (A.size() > 1 && ia >= 0)
     std::cout <<"f_i = M*a"<< A[1]*vec[ia];
-    if (alpha1 > 0.0)
-      std::cout <<"f_d1/alpha1 = M*v (alpha1="<< alpha1 <<")"<< A[1]*vec[iv];
-    if (alpha2 > 0.0)
-      std::cout <<"f_d2/alpha2 = K*v (alpha2="<< alpha2 <<")"<< A[2]*vec[iv];
+  if (alpha1 > 0.0 && A.size() > 1 && iv >= 0)
+    std::cout <<"f_d1/alpha1 = M*v (alpha1="<< alpha1 <<")"<< A[1]*vec[iv];
+  if (alpha2 > 0.0 && A.size() > 2 && iv >= 0)
+    std::cout <<"f_d2/alpha2 = K*v (alpha2="<< alpha2 <<")"<< A[2]*vec[iv];
 #endif
 
-    dF.add(A[1]*vec[ia],-1.0);      // dF = Fext - M*a
+  if (A.size() > 1 && ia >= 0)
+    dF.add(A[1]*vec[ia],-1.0);    // dF = Fext - M*a
 
-    if (alpha1 > 0.0)
-      dF.add(A[1]*vec[iv],-alpha1); // dF -= alpha1*M*v
+  if (alpha1 > 0.0 && A.size() > 1 && iv >= 0)
+    dF.add(A[1]*vec[iv],-alpha1); // dF -= alpha1*M*v
 
-    if (alpha2 > 0.0)
-      dF.add(A[2]*vec[iv],-alpha2); // dF -= alpha2*K*v
-  }
+  if (alpha2 > 0.0 && A.size() > 2 && iv >= 0)
+    dF.add(A[2]*vec[iv],-alpha2); // dF -= alpha2*K*v
 
 #if SP_DEBUG > 2
   std::cout <<"\nElement right-hand-side vector"<< b.front();

--- a/src/SIM/SIM1D.h
+++ b/src/SIM/SIM1D.h
@@ -112,9 +112,9 @@ protected:
   //! \param[in] ldim Dimension of the boundary item to receive the property
   //! \param[in] dirs Which local DOFs to constrain
   //! \param[in] code In-homogeneous Dirichlet condition property code
-  //! \param[in] basis Which basis to apply the constraint to (mixed methods)
+  //! \param ngnod Total number of global nodes in the model (might be updated)
   virtual bool addConstraint(int patch, int lndx, int ldim,
-                             int dirs, int code, int&, char basis = 1);
+                             int dirs, int code, int& ngnod, char = 1);
 
   //! \brief Returns a FEM model generator for a default single-patch model.
   //! \param[in] geo XML element containing geometry definition


### PR DESCRIPTION
This (last commit) adds the support for boundary conditions in skew coordinate systems for 1D patches.
The local axes are calculated with the tanget direction as the local X-axis, the the binormal vector (that is, the normal vector of the plane of curvature) as the local Y-axis. If the curve is straight, the local Y-direction is chosen arbitrarily.

There is a potential issue when it comes to fixing rotations for C1-patches, where the local directions are are imposed to the second control point. What is the tangent (and binormal) directions here? Currently, we use the same as for the end point, but this might not be strictly correct unless the two points are very close to each other, or the curvature is very small.