### PR TITLE
Added: Optionally collapse degenerated faces into an edge or node.

### DIFF
--- a/src/ASM/ASM3D.h
+++ b/src/ASM/ASM3D.h
@@ -144,7 +144,6 @@ public:
   //! \param[in] zeta Parameter in w-direction
   //! \param[in] dof Which DOFs to constrain at the node
   //! \param[in] code Inhomogeneous dirichlet condition code
-  //! \param[in] basis Which basis to constrain node for
   //!
   //! \details The parameter values have to be in the domain [0.0,1.0], where
   //! 0.0 means the beginning of the domain and 1.0 means the end. For values
@@ -152,7 +151,7 @@ public:
   //! \a r*n, where \a r denotes the given relative parameter value,
   //! and \a n is the number of nodes along that parameter direction.
   virtual void constrainNode(double xi, double eta, double zeta,
-                             int dof = 123, int code = 0, char basis = 1) = 0;
+                             int dof = 123, int code = 0) = 0;
 
   //! \brief Calculates parameter values for visualization nodal points.
   //! \param[out] prm Parameter values in given direction for all points

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -228,7 +228,7 @@ public:
   //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
   //! \param[in] lIndex Local index of the boundary face/edge
   //! \param nodes Array of node numbers
-  //! \param[in] basis Which basis to grab nodes for (0 for all)
+  //! \param[in] basis Which basis to grab nodes for (for mixed methods)
   //! \param[in] thick Thickness of connection
   //! \param[in] orient Local orientation of the boundary face/edge
   //! \param[in] local If \e true, return patch-local numbers
@@ -321,7 +321,7 @@ public:
 
   //! \brief Makes two opposite boundaries periodic.
   //! \param[in] dir Parameter direction defining the periodic boundaries
-  //! \param[in] basis Which basis to connect (mixed methods), 0 means all
+  //! \param[in] basis Which basis to connect (mixed methods)
   //! \param[in] master 1-based index of the first master node in this basis
   virtual void closeBoundaries(int dir = 1, int basis = 0, int master = 1) {}
 

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -182,7 +182,7 @@ public:
                             int thick = 1);
 
   //! \brief Makes the two end vertices of the curve periodic.
-  //! \param[in] basis Which basis to connect (mixed methods), 0 means all
+  //! \param[in] basis Which basis to connect (mixed methods)
   //! \param[in] master 1-based index of the first master node in this basis
   virtual void closeBoundaries(int, int basis, int master);
 
@@ -263,10 +263,9 @@ public:
   //! \brief Evaluates and interpolates a function over a given geometry.
   //! \param[in] func The function to evaluate
   //! \param[out] vec The obtained coefficients after interpolation
