### PR TITLE
Support for spline patch definition in the xinp directly instead of via file

### DIFF
--- a/Apps/Common/MultiPatchModelGenerator.h
+++ b/Apps/Common/MultiPatchModelGenerator.h
@@ -35,12 +35,11 @@ public:
   virtual ~MultiPatchModelGenerator1D() {}
 
   //! \brief Creates a geometry.
-  //! \param[in] m Simulator object with patch read function to use
-  std::vector<ASMbase*> createGeometry(const SIMinput& m) const;
+  virtual bool createGeometry(SIMinput& sim) const;
   //! \brief Creates topology for geometry.
   virtual bool createTopology(SIMinput& sim) const;
   //! \brief Creates topology sets for geometry.
-  virtual TopologySet createTopologySets(const SIMinput& sim) const;
+  virtual bool createTopologySets(SIMinput& sim) const;
 
   //! \brief Generates knot vectors for subdivision.
   //! \param[in] cur Univariate patch to extract subpatch from
@@ -76,12 +75,11 @@ public:
   virtual ~MultiPatchModelGenerator2D() {}
 
   //! \brief Creates a geometry.
-  //! \param[in] m Simulator object with patch read function to use
-  std::vector<ASMbase*> createGeometry(const SIMinput& m) const;
+  virtual bool createGeometry(SIMinput& sim) const;
   //! \brief Creates topology for geometry.
   virtual bool createTopology(SIMinput& sim) const;
   //! \brief Creates topology sets for geometry.
-  virtual TopologySet createTopologySets(const SIMinput& sim) const;
+  virtual bool createTopologySets(SIMinput& sim) const;
 
   //! \brief Generates knot vectors for subdivision.
   //! \param[in] srf Bivariate patch to extract subpatch from
@@ -123,12 +121,11 @@ public:
   virtual ~MultiPatchModelGenerator3D() {}
 
   //! \brief Creates a geometry.
-  //! \param[in] m Simulator object with patch read function to use
-  std::vector<ASMbase*> createGeometry(const SIMinput& m) const;
+  virtual bool createGeometry(SIMinput& sim) const;
   //! \brief Creates topology for geometry.
   virtual bool createTopology(SIMinput& sim) const;
   //! \brief Creates topology sets for geometry.
-  virtual TopologySet createTopologySets(const SIMinput& sim) const;
+  virtual bool createTopologySets(SIMinput& sim) const;
 
   //! \brief Generates knot vectors for subdivision.
   //! \param[in] vol Trivariate patch to extract subpatch from

--- a/Apps/Common/Test/TestMultiPatchModelGenerator.C
+++ b/Apps/Common/Test/TestMultiPatchModelGenerator.C
@@ -148,8 +148,8 @@ TEST_P(TestMultiPatchModelGenerator2D, Generate)
   TestModelGeneratorWrapper<MultiPatchModelGenerator2D> gen(doc.RootElement());
   std::string g2 = gen.createG2(GetParam().dim);
   SIM2D sim;
-  TopologySet sets = gen.createTopologySets(sim);
-  DoTest(GetParam(), g2, sets);
+  gen.createTopologySets(sim);
+  DoTest(GetParam(), g2, sim.getTopology());
 }
 
 
@@ -212,11 +212,10 @@ TEST(TestMultiPatchModelGenerator2D, InnerPatches)
   TiXmlDocument doc;
   doc.Parse("<geometry nx=\"3\" ny=\"3\" sets=\"true\"/>");
   TestModelGeneratorWrapper<MultiPatchModelGenerator2D> gen(doc.RootElement());
-  std::string g2 = gen.createG2(2);
   SIM2D sim;
-  TopologySet sets = gen.createTopologySets(sim);
-  ASSERT_EQ(sets["InnerPatches"].size(), 1u);
-  ASSERT_EQ(sets["InnerPatches"].begin()->patch, 5u);
+  gen.createTopologySets(sim);
+  ASSERT_EQ(sim.topology("InnerPatches").size(), 1u);
+  ASSERT_EQ(sim.topology("InnerPatches").begin()->patch, 5u);
 }
 
 
