### PR TITLE
AdaptiveSIM refactor

### DIFF
--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -128,7 +128,7 @@ void ASMs1D::clear (bool retainGeometry)
 }
 
 
-bool ASMs1D::refine (const LR::RefineData& prm, Vectors&, const char*)
+bool ASMs1D::refine (const LR::RefineData& prm, Vectors&)
 {
   if (!curv) return false;
 

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -136,7 +136,7 @@ public:
 
   //! \brief Refines the mesh adaptively.
   //! \param[in] prm Input data used to control the mesh refinement
-  virtual bool refine(const LR::RefineData& prm, Vectors&, const char*);
+  virtual bool refine(const LR::RefineData& prm, Vectors&);
 
   //! \brief Refines the parametrization based on a mesh density function.
   //! \param[in] refC Mesh refinement criteria function

--- a/src/ASM/ASMunstruct.h
+++ b/src/ASM/ASMunstruct.h
@@ -29,15 +29,15 @@ namespace LR //! Utilities for LR-splines.
   /*!
     \brief A struct of data to control the mesh refinement.
     \details The \a options parameters have the following interpretation:
-    options[0] is the beta percentage of elements to refine,
-    options[1] is the knotline multiplicity (default 1),
-    options[2] is the refinement scheme (default 0),
-    (FULLSPAN=0, MINSPAN=1, ISOTROPIC_ELEMENTS=2, ISOTROPIC_FUNCTIONS=3),
-    options[3] is nonzero if testing for linear independence at all iterations,
-    options[4] is the maximum number of T-joints allowed in the model,
-    options[5] is the maximum allowed parametric aspect ratio of an element,
-    options[6] is one if all "gaps" are to be closed,
-    options[7] is one if using "true beta".
+    - options[0] : the beta percentage of elements to refine
+    - options[1] : the knotline multiplicity (default 1)
+    - options[2] : the refinement scheme (default 0),
+                   see AdaptiveSetup::RefScheme
+    - options[3] : nonzero if testing for linear independence at all iterations
+    - options[4] : the maximum number of T-joints allowed in the model
+    - options[5] : the maximum allowed parametric aspect ratio of an element
+    - options[6] : one if all "gaps" are to be closed
+    - options[7] : one if using "true beta"
   */
   struct RefineData
   {
@@ -48,6 +48,8 @@ namespace LR //! Utilities for LR-splines.
 
     //! \brief Default constructor.
     explicit RefineData(bool rs = false) : refShare(rs) {}
+    //! \brief Clears the refinement parameters.
+    void clear() { options.clear(); elements.clear(); errors.clear(); }
   };
 }
 

--- a/src/ASM/ASMunstruct.h
+++ b/src/ASM/ASMunstruct.h
@@ -16,6 +16,7 @@
 
 #include "MatVec.h"
 #include <set>
+#include <string>
 
 typedef std::vector<int> IntVec; //!< General integer vector
 typedef std::set<int>    IntSet; //!< General integer set
@@ -68,9 +69,7 @@ public:
   //! \brief Refines the mesh adaptively.
   //! \param[in] prm Input data used to control the mesh refinement
   //! \param sol Control point results values that are transferred to new mesh
-  //! \param[in] fName Optional file name for an image of the resulting mesh
-  virtual bool refine(const LR::RefineData& prm, Vectors& sol,
-                      const char* fName = nullptr) = 0;
+  virtual bool refine(const LR::RefineData& prm, Vectors& sol) = 0;
 
   //! \brief Remaps element-wise errors from geometry mesh to refinement mesh.
   //! \param[out] errors The remapped errors
@@ -87,6 +86,11 @@ public:
   virtual IntVec getBoundaryCovered(const IntSet&) const { return IntVec(); }
   //! \brief Extends the refinement domain with information for neighbors.
   virtual void extendRefinementDomain(IntSet&, const IntSet&) const {}
+
+  //! \brief Stores the mesh basis to encapsulated postscript files.
+  //! \param[in] fName Prefix for file names
+  //! \param[in] fType Flag telling which file type(s) to write (15 means all)
+  virtual void storeMesh(const std::string& fName, int fType = 15) const {}
 };
 
 #endif

--- a/src/ASM/LR/ASMLRSpline.C
+++ b/src/ASM/LR/ASMLRSpline.C
@@ -152,8 +152,7 @@ ASMLRSpline::ASMLRSpline (const ASMLRSpline& patch, unsigned char n_f)
 }
 
 
-bool ASMLRSpline::refine (const LR::RefineData& prm,
-                          Vectors& sol, const char* fName)
+bool ASMLRSpline::refine (const LR::RefineData& prm, Vectors& sol)
 {
   PROFILE2("ASMLRSpline::refine()");
 
@@ -164,11 +163,8 @@ bool ASMLRSpline::refine (const LR::RefineData& prm,
     nnod = geo->nBasisFunctions();
     return true;
   }
-  else if (prm.errors.empty() && prm.elements.empty()) {
-    if (fName)
-      storeMesh(fName);
+  else if (prm.errors.empty() && prm.elements.empty())
     return true;
-  }
 
   IntVec nf(sol.size());
   for (size_t j = 0; j < sol.size(); j++)
@@ -185,9 +181,6 @@ bool ASMLRSpline::refine (const LR::RefineData& prm,
       sol[i].resize(nf[i]*geo->nBasisFunctions());
       LR::contractControlPoints(geo,sol[i],nf[i]);
     }
-
-  if (fName)
-    storeMesh(fName);
 
   IFEM::cout <<"Refined mesh: "<< geo->nElements() <<" elements "
              << geo->nBasisFunctions() <<" nodes."<< std::endl;
@@ -399,27 +392,4 @@ std::pair<size_t,double> ASMLRSpline::findClosestNode (const Vec3& X) const
   }
 
   return std::make_pair(iclose,distance);
-}
-
-
-void ASMLRSpline::storeMesh(const char* fName)
-{
-  std::string fname(fName);
-  std::ofstream lrOut("lrspline_"+fname);
-  lrOut << *geo;
-  lrOut.close();
-
-  // open files for writing
-  std::ofstream paramMeshFile("param_"+fname);
-  std::ofstream physicalMeshFile("physical_"+fname);
-  std::ofstream paramDotMeshFile("param_dot_"+fname);
-  std::ofstream physicalDotMeshFile("physical_dot_"+fname);
-
-  LR::LRSplineSurface* lr = dynamic_cast<LR::LRSplineSurface*>(geo);
-  if (lr) {
-    lr->writePostscriptMesh(paramMeshFile);
-    lr->writePostscriptElements(physicalMeshFile);
-    lr->writePostscriptFunctionSpace(paramDotMeshFile);
-    lr->writePostscriptMeshWithControlPoints(physicalDotMeshFile);
-  }
 }

--- a/src/ASM/LR/ASMLRSpline.h
+++ b/src/ASM/LR/ASMLRSpline.h
@@ -90,9 +90,7 @@ public:
   //! \brief Refines the mesh adaptively.
   //! \param[in] prm Input data used to control the mesh refinement
   //! \param sol Control point results values that are transferred to new mesh
-  //! \param[in] fName Optional file name for an image of the resulting mesh
-  virtual bool refine(const LR::RefineData& prm, Vectors& sol,
-                      const char* fName = nullptr);
+  virtual bool refine(const LR::RefineData& prm, Vectors& sol);
 
   using ASMbase::evalSolution;
   //! \brief Projects the secondary solution field onto the primary basis.
@@ -181,11 +179,6 @@ protected:
   bool doRefine(const LR::RefineData& prm, LR::LRSpline* lrspline);
 
   LR::LRSpline* geo; //!< Pointer to the actual spline geometry object
-
-private:
-  //! \brief Store basis to eps files.
-  //! \param[in] fName Prefix for file names
-  void storeMesh(const char* fName);
 };
 
 #endif

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -192,9 +192,7 @@ public:
   //! \brief Refines the mesh adaptively.
   //! \param[in] prm Input data used to control the mesh refinement
   //! \param sol Control point results values that are transferred to new mesh
-  //! \param[in] fName Optional file name for an image of the resulting mesh
-  virtual bool refine(const LR::RefineData& prm, Vectors& sol,
-                      const char* fName = nullptr);
+  virtual bool refine(const LR::RefineData& prm, Vectors& sol);
   //! \brief Raises the order of the tensor spline object for this patch.
   //! \param[in] ru Number of times to raise the order in u-direction
   //! \param[in] rv Number of times to raise the order in v-direction
@@ -405,6 +403,11 @@ public:
   //! \brief Returns a field using the projection basis.
   //! \param[in] coefs The coefficients for the field
   virtual Fields* getProjectedFields(const Vector& coefs, size_t = 0) const;
+
+  //! \brief Stores the mesh basis to encapsulated postscript files.
+  //! \param[in] fName Prefix for file names
+  //! \param[in] fType Flag telling which file type(s) to write
+  virtual void storeMesh(const std::string& fName, int fType) const;
 
 protected:
   //! \brief Struct representing an inhomogeneous Dirichlet boundary condition.

