### PR TITLE
Fix triangle quadrature

### DIFF
--- a/src/Utility/Test/TestTriangleQuadrature.C
+++ b/src/Utility/Test/TestTriangleQuadrature.C
@@ -1,0 +1,35 @@
+//==============================================================================
+//!
+//! \file TestTriangleQuadrature.C
+//!
+//! \date Jul 31 2019
+//!
+//! \author Arne Morten Kvarving / SINTEF
+//!
+//! \brief Tests for triangle quadratures.
+//!
+//==============================================================================
+
+#include "TriangleQuadrature.h"
+
+#include "gtest/gtest.h"
+#include <numeric>
+
+
+TEST(TestTriangleQuadrature, Sanity)
+{
+  // Quadratures that are intended to not exist
+  for (int i : {-1,2,5}) {
+    EXPECT_EQ(TriangleQuadrature::getCoord(i), nullptr);
+    EXPECT_EQ(TriangleQuadrature::getWeight(i), nullptr);
+  }
+
+  for (int i : {1,3,4}) {
+    const double* c = TriangleQuadrature::getCoord(i);
+    const double* w = TriangleQuadrature::getWeight(i);
+    double sum = std::accumulate(w, w+i, 0.0);
+    EXPECT_FLOAT_EQ(sum, 1.0);
+    for (int j = 0; j < i; ++j)
+      EXPECT_TRUE(c[j] >= 0.0 && c[j] <= 1.0);
+  }
+}

--- a/src/Utility/TriangleQuadrature.C
+++ b/src/Utility/TriangleQuadrature.C
@@ -42,7 +42,7 @@ static const double T4[8] = {
 };
 //! \brief 4-point rule weights.
 static const double W4[4] = {
- -0.5635,
+ -0.5625,
   0.5208333333333333,
   0.5208333333333333,
   0.5208333333333333,


### PR DESCRIPTION
This fixes a typo in the 4 point triangle quadrature rule and adds a simple unit test.