@@ -227,8 +226,8 @@ TEST_P(TestMultiPatchModelGenerator3D, Generate)
   TestModelGeneratorWrapper<MultiPatchModelGenerator3D> gen(doc.RootElement());
   std::string g2 = gen.createG2(GetParam().dim);
   SIM3D sim;
-  TopologySet sets = gen.createTopologySets(sim);
-  DoTest(GetParam(), g2, sets);
+  gen.createTopologySets(sim);
+  DoTest(GetParam(), g2, sim.getTopology());
 }
 
 
@@ -832,17 +831,15 @@ INSTANTIATE_TEST_CASE_P(TestGetSubPatch3D,
                         TestGetSubPatch3D,
                         testing::ValuesIn(SubPatch3D));
 
-
 TEST(TestMultiPatchModelGenerator3D, InnerPatches)
 {
   TiXmlDocument doc;
   doc.Parse("<geometry nx=\"3\" ny=\"3\" nz=\"3\"  sets=\"true\"/>");
   TestModelGeneratorWrapper<MultiPatchModelGenerator3D> gen(doc.RootElement());
-  std::string g2 = gen.createG2(2);
   SIM3D sim;
-  TopologySet sets = gen.createTopologySets(sim);
-  ASSERT_EQ(sets["InnerPatches"].size(), 1u);
-  ASSERT_EQ(sets["InnerPatches"].begin()->patch, 14u);
+  gen.createTopologySets(sim);
+  ASSERT_EQ(sim.topology("InnerPatches").size(), 1u);
+  ASSERT_EQ(sim.topology("InnerPatches").begin()->patch, 14u);
 }
 
 

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -1850,7 +1850,8 @@ bool ASMs2D::integrate (Integrand& integrand,
         A->destruct();
 
 #ifdef SP_DEBUG
-        if (iel == -dbgElm) break; // Skipping all elements, except for -dbgElm
+        if (iel == -dbgElm)
+          break; // Skipping all elements, except for -dbgElm
 #endif
       }
     }
@@ -1931,7 +1932,7 @@ bool ASMs2D::integrate (Integrand& integrand,
         if (fe.iel < 1) continue; // zero-area element
 
 #ifdef SP_DEBUG
-        if (dbgElm < 0 && iel != -dbgElm)
+        if (dbgElm < 0 && 1+iel != -dbgElm)
           continue; // Skipping all elements, except for -dbgElm
 #endif
 
@@ -2055,7 +2056,8 @@ bool ASMs2D::integrate (Integrand& integrand,
         A->destruct();
 
 #ifdef SP_DEBUG
-        if (iel == -dbgElm) break; // Skipping all elements, except for -dbgElm
+        if (iel == -dbgElm)
+          break; // Skipping all elements, except for -dbgElm
 #endif
       }
     }
