### PR TITLE
added: full support for schur-complement block preconditioners

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ if(NOT PETSC_FOUND)
                    ${PROJECT_SOURCE_DIR}/src/LinAlg/PETScPCPerm.C
                    ${PROJECT_SOURCE_DIR}/src/LinAlg/PETScPCProd.C
                    ${PROJECT_SOURCE_DIR}/src/LinAlg/PETScPCScale.C
+                   ${PROJECT_SOURCE_DIR}/src/LinAlg/PETScSchurPC.C
                    ${PROJECT_SOURCE_DIR}/src/LinAlg/PETScSolParams.C)
 endif()
 

--- a/src/LinAlg/LinSolParams.C
+++ b/src/LinAlg/LinSolParams.C
@@ -65,20 +65,20 @@ bool SettingMap::hasValue(const std::string& key) const
 LinSolParams::BlockParams::BlockParams() :
   basis(1), comps(0)
 {
-  addValue("pc", "default");
-  addValue("multigrid_ksp", "defrichardson");
+  this->addValue("pc", "default");
+  this->addValue("multigrid_ksp", "defrichardson");
 }
 
 LinSolParams::LinSolParams()
   : blocks(1)
 {
-  addValue("type", "gmres");
-  addValue("rtol", "1e-6");
-  addValue("atol", "1e-20");
-  addValue("dtol", "1e6");
-  addValue("maxits", "1000");
-  addValue("gmres_restart_iterations", "100");
-  addValue("verbosity", "1");
+  this->addValue("type", "gmres");
+  this->addValue("rtol", "1e-6");
+  this->addValue("atol", "1e-20");
+  this->addValue("dtol", "1e6");
+  this->addValue("maxits", "1000");
+  this->addValue("gmres_restart_iterations", "100");
+  this->addValue("verbosity", "1");
 }
 
 
