### PR TITLE
Some cleaning of the SIMxD classes

### DIFF
--- a/Apps/Common/MultiPatchModelGenerator.C
+++ b/Apps/Common/MultiPatchModelGenerator.C
@@ -22,8 +22,6 @@
 #include "Vec3Oper.h"
 #include "tinyxml.h"
 #include <array>
-#include <GoTools/geometry/ObjectHeader.h>
-#include <string>
 
 
 std::string MultiPatchModelGenerator1D::createG2 (int nsd) const
@@ -191,9 +189,7 @@ bool MultiPatchModelGenerator1D::createTopology (SIMinput& sim) const
     }
     else {
       IFEM::cout <<"\tPeriodic I-direction P0\n";
-      ASMs1D* pch = dynamic_cast<ASMs1D*>(sim.getPatch(0, true));
-      if (pch)
-        pch->closeEnds();
+      sim.getPatch(0,true)->closeBoundaries();
     }
 
   return true;
@@ -446,9 +442,7 @@ bool MultiPatchModelGenerator2D::createTopology (SIMinput& sim) const
       }
       else {
         IFEM::cout <<"\tPeriodic I-direction P"<< IJ(0,j) << std::endl;
-        ASMs2D* pch = dynamic_cast<ASMs2D*>(sim.getPatch(IJ(0,j), true));
-        if (pch)
-          pch->closeEdges(1);
+        sim.getPatch(IJ(0,j),true)->closeBoundaries(1);
       }
 
   if (periodic_y)
@@ -459,9 +453,7 @@ bool MultiPatchModelGenerator2D::createTopology (SIMinput& sim) const
       }
       else {
         IFEM::cout <<"\tPeriodic J-direction P"<< IJ(i,0)<< std::endl;
-        ASMs2D* pch = dynamic_cast<ASMs2D*>(sim.getPatch(IJ(i,0), true));
-        if (pch)
-          pch->closeEdges(2);
+        sim.getPatch(IJ(i,0),true)->closeBoundaries(2);
       }
 
   return true;
@@ -802,9 +794,7 @@ bool MultiPatchModelGenerator3D::createTopology (SIMinput& sim) const
             return false;
         } else {
           IFEM::cout <<"\tPeriodic I-direction P"<< IJK(0,j,k) << std::endl;
-          ASMs3D* pch = dynamic_cast<ASMs3D*>(sim.getPatch(IJK(0,j,k), true));
-          if (pch)
-            pch->closeFaces(1);
+          sim.getPatch(IJK(0,j,k),true)->closeBoundaries(1);
         }
 
   if (periodic_y)
@@ -813,12 +803,10 @@ bool MultiPatchModelGenerator3D::createTopology (SIMinput& sim) const
         if (ny > 1) {
           if (!sim.addConnection(IJK(i,0,k), IJK(i,ny-1,k), 3, 4, 0, 0, false, 2))
             return false;
-         } else {
+        } else {
           IFEM::cout <<"\tPeriodic J-direction P"<< IJK(i,0,k) << std::endl;
-          ASMs3D* pch = dynamic_cast<ASMs3D*>(sim.getPatch(IJK(i,0,k), true));
-          if (pch)
-            pch->closeFaces(2);
-         }
+          sim.getPatch(IJK(i,0,k),true)->closeBoundaries(2);
+        }
 
   if (periodic_z)
     for (size_t j = 0; j < ny; ++j)
@@ -828,9 +816,7 @@ bool MultiPatchModelGenerator3D::createTopology (SIMinput& sim) const
             return false;
         } else {
           IFEM::cout <<"\tPeriodic K-direction P"<< IJK(i,j,0) << std::endl;
-          ASMs3D* pch = dynamic_cast<ASMs3D*>(sim.getPatch(IJK(i,j,0), true));
-          if (pch)
-            pch->closeFaces(3);
+          sim.getPatch(IJK(i,j,0),true)->closeBoundaries(3);
         }
 
   return true;

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -319,6 +319,12 @@ public:
   //! \brief Copies the parameter domain from another patch.
   virtual void copyParameterDomain(const ASMbase*) {}
 