@@ -2385,8 +2387,13 @@ bool ASMs2D::integrate (Integrand& integrand, int lIndex,
         else if (nsd > 2)
           fe.G = Jac; // Store tangent vectors in fe.G for shells
 
+#if SP_DEBUG > 4
+        if (iel == dbgElm || iel == -dbgElm || dbgElm == 0)
+          std::cout <<"\n"<< fe;
+#endif
+
 	// Cartesian coordinates of current integration point
-        X.assign(Xnod * fe.N);
+	X.assign(Xnod * fe.N);
 	X.t = time.t;
 
 	// Evaluate the integrand and accumulate element contributions
@@ -2400,7 +2407,7 @@ bool ASMs2D::integrate (Integrand& integrand, int lIndex,
 
       // Assembly of global system integral
       if (ok && !glInt.assemble(A->ref(),fe.iel))
-	ok = false;
+        ok = false;
 
       A->destruct();
 
@@ -2857,6 +2864,10 @@ bool ASMs2D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
 
     // Store tangent vectors in fe.G for shells
     if (nsd > 2) fe.G = Jac;
+
+#if SP_DEBUG > 4
+    std::cout <<"\n"<< fe;
+#endif
 
     // Now evaluate the solution field
     if (!integrand.evalSol(solPt,fe,Xtmp*fe.N,ip))

--- a/src/ASM/FiniteElement.C
+++ b/src/ASM/FiniteElement.C
@@ -27,6 +27,7 @@ std::ostream& FiniteElement::write (std::ostream& os) const
   if (!N.empty())      os <<"N:"<< N;
   if (!dNdX.empty())   os <<"dNdX:"<< dNdX;
   if (!d2NdX2.empty()) os <<"d2NdX2: "<< d2NdX2;
+  if (!d3NdX3.empty()) os <<"d3NdX3: "<< d3NdX3;
   if (!G.empty())      os <<"G:"<< G;
   if (!H.empty())      os <<"H:"<< H;
   if (!Navg.empty())   os <<"Navg:"<< Navg;

--- a/src/ASM/Test/TestMatlabPatch.C
+++ b/src/ASM/Test/TestMatlabPatch.C
@@ -34,7 +34,7 @@ public:
     // Create topological boundary entities (vertices and edges)
     TiXmlDocument doc;
     doc.Parse("<geometry sets=\"true\"/>",nullptr,TIXML_ENCODING_UTF8);
-    myEntitys = DefaultGeometry2D(doc.RootElement()).createTopologySets(*this);
+    DefaultGeometry2D(doc.RootElement()).createTopologySets(*this);
     EXPECT_EQ(myEntitys.size(),10U);
   }
   virtual ~SIM2D_default() {}

--- a/src/SIM/AdaptiveSIM.h
+++ b/src/SIM/AdaptiveSIM.h
@@ -85,18 +85,6 @@ protected:
   virtual bool assembleAndSolveSystem();
 
 private:
-  //! \brief Element error and associated index.
-  //! \note The error value must be first and the index second, such that the
-  //! internally defined greater-than operator can be used when sorting the
-  //! error+index pairs in decreasing error order.
-  typedef std::pair<double,int> DblIdx;
-
-  //! \brief Save errors to text file for inspection.
-  //! \param errors The calculate errors
-  //! \param refineSize Number of functions marked for refinement
-  //! \param step Refinement step
-  void saveErrors(const std::vector<DblIdx>& errors, size_t refineSize, int step);
-
   SIMoutput& model; //!< The isogeometric FE model
   bool       alone; //!< If \e false, this class is wrapped by SIMSolver
 

--- a/src/SIM/ModelGenerator.h
+++ b/src/SIM/ModelGenerator.h
@@ -14,8 +14,6 @@
 #ifndef _MODEL_GENERATOR_H
 #define _MODEL_GENERATOR_H
 
-#include "TopologySet.h"
-#include <vector>
 #include <string>
 
 class SIMinput;
@@ -36,16 +34,14 @@ public:
   //! \brief Empty destructor.
   virtual ~ModelGenerator() {}
 
-  //! \brief Creates a geometry.
-  //! \param[in] m Simulator object with patch read function to use
-  virtual std::vector<ASMbase*> createGeometry(const SIMinput& m) const;
+  //! \brief Creates geometry for the specified \a sim object..
+  virtual bool createGeometry(SIMinput& sim) const;
+
+  //! \brief Creates topology sets for the specified \a sim object.
+  virtual bool createTopologySets(SIMinput& sim) const = 0;
 
   //! \brief Creates topology for multi-patch geometries.
   virtual bool createTopology(SIMinput&) const { return true; }
-
-  //! \brief Creates topology sets for geometry.
-  //! \param[in] sim Simulator object with patch ownerships
-  virtual TopologySet createTopologySets(const SIMinput& sim) const = 0;
 
 protected:
   //! \brief Generates the G2 description of the geometry.
@@ -74,8 +70,8 @@ public:
   //! \brief Empty destructor.
   virtual ~DefaultGeometry1D() {}
 
-  //! \brief Creates topology sets for geometry.
-  virtual TopologySet createTopologySets(const SIMinput&) const;
+  //! \brief Creates topology sets for the specified \a sim object.
+  virtual bool createTopologySets(SIMinput& sim) const;
 
 protected:
   //! \brief Generates the G2 description of the geometry.
@@ -96,8 +92,8 @@ public:
   //! \brief Empty destructor.
   virtual ~DefaultGeometry2D() {}
 
-  //! \brief Creates topology sets for geometry.
-  virtual TopologySet createTopologySets(const SIMinput&) const;
+  //! \brief Creates topology sets for the specified \a sim object.
+  virtual bool createTopologySets(SIMinput& sim) const;
 
 protected:
   //! \brief Generates the G2 description of the geometry.
@@ -118,8 +114,8 @@ public:
   //! \brief Empty destructor.
   virtual ~DefaultGeometry3D() {}
 
-  //! \brief Creates topology sets for geometry.
-  virtual TopologySet createTopologySets(const SIMinput&) const;
+  //! \brief Creates topology sets for the specified \a sim object.
+  virtual bool createTopologySets(SIMinput& sim) const;
 
 protected:
   //! \brief Generates the G2 description of the geometry.

--- a/src/SIM/SIM1D.h
+++ b/src/SIM/SIM1D.h
@@ -43,20 +43,6 @@ public:
   //! \brief Returns the number of parameter dimensions in the model.
   virtual unsigned short int getNoParamDim() const { return 1; }
 
-  //! \brief Reads a patch from given input stream.
-  //! \param[in] isp The input stream to read from
-  //! \param[in] pchInd 0-based index of the patch to read
-  //! \param[in] unf Number of unknowns per basis function for each field
-  virtual ASMbase* readPatch(std::istream& isp, int pchInd,
-                             const CharVec& unf) const;
-
-  //! \brief Reads patches from given input stream.
-  //! \param[in] isp The input stream to read from
-  //! \param[out] patches Array of patches that were read
-  //! \param[in] whiteSpace For message formatting
-  virtual bool readPatches(std::istream& isp, PatchVec& patches,
-                           const char* whiteSpace) const;
-
   //! \brief Connects two patches.
   //! \param[in] master Master patch
   //! \param[in] slave Slave patch
@@ -110,6 +96,14 @@ protected:
   //! \brief Returns a FEM model generator for a default single-patch model.
   //! \param[in] geo XML element containing geometry definition
   virtual ModelGenerator* getModelGenerator(const TiXmlElement* geo) const;
+
+  //! \brief Reads a patch from given input stream.
+  //! \param[in] isp The input stream to read from
+  //! \param[in] pchInd 0-based index of the patch to read
+  //! \param[in] unf Number of unknowns per basis function for each field
+  //! \param[in] whiteSpace For message formatting
+  virtual ASMbase* readPatch(std::istream& isp, int pchInd, const CharVec& unf,
+                             const char* whiteSpace) const;
 
 protected:
   unsigned char nf; //!< Number of scalar fields

--- a/src/SIM/SIM2D.h
+++ b/src/SIM/SIM2D.h
@@ -57,20 +57,6 @@ public:
   virtual void clonePatches(const PatchVec& patches,
                             const std::map<int,int>& g2ln);
 
-  //! \brief Reads a patch from given input stream.
-  //! \param[in] isp The input stream to read from
-  //! \param[in] pchInd 0-based index of the patch to read
-  //! \param[in] unf Number of unknowns per basis function for each field
-  virtual ASMbase* readPatch(std::istream& isp, int pchInd,
-                             const CharVec& unf) const;
-
-  //! \brief Reads patches from given input stream.
-  //! \param[in] isp The input stream to read from
-  //! \param[out] patches Array of patches that were read
-  //! \param[in] whiteSpace For message formatting
-  virtual bool readPatches(std::istream& isp, PatchVec& patches,
-                           const char* whiteSpace) const;
-
   //! \brief Connects two patches.
   //! \param[in] master Master patch
   //! \param[in] slave Slave patch
@@ -138,6 +124,14 @@ protected:
   //! \brief Returns a FEM model generator for a default single-patch model.
   //! \param[in] geo XML element containing geometry definition
   virtual ModelGenerator* getModelGenerator(const TiXmlElement* geo) const;
+
+  //! \brief Reads a patch from given input stream.
+  //! \param[in] isp The input stream to read from
+  //! \param[in] pchInd 0-based index of the patch to read
+  //! \param[in] unf Number of unknowns per basis function for each field
+  //! \param[in] whiteSpace For message formatting
+  virtual ASMbase* readPatch(std::istream& isp, int pchInd, const CharVec& unf,
+                             const char* whiteSpace) const;
 
 protected:
   CharVec nf;         //!< Number of scalar fields

--- a/src/SIM/SIM3D.C
+++ b/src/SIM/SIM3D.C
@@ -670,60 +670,30 @@ bool SIM3D::addConstraint (int patch, int lndx, int line, double xi,
 }
 
 
-ASMbase* SIM3D::readPatch (std::istream& isp, int pchInd,
-                           const CharVec& unf) const
+ASMbase* SIM3D::readPatch (std::istream& isp, int pchInd, const CharVec& unf,
+                           const char* whiteSpace) const
 {
   const CharVec& uunf = unf.empty() ? nf : unf;
   bool isMixed = uunf.size() > 1 && uunf[1] > 0;
   ASMbase* pch = ASM3D::create(opt.discretization,uunf,isMixed);
   if (pch)
   {
-    if (!pch->read(isp))
-      delete pch, pch = nullptr;
-    else if (pch->empty() || this->getLocalPatchIndex(pchInd+1) < 1)
-      delete pch, pch = nullptr;
+    if (!pch->read(isp) || this->getLocalPatchIndex(pchInd+1) < 1)
+    {
+      delete pch;
+      pch = nullptr;
+    }
     else
-      pch->idx = myModel.size();
-  }
-
-  if (checkRHSys && pch)
-    if (dynamic_cast<ASM3D*>(pch)->checkRightHandSystem())
-      IFEM::cout <<"\tSwapped."<< std::endl;
-
-  return pch;
-}
-
-
-bool SIM3D::readPatches (std::istream& isp, PatchVec& patches,
-                         const char* whiteSpace) const
-{
-  bool isMixed = nf.size() > 1 && nf[1] > 0;
-  for (int pchInd = 1; isp.good(); pchInd++)
-  {
-    ASMbase* pch = ASM3D::create(opt.discretization,nf,isMixed);
-    if (pch)
     {
       if (whiteSpace)
-        IFEM::cout << whiteSpace <<"Reading patch "<< pchInd << std::endl;
-      if (!pch->read(isp))
-      {
-        delete pch;
-        return false;
-      }
-      else if (pch->empty() || this->getLocalPatchIndex(pchInd) < 1)
-        delete pch;
-      else
-      {
-        pch->idx = patches.size();
-        patches.push_back(pch);
-        if (checkRHSys)
-          if (dynamic_cast<ASM3D*>(pch)->checkRightHandSystem())
-            IFEM::cout <<"\tSwapped."<< std::endl;
-      }
+        IFEM::cout << whiteSpace <<"Reading patch "<< pchInd+1 << std::endl;
+      if (checkRHSys && dynamic_cast<ASM3D*>(pch)->checkRightHandSystem())
+        IFEM::cout <<"\tSwapped."<< std::endl;
+      pch->idx = myModel.size();
     }
   }
 
-  return true;
+  return pch;
 }
 
 

--- a/src/SIM/SIM3D.h
+++ b/src/SIM/SIM3D.h
@@ -57,20 +57,6 @@ public:
   virtual void clonePatches(const PatchVec& patches,
                             const std::map<int,int>& g2ln);
 
-  //! \brief Reads a patch from given input stream.
-  //! \param[in] isp The input stream to read from
-  //! \param[in] pchInd 0-based index of the patch to read
-  //! \param[in] unf Number of unknowns per basis function for each field
-  virtual ASMbase* readPatch(std::istream& isp, int pchInd,
-                             const CharVec& unf) const;
-
-  //! \brief Reads patches from given input stream.
-  //! \param[in] isp The input stream to read from
-  //! \param[out] patches Array of patches that were read
-  //! \param[in] whiteSpace For message formatting
-  virtual bool readPatches(std::istream& isp, PatchVec& patches,
-                           const char* whiteSpace) const;
-
   //! \brief Connects two patches.
   //! \param[in] master Master patch
   //! \param[in] slave Slave patch
@@ -149,6 +135,14 @@ protected:
   //! \brief Returns a FEM model generator for a default single-patch model.
   //! \param[in] geo XML element containing geometry definition
   virtual ModelGenerator* getModelGenerator(const TiXmlElement* geo) const;
+
+  //! \brief Reads a patch from given input stream.
+  //! \param[in] isp The input stream to read from
+  //! \param[in] pchInd 0-based index of the patch to read
+  //! \param[in] unf Number of unknowns per basis function for each field
+  //! \param[in] whiteSpace For message formatting
+  virtual ASMbase* readPatch(std::istream& isp, int pchInd, const CharVec& unf,
+                             const char* whiteSpace) const;
 
 protected:
   CharVec nf;         //!< Number of scalar fields

--- a/src/SIM/SIMdummy.h
+++ b/src/SIM/SIMdummy.h
@@ -39,14 +39,6 @@ public:
   virtual ~SIMdummy() {}
   //! \brief Returns the number of parameter dimensions in the model.
   virtual unsigned short int getNoParamDim() const { return 0; }
-  //! \brief Reads a patch from given input stream.
-  virtual ASMbase* readPatch(std::istream&,int,
-                             const std::vector<unsigned char>&) const
-  { return nullptr; }
-  //! \brief Reads patches from given input stream.
-  virtual bool readPatches(std::istream&,
-                           std::vector<ASMbase*>&,const char*) const
-  { return false; }
   //! \brief Creates the computational FEM model from the spline patches.
   virtual bool createFEMmodel(char) { return false; }
 
@@ -59,6 +51,10 @@ protected:
   //! \brief Creates a model generator.
   virtual ModelGenerator* getModelGenerator(const TiXmlElement*) const
   { return nullptr; }
+  //! \brief Reads a patch from given input stream.
+  virtual ASMbase* readPatch(std::istream&,int,
+                             const std::vector<unsigned char>&,
+                             const char*) const { return nullptr; }
 };
 
 #endif

