### PR TITLE
added: also store the eigen modes in equation ordering

### DIFF
--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -1617,7 +1617,8 @@ bool SIMbase::systemModes (std::vector<Mode>& solution,
   for (int i = 1; i <= nev && ok; i++)
   {
     solution[i-1].eigNo = i;
-    if (!mySam->expandVector(eigVec.getColumn(i),solution[i-1].eigVec))
+    solution[i-1].eqnVec = eigVec.getColumn(i);
+    if (!mySam->expandVector(solution[i-1].eqnVec,solution[i-1].eigVec))
       ok = false;
     else if (!freq)
       solution[i-1].eigVal = eigVal(i);

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -47,6 +47,7 @@ struct Mode
   int    eigNo;  //!< Eigenvalue identifier
   double eigVal; //!< Eigenvalue associated with this mode
   Vector eigVec; //!< Eigenvector associated with this mode
+  Vector eqnVec; //!< Eigenvector associated with this mode in equation order
   // \brief Default constructor.
   Mode() : eigNo(0), eigVal(0.0) {}
 };

--- a/src/Utility/HDF5Writer.C
+++ b/src/Utility/HDF5Writer.C
@@ -418,6 +418,11 @@ void HDF5Writer::writeSIM (int level, const DataEntry& entry,
             writeArray(group2, str4.str()+"/Frequency", -1, 1, &vec[k].eigVal, H5T_NATIVE_DOUBLE);
           else
             writeArray(group2, str4.str()+"/Value", -1, 1, &vec[k].eigVal, H5T_NATIVE_DOUBLE);
+          if (i == 0) {
+            str4 << "/eqn/";
+            writeArray(group2, str4.str(), i+1,
+                       vec[k].eqnVec.size(), vec[k].eqnVec.ptr(), H5T_NATIVE_DOUBLE);
+          }
           H5Gclose(group2);
         }
       }


### PR DESCRIPTION
so we can output these to hdf5. these are required when doing reduced
order models. this makes it easy to obtain them without having to use
hackery every time.