### PR TITLE
Changed: Make sure we generate IDs for LR objects

### DIFF
--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -560,6 +560,7 @@ bool ASMu2D::generateFEMTopology ()
   if (tensorPrjBas)
   {
     projBasis.reset(new LR::LRSplineSurface(tensorPrjBas));
+    projBasis->generateIDs();
     delete tensorPrjBas;
     tensorPrjBas = nullptr;
   }
@@ -2560,6 +2561,9 @@ bool ASMu2D::refine (const LR::RefineData& prm,
       projBasis->insert_const_u_edge(line->const_par_,
                                      line->start_, line->stop_,
                                      line->multiplicity());
+
+  if (projBasis != lrspline)
+    projBasis->generateIDs();
 
   IFEM::cout <<"Refined projection basis: "<< projBasis->nElements()
              <<" elements "<< projBasis->nBasisFunctions() <<" nodes."

--- a/src/ASM/LR/LRSplineField2D.C
+++ b/src/ASM/LR/LRSplineField2D.C
@@ -44,6 +44,8 @@ LRSplineField2D::LRSplineField2D (const ASMu2D* patch,
   else
     for (size_t i = 0; i < nno && vit != end; ++i, vit += nf)
       values[i] = *(vit+cmp-1);
+
+  basis->generateIDs();
 }
 
 

--- a/src/ASM/LR/LRSplineField3D.C
+++ b/src/ASM/LR/LRSplineField3D.C
@@ -44,6 +44,8 @@ LRSplineField3D::LRSplineField3D (const ASMu3D* patch,
   else
     for (size_t i = 0; i < nno && vit != end; ++i, vit += nf)
       values[i] = *(vit+cmp-1);
+
+  basis->generateIDs();
 }
 
 

--- a/src/ASM/LR/LRSplineFields2D.C
+++ b/src/ASM/LR/LRSplineFields2D.C
@@ -48,6 +48,8 @@ LRSplineFields2D::LRSplineFields2D (const ASMu2D* patch,
     for (size_t i = 0; i < nno && vit != end; ++i, vit += nfc)
       for (size_t j = 0; j < nf; ++j)
         values[nf*i+j] = *(vit+j);
+
+  basis->generateIDs();
 }
 
 

--- a/src/ASM/LR/LRSplineFields3D.C
+++ b/src/ASM/LR/LRSplineFields3D.C
@@ -48,6 +48,8 @@ LRSplineFields3D::LRSplineFields3D (const ASMu3D* patch,
     for (size_t i = 0; i < nno && vit != end; ++i, vit += nfc)
       for (size_t j = 0; j < nf; ++j)
         values[nf*i+j] = *(vit+j);
+
+  basis->generateIDs();
 }
 
 

--- a/src/ASM/LR/Test/TestASMu2D.C
+++ b/src/ASM/LR/Test/TestASMu2D.C
@@ -189,6 +189,7 @@ TEST(TestASMu2D, TransferGaussPtVars)
 
   ASMu2D* pch = static_cast<ASMu2D*>(sim.createDefaultModel());
   LR::LRSplineSurface* lr = pch->getSurface();
+  lr->generateIDs();
 
   RealArray oldAr(9), newAr;
   const double* xi = GaussQuadrature::getCoord(3);
@@ -200,16 +201,16 @@ TEST(TestASMu2D, TransferGaussPtVars)
     pchNew->uniformRefine(idx, 1);
     LR::LRSplineSurface* lrNew = pchNew->getSurface();
     ASSERT_TRUE(lrNew != nullptr);
+    lrNew->generateIDs();
     for (id[1] = 0; id[1] < 3; ++id[1])
       for (id[0] = 0; id[0] < 3; ++id[0])
         oldAr[id[0]+id[1]*3] = (1.0 + xi[id[idx]]) / 2.0;
     pchNew->transferGaussPtVars(lr, oldAr, newAr, 3);
     size_t k = 0;
-    for (size_t iEl = 0; iEl < 2; ++iEl) {
+    for (size_t iEl = 0; iEl < 2; ++iEl)
       for (id[1] = 0; id[1] < 3; ++id[1])
         for (id[0] = 0; id[0] < 3; ++id[0], ++k)
           EXPECT_FLOAT_EQ(newAr[k], 0.5*iEl + 0.5*(xi[id[idx]] + 1.0) / 2.0);
-    }
   }
 }
 
@@ -221,11 +222,13 @@ TEST(TestASMu2D, TransferGaussPtVarsN)
 
   ASMu2D* pch = static_cast<ASMu2D*>(sim.createDefaultModel());
   LR::LRSplineSurface* lr = pch->getSurface();
+  lr->generateIDs();
 
   ASMu2D* pchNew = static_cast<ASMu2D*>(sim2.createDefaultModel());
   pchNew->uniformRefine(0, 1);
   LR::LRSplineSurface* lrNew = pchNew->getSurface();
   ASSERT_TRUE(lrNew != nullptr);
+  lrNew->generateIDs();
 
   RealArray oldAr(9), newAr;
   std::iota(oldAr.begin(), oldAr.end(), 1);


### PR DESCRIPTION
Same as first commit of #352, but also with similar fix for the projection basis in ASMu2D.
Otherwise, one of the Kirchhoff-tests using separate basis for projection still crashed.
Need this now since VikingScientist/LRsplines#28 has been pulled and installed on the apt repository.