+  //! \brief Makes two opposite boundaries periodic.
+  //! \param[in] dir Parameter direction defining the periodic boundaries
+  //! \param[in] basis Which basis to connect (mixed methods), 0 means all
+  //! \param[in] master 1-based index of the first master node in this basis
+  virtual void closeBoundaries(int dir = 1, int basis = 0, int master = 1) {}
+
   //! \brief Merges a given node in this patch with a given global node.
   //! \param[in] inod 1-based node index local to current patch
   //! \param[in] globalNum Global number of the node to merge \a node with

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -491,7 +491,7 @@ bool ASMs1D::connectBasis (ASMs1D& neighbor, int slave, int master, int thick)
 }
 
 
-void ASMs1D::closeEnds (int basis, int master)
+void ASMs1D::closeBoundaries (int, int basis, int master)
 {
   if (basis < 1) basis = 1;
   int n1 = this->getSize(basis);

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -182,9 +182,9 @@ public:
                             int thick = 1);
 
   //! \brief Makes the two end vertices of the curve periodic.
-  //! \param[in] basis Which basis to connect (mixed methods), 0 means both
+  //! \param[in] basis Which basis to connect (mixed methods), 0 means all
   //! \param[in] master 1-based index of the first master node in this basis
-  virtual void closeEnds(int basis = 0, int master = 1);
+  virtual void closeBoundaries(int, int basis, int master);
 
 
   // Methods for integration of finite element quantities.

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -700,7 +700,7 @@ bool ASMs2D::connectBasis (int edge, ASMs2D& neighbor, int nedge, bool revers,
 }
 
 
-void ASMs2D::closeEdges (int dir, int basis, int master)
+void ASMs2D::closeBoundaries (int dir, int basis, int master)
 {
   int n1, n2;
   if (basis < 1) basis = 1;

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -294,9 +294,9 @@ public:
 
   //! \brief Makes two opposite boundary edges periodic.
   //! \param[in] dir Parameter direction defining the periodic edges
-  //! \param[in] basis Which basis to connect (mixed methods), 0 means both
+  //! \param[in] basis Which basis to connect (mixed methods), 0 means all
   //! \param[in] master 1-based index of the first master node in this basis
-  virtual void closeEdges(int dir, int basis = 0, int master = 1);
+  virtual void closeBoundaries(int dir, int basis, int master);
 
   //! \brief Collapses a degenereated edge into a single node.
   //! \param[in] dir Parameter direction defining the edge to collapse

--- a/src/ASM/ASMs2DC1.C
+++ b/src/ASM/ASMs2DC1.C
@@ -145,7 +145,7 @@ bool ASMs2DC1::connectC1 (int edge, ASMs2DC1* neighbor, int nedge, bool revers)
 }
 
 