@@ -93,23 +93,23 @@ bool LinSolParams::BlockParams::read(const TiXmlElement* elem, const std::string
     if (!strcasecmp(child->Value(), "multigrid")) {
       std::string v;
       if (utl::getAttribute(child, "smoother", v))
-        addValue("multigrid_smoother", v);
+        this->addValue("multigrid_smoother", v);
       if (utl::getAttribute(child, "levels", v))
-        addValue("multigrid_levels", v);
+        this->addValue("multigrid_levels", v);
       if (utl::getAttribute(child, "no_smooth", v)) {
-        addValue("multigrid_no_smooth", v);
-        addValue("multigrid_no_fine_smooth", v);
+        this->addValue("multigrid_no_smooth", v);
+        this->addValue("multigrid_no_fine_smooth", v);
       }
       if (utl::getAttribute(child, "finesmoother", v))
-        addValue("multigrid_finesmoother", v);
+        this->addValue("multigrid_finesmoother", v);
       if (utl::getAttribute(child, "multigrid_no_fine_smooth", v))
-        addValue("multigrid_no_fine_smooth", v);
+        this->addValue("multigrid_no_fine_smooth", v);
       if (utl::getAttribute(child, "ksp", v))
-        addValue("multigrid_ksp", v);
+        this->addValue("multigrid_ksp", v);
       if (utl::getAttribute(child, "coarse_solver", v))
-        addValue("multigrid_coarse_solver", v);
+        this->addValue("multigrid_coarse_solver", v);
       if (utl::getAttribute(child, "max_coarse_size", v))
-        addValue("multigrid_max_coarse_size", v);
+        this->addValue("multigrid_max_coarse_size", v);
     } else if (!strcasecmp(child->Value(),"dirsmoother")) {
       int order;
       std::string type;
@@ -123,13 +123,13 @@ bool LinSolParams::BlockParams::read(const TiXmlElement* elem, const std::string
     } else if (!strcasecmp(child->Value(), "asm")) {
       std::string v;
       if (utl::getAttribute(child, "nx", v))
-        addValue("asm_nx", v);
+        this->addValue("asm_nx", v);
       else if (utl::getAttribute(child, "ny", v))
-        addValue("asm_ny", v);
+        this->addValue("asm_ny", v);
       else if (utl::getAttribute(child, "nz", v))
-        addValue("asm_nz", v);
+        this->addValue("asm_nz", v);
       else if (utl::getAttribute(child, "overlap", v))
-        addValue("asm_overlap", v);
+        this->addValue("asm_overlap", v);
     } else { // generic value or container tag - add with tag name as key
       std::string key = child->Value();
       if (child->FirstChildElement()) {
@@ -137,17 +137,17 @@ bool LinSolParams::BlockParams::read(const TiXmlElement* elem, const std::string
           return false;
       } else
         if (value = utl::getValue(child, key.c_str()))
-          addValue(prefix+key, value);
+          this->addValue(prefix+key, value);
     }
 
-  if (!hasValue("multigrid_finesmoother") && hasValue("multigrid_smoother"))
-    addValue("multigrid_finesmoother", getStringValue("multigrid_smoother"));
+  if (!this->hasValue("multigrid_finesmoother") && this->hasValue("multigrid_smoother"))
+    this->addValue("multigrid_finesmoother", this->getStringValue("multigrid_smoother"));
 
-  if (!hasValue("multigrid_finesmoother") && hasValue("multigrid_smoother"))
-    addValue("multigrid_finesmoother", getStringValue("multigrid_smoother"));
+  if (!this->hasValue("multigrid_finesmoother") && this->hasValue("multigrid_smoother"))
+    this->addValue("multigrid_finesmoother", this->getStringValue("multigrid_smoother"));
 
-  if (!hasValue("multigrid_no_smooth") || getIntValue("multgrid_no_smooth") < 1)
-    addValue("multigrid_no_smooth", "1");
+  if (!this->hasValue("multigrid_no_smooth") || this->getIntValue("multgrid_no_smooth") < 1)
+    this->addValue("multigrid_no_smooth", "1");
 
   return true;
 }
@@ -156,32 +156,32 @@ bool LinSolParams::BlockParams::read(const TiXmlElement* elem, const std::string
 bool LinSolParams::read (const TiXmlElement* elem)
 {
   if (elem->Attribute("verbosity"))
-    addValue("verbosity", elem->Attribute("verbosity"));
+    this->addValue("verbosity", elem->Attribute("verbosity"));
 
   const TiXmlElement* child = elem->FirstChildElement();
   int parseblock = 0;
   for (; child; child = child->NextSiblingElement()) {
     const char* value;
     if ((value = utl::getValue(child,"type")))
-      addValue("type", value);
+      this->addValue("type", value);
     else if ((value = utl::getValue(child,"gmres_restart_iterations")))
-      addValue("gmres_restart_iterations", value);
+      this->addValue("gmres_restart_iterations", value);
     else if ((value = utl::getValue(child,"pc")))
-      addValue("pc", value);
+      this->addValue("pc", value);
     else if ((value = utl::getValue(child,"schur")))
-      addValue("schur", value);
+      this->addValue("schur", value);
     else if (!strcasecmp(child->Value(),"block")) {
       blocks.resize(++parseblock);
       blocks.back().read(child);
     }
     else if ((value = utl::getValue(child,"atol")))
-      addValue("atol", value);
+      this->addValue("atol", value);
     else if ((value = utl::getValue(child,"rtol")))
-      addValue("rtol", value);
+      this->addValue("rtol", value);
     else if ((value = utl::getValue(child,"dtol")))
-      addValue("dtol", value);
+      this->addValue("dtol", value);
     else if ((value = utl::getValue(child,"maxits")))
-      addValue("maxits", value);
+      this->addValue("maxits", value);
   }
 
   if (parseblock == 0)

--- a/src/LinAlg/PETScMatrix.C
+++ b/src/LinAlg/PETScMatrix.C
@@ -13,6 +13,7 @@
 
 #include "PETScMatrix.h"
 #include "PETScSolParams.h"
+#include "PETScSchurPC.h"
 #include "LinSolParams.h"
 #include "LinAlgInit.h"
 #include "SAMpatchPETSc.h"
@@ -756,7 +757,10 @@ bool PETScMatrix::setParameters(PETScMatrix* P, PETScVector* Pb)
 
       KSPSetType(subksp[m],"preonly");
       KSPGetPC(subksp[m],&subpc[m]);
-      solParams.setupPC(subpc[m], m, prefix, adm.dd.getBlockEqs(m));
+      if (solParams.getBlock(m).getStringValue("pc") == "schur")
+        new PETScSchurPC(subpc[m], matvec, solParams.getBlock(m), adm);
+      else
+        solParams.setupPC(subpc[m], m, prefix, adm.dd.getBlockEqs(m));
     }
   }
 

--- a/src/LinAlg/PETScSchurPC.C
+++ b/src/LinAlg/PETScSchurPC.C
@@ -1,0 +1,130 @@
+// $Id$
+//==============================================================================
+//!
+//! \file PETScSchurPC.C
+//!
+//! \date Jun 4 2019
+//!
+//! \author Arne Morten Kvarving / SINTEF
+//!
+//! \brief Schur-complement preconditioner using PETSc.
+//!
+//==============================================================================
+
+#include "PETScSchurPC.h"
+#include "LinSolParams.h"
+#include "ProcessAdm.h"
+#include <tinyxml.h>
+
+
+PETScSchurPC::PETScSchurPC (PC& pc_init, const std::vector<Mat>& blocks,
+                            const LinSolParams::BlockParams& params, const ProcessAdm& adm)
+  : m_blocks(&blocks)
+{
+  PCSetType(pc_init, PCSHELL);
+  PCShellSetContext(pc_init, this);
+  PCShellSetName(pc_init, "Schur complement preconditioner");
+  PCShellSetApply(pc_init, PETScSchurPC::Apply_Outer);
+  PCShellSetDestroy(pc_init, PETScSchurPC::Destroy);
+
+  KSPCreate(*adm.getCommunicator(), &inner_ksp);
+  KSPSetType(inner_ksp, KSPPREONLY);
+  KSPSetOperators(inner_ksp, blocks[0], blocks[0]);
+  PC pc;
+  KSPGetPC(inner_ksp, &pc);
+  std::string schurpc = params.getStringValue("schurpc");
+  if (schurpc.empty())
+    schurpc = PCGAMG;
+  PCSetType(pc, schurpc.c_str());
+  KSPSetFromOptions(inner_ksp);
+  KSPSetUp(inner_ksp);
+  KSPView(inner_ksp, PETSC_VIEWER_STDOUT_WORLD);
+
+  KSPCreate(*adm.getCommunicator(), &outer_ksp);
+  KSPGetPC(outer_ksp, &pc);
+  PCSetType(pc, PCNONE);
+  int maxits = params.getIntValue("schur_maxits");
+  if (maxits < 1)
+    maxits = 1000;
+  double atol = params.getDoubleValue("schur_atol");
+  if (atol == 0.0)
+    atol = 1e-16;
+  double dtol = params.getDoubleValue("schur_dtol");
+  if (dtol == 0.0)
+    dtol = 1e100;
+  double rtol = params.getDoubleValue("schur_rtol");
+  if (rtol == 0.0)
+    rtol = 1e-12;
+  std::string type = params.getStringValue("schur_type");
+  if (type.empty())
+    type = KSPGMRES;
+  KSPSetType(outer_ksp, type.c_str());
+  KSPSetTolerances(outer_ksp, rtol, atol, dtol, maxits);
+
+  MatCreate(*adm.getCommunicator(), &outer_mat);
+  PetscInt r;
+  MatGetSize(blocks[3], &r, &r);
+  MatSetSizes(outer_mat, r, r, PETSC_DETERMINE, PETSC_DETERMINE);
+  MatSetFromOptions(outer_mat);
+  MatSetType(outer_mat, MATSHELL);
+  MatShellSetContext(outer_mat, this);
+  MatShellSetOperation(outer_mat, MATOP_MULT,
+                       (void(*)(void))&PETScSchurPC::Apply_Schur);
+  MatSetUp(outer_mat);
+
+  KSPSetOperators(outer_ksp, outer_mat, outer_mat);
+  KSPSetFromOptions(outer_ksp);
+  KSPSetUp(outer_ksp);
+  KSPView(outer_ksp, PETSC_VIEWER_STDOUT_WORLD);
+  PCSetUp(pc_init);
+
+  VecCreate(*adm.getCommunicator(), &tmp);
+  VecSetFromOptions(tmp);
+  MatGetSize(blocks[0], &r, &r);
+  VecSetSizes(tmp, r, PETSC_DETERMINE);
+  VecSetUp(tmp);
+}
+
+
+PETScSchurPC::~PETScSchurPC ()
+{
+  KSPDestroy(&inner_ksp);
+  KSPDestroy(&outer_ksp);
+  MatDestroy(&outer_mat);
+  VecDestroy(&tmp);
+}
+
+
+PetscErrorCode PETScSchurPC::Apply_Schur (Mat A, Vec x, Vec y)
+{
+  void* p;
+  MatShellGetContext(A, &p);
+  PETScSchurPC* spc = static_cast<PETScSchurPC*>(p);
+  MatMult(spc->m_blocks->at(1), x, spc->tmp);
+  KSPSolve(spc->inner_ksp, spc->tmp, spc->tmp);
+  MatMult(spc->m_blocks->at(2), spc->tmp, y);
+
+  return 0;
+}
+
+
+PetscErrorCode PETScSchurPC::Apply_Outer (PC pc, Vec x, Vec y)
+{
+  void* p;
+  PCShellGetContext(pc, &p);
+  PETScSchurPC* spc = static_cast<PETScSchurPC*>(p);
+  KSPSolve(spc->outer_ksp, x, y);
+
+  return 0;
+}
+
+
+PetscErrorCode PETScSchurPC::Destroy (PC pc)
+{
+  PETScSchurPC *shell;
+
+  PCShellGetContext(pc,(void**)&shell);
+  delete shell;
+
+  return 0;
+}

--- a/src/LinAlg/PETScSchurPC.h
+++ b/src/LinAlg/PETScSchurPC.h
@@ -1,0 +1,58 @@
+// $Id$
+//==============================================================================
+//!
+//! \file PETScSchurPC.h
+//!
+//! \date Jun 4 2019
+//!
+//! \author Arne Morten Kvarving / SINTEF
+//!
+//! \brief Schur-complement preconditioner using PETSc.
+//!
+//==============================================================================
+
+#include "PETScMatrix.h"
+#include <memory>
+
+
+/*!
+  \brief Class implementing a Schur-complement preconditioner for 2-block systems.
+ */
+
+
+class PETScSchurPC {
+public:
+  //! \brief The constructor sets up the preconditioner.
+  //! \param pc_init The PETSc PC to set up
+  //! \param blocks The matrix blocks
+  //! \param params Linear solver parameters
+  //! \param adm Processes administrator
+  PETScSchurPC(PC& pc_init, const std::vector<Mat>& blocks,
+               const LinSolParams::BlockParams& params, const ProcessAdm& adm);
+
+  //! \brief The destructor frees the PETSc structures.
+  ~PETScSchurPC();
+
+  //! \brief PETSc compatible function applying the Schur complement matrix.
+  //! \param A Shell matrix to apply
+  //! \param x Vector to apply matrix to
+  //! \param y Result of matrix-vector product
+  static PetscErrorCode Apply_Schur(Mat A, Vec x, Vec y);
+
+  //! \brief PETSc compatible function applying the Schur complement preconditioner.
+  //! \param pc Shell preconditioner to apply
+  //! \param x Vector to apply preconditioner to
+  //! \param y Result of preconditioner evaluation
+  static PetscErrorCode Apply_Outer(PC pc, Vec x, Vec y);
+
+  //! \brief Destroy a Schur preconditioner.
+  //! \param pc Preconditioner to destroy
+  static PetscErrorCode Destroy(PC pc);
+
+protected:
+  KSP inner_ksp; //!< The KSP for the approximation of inner matrix inverse
+  KSP outer_ksp; //!< The KSP for the approximated Schur complement
+  Mat outer_mat; //!< Matrix shell describing the Schur complement
+  Vec tmp; //!< Temporary vector
+  const std::vector<Mat>* m_blocks; //!< Matrix blocks in system
+};


### PR DESCRIPTION
previously only the SIMPLE (i.e. diagonal of A) approximation was
possible. now, any approximation can be used for A^-1.