--- a/src/SIM/SIMgeneric.C
+++ b/src/SIM/SIMgeneric.C
@@ -23,11 +23,11 @@ ASMbase* SIMgeneric::createDefaultModel ()
   ModelGenerator* gen = this->getModelGenerator(nullptr);
   if (!gen) return nullptr;
 
-  myModel = gen->createGeometry(*this);
+  bool okGen = gen->createGeometry(*this);
   nGlPatches = myModel.size();
   delete gen;
 
-  return nGlPatches > 0 ? myModel.front() : nullptr;
+  return okGen && nGlPatches > 0 ? myModel.front() : nullptr;
 }
 
 

--- a/src/SIM/SIMinput.h
+++ b/src/SIM/SIMinput.h
@@ -169,19 +169,10 @@ public:
   bool refine(const LR::RefineData& prm,
               Vectors& sol, const char* fName = nullptr);
 
-  //! \brief Reads a patch from given input stream.
-  //! \param[in] isp The input stream to read from
-  //! \param[in] pchInd 0-based index of the patch to read
-  //! \param[in] unf Number of unknowns per basis function for each field
-  virtual ASMbase* readPatch(std::istream& isp, int pchInd,
-                             const CharVec& unf = CharVec()) const = 0;
-
   //! \brief Reads patches from given input stream.
   //! \param[in] isp The input stream to read from