-void ASMs2DC1::closeEdges (int dir, int, int)
+void ASMs2DC1::closeBoundaries (int dir, int, int)
 {
   int n1, n2;
   if (!this->getSize(n1,n2)) return;

--- a/src/ASM/ASMs2DC1.h
+++ b/src/ASM/ASMs2DC1.h
@@ -88,9 +88,7 @@ public:
 
   //! \brief Makes two opposite boundary edges periodic.
   //! \param[in] dir Parameter direction defining the periodic edges
-  //! \param[in] basis Which basis to connect (mixed methods), 0 means both
-  //! \param[in] master 1-based index of the first master node in this basis
-  virtual void closeEdges(int dir, int basis = 0, int master = 1);
+  virtual void closeBoundaries(int dir, int, int);
 
   //! \brief Renumbers the global node numbers in the \a neighbors map.
   //! \param[in] old2new Old-to-new node number mapping

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -327,13 +327,11 @@ bool ASMs2Dmx::connectPatch (int edge, ASM2D& neighbor, int nedge, bool revers,
 }
 
 
-void ASMs2Dmx::closeEdges (int dir, int, int)
+void ASMs2Dmx::closeBoundaries (int dir, int, int)
 {
   size_t nbi = 1;
-  for (size_t i = 1;i <= m_basis.size(); ++i) {
-    this->ASMs2D::closeEdges(dir,i,nbi);
-    nbi += nb[i-1];
-  }
+  for (size_t i = 0; i < m_basis.size(); nbi += nb[i++])
+    this->ASMs2D::closeBoundaries(dir,1+i,nbi);
 }
 
 

--- a/src/ASM/ASMs2Dmx.h
+++ b/src/ASM/ASMs2Dmx.h
@@ -109,7 +109,7 @@ public:
 
   //! \brief Makes two opposite boundary edges periodic.
   //! \param[in] dir Parameter direction defining the periodic edges
-  virtual void closeEdges(int dir, int = 0, int = 1);
+  virtual void closeBoundaries(int dir, int, int);
 
 
   // Methods for integration of finite element quantities.

--- a/src/ASM/ASMs2DmxLag.C
+++ b/src/ASM/ASMs2DmxLag.C
@@ -213,13 +213,11 @@ bool ASMs2DmxLag::connectPatch (int edge, ASM2D& neighbor, int nedge, bool rever
 }
 
 
-void ASMs2DmxLag::closeEdges (int dir, int, int)
+void ASMs2DmxLag::closeBoundaries (int dir, int, int)
 {
-  size_t nbi = 0;
-  for (size_t i = 1; i <= nxx.size(); i++) {
-    this->ASMs2D::closeEdges(dir,i,nbi+1);
-    nbi += nb[i-1];
-  }
+  size_t nbi = 1;
+  for (size_t i = 0; i < nxx.size(); nbi += nb[i++])
+    this->ASMs2D::closeBoundaries(dir,1+i,nbi);
 }
 
 

--- a/src/ASM/ASMs2DmxLag.h
+++ b/src/ASM/ASMs2DmxLag.h
@@ -77,7 +77,7 @@ public:
 
   //! \brief Makes two opposite boundary edges periodic.
   //! \param[in] dir Parameter direction defining the periodic edges
-  virtual void closeEdges(int dir, int = 0, int = 1);
+  virtual void closeBoundaries(int dir, int, int);
 
 
   // Methods for integration of finite element quantities.

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -727,7 +727,7 @@ bool ASMs3D::connectBasis (int face, ASMs3D& neighbor, int nface, int norient,
 }
 
 
-void ASMs3D::closeFaces (int dir, int basis, int master)
+void ASMs3D::closeBoundaries (int dir, int basis, int master)
 {
   int n1, n2, n3;
   if (basis < 1) basis = 1;

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -353,9 +353,9 @@ public:
 
   //! \brief Makes two opposite boundary faces periodic.
   //! \param[in] dir Parameter direction defining the periodic faces
-  //! \param[in] basis Which basis to connect (mixed methods), 0 means both
+  //! \param[in] basis Which basis to connect (mixed methods), 0 means all
   //! \param[in] master 1-based index of the first master node in this basis
-  virtual void closeFaces(int dir, int basis = 0, int master = 1);
+  virtual void closeBoundaries(int dir, int basis, int master);
 
   //! \brief Sets the global node numbers for this patch.
   //! \param[in] nodes Vector of global node numbers (zero-based)

--- a/src/ASM/ASMs3Dmx.C
+++ b/src/ASM/ASMs3Dmx.C
@@ -344,13 +344,11 @@ bool ASMs3Dmx::connectPatch (int face, ASM3D& neighbor, int nface, int norient,
 }
 
 
-void ASMs3Dmx::closeFaces (int dir, int, int)
+void ASMs3Dmx::closeBoundaries (int dir, int, int)
 {
   size_t nbi = 1;
-  for (size_t i = 1;i <= m_basis.size(); ++i) {
-    this->ASMs3D::closeFaces(dir,i,nbi);
-    nbi += nb[i-1];
-  }
+  for (size_t i = 0; i < m_basis.size(); nbi += nb[i++])
+    this->ASMs3D::closeBoundaries(dir,1+i,nbi);
 }
 
 

--- a/src/ASM/ASMs3Dmx.h
+++ b/src/ASM/ASMs3Dmx.h
@@ -102,7 +102,7 @@ public:
 
   //! \brief Makes two opposite boundary faces periodic.
   //! \param[in] dir Parameter direction defining the periodic faces
-  virtual void closeFaces(int dir, int = 0, int = 1);
+  virtual void closeBoundaries(int dir, int, int);
 
 
   // Methods for integration of finite element quantities.

--- a/src/ASM/ASMs3DmxLag.C
+++ b/src/ASM/ASMs3DmxLag.C
@@ -240,13 +240,11 @@ bool ASMs3DmxLag::connectPatch (int face, ASM3D& neighbor, int nface,
 }
 
 
-void ASMs3DmxLag::closeFaces (int dir, int, int)
+void ASMs3DmxLag::closeBoundaries (int dir, int, int)
 {
-  size_t nbi = 0;
-  for (size_t i = 1; i <= nxx.size(); i++) {
-    this->ASMs3D::closeFaces(dir,i,nbi+1);
-    nbi += nb[i-1];
-  }
+  size_t nbi = 1;
+  for (size_t i = 0; i < nxx.size(); nbi += nb[i++])
+    this->ASMs3D::closeBoundaries(dir,1+i,nbi);
 }
 
 

--- a/src/ASM/ASMs3DmxLag.h
+++ b/src/ASM/ASMs3DmxLag.h
@@ -77,7 +77,7 @@ public:
 
   //! \brief Makes two opposite boundary faces periodic.
   //! \param[in] dir Parameter direction defining the periodic faces
-  virtual void closeFaces(int dir, int = 0, int = 1);
+  virtual void closeBoundaries(int dir, int, int);
 
 
   // Methods for integration of finite element quantities.

--- a/src/SIM/SIM1D.h
+++ b/src/SIM/SIM1D.h
@@ -37,8 +37,8 @@ public:
   //! \param[in] itg Pointer to the integrand of the problem to solve
   //! \param[in] n Dimension of the primary solution field
   SIM1D(IntegrandBase* itg, unsigned char n = 1);
-  //! \brief The destructor deletes the twist angle function.
-  virtual ~SIM1D();
+  //! \brief Empty destructor.
+  virtual ~SIM1D() {}
 
   //! \brief Returns the number of parameter dimensions in the model.
   virtual unsigned short int getNoParamDim() const { return 1; }
@@ -78,12 +78,6 @@ public:
   Vector getSolution(const Vector& psol, double u,
                      int deriv = 0, int patch = 1) const;
 
-  //! \brief Updates the nodal rotations for problems with rotational DOFs.
-  //! \param[in] incSol Incremental solution to update the rotations with
-  //! \param[in] alpha Scaling factor for the incremental solution.
-  //! If 0.0, reinitialize the rotations from unity
-  virtual bool updateRotations(const Vector& incSol, double alpha);
-
 private:
   //! \brief Parses a subelement of the \a geometry XML-tag.
   bool parseGeometryTag(const TiXmlElement* elem);
@@ -91,9 +85,6 @@ private:
   bool parseBCTag(const TiXmlElement* elem);
 
 protected:
-  //! \brief Parses the twist angle description along the curve.
-  bool parseTwist(const TiXmlElement* elem);
-
   //! \brief Parses a data section from an XML document.
   //! \param[in] elem The XML element to parse
   virtual bool parse(const TiXmlElement* elem);
@@ -120,17 +111,8 @@ protected:
   //! \param[in] geo XML element containing geometry definition
   virtual ModelGenerator* getModelGenerator(const TiXmlElement* geo) const;
 
-public:
-  //! \brief Creates the computational FEM model from the spline patches.
-  //! \details Reimplemented to account for twist angle in beam problems.
-  virtual bool createFEMmodel(char = 'y');
-
 protected:
   unsigned char nf; //!< Number of scalar fields
-
-private:
-  RealFunc* twist; //!< Twist angle (for 3D beam problems only)
-  Vec3      XZp;   //!< Local Z-direction vector
 };
 
 #endif


### PR DESCRIPTION
* In the first commit, the beam-specific features are removed (they are now placed in the SIMElasticBar class instead), since this has relevance for elastic beam applications only.
* In the second commit, the periodicity input handling is moved to SIMinput and a virtual method in ASMbase is introduced to avoid casting the spline patch object when applying the periodicity conditions. 