--- a/src/ASM/LR/ASMu2Dmx.h
+++ b/src/ASM/LR/ASMu2Dmx.h
@@ -173,9 +173,12 @@ public:
   //! \brief Refines the mesh adaptively.
   //! \param[in] prm Input data used to control the refinement
   //! \param sol Control point results values that are transferred to new mesh
-  //! \param[in] fName Optional file name for an image of the resulting mesh
-  virtual bool refine(const LR::RefineData& prm, Vectors& sol,
-                      const char* fName = nullptr);
+  virtual bool refine(const LR::RefineData& prm, Vectors& sol);
+
+  //! \brief Stores the mesh basis to encapsulated postscript files.
+  //! \param[in] fName Prefix for file names
+  //! \param[in] fType Flag telling which file type(s) to write
+  virtual void storeMesh(const std::string& fName, int fType) const;
 
   //! \brief Connects all matching nodes on two adjacent boundary edges.
   //! \param[in] edge Local edge index of this patch, in range [1,4]
@@ -216,10 +219,6 @@ protected:
                             bool ignoreGlobalLM);
 
 private:
-  //! \brief Store bases to eps files.
-  //! \param[in] fName Prefix for file names
-  void storeMesh(const char* fName);
-
   std::vector<std::shared_ptr<LR::LRSplineSurface>> m_basis; //!< All bases
   LR::LRSplineSurface* threadBasis; //!< Basis for thread groups
   std::shared_ptr<LR::LRSplineSurface> refBasis; //!< Basis to refine based on

--- a/src/ASM/LR/ASMu3Dmx.C
+++ b/src/ASM/LR/ASMu3Dmx.C
@@ -907,21 +907,21 @@ bool ASMu3Dmx::evalSolution (Matrix& sField, const IntegrandBase& integrand,
 }
 
 
