### PR TITLE
Fixed: Don't increment part ID for adaptive grids.

### DIFF
--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -300,31 +300,32 @@ bool SIMoutput::writeGlvG (int& nBlock, const char* inpFile, bool doClear)
 
   ElementBlock* lvb;
   char pname[32];
-  size_t i;
 
   // Convert and write model geometry
-  for (i = 0; i < myModel.size(); i++)
+  for (const ASMbase* pch : myModel)
   {
-    if (myModel[i]->empty()) continue; // skip empty patches
+    if (pch->empty())
+      continue; // skip empty patches
 
     if (msgLevel > 1)
-      IFEM::cout <<"Writing geometry for patch "<< i+1 << std::endl;
-    size_t nd = myModel[i]->getNoParamDim();
+      IFEM::cout <<"Writing geometry for patch "
+                 << pch->idx+1 << std::endl;
+    size_t nd = pch->getNoParamDim();
     lvb = new ElementBlock(nd == 3 ? 8 : (nd == 2 ? 4 : 2));
-    if (!myModel[i]->tesselate(*lvb,opt.nViz))
+    if (!pch->tesselate(*lvb,opt.nViz))
       return false;
 
-    sprintf(pname,"Patch %ld",myModel[i]->idx+1);
-    if (!myVtf->writeGrid(lvb,pname,++nBlock))
+    sprintf(pname,"Patch %zu",pch->idx+1);
+    if (!myVtf->writeGrid(lvb,pname,pch->idx+1,++nBlock))
       return false;
   }
 
   // Additional geometry for immersed boundaries
-  for (i = 0; i < myModel.size(); i++)
-    if ((lvb = myModel[i]->immersedGeometry()))
+  for (const ASMbase* pch : myModel)
+    if ((lvb = pch->immersedGeometry()))
     {
-      sprintf(pname,"Immersed boundary %zu",i+1);
-      if (!myVtf->writeGrid(lvb,pname,++nBlock))
+      sprintf(pname,"Immersed boundary %zu",pch->idx+1);
+      if (!myVtf->writeGrid(lvb,pname,nGlPatches+pch->idx+1,++nBlock))
         return false;
     }
 

--- a/src/Utility/VTF.h
+++ b/src/Utility/VTF.h
@@ -23,9 +23,7 @@ class Tensor;
 class Vec3;
 
 typedef std::pair<int,const ElementBlock*> GridBlock; //!< Convenience type
-#ifndef _VEC3_H
 typedef std::pair<Vec3,Vec3>               Vec3Pair;  //!< Convenience type
-#endif
 
 class VTFAFile;
 class VTFAStateInfoBlock;
@@ -61,7 +59,7 @@ public:
   //! \brief The constructor opens a new VTF-file.
   //! \param[in] filename Name of the VTF-file
   //! \param[in] type     File type (0 = ASCII, 1 = BINARY)
-  VTF(const char* filename, int type = 0);
+  VTF(const char* filename, int type);
   //! \brief No copying of this class.
   VTF(const VTF&) = delete;
   //! \brief The destructor finalizes and closes the VTF-file.
@@ -70,8 +68,10 @@ public:
   //! \brief Writes the FE geometry to the VTF-file.
   //! \param[in] g The FE grid that all results written are referred to
   //! \param[in] partname Name of the geometry being written
-  //! \param[in] gID Geometry block identifier
-  virtual bool writeGrid(const ElementBlock* g, const char* partname, int gID);
+  //! \param[in] partID Part identifier
+  //! \param[in] geomID Geometry block identifier
+  virtual bool writeGrid(const ElementBlock* g, const char* partname,
+                         int partID, int geomID);
 
   //! \brief Writes a transformation matrix to the VTF-file.
   //! \param[in] X Position part of the transformation
@@ -111,6 +111,7 @@ public:
                   int idBlock = 1, int gID = 1);
   //! \brief Writes a block of point vector results to the VTF-file.
   //! \param[in] pntResult A set of result vectors with associated attack points
+  //! \param[in] partID Part identifier
   //! \param gID Running geometry block identifier
   //! \param[in] idBlock Result block identifier
   //! \param[in] resultName Name of the result quantity
@@ -119,14 +120,16 @@ public:
   //!
   //! \details This method creates a separate geometry block consisting of the
   //! attack points of the result vectors, since they are independent of the
-  //! FE geometry created by the \a writeGrid method.
-  virtual bool writeVectors(const std::vector<Vec3Pair>& pntResult, int& gID,
-                            int idBlock = 1, const char* resultName = nullptr,
+  //! FE geometry created by the writeGrid() method.
+  virtual bool writeVectors(const std::vector<Vec3Pair>& pntResult,
+                            int partID, int& gID, int idBlock = 1,
+                            const char* resultName = nullptr,
                             int iStep = 0, int iBlock = 1);
   //! \brief Writes a block of points (no results) to the VTF-file.
   //! \param[in] points Vector of point coordinates
+  //! \param[in] partID Part identifier
   //! \param gID Running geometry block identifier
-  bool writePoints(const std::vector<Vec3>& points, int& gID);
+  bool writePoints(const std::vector<Vec3>& points, int partID, int& gID);
 
   //! \brief Writes a scalar block definition to the VTF-file.
   //! \param[in] sBlockID The result block that makes up this scalar block
@@ -196,14 +199,16 @@ public:
 private:
   //! \brief Writes a node block to the VTF-file.
   //! \details The coordinates of the last added element block are written.
-  //! \param[in] blockID Node block identifier
-  bool writeNodes(int blockID);
+  //! \param[in] iBlockID Node block identifier
+  bool writeNodes(int iBlockID);
   //! \brief Writes an element block to the VTF-file.
   //! \details The element topology of the last added element block is written.
   //! \param[in] partName Name used to identify the part in GLview
-  //! \param[in] blockID Element block identifier
-  //! \param[in] nodesID Node block which the written element block refers to
-  bool writeElements(const char* partName, int blockID, int nodesID);
+  //! \param[in] partID Part identifier
+  //! \param[in] iBlockID Element block identifier
+  //! \param[in] iNodeBlockID Node block which the element block refers to
+  bool writeElements(const char* partName, int partID,
+                     int iBlockID, int iNodeBlockID);
   //! \brief Prints an error message to \a std::cerr.
   //! \param[in] msg The message to print
   //! \param[in] ID If non-negative, the value is appended to the message


### PR DESCRIPTION
This also fixes the annoying vanishing meshlines in GLviewInova
when using the slide bar to go from one step to the next, and
avoids the freeze of Ceetron Analyzer when selecting another step.