-  //! \param[out] patches Array of patches that were read
   //! \param[in] whiteSpace For message formatting
-  virtual bool readPatches(std::istream& isp, PatchVec& patches,
-                           const char* whiteSpace = "") const = 0;
+  bool readPatches(std::istream& isp, const char* whiteSpace = "");
 
   //! \brief Connects two patches.
   //! \param[in] master Master patch
@@ -198,6 +189,20 @@ public:
                              int dim = 1, int thick = 1) { return false; }
 
 protected:
+  //! \brief Helper method returning a stream for patch geometry input.
+  //! \param[in] tag The XML-tag containing the patch geometry definition
+  //! \param[in] patch The value of the \a tag, either a file name or g2 string
+  static std::istream* getPatchStream (const char* tag, const char* patch);
+
+  //! \brief Reads a patch from given input stream.
+  //! \param[in] isp The input stream to read from
+  //! \param[in] pchInd 0-based index of the patch to read
+  //! \param[in] unf Number of unknowns per basis function for each field
+  //! \param[in] whiteSpace For message formatting
+  virtual ASMbase* readPatch(std::istream& isp, int pchInd,
+                             const CharVec& unf = CharVec(),
+                             const char* whiteSpace = "") const = 0;
+
   //! \brief Reads global node data for a patch from given input stream.
   //! \param[in] isn The input stream to read from
   //! \param[in] pchInd 0-based index of the patch to read node data for
