### PR TITLE
Fixed: Use InsertAfterChild instead of LinkEndChild in XMLInputBase

### DIFF
--- a/src/SIM/ModelGenerator.C
+++ b/src/SIM/ModelGenerator.C
@@ -56,7 +56,7 @@ bool ModelGenerator::createGeometry (SIMinput& sim) const
   utl::getAttribute(geo,"rational",rational);
 
   std::istringstream g2(this->createG2(sim.getNoSpaceDim(),rational));
-  return sim.readPatches(g2);
+  return sim.readPatches(g2,nullptr);
 }
 
 

--- a/src/SIM/SIMargsBase.C
+++ b/src/SIM/SIMargsBase.C
@@ -23,6 +23,8 @@ bool SIMargsBase::parseArg (const char* argv)
 {
   if (!strncmp(argv,"-adap",5) && !isdigit(argv[5]))
     adap = true;
+  else if (!strncmp(argv,"-noadap",7))
+    adap = false;
   else if (!strcmp(argv,"-1D"))
     dim = 1;
   else if (!strcmp(argv,"-2D"))

--- a/src/SIM/SIMargsBase.h
+++ b/src/SIM/SIMargsBase.h
@@ -25,7 +25,7 @@ class SIMargsBase : public XMLInputBase
 {
 public:
   //! \brief The constructor initializes the default parameter values.
-  explicit SIMargsBase(const char* ctx) : context(ctx), dim(3), adap(false)  {}
+  explicit SIMargsBase(const char* ctx) : context(ctx), dim(3), adap(false) {}
 
   //! \brief Parses a command-line argument.
   virtual bool parseArg(const char* argv);

--- a/src/SIM/XMLInputBase.h
+++ b/src/SIM/XMLInputBase.h
@@ -7,7 +7,7 @@
 //!
 //! \author Arne Morten Kvarving / SINTEF
 //!
-//! \brief Base class for xml input parsing functionality.
+//! \brief Base class for XML input parsing functionality.
 //!
 //==============================================================================
 
@@ -22,7 +22,7 @@ class TiXmlElement;
 /*!
   \brief Base class for XML based input file parsing.
   \details This class is inherited by SIMadmin for input parsing handling,
-  and is also used in applications for pre-parsing of the input file.
+  and can also be used by applications for pre-parsing of the input file.
 */
 
 class XMLInputBase
@@ -30,20 +30,21 @@ class XMLInputBase
 public:
   //! \brief Reads an XML input file.
   //! \param[in] fileName File to read
-  //! \param[in] verbose True to print the tags being parsed to output
+  //! \param[in] verbose If \e true, print the tags being parsed
   bool readXML(const char* fileName, bool verbose = true);
 
 protected:
   //! \brief Parses a data section from an XML element.
   virtual bool parse(const TiXmlElement* elem) = 0;
 
-  //! \brief Recursive helper method for processing the \a include XML-tags.
-  void injectIncludeFiles(TiXmlElement* tag) const;
+  //! \brief Returns a list of prioritized XML-tags.
+  virtual const char** getPrioritizedTags() const { return nullptr; }
 
+private:
   //! \brief Handles the parsing order for certain XML-tags.
   //! \param[in] base The base tag containing the elements to be prioritized
   //! \param[out] parsed Vector of XML-elements that was parsed
-  //! \param verbose True to print the tags being parsed to output
+  //! \param[in] verbose If \e true, print the tags being parsed
   //!
   //! \details Certain tags need to be parsed before others. This method takes
   //! care of this. It is called by the \a readXML method in order to read the
@@ -55,8 +56,8 @@ protected:
                           std::vector<const TiXmlElement*>& parsed,
                           bool verbose);
 
-  //! \brief Returns a list of prioritized XML-tags.
-  virtual const char** getPrioritizedTags() const { return nullptr; }
+  //! \brief Recursive helper method for processing the \a include XML-tags.
+  bool injectIncludeFiles(TiXmlElement* tag, bool verbose) const;
 };
 
 #endif


### PR DESCRIPTION
when the included file contains for than one tag, to ensure they are inserted into the right place.
Added: Debug print of the expanded XML-file content.