-bool ASMu3Dmx::refine (const LR::RefineData& prm,
-                       Vectors& sol, const char* fName)
+bool ASMu3Dmx::refine (const LR::RefineData& prm, Vectors& sol)
 {
-  if (shareFE) return true;
+  if (shareFE)
+    return true;
 
-  if (!prm.errors.empty() || !prm.elements.empty()) {
-    for (size_t j = 0; j < sol.size(); ++j) {
-      size_t ofs = 0;
-      for (size_t i = 0; i< m_basis.size(); ++i) {
-        LR::extendControlPoints(m_basis[i].get(), sol[j], nfx[i], ofs);
-        ofs += nfx[i]*nb[i];
-      }
+  if (prm.errors.empty() && prm.elements.empty())
+    return true;
+
+  for (Vector& solvec : sol) {
+    size_t ofs = 0;
+    for (size_t j = 0; j < m_basis.size(); j++) {
+      LR::extendControlPoints(m_basis[j].get(), solvec, nfx[j], ofs);
+      ofs += nfx[j]*nb[j];
     }
-  } else
-    return true; // No refinement
+  }
 
   if (doRefine(prm, refBasis.get())) {
     for (const LR::MeshRectangle* rect : refBasis->getAllMeshRectangles())
@@ -997,7 +997,7 @@ Vec3 ASMu3Dmx::getCoord (size_t inod) const
 {
   size_t b = 0;
   size_t nbb = 0;
-  while (b < nb.size() && nbb + nb[b] < inod)
+  while (b < nb.size() && nbb+nb[b] < inod)
     nbb += nb[b++];
   ++b;
 

--- a/src/ASM/LR/ASMu3Dmx.h
+++ b/src/ASM/LR/ASMu3Dmx.h
@@ -181,9 +181,7 @@ public:
   //! \brief Refines the mesh adaptively.
   //! \param[in] prm Input data used to control the refinement
   //! \param sol Control point results values that are transferred to new mesh
-  //! \param[in] fName Optional file name for an image of the resulting mesh
-  virtual bool refine(const LR::RefineData& prm, Vectors& sol,
-                      const char* fName = nullptr);
+  virtual bool refine(const LR::RefineData& prm, Vectors& sol);
 
   //! \brief Remap (geometry) element wise errors to refinement basis functions.
   //! \param     errors The remapped errors

--- a/src/LinAlg/Test/TestMatrix.C
+++ b/src/LinAlg/Test/TestMatrix.C
@@ -10,7 +10,7 @@
 //!
 //==============================================================================
 
-#include "matrixnd.h"
+#include "MatVec.h"
 
 #include "gtest/gtest.h"
 #include <numeric>
@@ -89,6 +89,12 @@ TEST(TestMatrix, Multiply)
 
   EXPECT_FLOAT_EQ(x.sum(),0.0);
   EXPECT_FLOAT_EQ(y.sum(),0.0);
+
+  u.std::vector<double>::resize(5);
+  v = 0.5*A*u;
+  EXPECT_FLOAT_EQ(v(1),67.5);
+  EXPECT_FLOAT_EQ(v(2),75.0);
+  EXPECT_FLOAT_EQ(v(3),82.5);
 }
 
 

--- a/src/LinAlg/matrixnd.h
+++ b/src/LinAlg/matrixnd.h
@@ -17,7 +17,7 @@
 #include "matrix.h"
 
 
-namespace utl //! General utility classes and functions.
+namespace utl
 {
   /*!
     \brief Three-dimensional rectangular matrix with some algebraic operations.
@@ -31,9 +31,13 @@ namespace utl //! General utility classes and functions.
   public:
     //! \brief Constructor creating an empty matrix.
     matrix3d() {}
+    //! \brief Constructor using an external vector for matrix element storage.
+    explicit matrix3d(vector<T>& vec) : matrixBase<T>(vec) {}
     //! \brief Constructor creating a matrix of dimension
     //! \f$n_1 \times n_2 \times n_3\f$.
     matrix3d(size_t n_1, size_t n_2, size_t n_3) : matrixBase<T>(n_1,n_2,n_3) {}
+    //! \brief Copy constructor.
+    matrix3d(const matrix3d<T>& mat) : matrixBase<T>(mat) {}
     //! \brief Constructor to read a matrix from a stream.
     matrix3d(std::istream& is, std::streamsize max = 10)
     {
@@ -70,6 +74,17 @@ namespace utl //! General utility classes and functions.
     void resize(size_t n_1, size_t n_2, size_t n_3, bool forceClear = false)
     {
       this->redim(n_1,n_2,n_3,1,forceClear);
+    }
+
+    //! \brief Assignment operator.
+    matrix3d<T>& operator=(const matrix3d<T>& A)
+    {
+      if (&A == this)
+        return *this;
+
+      memcpy(this->n,A.n,sizeof(A.n));
+      this->elem = A.elem;
+      return *this;
     }
 
     //! \brief Index-1 based element access.
@@ -212,10 +227,14 @@ namespace utl //! General utility classes and functions.
   public:
     //! \brief Constructor creating an empty matrix.
     matrix4d() {}
+    //! \brief Constructor using an external vector for matrix element storage.
+    explicit matrix4d(vector<T>& vec) : matrixBase<T>(vec) {}
     //! \brief Constructor creating a matrix of dimension
     //! \f$n_1 \times n_2 \times n_3 \times n_4\f$.
     matrix4d(size_t n_1, size_t n_2, size_t n_3, size_t n_4)
       : matrixBase<T>(n_1,n_2,n_3,n_4) {}
+    //! \brief Copy constructor.
+    matrix4d(const matrix4d<T>& mat) : matrixBase<T>(mat) {}
 
     //! \brief Empty destructor.
     virtual ~matrix4d() {}
@@ -232,6 +251,17 @@ namespace utl //! General utility classes and functions.
                 bool forceClear = false)
     {
       this->redim(n_1,n_2,n_3,n_4,forceClear);
+    }
+
+    //! \brief Assignment operator.
+    matrix4d<T>& operator=(const matrix4d<T>& A)
+    {
+      if (&A == this)
+        return *this;
+
+      memcpy(this->n,A.n,sizeof(A.n));
+      this->elem = A.elem;
+      return *this;
     }
 
     //! \brief Index-1 based element access.
@@ -440,7 +470,7 @@ namespace utl //! General utility classes and functions.
     if (A.empty())
       return s <<" (empty)"<< std::endl;
 
-    s <<"Dimension: "<< A.dim(1) <<" "<< A.dim(2) <<" "<< A.dim(3);
+    s <<" Dimension: "<< A.dim(1) <<" "<< A.dim(2) <<" "<< A.dim(3);
     matrix<T> B(A.dim(1),A.dim(2));
     const T* Aptr = A.ptr();
     for (size_t k = 0; k < A.dim(3); k++, Aptr += B.size())
@@ -462,7 +492,7 @@ namespace utl //! General utility classes and functions.
     if (A.empty())
       return s <<" (empty)"<< std::endl;
 
-    s <<"Dimension: "<< A.dim(1) <<" "<< A.dim(2)
+    s <<" Dimension: "<< A.dim(1) <<" "<< A.dim(2)
       <<" "<< A.dim(3) <<" "<< A.dim(4);
     matrix<T> B(A.dim(1),A.dim(2));
     const T* Aptr = A.ptr();

--- a/src/SIM/AdaptiveSIM.C
+++ b/src/SIM/AdaptiveSIM.C
@@ -14,211 +14,41 @@
 #include "AdaptiveSIM.h"
 #include "SIMoutput.h"
 #include "SIMenums.h"
-#include "ASMbase.h"
-#include "ASMmxBase.h"
 #include "ASMunstruct.h"
-#include "IntegrandBase.h"
-#include "Utilities.h"
 #include "IFEM.h"
-#include "tinyxml.h"
-#include <fstream>
-#include <sstream>
-#include <cstdio>
 
 
-AdaptiveSIM::AdaptiveSIM (SIMoutput& sim, bool sa) : SIMadmin(sim), model(sim)
+AdaptiveSIM::AdaptiveSIM (SIMoutput& sim, bool sa)
+  : SIMadmin(sim), AdaptiveSetup(sim,sa)
 {
-  alone  = sa;
   geoBlk = nBlock = 0;
-
-  // Default grid adaptation parameters
-  linIndepTest = false;
-  beta         = 10.0;
-  errTol       = 1.0;
-  rCond        = 1.0;
-  condLimit    = 1.0e12;
-  maxStep      = 10;
-  maxDOFs      = 1000000;
-  scheme       = 0;     // fullspan
-  knot_mult    = 1;     // maximum regularity (continuity)
-  threshold    = NONE;
-  adaptor      = 0;
-  adNorm       = 0;
-  maxTjoints   = -1;
-  maxAspRatio  = -1.0;
-  closeGaps    = false;
-  symmEps      = 1.0e-6;
-  storeMesh    = 1;
-
   solution.resize(1);
 }
 
 
 bool AdaptiveSIM::parse (const TiXmlElement* elem)
 {
-  if (strcasecmp(elem->Value(),"adaptive"))
-    return alone ? model.parse(elem) : true;
-
-  const TiXmlElement* child = elem->FirstChildElement();
-  for (; child; child = child->NextSiblingElement()) {
-    const char* value = utl::getValue(child,"maxstep");
-    if (value)
-      maxStep = atoi(value);
-    else if ((value = utl::getValue(child,"maxdof")))
-      maxDOFs = atoi(value);
-    else if ((value = utl::getValue(child,"errtol")))
-      errTol = atof(value);
-    else if ((value = utl::getValue(child,"maxcondition")))
-      condLimit = atof(value);
-    else if ((value = utl::getValue(child,"knot_mult")))
-      knot_mult = atoi(value);
-    else if ((value = utl::getValue(child,"store_mesh"))) {
-      meshPrefix = value;
-      utl::getAttribute(child, "type", storeMesh);
-    }
-    else if (!strcasecmp(child->Value(), "store_eps_mesh")) {
-      meshPrefix = "mesh";
-      storeMesh = 30; // all postscript mesh files
-    }
-    else if ((value = utl::getValue(child,"store_errors")))
-      errPrefix = value;
-    else if (!strcasecmp(child->Value(), "store_errors"))
-      errPrefix = "error";
-    else if (!strcasecmp(child->Value(), "test_linear_independence"))
-      linIndepTest = true;
-    else if ((value = utl::getValue(child,"scheme"))) {
-      if (!strcasecmp(value,"fullspan"))
-        scheme = 0;
-      else if (!strcasecmp(value,"minspan"))
-        scheme = 1;
-      else if (!strcasecmp(value,"isotropic_function"))
-        scheme = 2;
-      else
-        std::cerr <<"  ** AdaptiveSIM::parse: Unknown refinement scheme \""
-                  << value <<"\" (ignored)"<< std::endl;
-      utl::getAttribute(child, "maxTjoints", maxTjoints);
-      utl::getAttribute(child, "maxAspectRatio", maxAspRatio);
-      utl::getAttribute(child, "closeGaps", closeGaps);
-      IFEM::cout <<"\tRefinement scheme: "<< scheme << std::endl;
-    }
-    else if ((value = utl::getValue(child,"use_norm"))) {
-      adaptor = atoi(value);
-      utl::getAttribute(child, "index", adNorm);
-    }
-    else if ((value = utl::getValue(child,"use_sub_norm")))
-      adNorm = atoi(value);
-    else if ((value = utl::getValue(child,"beta"))) {
-      beta = atof(value);
-      std::string type;
-      utl::getAttribute(child, "type", type, true);
-      if (type.compare("threshold") == 0 || type.compare("threashold") == 0)
-        threshold = MAXIMUM;
-      else if (type.compare("maximum") == 0)
-        threshold = MAXIMUM;
-      else if (type.compare("average") == 0)
-        threshold = AVERAGE;
-      else if (type.compare("minimum") == 0)
-        threshold = MINIMUM;
-      else if (type.compare("truebeta") == 0)
-        threshold = TRUE_BETA;
-      else if (type.compare("dorfel") == 0)
-        threshold = DORFEL;
-      else if (type.compare("symmetrized") == 0) {
-        threshold = SYMMETRIZED;
-        utl::getAttribute(child,"eps",symmEps);
-      }
-      IFEM::cout <<"\tRefinement percentage: "<< beta <<" type="<< threshold;
-      if (threshold == SYMMETRIZED)
-        IFEM::cout <<" (eps = "<< symmEps <<")";
-      IFEM::cout << std::endl;
-    }
-  }
-
-  return true;
+  return this->AdaptiveSetup::parse(elem);
 }
 
 
 bool AdaptiveSIM::parse (char* keyWord, std::istream& is)
 {
-  if (!strncasecmp(keyWord,"ADAPTIVE",8))
-  {
-    std::istringstream cline(utl::readLine(is));
-
-    cline >> beta >> errTol;
-    if (cline.fail() || cline.bad()) return false;
-
-    int itmp;
-    cline >> itmp;
-    if (!cline.fail() && !cline.bad())
-      maxStep = itmp;
-
-    cline >> itmp;
-    if (!cline.fail() && !cline.bad())
-      maxDOFs = itmp;
-
-    cline >> itmp; // read knotline multiplicity
-    if (!cline.fail() && !cline.bad())
-      knot_mult = itmp;
-
-    cline >> itmp; // read refinement scheme
-    // (0=fullspan, 1=minspan, 2=structured mesh)
-    if (!cline.fail() && !cline.bad())
-      scheme = itmp;
-  }
-  else
-    return model.parse(keyWord,is);
-
-  return true;
-}
-
-
-void AdaptiveSIM::setAdaptationNorm (size_t normGroup, size_t normIdx)
-{
-  adaptor = normGroup;
-  adNorm  = normIdx;
+  return this->AdaptiveSetup::parse(keyWord,is);
 }
 
 
 bool AdaptiveSIM::initAdaptor (size_t normGroup)
 {
-  if (normGroup > 0)
-    adaptor = normGroup; // Override value from input file
-  else if (adaptor == 0 && !model.haveAnaSol() && !opt.project.empty())
-    adaptor = 1; // Set default to first projection if no analytical solution
-
-  SIMoptions::ProjectionMap::const_iterator pit = opt.project.begin();
-  for (size_t j = 1; pit != opt.project.end(); ++pit, j++)
-    if (j == adaptor) break;
-
-  IFEM::cout <<"\n\n >>> Starting adaptive simulation based on";
-  if (pit != opt.project.end())
-  {
-    IFEM::cout <<"\n     "<< pit->second
-               <<" error estimates (norm group "<< adaptor
-               <<") <<<"<< std::endl;
-    if (!adNorm) adNorm = 2; // Use norm 2, unless specified
-  }
-  else if (model.haveAnaSol())
-  {
-    adaptor = 0; // Assuming the exact errors are stored in the first group
-    if (!adNorm) adNorm = 4; // Use norm 4, unless specified
-    IFEM::cout <<" exact errors ";
-    if (adNorm != 4)
-      IFEM::cout <<"(norm index "<< adNorm <<") ";
-    IFEM::cout <<"<<<"<< std::endl;
-  }
-  else
-  {
-    IFEM::cout <<" - nothing, can not do that! <<<"<< std::endl;
+  if (!this->initPrm(normGroup))
     return false;
-  }
 
   projs.resize(opt.project.size());
   if (opt.format >= 0)
   {
     prefix.reserve(opt.project.size());
-    for (pit = opt.project.begin(); pit != opt.project.end(); ++pit)
-      prefix.push_back(pit->second);
+    for (const SIMoptions::ProjectionMap::value_type& prj : opt.project)
+      prefix.push_back(prj.second);
   }
 
   return true;
@@ -336,302 +166,25 @@ typedef std::pair<double,int> DblIdx;
 
 bool AdaptiveSIM::adaptMesh (int iStep, std::streamsize outPrec)
 {
-  ASMbase* thePatch = model.getPatch(1);
-  if (!thePatch)
-    return false; // No patches in the model, nothing to do here
-
   if (iStep < 2)
     return true; // No refinement in the first adaptive cycle
 
   if (outPrec > 0)
   {
     std::streamsize oldPrec = IFEM::cout.precision(outPrec);
-    this->printNorms();
+    this->printNorms(gNorm,eNorm);
     IFEM::cout.precision(oldPrec);
   }
   else
-    this->printNorms();
+    this->printNorms(gNorm,eNorm);
 
-  if (adaptor >= gNorm.size() || adaptor >= eNorm.rows() || eNorm.cols() == 0)
-    return false; // Refinement norm index out of range, or no element errors
-
-  // Cannot adapt on exact errors without an exact solution
-  if (adaptor == 0 && !model.haveAnaSol())
-    return false; // Cannot adapt on exact errors without an exact solution
-
-  // Define the reference norm
-  double refNorm = 0.01*model.getReferenceNorm(gNorm,adaptor);
-  if (refNorm < -epsZ)
-  {
-    std::cerr <<" *** AdaptiveSIM::adaptMesh: Negative reference norm."
-              <<" Check orientation of your model."<< std::endl;
-    return false; // Negative reference norm, modelling error?
-  }
-  else if (refNorm < epsZ)
-    return false; // Zero reference norm, probably no load on the model
-
-  // Check if further refinement is required
-  if (iStep > maxStep || model.getNoDOFs() > (size_t)maxDOFs)
-    return false; // Refinement cycle or model size limit reached
-  else if (gNorm[adaptor](adNorm) < errTol*refNorm)
-    return false; // Discretization error tolerance reached
-  else if (1.0/rCond > condLimit)
-  {
-    IFEM::cout <<"\n  ** Terminating the adaptive cycles due to instability."
-               <<"\n     The last condition number "<< 1.0/rCond
-               <<" is higher than the limit "<< condLimit << std::endl;
-    return false; // Condition number limit reached
-  }
-
-  // Calculate row index in eNorm of the error norm to adapt based on
-  size_t i, eRow = adNorm;
-  NormBase* norm = model.getNormIntegrand();
-  for (i = 0; i < adaptor; i++)
-    eRow += norm->getNoFields(i+1);
-  delete norm;
-
+  // Set up refinement parameters
   LR::RefineData prm;
-  prm.options.reserve(8);
-  prm.options.push_back(beta);
-  prm.options.push_back(knot_mult);
-  prm.options.push_back(scheme);
-  prm.options.push_back(linIndepTest);
-  prm.options.push_back(maxTjoints);
-  prm.options.push_back(floor(maxAspRatio));
-  prm.options.push_back(closeGaps);
-  prm.options.push_back(threshold == TRUE_BETA ? 1 : 0);
-
-  if (threshold == TRUE_BETA)
-  {
-    if (model.getNoPatches() > 1)
-    {
-      std::cerr <<" *** AdaptiveSIM::adaptMesh: True beta refinement"
-                <<" is not available for multi-patch models."<< std::endl;
-      return false;
-    }
-
-    IFEM::cout <<"\nRefining by increasing solution space by "<< beta
-               <<" percent."<< std::endl;
-    prm.errors.resize(thePatch->getNoRefineElms());
-    dynamic_cast<ASMunstruct*>(thePatch)->remapErrors(prm.errors,
-                                                      eNorm.getRow(eRow), true);
-
-    return model.refine(prm) & this->writeMesh(iStep);
-  }
-
-  std::vector<DblIdx> errors;
-  if (scheme == 2) // use errors per function
-  {
-    if (thePatch->getNoRefineNodes() == thePatch->getNoNodes(1))
-      errors.resize(model.getNoNodes(),DblIdx(0.0,0));
-    else if (model.getNoPatches() == 1)
-      errors.resize(thePatch->getNoRefineNodes(),DblIdx(0.0,0));
-    else
-    {
-      std::cerr <<" *** AdaptiveSIM::adaptMesh: Multi-patch refinement"
-                <<" is not available for mixed models."<< std::endl;
-      return false;
-    }
-
-    for (i = 0; i < errors.size(); i++)
-      errors[i].second = i;
-
-    for (ASMbase* patch : model.getFEModel())
-    {
-      // extract element norms for this patch
-      Vector locNorm(patch->getNoElms());
-      for (i = 1; i <= patch->getNoElms(); ++i)
-        locNorm(i) = eNorm(eRow, patch->getElmID(i));
-
-      // remap from geometry basis to refinement basis
-      Vector locErr(patch->getNoRefineNodes());
-      dynamic_cast<ASMunstruct*>(patch)->remapErrors(locErr, locNorm);
-
-      // insert into global error array
-      for (i = 0; i < locErr.size(); ++i)
-        if (model.getNoPatches() > 1)
-          errors[patch->getNodeID(i+1)-1].first += locErr[i];
-        else
-          errors[i].first += locErr[i];
-    }
-  }
-
-  else // use errors per element
-  {
-    if (model.getNoPatches() > 1) // not supported for multi-patch models
-    {
-      std::cerr <<" *** AdaptiveSIM::adaptMesh: Multi-patch refinement"
-                <<" is available for isotropic_function only."<< std::endl;
-      return false;
-    }
-    for (i = 0; i < eNorm.cols(); i++)
-      errors.push_back(DblIdx(eNorm(eRow,1+i),i));
-  }
-
-  // Sort the elements in the sequence of decreasing errors
-  std::sort(errors.begin(),errors.end(),std::greater<DblIdx>());
-
-  // find the list of refinable elements/basisfunctions
-  // the variable 'toBeRefined' contains one of the following:
-  //   - list of elements to be refined (if fullspan or minspan)
-  //   - list of basisfunctions to be refined (if structured mesh)
-  double limit, sumErr = 0.0, curErr = 0.0;
-  switch (threshold) {
-  case MAXIMUM: // beta percent of max error (less than 100%)
-    limit = errors.front().first * beta/100.0;
-    break;
-  case AVERAGE: // beta percent of avg error (typical 100%)
-    for (const DblIdx& error : errors)
-      sumErr += error.first;
-    limit = sumErr/errors.size() * beta/100.0;
-    break;
-  case MINIMUM: // beta percent of min error (more than 100%)
-    limit = errors.back().first  * beta/100.0;
-    break;
-  case DORFEL:
-    limit = errors.back().first;
-    for (const DblIdx& error : errors)
-      sumErr += error.first;
-    sumErr *= beta/100.0;
-    for (const DblIdx& error : errors)
-      if (curErr < sumErr)
-        curErr += error.first;
-      else
-      {
-        limit = error.first;
-        break;
-      }
-    break;
-  default:
-    limit = 0.0;
-  }
-
-  size_t refineSize;
-  if (threshold == NONE || threshold == SYMMETRIZED)
-    refineSize = ceil(errors.size()*beta/100.0);
-  else
-    refineSize = std::upper_bound(errors.begin(), errors.end(), DblIdx(limit,0),
-                                  std::greater_equal<DblIdx>())
-               - errors.begin();
-
-  if (threshold == SYMMETRIZED)
-  {
-    double fErr = errors[refineSize-1].first;
-    double fEps = fabs(fErr)*symmEps;
-    while (refineSize < errors.size() &&
-           fabs(errors[refineSize].first-fErr) < fEps)
-      ++refineSize;
-  }
-
-  if (!errPrefix.empty())
-  {
-    char suffix[9];
-    sprintf(suffix,"_%03d.txt",iStep-1);
-    std::ofstream of(errPrefix+suffix);
-    of.precision(16);
-    of <<"# Index   Error\n";
-    for (i = 0; i < errors.size(); i++)
-    {
-      of << errors[i].second <<" "<< errors[i].first << std::endl;
-      if (1+i == refineSize)
-        of <<"\n# ------------- Below here not refined ---------#\n\n";
-    }
-  }
-
-  IFEM::cout <<"\nRefining "<< refineSize
-             << (scheme < 2 ? " elements" : " basis functions")
-             <<" with errors in range ["<< errors[refineSize-1].first
-             <<","<< errors.front().first <<"] ";
-
-  switch (threshold) {
-  case NONE:
-    IFEM::cout << beta <<"% of all "
-               << (scheme < 2 ? "elements" : "basis functions");
-    break;
-  case MAXIMUM:
-    IFEM::cout << beta <<"% of max error ("<< limit <<")";
-    break;
-  case AVERAGE:
-    IFEM::cout << beta <<"% of average error ("<< limit <<")";
-    break;
-  case MINIMUM:
-    IFEM::cout << beta <<"% of min error ("<< limit <<")";
-    break;
-  case DORFEL:
-    IFEM::cout << beta <<"% of total error ("<< limit <<")";
-    break;
-  default:
-    break;
-  }
-  IFEM::cout << std::endl;
-
-  if (refineSize < 1 || refineSize > errors.size())
+  if (this->calcRefinement(prm,iStep,gNorm,eNorm.getRow(eRow)) <= 0)
     return false;
-
-  prm.elements.reserve(refineSize);
-  for (i = 0; i < refineSize; i++)
-    prm.elements.push_back(errors[i].second);
 
   // Now refine the mesh and write out resulting grid
   return model.refine(prm) & this->writeMesh(iStep);
-}
-
-
-void AdaptiveSIM::printNorms (size_t w) const
-{
-  model.printNorms(gNorm,w);
-
-  // Print out the norm used for mesh adaptation
-  size_t i, eRow = adNorm;
-  if (adaptor > 0 && adaptor < gNorm.size())
-  {
-    NormBase* norm = model.getNormIntegrand();
-
-    const Vector& aNorm = gNorm[adaptor];
-    IFEM::cout <<"\nError estimate"
-               << utl::adjustRight(w-14,norm->getName(adaptor+1,adNorm))
-               << aNorm(adNorm)
-               <<"\nRelative error (%) : "
-               << 100.0*aNorm(adNorm)/model.getReferenceNorm(gNorm,adaptor);
-    if (model.haveAnaSol() && adaptor != 0)
-      IFEM::cout <<"\nEffectivity index  : "
-                 << model.getEffectivityIndex(gNorm,adaptor,adNorm);
-    IFEM::cout <<"\n"<< std::endl;
-
-    // Calculate the row-index for the corresponding element norms
-    for (i = 0; i < adaptor; i++)
-      eRow += norm->getNoFields(i+1);
-
-    delete norm;
-  }
-
-  if (eNorm.rows() < eRow || eNorm.cols() < 1)
-    return;
-
-  // Compute some additional error measures
-  double avg_norm = eNorm(eRow,1);
-  double min_err  = avg_norm;
-  double max_err  = avg_norm;
-  for (i = 2; i <= eNorm.cols(); i++)
-  {
-    avg_norm += eNorm(eRow,i);
-    if (min_err > eNorm(eRow,i))
-      min_err = eNorm(eRow,i);
-    else if (max_err < eNorm(eRow,i))
-      max_err = eNorm(eRow,i);
-  }
-  avg_norm /= eNorm.cols();
-
-  double RMS_norm = 0.0;
-  for (i = 1; i <= eNorm.cols(); i++)
-    RMS_norm += pow(eNorm(eRow,i)-avg_norm,2.0);
-  RMS_norm = sqrt(RMS_norm/eNorm.cols())/avg_norm;
-
-  IFEM::cout <<  "Root mean square (RMS) of error      : "<< RMS_norm
-             <<"\nMin element error                    : "<< min_err
-             <<"\nMax element error                    : "<< max_err
-             <<"\nAverage element error                : "<< avg_norm
-             << std::endl;
 }
 
 
@@ -669,33 +222,4 @@ bool AdaptiveSIM::writeGlv (const char* infile, int iStep)
 
   // Write state information
   return model.writeGlvStep(iStep,iStep,1);
-}
-
-
-bool AdaptiveSIM::writeMesh (int iStep) const
-{
-  if (meshPrefix.empty() || storeMesh < 1)
-    return true;
-
-  if (storeMesh%2)
-  {
-    // Write all patches to the same file
-    char suffix[8];
-    sprintf(suffix,"_%03d.lr",iStep);
-    std::ofstream os(meshPrefix+suffix);
-    model.dumpGeometry(os);
-  }
-
-  if (storeMesh > 2)
-    for (ASMbase* pch : model.getFEModel())
-    {
-      char patchFile[256];
-      if (model.getNoPatches() > 1)
-        sprintf(patchFile,"%zu_%s_%03d",pch->idx+1,meshPrefix.c_str(),iStep);
-      else
-        sprintf(patchFile,"%s_%03d",meshPrefix.c_str(),iStep);
-      dynamic_cast<ASMunstruct*>(pch)->storeMesh(patchFile,storeMesh/2);
-    }
-
-  return true;
 }

--- a/src/SIM/AdaptiveSIM.h
+++ b/src/SIM/AdaptiveSIM.h
@@ -84,19 +84,20 @@ protected:
   //! \brief Assembles and solves the linear FE equation system.
   virtual bool assembleAndSolveSystem();
 
+  //! \brief Dumps current mesh to external file(s) for inspection.
+  //! \param[in] iStep Current refinement step (1=initial grid)
+  bool writeMesh(int iStep) const;
+
 private:
   SIMoutput& model; //!< The isogeometric FE model
   bool       alone; //!< If \e false, this class is wrapped by SIMSolver
 
-  bool   storeMesh;    //!< Creates a series of eps-files for intermediate steps
-  bool   storeErrors;  //!< Store errors used for adaptation to text files
   bool   linIndepTest; //!< Test mesh for linear independence after refinement
   double beta;         //!< Refinement percentage in each step
   double errTol;       //!< Global error stop tolerance
   double condLimit;    //!< Upper limit on condition number
   int    maxStep;      //!< Maximum number of adaptive refinements
   int    maxDOFs;      //!< Maximum number of degrees of freedom
-  int    symmetry;     //!< Always refine a multiplum of this
   int    knot_mult;    //!< Knotline multiplicity
   int    maxTjoints;   //!< Maximum number of hanging nodes on one element
   double maxAspRatio;  //!< Maximum element aspect ratio
@@ -120,6 +121,10 @@ private:
 
   std::vector<Vector>      projs;  //!< Projected secondary solutions
   std::vector<std::string> prefix; //!< Norm prefices for VTF-output
+
+  std::string errPrefix;  //!< Prefix for text-files with refinement indicators
+  std::string meshPrefix; //!< Prefix for output files with refined meshes
+  int         storeMesh;  //!< Flag telling which mesh output we want
 
 protected:
   Vectors solution; //!< All solutions (galerkin projections)

--- a/src/SIM/AdaptiveSetup.C
+++ b/src/SIM/AdaptiveSetup.C
@@ -1,0 +1,521 @@
+// $Id$
+//==============================================================================
+//!
+//! \file AdaptiveSetup.C
+//!
+//! \date May 7 2019
+//!
+//! \author Knut Morten Okstad / SINTEF
+//!
+//! \brief Adaptive solution setup for linear and nonlinear FEM simulators.
+//!
+//==============================================================================
+
+#include "AdaptiveSetup.h"
+#include "SIMoutput.h"
+#include "SIMenums.h"
+#include "ASMbase.h"
+#include "ASMunstruct.h"
+#include "IntegrandBase.h"
+#include "Utilities.h"
+#include "IFEM.h"
+#include "tinyxml.h"
+#include <fstream>
+#include <sstream>
+#include <cstdio>
+
+
+AdaptiveSetup::AdaptiveSetup (SIMoutput& sim, bool sa) : model(sim), alone(sa)
+{
+  // Default grid adaptation parameters
+  linIndep   = false;
+  beta       = 10.0;
+  errTol     = 1.0;
+  rCond      = 1.0;
+  condLimit  = 1.0e12;
+  maxStep    = 10;
+  maxDOFs    = 1000000;
+  scheme     = FULLSPAN;
+  knot_mult  = 1;
+  threshold  = NONE;
+  adaptor    = 0;
+  adNorm     = 0;
+  eRow       = 0;
+  maxTjoints = -1;
+  maxAspect  = -1.0;
+  closeGaps  = false;
+  symmEps    = 1.0e-6;
+  storeMesh  = 1;
+}
+
+
+bool AdaptiveSetup::parse (const TiXmlElement* elem)
+{
+  if (strcasecmp(elem->Value(),"adaptive"))
+    return alone ? model.parse(elem) : true;
+
+  const TiXmlElement* child = elem->FirstChildElement();
+  for (; child; child = child->NextSiblingElement()) {
+    const char* value = utl::getValue(child,"maxstep");
+    if (value)
+      maxStep = atoi(value);
+    else if ((value = utl::getValue(child,"maxdof")))
+      maxDOFs = atoi(value);
+    else if ((value = utl::getValue(child,"errtol")))
+      errTol = atof(value);
+    else if ((value = utl::getValue(child,"maxcondition")))
+      condLimit = atof(value);
+    else if ((value = utl::getValue(child,"knot_mult")))
+      knot_mult = atoi(value);
+    else if ((value = utl::getValue(child,"store_mesh"))) {
+      mshPrefix = value;
+      utl::getAttribute(child,"type",storeMesh);
+    }
+    else if (!strcasecmp(child->Value(),"store_eps_mesh")) {
+      mshPrefix = "mesh";
+      storeMesh = 30; // all postscript mesh files and lr-files
+    }
+    else if ((value = utl::getValue(child,"store_errors")))
+      errPrefix = value;
+    else if (!strcasecmp(child->Value(),"store_errors"))
+      errPrefix = "error";
+    else if (!strcasecmp(child->Value(),"test_linear_independence"))
+      linIndep = true;
+    else if ((value = utl::getValue(child,"scheme"))) {
+      if (!strcasecmp(value,"fullspan"))
+        scheme = FULLSPAN;
+      else if (!strcasecmp(value,"minspan"))
+        scheme = MINSPAN;
+      else if (!strcasecmp(value,"isotropic_function"))
+        scheme = ISOTROPIC_FUNCTION;
+      else
+        std::cerr <<"  ** AdaptiveSetup::parse: Unknown refinement scheme \""
+                  << value <<"\" (ignored)"<< std::endl;
+      utl::getAttribute(child,"maxTjoints",maxTjoints);
+      utl::getAttribute(child,"maxAspectRatio",maxAspect);
+      utl::getAttribute(child,"closeGaps",closeGaps);
+      IFEM::cout <<"\tRefinement scheme: "<< scheme << std::endl;
+    }
+    else if ((value = utl::getValue(child,"use_norm"))) {
+      adaptor = atoi(value);
+      utl::getAttribute(child,"index",adNorm);
+    }
+    else if ((value = utl::getValue(child,"use_sub_norm")))
+      adNorm = atoi(value);
+    else if ((value = utl::getValue(child,"beta"))) {
+      beta = atof(value);
+      std::string type;
+      utl::getAttribute(child,"type",type,true);
+      if (type.compare("threshold") == 0 || type.compare("threashold") == 0)
+        threshold = MAXIMUM;
+      else if (type.compare("maximum") == 0)
+        threshold = MAXIMUM;
+      else if (type.compare("average") == 0)
+        threshold = AVERAGE;
+      else if (type.compare("minimum") == 0)
+        threshold = MINIMUM;
+      else if (type.compare("truebeta") == 0)
+        threshold = TRUE_BETA;
+      else if (type.compare("dorfel") == 0)
+        threshold = DORFEL;
+      else if (type.compare("symmetrized") == 0) {
+        threshold = SYMMETRIZED;
+        utl::getAttribute(child,"eps",symmEps);
+      }
+      IFEM::cout <<"\tRefinement percentage: "<< beta <<" type="<< threshold;
+      if (threshold == SYMMETRIZED)
+        IFEM::cout <<" (eps = "<< symmEps <<")";
+      IFEM::cout << std::endl;
+    }
+  }
+
+  return true;
+}
+
+
+bool AdaptiveSetup::parse (char* keyWord, std::istream& is)
+{
+  if (!strncasecmp(keyWord,"ADAPTIVE",8))
+  {
+    std::istringstream cline(utl::readLine(is));
+
+    cline >> beta >> errTol;
+    if (cline.fail() || cline.bad()) return false;
+
+    int itmp;
+    cline >> itmp;
+    if (!cline.fail() && !cline.bad())
+      maxStep = itmp;
+
+    cline >> itmp;
+    if (!cline.fail() && !cline.bad())
+      maxDOFs = itmp;
+
+    cline >> itmp; // read knotline multiplicity
+    if (!cline.fail() && !cline.bad())
+      knot_mult = itmp;
+
+    cline >> itmp; // read refinement scheme
+    // (0=fullspan, 1=minspan, 2=structured mesh)
+    if (!cline.fail() && !cline.bad())
+      scheme = (RefScheme)itmp;
+  }
+  else
+    return model.parse(keyWord,is);
+
+  return true;
+}
+
+
+bool AdaptiveSetup::initPrm (size_t normGroup)
+{
+  if (normGroup > 0)
+    adaptor = normGroup; // Override value from input file
+  else if (adaptor == 0 && !model.haveAnaSol() && !model.opt.project.empty())
+    adaptor = 1; // Set default to first projection if no analytical solution
+
+  size_t iGroup = 0;
+  IFEM::cout <<"\n\n >>> Starting adaptive simulation based on";
+  for (const SIMoptions::ProjectionMap::value_type& prj : model.opt.project)
+    if (++iGroup == adaptor)
+    {
+      IFEM::cout <<"\n     "<< prj.second
+                 <<" error estimates (norm group "<< iGroup
+                 <<") <<<"<< std::endl;
+      break;
+    }
+
+  if (iGroup == adaptor && adaptor > 0)
+  {
+    if (!adNorm) adNorm = 2; // Use norm 2, unless specified
+  }
+  else if (model.haveAnaSol())
+  {
+    adaptor = 0; // Assuming the exact errors are stored in the first group
+    if (!adNorm) adNorm = 4; // Use norm 4, unless specified
+    IFEM::cout <<" exact errors ";
+    if (adNorm != 4)
+      IFEM::cout <<"(norm index "<< adNorm <<") ";
+    IFEM::cout <<"<<<"<< std::endl;
+  }
+  else
+  {
+    IFEM::cout <<" - nothing, can not do that! <<<"<< std::endl;
+    return false;
+  }
+
+  // Calculate row index in eNorm of the quantity to base the adaptation on
+  eRow = adNorm;
+  NormBase* norm = model.getNormIntegrand();
+  for (iGroup = 1; iGroup <= adaptor; iGroup++)
+    eRow += norm->getNoFields(iGroup);
+  delete norm;
+
+  return true;
+}
+
+
+//! \brief Element error and associated index.
+//! \note The error value must be first and the index second, such that the
+//! internally defined greater-than operator can be used when sorting the
+//! error+index pairs in decreasing error order.
+typedef std::pair<double,int> DblIdx;
+
+
+int AdaptiveSetup::calcRefinement (LR::RefineData& prm, int iStep,
+                                   const Vectors& gNorm,
+                                   const Vector& refIn) const
+{
+  prm.clear();
+
+  ASMbase* thePatch = model.getPatch(1);
+  if (!thePatch)
+    return 0; // No patches in the model, nothing to do here
+  else if (adaptor >= gNorm.size() || refIn.empty())
+    return 0; // Refinement norm index out of range, or no element errors
+  else if (adaptor == 0 && !model.haveAnaSol())
+    return 0; // Cannot adapt on exact errors without an exact solution
+
+  // Define the reference norm
+  double refNorm = 0.01*model.getReferenceNorm(gNorm,adaptor);
+  if (refNorm < -epsZ)
+  {
+    std::cerr <<" *** AdaptiveSetup::calcRefinement: Negative reference norm."
+              <<" Check orientation of your model."<< std::endl;
+    return -1; // Negative reference norm, modelling error?
+  }
+  else if (refNorm < epsZ)
+    return 0; // Zero reference norm, probably no load on the model
+
+  // Check if further refinement is required
+  if (iStep > maxStep || model.getNoDOFs() > (size_t)maxDOFs)
+    return 0; // Refinement cycle or model size limit reached
+  else if (gNorm[adaptor](adNorm) < errTol*refNorm)
+    return 0; // Discretization error tolerance reached
+  else if (1.0/rCond > condLimit)
+  {
+    IFEM::cout <<"\n  ** Terminating the adaptive cycles due to instability."
+               <<"\n     The last condition number "<< 1.0/rCond
+               <<" is higher than the limit "<< condLimit << std::endl;
+    return 0; // Condition number limit reached
+  }
+
+  prm.options.reserve(8);
+  prm.options.push_back(beta);
+  prm.options.push_back(knot_mult);
+  prm.options.push_back(scheme);
+  prm.options.push_back(linIndep);
+  prm.options.push_back(maxTjoints);
+  prm.options.push_back(floor(maxAspect));
+  prm.options.push_back(closeGaps);
+  prm.options.push_back(threshold == TRUE_BETA ? 1 : 0);
+
+  if (threshold == TRUE_BETA)
+  {
+    if (model.getNoPatches() > 1)
+    {
+      std::cerr <<" *** AdaptiveSetup::calcRefinement: True beta refinement"
+                <<" is not available for multi-patch models."<< std::endl;
+      return -2;
+    }
+
+    IFEM::cout <<"\nRefining by increasing solution space by "<< beta
+               <<" percent."<< std::endl;
+    prm.errors.resize(thePatch->getNoRefineElms());
+    dynamic_cast<ASMunstruct*>(thePatch)->remapErrors(prm.errors,refIn,true);
+    return prm.errors.size();
+  }
+
+  size_t i, refineSize;
+  std::vector<DblIdx> error;
+
+  if (scheme == ISOTROPIC_FUNCTION) // use errors per function
+  {
+    if (thePatch->getNoRefineNodes() == thePatch->getNoNodes(1))
+      error.resize(model.getNoNodes(),DblIdx(0.0,0));
+    else if (model.getNoPatches() == 1)
+      error.resize(thePatch->getNoRefineNodes(),DblIdx(0.0,0));
+    else
+    {
+      std::cerr <<" *** AdaptiveSetup::calcRefinement: Multi-patch refinement"
+                <<" is not available for mixed models."<< std::endl;
+      return -3;
+    }
+
+    for (i = 0; i < error.size(); i++)
+      error[i].second = i;
+
+    for (ASMbase* patch : model.getFEModel())
+    {
+      // Extract element norms for this patch
+      RealArray locNorm(patch->getNoElms());
+      for (i = 1; i <= locNorm.size(); i++)
+        locNorm[i-1] = refIn(patch->getElmID(i));
+
+      // Remap from geometry basis to refinement basis
+      RealArray locErr(patch->getNoRefineNodes());
+      dynamic_cast<ASMunstruct*>(patch)->remapErrors(locErr,locNorm);
+
+      // Insert into global error array
+      for (i = 0; i < locErr.size(); i++)
+        if (model.getNoPatches() > 1)
+          error[patch->getNodeID(i+1)-1].first += locErr[i];
+        else
+          error[i].first += locErr[i];
+    }
+  }
+
+  else // use errors per element
+  {
+    if (model.getNoPatches() > 1) // not supported for multi-patch models
+    {
+      std::cerr <<" *** AdaptiveSetup::adaptMesh: Multi-patch refinement"
+                <<" is available for isotropic_function only."<< std::endl;
+      return -4;
+    }
+
+    for (i = 0; i < refIn.size(); i++)
+      error.push_back(DblIdx(refIn(1+i),i));
+  }
+
+  // Sort the elements in the sequence of decreasing errors
+  std::sort(error.begin(),error.end(),std::greater<DblIdx>());
+
+  // Find the list of refinable elements or basis functions.
+  // The variable prm.elements will contain one of the following:
+  // - list of elements to be refined (if fullspan or minspan)
+  // - list of basis functions to be refined (if structured mesh)
+  double limit, sumErr = 0.0, curErr = 0.0;
+  switch (threshold) {
+  case MAXIMUM: // beta percent of max error (less than 100%)
+    limit = error.front().first * beta*0.01;
+    break;
+  case AVERAGE: // beta percent of avg error (typical 100%)
+    for (const DblIdx& e : error) sumErr += e.first;
+    limit = (sumErr/error.size()) * beta*0.01;
+    break;
+  case MINIMUM: // beta percent of min error (more than 100%)
+    limit = error.back().first * beta*0.01;
+    break;
+  case DORFEL:
+    limit = error.back().first;
+    for (const DblIdx& e : error) sumErr += e.first;
+    sumErr *= beta*0.01;
+    for (const DblIdx& e : error)
+      if (curErr < sumErr)
+        curErr += e.first;
+      else
+      {
+        limit = e.first;
+        break;
+      }
+    break;
+  default:
+    limit = 0.0;
+  }
+
+  if (threshold == NONE || threshold == SYMMETRIZED)
+    refineSize = ceil(error.size()*beta/100.0);
+  else
+    refineSize = std::upper_bound(error.begin(), error.end(), DblIdx(limit,0),
+                                  std::greater_equal<DblIdx>()) - error.begin();
+
+  if (threshold == SYMMETRIZED)
+  {
+    double fErr = error[refineSize-1].first;
+    double fEps = fabs(fErr)*symmEps;
+    while (refineSize < error.size() &&
+           fabs(error[refineSize].first-fErr) < fEps)
+      ++refineSize;
+  }
+
+  if (!errPrefix.empty())
+  {
+    char suffix[9];
+    sprintf(suffix,"_%03d.txt",iStep-1);
+    std::ofstream of(errPrefix+suffix);
+    of.precision(16);
+    of <<"# Index   Error\n";
+    for (i = 0; i < error.size(); i++)
+    {
+      of << error[i].second <<" "<< error[i].first << std::endl;
+      if (1+i == refineSize)
+        of <<"\n# ------------- Below here not refined ---------#\n\n";
+    }
+  }
+
+  const char* str = scheme < ISOTROPIC_FUNCTION ? "elements":"basis functions";
+  IFEM::cout <<"\nRefining "<< refineSize <<" "<< str
+             <<" with errors in range ["<< error[refineSize-1].first
+             <<","<< error.front().first <<"] ";
+
+  switch (threshold) {
+  case NONE:
+    IFEM::cout << beta <<"% of all "<< str;
+    break;
+  case MAXIMUM:
+    IFEM::cout << beta <<"% of max error ("<< limit <<")";
+    break;
+  case AVERAGE:
+    IFEM::cout << beta <<"% of average error ("<< limit <<")";
+    break;
+  case MINIMUM:
+    IFEM::cout << beta <<"% of min error ("<< limit <<")";
+    break;
+  case DORFEL:
+    IFEM::cout << beta <<"% of total error ("<< limit <<")";
+    break;
+  default:
+    break;
+  }
+  IFEM::cout << std::endl;
+
+  prm.elements.reserve(refineSize);
+  for (i = 0; i < refineSize; i++)
+    prm.elements.push_back(error[i].second);
+
+  return refineSize;
+}
+
+
+void AdaptiveSetup::printNorms (const Vectors& gNorm,
+                                const Matrix& eNorm, size_t w) const
+{
+  model.printNorms(gNorm,w);
+
+  // Print out the norm used for mesh adaptation
+  if (adaptor > 0 && adaptor < gNorm.size())
+  {
+    NormBase* norm = model.getNormIntegrand();
+
+    const Vector& aNorm = gNorm[adaptor];
+    IFEM::cout <<"\nError estimate"
+               << utl::adjustRight(w-14,norm->getName(adaptor+1,adNorm))
+               << aNorm(adNorm)
+               <<"\nRelative error (%) : "
+               << 100.0*aNorm(adNorm)/model.getReferenceNorm(gNorm,adaptor);
+    if (model.haveAnaSol() && adaptor != 0)
+      IFEM::cout <<"\nEffectivity index  : "
+                 << model.getEffectivityIndex(gNorm,adaptor,adNorm);
+    IFEM::cout <<"\n"<< std::endl;
+
+    delete norm;
+  }
+
+  if (eNorm.rows() < eRow || eNorm.cols() < 1)
+    return;
+
+  // Compute some additional error measures
+  double avg_norm = eNorm(eRow,1);
+  double min_err  = avg_norm;
+  double max_err  = avg_norm;
+  for (size_t i = 2; i <= eNorm.cols(); i++)
+  {
+    avg_norm += eNorm(eRow,i);
+    if (min_err > eNorm(eRow,i))
+      min_err = eNorm(eRow,i);
+    else if (max_err < eNorm(eRow,i))
+      max_err = eNorm(eRow,i);
+  }
+  avg_norm /= eNorm.cols();
+
+  double RMS_norm = 0.0;
+  for (size_t c = 1; c <= eNorm.cols(); c++)
+    RMS_norm += pow(eNorm(eRow,c)-avg_norm,2.0);
+  RMS_norm = sqrt(RMS_norm/eNorm.cols())/avg_norm;
+
+  IFEM::cout <<  "Root mean square (RMS) of error      : "<< RMS_norm
+             <<"\nMin element error                    : "<< min_err
+             <<"\nMax element error                    : "<< max_err
+             <<"\nAverage element error                : "<< avg_norm
+             << std::endl;
+}
+
+
+bool AdaptiveSetup::writeMesh (int iStep) const
+{
+  if (mshPrefix.empty() || storeMesh < 1)
+    return true;
+
+  if (storeMesh%2)
+  {
+    // Write all patches to the same file
+    char suffix[8];
+    sprintf(suffix,"_%03d.lr",iStep);
+    std::ofstream os(mshPrefix+suffix);
+    model.dumpGeometry(os);
+  }
+
+  if (storeMesh > 2)
+    for (ASMbase* pch : model.getFEModel())
+    {
+      char patchFile[256];
+      if (model.getNoPatches() > 1)
+        sprintf(patchFile,"%zu_%s_%03d",pch->idx+1,mshPrefix.c_str(),iStep);
+      else
+        sprintf(patchFile,"%s_%03d",mshPrefix.c_str(),iStep);
+      dynamic_cast<ASMunstruct*>(pch)->storeMesh(patchFile,storeMesh/2);
+    }
+
+  return true;
+}

--- a/src/SIM/AdaptiveSetup.h
+++ b/src/SIM/AdaptiveSetup.h
@@ -1,0 +1,123 @@
+// $Id$
+//==============================================================================
+//!
+//! \file AdaptiveSetup.h
+//!
+//! \date May 7 2019
+//!
+//! \author Knut Morten Okstad / SINTEF
+//!
+//! \brief Adaptive solution setup for linear and nonlinear FEM simulators.
+//!
+//==============================================================================
+
+#ifndef _ADAPTIVE_SETUP_H
+#define _ADAPTIVE_SETUP_H
+
+#include "MatVec.h"
+
+class SIMoutput;
+class TiXmlElement;
+namespace LR { struct RefineData; }
+
+
+/*!
+  \brief Adaptive solution setup for linear and nonlinear FEM simulators.
+  \details This class contains parameters for controlling the mesh refinement
+  in an adaptive simulation procedure, with methods for parsing the parameters
+  from the input file and to calculate the actual refinement indicators to be
+  passed to the LR-spline based mesh refinement methods. It also has methods
+  for printing out the global error norms that are used in the mesh-refinement
+  calculation, and for dumping the refined meshes to files in different formats.
+*/
+
+class AdaptiveSetup
+{
+public:
+  //! \brief The constructor initializes default adaptation parameters.
+  //! \param sim The FE model
+  //! \param[in] sa If \e true, this is a stand-alone driver
+  explicit AdaptiveSetup(SIMoutput& sim, bool sa = true);
+  //! \brief Empty destructor.
+  virtual ~AdaptiveSetup() {}
+
+  //! \brief Sets the norm group/index of the norm to base mesh adaptation on.
+  void setAdaptationNorm(size_t g, size_t i = 0) { adaptor = g; adNorm = i; }
+
+  //! \brief Initializes the norm group parameters.
+  //! \param[in] normGroup Index to the norm group to base mesh adaptation on
+  bool initPrm(size_t normGroup);
+
+  //! \brief Calculates mesh refinement control data based on error estimates.
+  //! \param[out] prm Mesh refinement control data
+  //! \param[in] iStep Refinement step counter
+  //! \param[in] gNorm Global norms
+  //! \param[in] refIn Element refinement indicators (element error norms)
+  //! \return Number of elements to be refined
+  //! \return If zero, no refinement needed
+  //! \return Negative value on error
+  int calcRefinement(LR::RefineData& prm, int iStep,
+                     const Vectors& gNorm, const Vector& refIn) const;
+
+  //! \brief Parses a data section from an input stream.
+  //! \param[in] keyWord Keyword of current data section to read
+  //! \param is The file stream to read from
+  bool parse(char* keyWord, std::istream& is);
+  //! \brief Parses a data section from an XML document.
+  //! \param[in] elem The XML element to parse
+  bool parse(const TiXmlElement* elem);
+
+  //! \brief Prints out global norms to the log stream.
+  //! \param[in] gNorm Global norms
+  //! \param[in] eNorm Element norms
+  //! \param[in] w Field width for global norm labels
+  void printNorms(const Vectors& gNorm,
+                  const Matrix& eNorm, size_t w = 36) const;
+
+  //! \brief Dumps current mesh to external file(s) for inspection.
+  //! \param[in] iStep Current refinement step (1=initial grid)
+  bool writeMesh(int iStep) const;
+
+  //! \brief Returns the row-index of the element norm to use for adaptation.
+  size_t eIdx() const { return eRow; }
+
+protected:
+  SIMoutput& model; //!< The isogeometric FE model
+
+  size_t adaptor; //!< Norm group to base the mesh adaptation on
+  size_t adNorm;  //!< Which norm to base the mesh adaptation on
+  size_t eRow;    //!< Row-index in \a eNorm of the norm to use for adaptation
+  double rCond;   //!< Actual reciprocal condition number of the last mesh
+
+private:
+  bool   alone;      //!< If \e false, this class is wrapped by SIMSolver
+  bool   linIndep;   //!< Test mesh for linear independence after refinement
+  double beta;       //!< Refinement percentage in each step
+  double errTol;     //!< Global error stop tolerance
+  double condLimit;  //!< Upper limit on condition number
+  int    maxStep;    //!< Maximum number of adaptive refinements
+  int    maxDOFs;    //!< Maximum number of degrees of freedom
+  int    knot_mult;  //!< Knotline multiplicity
+  int    maxTjoints; //!< Maximum number of hanging nodes on one element
+  double maxAspect;  //!< Maximum element aspect ratio
+  bool   closeGaps;  //!< Split elements with a hanging node on each side
+  double symmEps;    //!< Epsilon used for symmetrized selection method
+
+  //! \brief Enum defining the refinement threshold flag values.
+  enum Threshold { NONE=0, MAXIMUM, AVERAGE, MINIMUM, TRUE_BETA,
+                   DORFEL, SYMMETRIZED };
+
+  //! \brief Enum defining available refinement scheme options.
+  enum RefScheme { FULLSPAN=0, MINSPAN=1,
+                   ISOTROPIC_FUNCTION=2,
+                   ISOTROPIC_ELEMENT=3 };
+
+  Threshold   threshold; //!< Flag for how to interpret the parameter \a beta
+  RefScheme   scheme;    //!< The actual refinement scheme to use
+
+  int         storeMesh; //!< Flag telling what kind of mesh output we want
+  std::string mshPrefix; //!< Prefix for output files with refined meshes
+  std::string errPrefix; //!< Prefix for text files with refinement indicators
+};
+
+#endif

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -87,6 +87,17 @@ SIMbase::~SIMbase ()
 }
 
 
+/*!
+  Adds profiling to the virtual read() method.
+*/
+
+bool SIMbase::readModel (const char* fileName)
+{
+  PROFILE1("Model input");
+  return this->read(fileName);
+}
+
+
 void SIMbase::clearProperties ()
 {
   for (ASMbase* patch : myModel)

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -74,6 +74,9 @@ public:
   // Model input and pre-processing methods
   // ======================================
 
+  //! \brief Reads model data from the specified input file \a *fileName.
+  bool readModel(const char* fileName);
+
   //! \brief Creates the computational FEM model from the spline patches.
   //! \param[in] resetNumb If \e 'y', start element and node numbers from zero
   virtual bool createFEMmodel(char resetNumb = 'y') = 0;

--- a/src/SIM/SIMinput.C
+++ b/src/SIM/SIMinput.C
@@ -1232,28 +1232,26 @@ IntVec SIMinput::getFunctionsForElements (const IntVec& elements)
 }
 
 
-bool SIMinput::refine (const LR::RefineData& prm, const char* fName)
+bool SIMinput::refine (const LR::RefineData& prm)
 {
   Vectors svec;
-  return this->refine(prm,svec,fName);
+  return this->refine(prm,svec);
 }
 
 
-bool SIMinput::refine (const LR::RefineData& prm,
-                       Vector& sol, const char* fName)
+bool SIMinput::refine (const LR::RefineData& prm, Vector& sol)
 {
   if (sol.empty())
-    return this->refine(prm,fName);
+    return this->refine(prm);
 
   Vectors svec(1,sol);
-  bool result = this->refine(prm,svec,fName);
+  bool result = this->refine(prm,svec);
   sol = svec.front();
   return result;
 }
 
 
-bool SIMinput::refine (const LR::RefineData& prm,
-                       Vectors& sol, const char* fName)
+bool SIMinput::refine (const LR::RefineData& prm, Vectors& sol)
 {
   ASMunstruct* pch = nullptr;
   for (size_t i = 0; i < myModel.size(); i++)
@@ -1266,7 +1264,7 @@ bool SIMinput::refine (const LR::RefineData& prm,
 
   // Single patch models only pass refinement call to the ASM level
   if (myModel.size() == 1 && pch)
-    return (isRefined = pch->refine(prm,sol,fName));
+    return (isRefined = pch->refine(prm,sol));
 
   if (!prm.errors.empty()) // refinement by true_beta
   {
@@ -1327,14 +1325,11 @@ bool SIMinput::refine (const LR::RefineData& prm,
     pch->extendRefinementDomain(refineIndices[i],conformingIndices[i]);
     LR::RefineData prmloc(prm);
     prmloc.elements = IntVec(refineIndices[i].begin(),refineIndices[i].end());
-    char patchName[256];
-    if (fName)
-      sprintf(patchName, "%zu_%s", i, fName);
 
     Vectors lsol(sol.size());
     for (size_t j = 0; j < sol.size(); j++)
       myModel[i]->extractNodeVec(sol[j], lsol[j], sol[j].size()/ngNodes);
-    if (!pch->refine(prmloc,lsol, fName ? patchName : fName))
+    if (!pch->refine(prmloc,lsol))
       return false;
     for (const Vector& s : lsol)
       lsols.push_back(s);

--- a/src/SIM/SIMinput.h
+++ b/src/SIM/SIMinput.h
@@ -154,22 +154,15 @@ public:
 
   //! \brief Refines the mesh adaptively.
   //! \param[in] prm Input data used to control the refinement
-  //! \param[in] fName Optional mesh output file (Encapsulated PostScript)
-  bool refine(const LR::RefineData& prm, const char* fName = nullptr);
-
+  bool refine(const LR::RefineData& prm);
   //! \brief Refines the mesh adaptively.
   //! \param[in] prm Input data used to control the refinement
   //! \param[in] sol Vector to interpolate onto refined mesh
-  //! \param[in] fName Optional mesh output file (Encapsulated PostScript)
-  bool refine(const LR::RefineData& prm,
-              Vector& sol, const char* fName = nullptr);
-
+  bool refine(const LR::RefineData& prm, Vector& sol);
   //! \brief Refines the mesh adaptively.
   //! \param[in] prm Input data used to control the refinement
   //! \param[in] sol Vectors to interpolate onto refined mesh
-  //! \param[in] fName Optional mesh output file (Encapsulated PostScript)
-  bool refine(const LR::RefineData& prm,
-              Vectors& sol, const char* fName = nullptr);
+  bool refine(const LR::RefineData& prm, Vectors& sol);
 
   //! \brief Reads patches from given input stream.
   //! \param[in] isp The input stream to read from


### PR DESCRIPTION
This contains some items that used to be in #346 which now is a bit long and untidy. That branch will be rebased on this later. The main point here is to split out the parameter setup and the error_norm-to-refinement_indicator calculations in a separate class, AdaptiveSetup, which then AdaptiveSIM inherit from.

The motivation is that AdaptiveSetup then also can be re-used in nonlinear/dynamic solvers which have their own time-stepping drivers, etc.
