### PR TITLE
added: singleton entry point for stb image

### DIFF
--- a/src/Utility/StbImage.C
+++ b/src/Utility/StbImage.C
@@ -1,0 +1,23 @@
+// $Id$
+//==============================================================================
+//!
+//! \file StbImage.C
+//!
+//! \date Mar 7 2019
+//!
+//! \author Arne Morten Kvarving / SINTEF
+//!
+//! \brief Singleton wrapper for stb_image.
+//!
+//==============================================================================
+
+#include "StbImage.h"
+
+#define STB_IMAGE_IMPLEMENTATION
+#include "stb_image.h"
+
+unsigned char* stb::loadImage(const char* file, int& width,
+                              int& height, int& nrChannels)
+{
+  return stbi_load(file,&width,&height,&nrChannels,0);
+}

--- a/src/Utility/StbImage.h
+++ b/src/Utility/StbImage.h
@@ -1,0 +1,27 @@
+// $Id$
+//==============================================================================
+//!
+//! \file StbImage.h
+//!
+//! \date Mar 7 2019
+//!
+//! \author Arne Morten Kvarving / SINTEF
+//!
+//! \brief Singleton wrapper for stb_image.
+//!
+//==============================================================================
+
+#ifndef STBIMAGE_H_
+#define STBIMAGE_H_
+
+//! \brief Namespace for STB routines.
+namespace stb {
+  //! \brief Load an image from file.
+  //! \param[in] file The file to load
+  //! \param[out] width The width of the image
+  //! \param[out] height The height of the image
+  //! \param[out] nrChannels The number of channels in the image
+  unsigned char* loadImage(const char* file, int& width, int& height, int& nrChannels);
+}
+
+#endif


### PR DESCRIPTION
the header can only be used once. we need this wrapper
class with multiple texture material types.