### PR TITLE
Fixed mixed adaptive simulations on meshes with reduced continuity

### DIFF
--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -412,6 +412,9 @@ bool ASMu2D::raiseOrder (int ru, int rv)
   refine and raiseOrder operations will apply to the projection basis
   and not on the geometry basis.
   In the second call, the pointers are swapped back.
+
+  The method can also be invoked twice with \a init = \e false in case the
+  projection basis is to be read from a file.
 */
 
 bool ASMu2D::createProjectionBasis (bool init)

--- a/src/ASM/LR/ASMu2Dmx.C
+++ b/src/ASM/LR/ASMu2Dmx.C
@@ -964,12 +964,11 @@ bool ASMu2Dmx::refine (const LR::RefineData& prm,
         if (refBasis == m_basis[j])
           continue;
         else {
-          int p = m_basis[j]->order(line->span_u_line_ ? 1 : 0);
           int mult = 1;
           if (ASMmxBase::Type == ASMmxBase::REDUCED_CONT_RAISE_BASIS1 ||
               ASMmxBase::Type == ASMmxBase::REDUCED_CONT_RAISE_BASIS2) {
             if (line->multiplicity_ > 1)
-              mult = p;
+              mult = line->multiplicity_;
             else
               mult = (j == 0 && ASMmxBase::Type == REDUCED_CONT_RAISE_BASIS1) ||
                      (j == 1 && ASMmxBase::Type == REDUCED_CONT_RAISE_BASIS2) ? 2 : 1;

--- a/src/ASM/LR/ASMu2Dmx.C
+++ b/src/ASM/LR/ASMu2Dmx.C
@@ -1131,11 +1131,10 @@ size_t ASMu2Dmx::getNoRefineElms() const
 
 void ASMu2Dmx::storeMesh (const char* fName)
 {
-  int basis = 0;
-  for (const auto& patch : m_basis)
+  auto&& writeBasis = [this,fName](const LR::LRSplineSurface* patch, const char* tag)
   {
     std::stringstream str;
-    str <<"_patch"<< idx <<"_basis"<< ++basis <<"_"<< fName;
+    str << "_patch" << idx << "_" << tag <<"_" << fName;
     std::ofstream paramMeshFile("param"+str.str());
     patch->writePostscriptMesh(paramMeshFile);
     std::ofstream physMeshFile("physical"+str.str());
@@ -1144,5 +1143,14 @@ void ASMu2Dmx::storeMesh (const char* fName)
     patch->writePostscriptElements(pdotFile);
     std::ofstream physdotFile("physical_dot"+str.str());
     patch->writePostscriptMeshWithControlPoints(physdotFile);
+  };
+
+  std::string btag("basis1");
+  for (const auto& patch : m_basis)
+  {
+    writeBasis(patch.get(), btag.c_str());
+    ++btag.back();
   }
+  writeBasis(projBasis.get(), "proj");
+  writeBasis(refBasis.get(), "ref");
 }

--- a/src/Utility/SplineUtils.C
+++ b/src/Utility/SplineUtils.C
@@ -303,3 +303,17 @@ Go::SplineVolume* SplineUtils::project (const Go::SplineVolume* volume,
                                                       volume->rational(),
                                                       weights);
 }
+
+
+std::vector<double> SplineUtils::buildKnotVector(int p,
+                                                 const std::vector<double>& knots,
+                                                 const std::vector<int>& cont)
+{
+  std::vector<double> result;
+  result.reserve(p+knots.size()+1);
+  for (size_t i = 0; i < knots.size(); ++i)
+    for (int k = 0; k < p-cont[i]; ++k)
+      result.push_back(knots[i]);
+
+  return result;
+}

--- a/src/Utility/SplineUtils.h
+++ b/src/Utility/SplineUtils.h
@@ -80,6 +80,10 @@ namespace SplineUtils //! Various utility functions on spline objects.
   Go::SplineVolume* project(const Go::SplineVolume* volume,
                             const FunctionBase& f,
                             int nComp = 1, Real time = Real(0));
+
+  //! \brief Builds a knot vector from a given polynomial order, knots and continuities.
+  std::vector<double> buildKnotVector(int p, const std::vector<double>& simple_knots,
+                                      const std::vector<int>& continuities);
 }
 
 #endif

--- a/src/Utility/Test/TestSplineUtils.C
+++ b/src/Utility/Test/TestSplineUtils.C
@@ -432,3 +432,21 @@ TEST(TestSplineUtils, ProjectSurface)
   EXPECT_FLOAT_EQ(result4.x, -0.02189938149140131);
   EXPECT_FLOAT_EQ(result4.y,  0.06514225417205573);
 }
+
+
+TEST(TestSplineUtils, BuildKnotVector)
+{
+  const std::vector<double>& ref = {0.0, 0.0, 0.0, 0.0,
+                                    1.0,
+                                    2.0,
+                                    3.0, 3.0,
+                                    4.0,
+                                    5.0, 5.0, 5.0, 5.0};
+  std::vector<double> res = SplineUtils::buildKnotVector(3,
+                                                        {0.0, 1.0, 2.0, 3.0, 4.0, 5.0},
+                                                        {-1, 2, 2, 1, 2, -1});
+
+  EXPECT_EQ(ref.size(), res.size());
+  for (size_t i = 0; i < ref.size(); ++i)
+    EXPECT_FLOAT_EQ(ref[i], res[i]);
+}


### PR DESCRIPTION
Previously we established a full-continuity basis for projection in these cases. We now keep the reduced continuity lines in the projection basis.

There is one caveat; we cannot automate this procedure when geometry is linear. In that case, a separate projection basis has to be specified through the <projection> keyword in the files.
I think this is a better compromise, the alternative is to flip the mixed establishment completely; have user give the highest order basis, and then establish the pressure basis through lowering order instead. This would require updating every single mixed setup already existing.