### PR TITLE
Fixed: Don't call initResultPoint in the project method

### DIFF
--- a/src/SIM/NewmarkNLSIM.C
+++ b/src/SIM/NewmarkNLSIM.C
@@ -31,6 +31,12 @@ NewmarkNLSIM::NewmarkNLSIM (SIMbase& sim) : NewmarkSIM(sim), Finert(nullptr)
 }
 
 
+NewmarkNLSIM::~NewmarkNLSIM ()
+{
+  delete Finert;
+}
+
+
 bool NewmarkNLSIM::parse (const TiXmlElement* elem)
 {
   bool ok = this->NewmarkSIM::parse(elem);

--- a/src/SIM/NewmarkNLSIM.h
+++ b/src/SIM/NewmarkNLSIM.h
@@ -175,8 +175,8 @@ class NewmarkNLSIM : public NewmarkSIM
 public:
   //! \brief The constructor initializes default solution parameters.
   explicit NewmarkNLSIM(SIMbase& sim);
-  //! \brief Empty destructor.
-  virtual ~NewmarkNLSIM() {}
+  //! \brief The destructor deletes the \a Finert system vector.
+  virtual ~NewmarkNLSIM();
 
   using NewmarkSIM::parse;
   //! \brief Parses a data section from an XML document.

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -556,12 +556,12 @@ protected:
   virtual bool renumberNodes(const std::map<int,int>& nodeMap);
 
   //! \brief Extracts all local solution vector(s) for a specified patch.
-  //! \param[in] problem Integrand to receive the patch-level solution vectors
+  //! \param[in] problem The integrand to receive patch-level solution vectors
   //! \param[in] sol Global primary solution vectors in DOF-order
   //! \param[in] pindx Local patch index to extract solution vectors for
   //!
-  //! \details This method is typically invoked before the \a integrate method
-  //! on the the specified path, in order to extract all patch-level vector
+  //! \details This method is typically invoked before ASMbase::integrate()
+  //! on the specified path, in order to extract all patch-level vector
   //! quantities needed by the Integrand. This also includes any dependent
   //! vectors from other simulator classes that have been registered.
   //! All patch-level vectors are stored within the provided integrand.
@@ -630,7 +630,7 @@ public:
   ASMbase* getPatch(int idx, bool glbIndex = false) const;
 
   //! \brief Initializes material properties for the given patch.
-  bool setPatchMaterial(size_t patch);
+  bool setPatchMaterial(size_t patch) const;
 
   //! \brief Returns a const reference to our global-to-local node mapping.
   const std::map<int,int>& getGlob2LocMap() const { return myGlb2Loc; }

--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -771,7 +771,7 @@ bool SIMoutput::writeGlvS2 (const Vector& psol, int iStep, int& nBlock,
     // Direct evaluation of secondary solution variables
 
     LocalSystem::patch = i;
-    myProblem->initResultPoints(time,true);
+    myProblem->initResultPoints(time,true); // include principal stresses
     this->extractPatchDependencies(myProblem,myModel,i);
     this->setPatchMaterial(i+1);
     if (!myModel[i]->evalSolution(field,*myProblem,opt.nViz))
@@ -972,7 +972,8 @@ bool SIMoutput::writeGlvP (const Vector& ssol, int iStep, int& nBlock,
       {
         size_t indx = 0;
         double cmax = field.getRow(1+j).normInf(indx,1,true);
-        updateMaxVal((*maxVal)[j],cmax,pch->idx,grid->getCoord(indx-1));
+        if (indx > 0 && indx <= grid->getNoNodes())
+          updateMaxVal((*maxVal)[j],cmax,pch->idx,grid->getCoord(indx-1));
       }
   }
 


### PR DESCRIPTION
This was added in 5f5d792c00b4ac7c77b9a732b4d4507a9f695036 but
will make global L2 projection fail for models with plasticity.
It appears that this commit from 2016 is not needed any more,
probably due to other changes/fixes elsewhere in the meantime.
Changed: Made setPatchMaterial const to avoid const_casting elsewhere.
Changed: Minor doxy-issues for extractPatchSolution.