-  //! \param[in] basis Basis number (mixed)
   //! \param[in] time Current time
   virtual bool evaluate(const FunctionBase* func, RealArray& vec,
-                        int basis, double time) const;
+                        int, double time) const;
 
   //! \brief Evaluates the secondary solution field at all visualization points.
   //! \param[out] sField Solution field

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -699,8 +699,9 @@ bool ASMs2D::connectBasis (int edge, ASMs2D& neighbor, int nedge, bool revers,
 
 void ASMs2D::closeBoundaries (int dir, int basis, int master)
 {
-  int n1, n2;
   if (basis < 1) basis = 1;
+
+  int n1, n2;
   if (!this->getSize(n1,n2,basis)) return;
 
   switch (dir)
@@ -720,8 +721,9 @@ void ASMs2D::closeBoundaries (int dir, int basis, int master)
 
 bool ASMs2D::collapseEdge (int edge, int basis)
 {
-  int i, n1, n2, node, nnod, incn = 1, master = 1;
   if (basis < 1) basis = 1;
+
+  int i, n1, n2, node, nnod, incn = 1, master = 1;
   for (i = 1; i <= basis; i++)
     if (!this->getSize(n1,n2,i))
       return false;
@@ -782,6 +784,8 @@ bool ASMs2D::collapseEdge (int edge, int basis)
 
 void ASMs2D::constrainEdge (int dir, bool open, int dof, int code, char basis)
 {
+  if (basis < 1) basis = 1;
+
   int n1 = 0, n2 = 0, node = 1;
   for (char i = 1; i <= basis; i++)
     if (!this->getSize(n1,n2,i))
@@ -1064,7 +1068,9 @@ size_t ASMs2D::constrainEdgeLocal (int dir, bool open, int dof, int code,
 
 void ASMs2D::constrainCorner (int I, int J, int dof, int code, char basis)
 {
-  int node = this->getCorner(I, J, basis);
+  if (basis < 1) basis = 1;
+
+  int node = this->getCorner(I,J,basis);
   if (node > 0)
     this->prescribe(node,dof,code);
 }
@@ -1340,8 +1346,7 @@ bool ASMs2D::updateCoords (const Vector& displ)
 void ASMs2D::getBoundaryNodes (int lIndex, IntVec& nodes, int basis,
                                int thick, int, bool local) const
 {
-  if (basis == 0)
-    basis = 1;
+  if (basis < 1) basis = 1;
 
   if (!this->getBasis(basis)) return; // silently ignore empty patches
 

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -188,9 +188,9 @@ public:
   //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
   //! \param[in] lIndex Local index of the boundary edge
   //! \param nodes Array of node numbers
-  //! \param[in] basis Which basis to grab nodes for (0 for all)
+  //! \param[in] basis Which basis to grab nodes for (for mixed methods)
   //! \param[in] thick Thickness of connection
-  //! \param[in] local If \e true return patch-local node numbers
+  //! \param[in] local If \e true, return patch-local node numbers
   virtual void getBoundaryNodes(int lIndex, IntVec& nodes,
                                 int basis, int thick = 1,
                                 int = 0, bool local = false) const;
@@ -243,7 +243,7 @@ public:
   //! \brief Constrains all DOFs on a given boundary edge.
   //! \param[in] dir Parameter direction defining the edge to constrain
   //! \param[in] open If \e true, exclude the end points of the edge
-  //! \param[in] dof Which DOFs to constrain at each node on the edge
+  //! \param[in] dof Which DOFs to constrain at each node along the edge
   //! \param[in] code Inhomogeneous dirichlet condition code
   //! \param[in] basis Which basis to constrain edge for
   virtual void constrainEdge(int dir, bool open, int dof, int code, char basis);
@@ -262,7 +262,7 @@ public:
   //! \param[in] J Parameter index in v-direction
   //! \param[in] dof Which DOFs to constrain at the node
   //! \param[in] code Inhomogeneous dirichlet condition code
-  //! \param[in] basis Which basis to constrain edge for
+  //! \param[in] basis Which basis to constrain node for
   //!
   //! \details The sign of the two indices is used to define whether we want
   //! the node at the beginning or the end of that parameter direction.
@@ -294,14 +294,14 @@ public:
 
   //! \brief Makes two opposite boundary edges periodic.
   //! \param[in] dir Parameter direction defining the periodic edges
-  //! \param[in] basis Which basis to connect (mixed methods), 0 means all
+  //! \param[in] basis Which basis to connect (mixed methods)
   //! \param[in] master 1-based index of the first master node in this basis
   virtual void closeBoundaries(int dir, int basis, int master);
 
   //! \brief Collapses a degenereated edge into a single node.
   //! \param[in] dir Parameter direction defining the edge to collapse
-  //! \param[in] basis Which basis to connect (mixed methods), 0 means both
-  virtual bool collapseEdge(int dir, int basis = 0);
+  //! \param[in] basis Which basis to collapse edge for
+  virtual bool collapseEdge(int dir, int basis = 1);
 
   //! \brief Sets the global node numbers for this patch.
   //! \param[in] nodes Vector of global node numbers (zero-based)
@@ -389,7 +389,7 @@ public:
   //! \param[in] npe Number of visualization nodes over each knot span
   //! \param[in] nf If nonzero, mixed evaluates nf fields on first basis
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-                            const int* npe, int nf = 0) const;
+                            const int* npe, int nf) const;
 
   //! \brief Evaluates the primary solution field at the given points.
   //! \param[out] sField Solution field
@@ -413,7 +413,7 @@ public:
   //! \param[in] npe Number of visualization nodes over each knot span
   //! \param[in] nf If nonzero, mixed evaluates nf fields on first basis
   virtual bool evalProjSolution(Matrix& sField, const Vector& locSol,
-                                const int* npe, int nf = 0) const;
+                                const int* npe, int nf) const;
 
   //! \brief Evaluates and interpolates a field over a given geometry.
   //! \param[in] basis The basis of the field to evaluate
@@ -533,8 +533,8 @@ protected:
   //! \brief Calculates parameter values for the Greville points.
   //! \param[out] prm Parameter values in given direction for all points
   //! \param[in] dir Parameter direction (0,1)
-  //! \param[in] basis Basis number (mixed)
-  bool getGrevilleParameters(RealArray& prm, int dir, int basis=1) const;
+  //! \param[in] basisNum Which basis to get Greville point parameters for
+  bool getGrevilleParameters(RealArray& prm, int dir, int basisNum = 1) const;
 
   //! \brief Calculates parameter values for the Quasi-Interpolation points.
   //! \param[out] prm Parameter values in given direction for all points

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -204,9 +204,9 @@ public:
   //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
   //! \param[in] lIndex Local index of the boundary face
   //! \param nodes Array of node numbers
-  //! \param[in] basis Which basis to grab nodes for (0 for all)
+  //! \param[in] basis Which basis to grab nodes for (for mixed methods)
   //! \param[in] thick Thickness of connection
-  //! \param[in] local If true return patch-local node numbers
+  //! \param[in] local If \e true, return patch-local node numbers
   virtual void getBoundaryNodes(int lIndex, IntVec& nodes,
                                 int basis, int thick = 1,
                                 int = 0, bool local = false) const;
@@ -265,7 +265,7 @@ public:
   //! \param[in] open If \e true, exclude all points along the face boundary
   //! \param[in] dof Which DOFs to constrain at each node on the face
   //! \param[in] code Inhomogeneous dirichlet condition code
-  //! \param[in] basis Basis to constrain edge for
+  //! \param[in] basis Which basis to constrain face for
   virtual void constrainFace(int dir, bool open, int dof,
                              int code = 0, char basis = 1);
   //! \brief Constrains all DOFs in local directions on a given boundary face.
@@ -282,9 +282,9 @@ public:
   //! \brief Constrains all DOFs on a given boundary edge.
   //! \param[in] lEdge Local index [1,12] of the edge to constrain
   //! \param[in] open If \e true, exclude the end points of the edge
-  //! \param[in] dof Which DOFs to constrain at each node on the edge
+  //! \param[in] dof Which DOFs to constrain at each node along the edge
   //! \param[in] code Inhomogeneous dirichlet condition code
-  //! \param[in] basis Basis to constrain edge for
+  //! \param[in] basis Which basis to constrain edge for
   virtual void constrainEdge(int lEdge, bool open, int dof,
                              int code = 0, char basis = 1);
 
@@ -294,7 +294,7 @@ public:
   //! \param[in] xi Parameter value defining the line to constrain
   //! \param[in] dof Which DOFs to constrain at each node along the line
   //! \param[in] code Inhomogeneous dirichlet condition code
-  //! \param[in] basis Basis to constrain line for
+  //! \param[in] basis Which basis to constrain line for
   //!
   //! \details The parameter \a xi has to be in the domain [0.0,1.0], where
   //! 0.0 means the beginning of the domain and 1.0 means the end. The line to
@@ -312,7 +312,7 @@ public:
   //! \param[in] K Parameter index in w-direction
   //! \param[in] dof Which DOFs to constrain at the node
   //! \param[in] code Inhomogeneous dirichlet condition code
-  //! \param[in] basis Basis to constrain corner for
+  //! \param[in] basis Which basis to constrain node for
   //!
   //! \details The sign of the three indices is used to define whether we want
   //! the node at the beginning or the end of that parameter direction.
@@ -325,7 +325,6 @@ public:
   //! \param[in] zeta Parameter in w-direction
   //! \param[in] dof Which DOFs to constrain at the node
   //! \param[in] code Inhomogeneous dirichlet condition code
-  //! \param[in] basis Basis to constrain node for
   //!
   //! \details The parameter values have to be in the domain [0.0,1.0], where
   //! 0.0 means the beginning of the domain and 1.0 means the end. For values
@@ -333,7 +332,7 @@ public:
   //! \a r*n, where \a r denotes the given relative parameter value,
   //! and \a n is the number of nodes along that parameter direction.
   virtual void constrainNode(double xi, double eta, double zeta, int dof,
-                             int code = 0, char basis = 1);
+                             int code = 0);
 
   //! \brief Connects all matching nodes on two adjacent boundary faces.
   //! \param[in] face Local face index of this patch, in range [1,6]
@@ -353,9 +352,16 @@ public:
 
   //! \brief Makes two opposite boundary faces periodic.
   //! \param[in] dir Parameter direction defining the periodic faces
-  //! \param[in] basis Which basis to connect (mixed methods), 0 means all
+  //! \param[in] basis Which basis to connect (mixed methods)
   //! \param[in] master 1-based index of the first master node in this basis
   virtual void closeBoundaries(int dir, int basis, int master);
+
+  //! \brief Collapses a degenereated face into a single node or edge.
+  //! \param[in] face Which face to collapse, in rage [1,6]
+  //! \param[in] edge Which edge to callapse on to, in range [0,12],
+  //! 0 means collapse on to vertex
+  //! \param[in] basis Which basis to collapse face for
+  virtual bool collapseFace(int face, int edge = 0, int basis = 1);
 
   //! \brief Sets the global node numbers for this patch.
   //! \param[in] nodes Vector of global node numbers (zero-based)
@@ -566,7 +572,7 @@ protected:
   //! \param[in] basis Which basis to connect the nodes for (mixed methods)
   //! \param[in] slave 0-based index of the first slave node in this basis
   //! \param[in] master 0-based index of the first master node in this basis
-  //! \param[in] coordCheck False to turn off coordinate checks
+  //! \param[in] coordCheck False to disable coordinate checks (periodic connections)
   //! \param[in] thick Thickness of connection
   bool connectBasis(int face, ASMs3D& neighbor, int nface, int norient,
                     int basis = 1, int slave = 0, int master = 0,
@@ -584,8 +590,8 @@ protected:
   //! \brief Calculates parameter values for the Greville points.
   //! \param[out] prm Parameter values in given direction for all points
   //! \param[in] dir Parameter direction (0,1,2)
-  //! \param[in] basis Basis number (mixed)
-  bool getGrevilleParameters(RealArray& prm, int dir, int basis=1) const;
+  //! \param[in] basisNum Which basis to get Greville point parameters for
+  bool getGrevilleParameters(RealArray& prm, int dir, int basisNum = 1) const;
 
   //! \brief Calculates parameter values for the Quasi-Interpolation points.
   //! \param[out] prm Parameter values in given direction for all points

--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -735,6 +735,8 @@ ASMu2D::DirichletEdge::DirichletEdge (LR::LRSplineSurface* sf,
 
 void ASMu2D::constrainEdge (int dir, bool open, int dof, int code, char basis)
 {
+  if (basis < 1) basis = 1;
+
   // Figure out function index offset (when using multiple basis)
   int offset = 1;
   for (int i = 1; i < basis; i++)
@@ -828,6 +830,8 @@ int ASMu2D::getCorner(int I, int J, int basis) const
 
 void ASMu2D::constrainCorner (int I, int J, int dof, int code, char basis)
 {
+  if (basis < 1) basis = 1;
+
   int corner = this->getCorner(I,J,basis);
   if (corner > 0)
     this->prescribe(corner,dof,code);

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -133,7 +133,7 @@ public:
   //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
   //! \param[in] lIndex Local index of the boundary edge
   //! \param nodes Array of node numbers
-  //! \param[in] basis Which basis to grab nodes for (0 for all)
+  //! \param[in] basis Which basis to grab nodes for (for mixed methods)
   //! \param[in] orient Orientation of boundary (used for sorting)
   //! \param[in] local If \e true, return patch-local node numbers
   virtual void getBoundaryNodes(int lIndex, IntVec& nodes, int basis, int = 1,
@@ -209,7 +209,7 @@ public:
   //! \brief Constrains all DOFs on a given boundary edge.
   //! \param[in] dir Parameter direction defining the edge to constrain
   //! \param[in] open If \e true, exclude the end points of the edge
-  //! \param[in] dof Which DOFs to constrain at each node on the edge
+  //! \param[in] dof Which DOFs to constrain at each node along the edge
   //! \param[in] code Inhomogeneous dirichlet condition code
   //! \param[in] basis Which basis to constrain edge for
   virtual void constrainEdge(int dir, bool open, int dof, int code, char basis);
@@ -228,7 +228,7 @@ public:
   //! \param[in] J Parameter index in v-direction
   //! \param[in] dof Which DOFs to constrain at the node
   //! \param[in] code Inhomogeneous dirichlet condition code
-  //! \param[in] basis Basis to constrain node for
+  //! \param[in] basis Which basis to constrain node for
   //!
   //! \details The sign of the two indices is used to define whether we want
   //! the node at the beginning or the end of that parameter direction.
@@ -257,14 +257,6 @@ public:
   //! \param[in] thick Thickness of connection
   virtual bool connectPatch(int edge, ASM2D& neighbor, int nedge, bool revers,
                             int = 0, bool coordCheck = true, int thick = 1);
-
-  /*
-  //! \brief Makes two opposite boundary edges periodic.
-  //! \param[in] dir Parameter direction defining the periodic edges
-  //! \param[in] basis Which basis to connect (mixed methods), 0 means both
-  //! \param[in] master 1-based index of the first master node in this basis
-  virtual void closeEdges(int dir, int basis = 0, int master = 1);
-  */
 
 
   // Methods for integration of finite element quantities.
@@ -331,6 +323,7 @@ public:
   //! \return Local node number within the patch that matches the point, if any
   //! \return 0 if no node (control point) matches this point
   virtual int evalPoint(const double* xi, double* param, Vec3& X) const;
+
   //! \brief Returns the element that contains a specified spatial point.
   //! \param[in] param The parameters of the point in the knot-span domain
   //! \return Local element number within the patch that contains the point
@@ -354,7 +347,7 @@ public:
   //! \param[in] npe Number of visualization nodes over each knot span
   //! \param[in] nf If nonzero, mixed evaluates nf fields on first basis
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-                            const int* npe, int nf = 0) const;
+                            const int* npe, int nf) const;
 
   //! \brief Evaluates the primary solution field at the given points.
   //! \param[out] sField Solution field
@@ -371,7 +364,7 @@ public:
   //! \param[in] npe Number of visualization nodes over each knot span
   //! \param[in] nf If nonzero, mixed evaluates nf fields on first basis
   virtual bool evalProjSolution(Matrix& sField, const Vector& locSol,
-                                const int* npe, int nf = 0) const;
+                                const int* npe, int nf) const;
 
   //! \brief Evaluates and interpolates a function over a given geometry.
   //! \param[in] func The function to evaluate
@@ -533,8 +526,8 @@ protected:
   //! \brief Calculates parameter values for the Greville points.
   //! \param[out] prm Parameter values in given direction for all points
   //! \param[in] dir Parameter direction (0,1)
-  //! \param[in] basisNum Basis to grab parameters for
-  bool getGrevilleParameters(RealArray& prm, int dir, int basisNum) const;
+  //! \param[in] basisNum Which basis to get Greville point parameters for
+  bool getGrevilleParameters(RealArray& prm, int dir, int basisNum = 1) const;
 
   //! \brief Returns the area in the parameter space for an element.
   //! \param[in] iel 1-based element index

--- a/src/ASM/Test/TestASMs3D.C
+++ b/src/ASM/Test/TestASMs3D.C
@@ -12,9 +12,9 @@
 
 #include "ASMs3D.h"
 #include "SIM3D.h"
+#include <array>
 
 #include "gtest/gtest.h"
-#include <numeric>
 
 
 class TestASMs3D : public testing::Test,
@@ -50,5 +50,225 @@ TEST_P(TestASMs3D, ConnectUneven)
 }
 
 
-const std::vector<int> orientations3D = {0,1,2,3,5,6,7,8,9,10,11,12};
-INSTANTIATE_TEST_CASE_P(TestASMs3D, TestASMs3D, testing::ValuesIn(orientations3D));
+INSTANTIATE_TEST_CASE_P(TestASMs3D, TestASMs3D,
+                        testing::Values(0,1,2,3,5,6,7,8,9,10,11,12));
+
+
+class ASMdegenerate3D : public ASMs3D
+{
+public:
+  ASMdegenerate3D(int iface, int iedge)
+  {
+    std::stringstream geo; // --- Xi ---    --- Eta ----    --- Zeta ---
+    geo <<"700 1 0 0 3 0"<<" 2 2 0 0 1 1"<<" 2 2 0 0 1 1"<<" 2 2 0 0 1 1\n";
+    auto&& defaultGeo = [&geo]() {
+      geo <<"0 0 0  3 0 0  0 1 0  3 1 0\n"
+          <<"0 0 2  3 0 2  0 1 2  3 1 2\n";
+    };
+
+    // Create a degenerated patch where face "iface"
+    // is collapsed into the edge "iedge"
+    switch (iface) {
+    case 1:
+      switch (iedge) {
+      case 0:
+        geo <<"0 0 0  3 0 0  0 0 0  3 1 0\n"
+            <<"0 0 0  3 0 2  0 0 0  3 1 2\n";
+        break;
+      case 5:
+        geo <<"0 0 0  3 0 0  0 1 0  3 1 0\n"
+            <<"0 0 0  3 0 2  0 1 0  3 1 2\n";
+        break;
+      case 7:
+        geo <<"0 0 2  3 0 0  0 1 2  3 1 0\n"
+            <<"0 0 2  3 0 2  0 1 2  3 1 2\n";
+        break;
+      case 9:
+        geo <<"0 0 0  3 0 0  0 0 0  3 1 0\n"
+            <<"0 0 2  3 0 2  0 0 2  3 1 2\n";
+        break;
+      case 11:
+        geo <<"0 1 0  3 0 0  0 1 0  3 1 0\n"
+            <<"0 1 2  3 0 2  0 1 2  3 1 0\n";
+        break;
+      default:
+        defaultGeo();
+      }
+      break;
+
+    case 2:
+      switch (iedge) {
+      case 0:
+        geo <<"0 0 0  3 0 0  0 1 0  3 0 0\n"
+            <<"0 0 2  3 0 0  0 1 2  3 0 0\n";
+        break;
+      case 6:
+        geo <<"0 0 0  3 0 0  0 1 0  3 1 0\n"
+            <<"0 0 2  3 0 0  0 1 2  3 1 0\n";
+        break;
+      case 8:
+        geo <<"0 0 0  3 0 2  0 1 0  3 1 2\n"
+            <<"0 0 2  3 0 2  0 1 2  3 1 2\n";
+        break;
+      case 10:
+        geo <<"0 0 0  3 0 0  0 1 0  3 0 0\n"
+            <<"0 0 2  3 0 2  0 1 2  3 0 2\n";
+        break;
+      case 12:
+        geo <<"0 0 0  3 1 0  0 1 0  3 1 0\n"
+            <<"0 0 2  3 1 2  0 1 2  3 1 2\n";
+        break;
+      default:
+        defaultGeo();
+      }
+      break;
+
+    case 3:
+      switch (iedge) {
+      case 0:
+        geo <<"0 0 0  0 0 0  0 1 0  3 1 0\n"
+            <<"0 0 0  0 0 0  0 1 2  3 1 2\n";
+        break;
+      case 1:
+        geo <<"0 0 0  3 0 0  0 1 0  3 1 0\n"
+            <<"0 0 0  3 0 0  0 1 2  3 1 2\n";
+        break;
+      case 3:
+        geo <<"0 0 2  3 0 2  0 1 0  3 1 0\n"
+            <<"0 0 2  3 0 2  0 1 2  3 1 2\n";
+        break;
+      case 9:
+        geo <<"0 0 0  0 0 0  0 1 0  3 1 0\n"
+            <<"0 0 2  0 0 2  0 1 2  3 1 2\n";
+        break;
+      case 10:
+        geo <<"3 0 0  3 0 0  0 1 0  3 1 0\n"
+            <<"3 0 2  3 0 2  0 1 2  3 1 2\n";
+        break;
+      default:
+        defaultGeo();
+      }
+      break;
+
+    case 4:
+      switch (iedge) {
+      case 0:
+        geo <<"0 0 0  3 0 0  0 1 0  0 1 0\n"
+            <<"0 0 2  3 0 2  0 1 0  0 1 0\n";
+        break;
+      case 2:
+        geo <<"0 0 0  3 0 0  0 1 0  3 1 0\n"
+            <<"0 0 2  3 0 2  0 1 0  3 1 0\n";
+        break;
+      case 4:
+        geo <<"0 0 0  3 0 0  0 1 2  3 1 2\n"
+            <<"0 0 2  3 0 2  0 1 2  3 1 2\n";
+        break;
+      case 11:
+        geo <<"0 0 0  3 0 0  0 1 0  0 1 0\n"
+            <<"0 0 2  3 0 2  0 1 2  0 1 2\n";
+        break;
+      case 12:
+        geo <<"0 0 0  3 0 0  3 1 0  3 1 0\n"
+            <<"0 0 2  3 0 2  3 1 2  3 1 2\n";
+        break;
+      default:
+        defaultGeo();
+      }
+      break;
+
+    case 5:
+      switch (iedge) {
+      case 0:
+        geo <<"0 0 0  0 0 0  0 0 0  0 0 0\n"
+            <<"0 0 2  3 0 2  0 1 2  3 1 2\n";
+        break;
+      case 1:
+        geo <<"0 0 0  3 0 0  0 0 0  3 0 0\n"
+            <<"0 0 2  3 0 2  0 1 2  3 1 2\n";
+        break;
+      case 2:
+        geo <<"0 1 0  3 1 0  0 1 0  3 1 0\n"
+            <<"0 0 2  3 0 2  0 1 2  3 1 2\n";
+        break;
+      case 5:
+        geo <<"0 0 0  0 0 0  0 1 0  0 1 0\n"
+            <<"0 0 2  3 0 2  0 1 2  3 1 2\n";
+        break;
+      case 6:
+        geo <<"3 0 0  3 0 0  3 1 0  3 1 0\n"
+            <<"0 0 2  3 0 2  0 1 2  3 1 2\n";
+        break;
+      default:
+        defaultGeo();
+      }
+      break;
+
+    case 6:
+      switch (iedge) {
+      case 0:
+        geo <<"0 0 0  3 0 0  0 1 0  3 1 0\n"
+            <<"1 0 2  1 0 2  1 0 2  1 0 2\n";
+        break;
+      case 3:
+        geo <<"0 0 0  3 0 0  0 1 0  3 1 0\n"
+            <<"0 0 2  3 0 2  0 0 2  3 0 2\n";
+        break;
+      case 4:
+        geo <<"0 0 0  3 0 0  0 1 0  3 1 0\n"
+            <<"0 1 2  3 1 2  0 1 2  3 1 2\n";
+        break;
+      case 7:
+        geo <<"0 0 0  3 0 0  0 1 0  3 1 0\n"
+            <<"0 0 2  0 0 2  0 1 2  0 1 2\n";
+        break;
+      case 8:
+        geo <<"0 0 0  3 0 0  0 1 0  3 1 0\n"
+            <<"3 0 2  3 0 2  3 1 2  3 1 2\n";
+        break;
+      default:
+        defaultGeo();
+      }
+      break;
+
+    default:
+      defaultGeo();
+      break;
+    }
+    EXPECT_TRUE(this->read(geo));
+  }
+  virtual ~ASMdegenerate3D() {}
+};
+
+
+TEST(TestASMs3D, Collapse)
+{
+  // Face-to-edge topology, see
+  // https://github.com/OPM/IFEM/blob/master/doc/sim-input.pdf Figures 2 and 3.
+  std::array<std::array<int,4>,6> faceTop = {{
+      {{ 5, 7, 9,11 }},
+      {{ 6, 8,10,12 }},
+      {{ 1, 3, 9,10 }},
+      {{ 2, 4,11,12 }},
+      {{ 1, 2, 5, 6 }},
+      {{ 3, 4, 7, 8 }} }};
+
+  for (int iface = 1; iface <= 6; iface++)
+    for (int iedge = 0; iedge <= 12; iedge++)
+    {
+      ASMdegenerate3D pch(iface,iedge);
+      ASSERT_TRUE(pch.uniformRefine(0,4));
+      ASSERT_TRUE(pch.uniformRefine(1,1));
+      ASSERT_TRUE(pch.uniformRefine(2,3));
+      ASSERT_TRUE(pch.generateFEMTopology());
+      std::cout <<"Degenerating F"<< iface <<" onto E"<< iedge << std::endl;
+#ifdef SP_DEBUG
+      pch.write(std::cout);
+#endif
+      const std::array<int,4>& face = faceTop[iface-1];
+      if (iedge == 0 || std::find(face.begin(),face.end(),iedge) != face.end())
+        EXPECT_TRUE(pch.collapseFace(iface,iedge));
+      else
+        EXPECT_FALSE(pch.collapseFace(iface,iedge));
+    }
+}

--- a/src/SIM/SIM2D.C
+++ b/src/SIM/SIM2D.C
@@ -250,7 +250,7 @@ bool SIM2D::parseGeometryTag (const TiXmlElement* elem)
 
     IFEM::cout <<"\tCollapsed edge P"<< patch <<" E"<< edge << std::endl;
     ASMs2D* pch = dynamic_cast<ASMs2D*>(this->getPatch(patch,true));
-    if (pch) pch->collapseEdge(edge);
+    if (pch) return pch->collapseEdge(edge);
   }
 
   else if (!strcasecmp(elem->Value(),"immersedboundary"))

--- a/src/SIM/SIM3D.C
+++ b/src/SIM/SIM3D.C
@@ -198,6 +198,29 @@ bool SIM3D::parseGeometryTag (const TiXmlElement* elem)
     }
   }
 
+  else if (!strcasecmp(elem->Value(),"collapse"))
+  {
+    if (!this->createFEMmodel()) return false;
+
+    int patch = 0, face = 1, edge = 0;
+    utl::getAttribute(elem,"patch",patch);
+    utl::getAttribute(elem,"face",face);
+    utl::getAttribute(elem,"edge",edge);
+
+    if (patch < 1 || patch > nGlPatches)
+    {
+      std::cerr <<" *** SIM3D::parse: Invalid patch index "
+                << patch << std::endl;
+      return false;
+    }
+
+    IFEM::cout <<"\tCollapsed face P"<< patch <<" F"<< face;
+    if (edge > 0) IFEM::cout <<" on to edge "<< edge;
+    IFEM::cout << std::endl;
+    ASMs3D* pch = dynamic_cast<ASMs3D*>(this->getPatch(patch,true));
+    if (pch) return pch->collapseFace(face,edge);
+  }
+
   return true;
 }
 


### PR DESCRIPTION
Changed: Removed the basis argument in the constrainNode method
in ASMs3D to be compliant with the ASMs2D method (they are not
in use for mixed problems). Also some minor doxy corrections.
Added: Unit tests for the collapse methods for ASMs2D and ASMs3D.

This might be needed for Arcon's testing.