@@ -232,6 +237,11 @@ public:
 
   //! \brief Deserialization support (for simulation restart).
   virtual bool deSerialize(const std::map<std::string,std::string>&);
+
+  //! \brief Returns access to a named topology entity (for model generators).
+  TopEntity& topology(const std::string& name) { return myEntitys[name]; }
+  //! \brief Returns the whole topology set container (for testing only).
+  const TopologySet& getTopology() const { return myEntitys; }
 
 private:
   //! \brief Sets initial conditions from a file.

--- a/src/SIM/Test/TestModelGenerator.C
+++ b/src/SIM/Test/TestModelGenerator.C
@@ -91,8 +91,8 @@ TEST_P(TestModelGenerator1D, Generate)
   TestModelGeneratorWrapper<DefaultGeometry1D> gen(doc.RootElement());
   std::string g2 = gen.createG2(GetParam().dim);
   SIM1D sim;
-  TopologySet sets = gen.createTopologySets(sim);
-  DoTest(GetParam(), g2, sets);
+  gen.createTopologySets(sim);
+  DoTest(GetParam(), g2, sim.getTopology());
 }
 
 
@@ -103,8 +103,8 @@ TEST_P(TestModelGenerator2D, Generate)
   TestModelGeneratorWrapper<DefaultGeometry2D> gen(doc.RootElement());
   std::string g2 = gen.createG2(GetParam().dim);
   SIM2D sim;
-  TopologySet sets = gen.createTopologySets(sim);
-  DoTest(GetParam(), g2, sets);
+  gen.createTopologySets(sim);
+  DoTest(GetParam(), g2, sim.getTopology());
 }
 
 
@@ -115,8 +115,8 @@ TEST_P(TestModelGenerator3D, Generate)
   TestModelGeneratorWrapper<DefaultGeometry3D> gen(doc.RootElement());
   std::string g2 = gen.createG2(GetParam().dim);
   SIM3D sim;
-  TopologySet sets = gen.createTopologySets(sim);
-  DoTest(GetParam(), g2, sets);
+  gen.createTopologySets(sim);
+  DoTest(GetParam(), g2, sim.getTopology());
 }
 
 


### PR DESCRIPTION
A convenience for small models that are not easily covered by the model-generator.
Did this last fall, then almost forgot it. But think it is nice-to-have functionality.
The others here are minor things.