### PR TITLE
Fixed: Undo the fix in e69c100b17d0e5cd59d3d4cb7efe3fa1302754c7

### DIFF
--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -383,7 +383,7 @@ void ASMu2D::extendRefinementDomain (IntSet& refineIndices,
       for (int edgeNode : bndry1[edge])
         if (edgeNode-1 == j)
         {
-          IntVec secondary = this->getOverlappingNodes(j);
+          IntVec secondary = this->getOverlappingNodes(j, edge/2+1);
           refineIndices.insert(secondary.begin(),secondary.end());
           done_with_this_node = true;
           break;


### PR DESCRIPTION
Fixes #347 which apparently was caused by this workaround.

Should probably revisit this later for a proper fix, but as this keeps popping up randomly for the multi-patch VCP test, I think we should merge this first. So far only one downstream regression is affected.
