### PR TITLE
 Added: Class ItgPoint representing an integration/evaluation point

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,7 +165,7 @@ else()
                          src/ASM/Integrand.h src/ASM/Lagrange.h
                          src/ASM/LocalIntegral.h src/ASM/SAMpatch.h
                          src/ASM/TimeDomain.h src/ASM/ASMs?D.h src/ASM/ASM?D.h
-                         src/ASM/DomainDecomposition.h
+                         src/ASM/DomainDecomposition.h src/ASM/ItgPoint.h
                          src/LinAlg/*.h src/SIM/*.h src/Utility/*.h
                          3rdparty/*.h
                          ${CMAKE_BINARY_DIR}/IFEM.h)

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -1560,14 +1560,12 @@ bool ASMs1D::evalProjSolution (Matrix& sField, const Vector& locSol,
 
   // Evaluate the projected solution field at each point
   Vector vals;
-  FiniteElement fe;
   sField.resize(f->getNoFields(),gpar.size());
 
   size_t ipt = 0;
-  for (size_t i = 0; i < gpar.size(); i++)
+  for (double u : gpar)
   {
-    fe.u = gpar[i];
-    f->valueFE(fe,vals);
+    f->valueFE(ItgPoint(u),vals);
     sField.fillColumn(++ipt,vals);
   }
 
@@ -1861,7 +1859,7 @@ bool ASMs1D::evaluate (const FunctionBase* func, RealArray& values,
 
 Fields* ASMs1D::getProjectedFields (const Vector& coefs, size_t) const
 {
-  if (proj == curv)
+  if (proj == curv || this->getNoProjectionNodes() == 0)
     return nullptr;
 
   size_t ncmp = coefs.size() / this->getNoProjectionNodes();

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -2753,16 +2753,13 @@ bool ASMs2D::evalProjSolution (Matrix& sField, const Vector& locSol,
 
   // Evaluate the projected solution field at each point
   Vector vals;
-  FiniteElement fe;
   sField.resize(f->getNoFields(),gpar[0].size()*gpar[1].size());
 
   size_t ipt = 0;
-  for (size_t j = 0; j < gpar[1].size(); j++)
-    for (size_t i = 0; i < gpar[0].size(); i++)
+  for (double v : gpar[1])
+    for (double u : gpar[0])
     {
-      fe.u = gpar[0][i];
-      fe.v = gpar[1][j];
-      f->valueFE(fe,vals);
+      f->valueFE(ItgPoint(u,v),vals);
       sField.fillColumn(++ipt,vals);
     }
 
@@ -3126,7 +3123,7 @@ int ASMs2D::getCorner (int I, int J, int basis) const
 
 Fields* ASMs2D::getProjectedFields (const Vector& coefs, size_t) const
 {
-  if (proj == this->getBasis(1))
+  if (proj == this->getBasis(1) || this->getNoProjectionNodes() == 0)
     return nullptr;
 
   size_t ncmp = coefs.size() / this->getNoProjectionNodes();
@@ -3142,6 +3139,8 @@ Fields* ASMs2D::getProjectedFields (const Vector& coefs, size_t) const
 
 size_t ASMs2D::getNoProjectionNodes () const
 {
+  if (!proj) return 0;
+
   return proj->numCoefs_u() * proj->numCoefs_v();
 }
 

--- a/src/ASM/ASMs2Drecovery.C
+++ b/src/ASM/ASMs2Drecovery.C
@@ -15,8 +15,7 @@
 #include "GoTools/geometry/SurfaceInterpolator.h"
 
 #include "ASMs2D.h"
-#include "ASMs2Dmx.h"
-#include "FiniteElement.h"
+#include "ItgPoint.h"
 #include "Field.h"
 #include "IntegrandBase.h"
 #include "CoordinateMapping.h"
@@ -485,16 +484,11 @@ bool ASMs2D::evaluate (const Field* field, RealArray& vec, int basisNum) const
   // Evaluate the result field at all sampling points.
   // Note: it is here assumed that *basis and *this have spline bases
   // defined over the same parameter domain.
-  Vector sValues(gpar[0].size()*gpar[1].size());
-  Vector::iterator it=sValues.begin();
-  for (size_t j=0;j<gpar[1].size();++j) {
-    FiniteElement fe;
-    fe.v = gpar[1][j];
-    for (size_t i=0;i<gpar[0].size();++i) {
-      fe.u = gpar[0][i];
-      *it++ = field->valueFE(fe);
-    }
-  }
+  Vector sValues;
+  sValues.reserve(gpar[0].size()*gpar[1].size());
+  for (double v : gpar[1])
+    for (double u : gpar[0])
+      sValues.push_back(field->valueFE(ItgPoint(u,v)));
 
   Go::SplineSurface* surf = this->getBasis(basisNum);
 

--- a/src/ASM/ASMs3Drecovery.C
+++ b/src/ASM/ASMs3Drecovery.C
@@ -15,7 +15,7 @@
 #include "GoTools/trivariate/VolumeInterpolator.h"
 
 #include "ASMs3D.h"
-#include "FiniteElement.h"
+#include "ItgPoint.h"
 #include "Field.h"
 #include "CoordinateMapping.h"
 #include "GaussQuadrature.h"
@@ -300,19 +300,12 @@ bool ASMs3D::evaluate (const Field* field, RealArray& vec, int basisNum) const
   // Evaluate the result field at all sampling points.
   // Note: it is here assumed that *basis and *this have spline bases
   // defined over the same parameter domain.
-  Vector sValues(gpar[0].size()*gpar[1].size()*gpar[2].size());
-  Vector::iterator it=sValues.begin();
-  for (size_t l=0;l<gpar[2].size();++l) {
-    FiniteElement fe;
-    fe.w = gpar[2][l];
-    for (size_t j=0;j<gpar[1].size();++j) {
-      fe.v = gpar[1][j];
-      for (size_t i=0;i<gpar[0].size();++i) {
-        fe.u = gpar[0][i];
-        *it++ = field->valueFE(fe);
-      }
-    }
-  }
+  Vector sValues;
+  sValues.reserve(gpar[0].size()*gpar[1].size()*gpar[2].size());
+  for (double w : gpar[2])
+    for (double v : gpar[1])
+      for (double u : gpar[0])
+        sValues.push_back(field->valueFE(ItgPoint(u,v,w)));
 
   Go::SplineVolume* svol = this->getBasis(basisNum);
 

--- a/src/ASM/Field.h
+++ b/src/ASM/Field.h
@@ -18,7 +18,7 @@
 #include <string>
 
 class ASMbase;
-class FiniteElement;
+class ItgPoint;
 class Vec4;
 
 
@@ -54,12 +54,12 @@ public:
   //==============================
 
   //! \brief Computes the value in a given node/control point.
-  //! \param[in] node Node number
+  //! \param[in] node 1-based node/control point index
   virtual double valueNode(size_t node) const = 0;
 
   //! \brief Computes the value at a given local coordinate.
-  //! \param[in] fe Finite element quantities
-  virtual double valueFE(const FiniteElement& fe) const = 0;
+  //! \param[in] x Local coordinate of evaluation point
+  virtual double valueFE(const ItgPoint& x) const = 0;
 
   //! \brief Computes the value at a given global coordinate.
   //! \param[in] x Global/physical coordinate for point
@@ -71,20 +71,19 @@ public:
   virtual bool valueGrid(RealArray& val, const int* npe) const { return false; }
 
   //! \brief Computes the gradient for a given local coordinate.
-  //! \param[in] fe Finite element quantities
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] grad Gradient of solution in a given local coordinate
-  virtual bool gradFE(const FiniteElement& fe, Vector& grad) const = 0;
-
-  //! \brief Computes the hessian for a given local coordinate.
-  //! \param[in] fe Finite element quantities
-  //! \param[out] d2UdX2 Hessian of solution in a given local coordinate
-  virtual bool hessianFE(const FiniteElement& fe, Matrix& d2UdX2) const
-  { return false; }
+  virtual bool gradFE(const ItgPoint& x, Vector& grad) const = 0;
 
   //! \brief Computes the gradient for a given global/physical coordinate.
-  //! \param[in] x Global coordinate
+  //! \param[in] x Global/physical coordinate for point
   //! \param[out] grad Gradient of solution in a given global coordinate
   virtual bool gradCoor(const Vec4& x, Vector& grad) const { return false; }
+
+  //! \brief Computes the hessian for a given local coordinate.
+  //! \param[in] x Local coordinate of evaluation point
+  //! \param[out] H Hessian of solution in a given local coordinate
+  virtual bool hessianFE(const ItgPoint& x, Matrix& H) const { return false; }
 
 protected:
   std::string fname; //!< Name of the field

--- a/src/ASM/Fields.h
+++ b/src/ASM/Fields.h
@@ -18,7 +18,7 @@
 #include <string>
 
 class ASMbase;
-class FiniteElement;
+class ItgPoint;
 class Vec4;
 
 
@@ -73,19 +73,19 @@ public:
   virtual bool valueNode(size_t node, Vector& vals) const;
 
   //! \brief Computes the value for a given local coordinate.
-  //! \param[in] fe Finite element definition
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] vals Values at local point in given element
-  virtual bool valueFE(const FiniteElement& fe, Vector& vals) const = 0;
+  virtual bool valueFE(const ItgPoint& x, Vector& vals) const = 0;
 
   //! \brief Computes the value for a given global coordinate.
-  //! \param[in] x Global coordinate of evaluation point
+  //! \param[in] x Global/physical coordinate for point
   //! \param[out] vals Values at given global coordinate
   virtual bool valueCoor(const Vec4& x, Vector& vals) const { return false; }
 
   //! \brief Computes the gradient for a given local coordinate.
-  //! \param[in] fe Finite element definition
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] grad Gradient at local point in given element
-  virtual bool gradFE(const FiniteElement& fe, Matrix& grad) const = 0;
+  virtual bool gradFE(const ItgPoint& x, Matrix& grad) const = 0;
 
   //! \brief Computes the gradient for a given global coordinate.
   //! \param[in] x Global coordinate of evaluation point
@@ -93,10 +93,9 @@ public:
   virtual bool gradCoor(const Vec4& x, Matrix& grad) const { return false; }
 
   //! \brief Computes the hessian for a given local coordinate.
-  //! \param[in] fe Finite element definition
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] H Hessian at local point in given element
-  virtual bool hessianFE(const FiniteElement& fe, Matrix3D& H) const
-  { return false; }
+  virtual bool hessianFE(const ItgPoint& x, Matrix3D& H) const { return false; }
 
 protected:
   unsigned char nf;  //!< Number of field components

--- a/src/ASM/FiniteElement.h
+++ b/src/ASM/FiniteElement.h
@@ -14,6 +14,7 @@
 #ifndef _FINITE_ELEMENT_H
 #define _FINITE_ELEMENT_H
 
+#include "ItgPoint.h"
 #include "MatVec.h"
 #include "Vec3.h"
 #include "Tensor.h"
@@ -23,12 +24,12 @@
   \brief Class representing a finite element.
 */
 
-class FiniteElement
+class FiniteElement : public ItgPoint
 {
 public:
   //! \brief Default constructor.
-  explicit FiniteElement(size_t n = 0, size_t i = 0) : iGP(i), N(n), Te(3)
-  { iel = p = q = r = 0; u = v = w = xi = eta = zeta = h = 0.0; detJxW = 1.0; }
+  explicit FiniteElement(size_t n = 0, size_t i = 0) : ItgPoint(i), N(n), Te(3)
+  { p = q = r = 0; h = 0.0; detJxW = 1.0; }
 
   //! \brief Empty destructor.
   virtual ~FiniteElement() {}
@@ -68,13 +69,6 @@ protected:
 
 public:
   // Gauss point quantities
-  size_t   iGP;    //!< Global integration point counter
-  double   u;      //!< First parameter of current point
-  double   v;      //!< Second parameter of current point
-  double   w;      //!< Third parameter of current point
-  double   xi;     //!< First local coordinate of current integration point
-  double   eta;    //!< Second local coordinate of current integration point
-  double   zeta;   //!< Third local coordinate of current integration point
   double   detJxW; //!< Weighted determinant of the coordinate mapping
   Vector     N;    //!< Basis function values
   Matrix    dNdX;  //!< First derivatives (gradient) of the basis functions
@@ -84,7 +78,6 @@ public:
   Matrix     H;    //!< Hessian
 
   // Element quantities
-  int                 iel;  //!< Element identifier
   short int           p;    //!< Polynomial order of the basis in u-direction
   short int           q;    //!< Polynomial order of the basis in v-direction
   short int           r;    //!< Polynomial order of the basis in r-direction

--- a/src/ASM/ItgPoint.h
+++ b/src/ASM/ItgPoint.h
@@ -1,0 +1,74 @@
+// $Id$
+//==============================================================================
+//!
+//! \file ItgPoint.h
+//!
+//! \date Sep 30 2019
+//!
+//! \author Knut Morten Okstad / SINTEF
+//!
+//! \brief Integration point representation.
+//!
+//==============================================================================
+
+#ifndef _ITG_POINT_H
+#define _ITG_POINT_H
+
+#include <cstddef>
+
+
+/*!
+  \brief Class representing an integration point.
+*/
+
+class ItgPoint
+{
+public:
+  //! \brief Default constructor.
+  explicit ItgPoint(size_t i = 0)
+  {
+    iGP = i;
+    iel = -1;
+    u = v = w = xi = eta = zeta = 0.0;
+  }
+
+  //! \brief Constructor initializing the spline domain parameters.
+  explicit ItgPoint(double a, double b = 0.0, double c = 0.0, size_t i = 0)
+  {
+    u = a;
+    v = b;
+    w = c;
+
+    iGP = i;
+    iel = -1;
+    xi = eta = zeta = 0.0;
+  }
+
+  //! \brief Alternative constructor initializing the spline domain parameters.
+  explicit ItgPoint(const double* par, size_t i = 0)
+  {
+    u = par[0];
+    v = par[1];
+    w = par[2];
+
+    iGP = i;
+    iel = -1;
+    xi = eta = zeta = 0.0;
+  }
+
+  //! \brief Empty destructor.
+  virtual ~ItgPoint() {}
+
+  size_t iGP; //!< Global integration point counter
+
+  double u; //!< First spline parameter of the point
+  double v; //!< Second spline parameter of the point
+  double w; //!< Third spline parameter of the point
+
+  int    iel;  //!< Identifier of the element containing this point
+  double xi;   //!< First local coordinate within current element
+  double eta;  //!< Second local coordinate within current element
+  double zeta; //!< Third local coordinate within current element
+};
+
+#endif

--- a/src/ASM/LR/LRSplineField2D.h
+++ b/src/ASM/LR/LRSplineField2D.h
@@ -26,8 +26,8 @@ namespace LR {
 /*!
   \brief Class for LR spline-based finite element scalar fields in 2D.
 
-  \details This class implements the methods required to evaluate a 2D
-  lr spline scalar field at a given point in parametrical or physical coordinates.
+  \details This class implements the methods required to evaluate a 2D LR spline
+  scalar field at a given point in parametrical or physical coordinates.
 */
 
 class LRSplineField2D : public FieldBase
@@ -37,10 +37,11 @@ public:
   //! \param[in] patch The spline patch on which the field is to be defined
   //! \param[in] v Array of control point field values
   //! \param[in] basis Basis to use from patch
-  //! \param[in] cmp Component to use from source field. Pass 0 to use vector as-is.
+  //! \param[in] cmp Component to use from source field.
+  //! Pass 0 to use vector as-is.
   //! \param[in] name Name of spline field
   LRSplineField2D(const ASMu2D* patch, const RealArray& v,
-                char basis = 1, char cmp = 1, const char* name = nullptr);
+                  char basis = 1, char cmp = 1, const char* name = nullptr);
   //! \brief Empty destructor.
   virtual ~LRSplineField2D() {}
 
@@ -52,22 +53,22 @@ public:
   virtual double valueNode(size_t node) const;
 
   //! \brief Computes the value at a given local coordinate.
-  //! \param[in] fe Finite element definition
-  virtual double valueFE(const FiniteElement& fe) const;
+  //! \param[in] x Local coordinate of evaluation point
+  virtual double valueFE(const ItgPoint& x) const;
 
   //! \brief Computes the value at a given global coordinate.
   //! \param[in] x Global/physical coordinate for point
   virtual double valueCoor(const Vec4& x) const;
 
   //! \brief Computes the gradient for a given local coordinate.
-  //! \param[in] fe Finite element
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] grad Gradient of solution in a given local coordinate
-  virtual bool gradFE(const FiniteElement& fe, Vector& grad) const;
+  virtual bool gradFE(const ItgPoint& x, Vector& grad) const;
 
   //! \brief Computes the hessian for a given local coordinate.
-  //! \param[in] fe Finite element quantities
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] H Hessian of solution in a given local coordinate
-  virtual bool hessianFE(const FiniteElement& fe, Matrix& H) const;
+  virtual bool hessianFE(const ItgPoint& x, Matrix& H) const;
 
 protected:
   const LR::LRSplineSurface* basis; //!< Spline basis description

--- a/src/ASM/LR/LRSplineField3D.h
+++ b/src/ASM/LR/LRSplineField3D.h
@@ -26,8 +26,8 @@ namespace LR {
 /*!
   \brief Class for LR spline-based finite element scalar fields in 3D.
 
-  \details This class implements the functions required to evaluate a 3D
-  LR spline scalar field at a given point in parametrical or physical coordinates.
+  \details This class implements the methods required to evaluate a 3D LR spline
+  scalar field at a given point in parametrical or physical coordinates.
 */
 
 class LRSplineField3D : public FieldBase
@@ -37,7 +37,8 @@ public:
   //! \param[in] patch The spline patch on which the field is to be defined
   //! \param[in] v Array of control point field values
   //! \param[in] basis Basis to use from patch
-  //! \param[in] cmp Component to use from source field. Pass 0 to use vector as-is.
+  //! \param[in] cmp Component to use from source field.
+  //! Pass 0 to use vector as-is.
   //! \param[in] name Name of spline field
   LRSplineField3D(const ASMu3D* patch, const RealArray& v,
                   char basis = 1, char cmp = 1, const char* name = nullptr);
@@ -52,22 +53,22 @@ public:
   virtual double valueNode(size_t node) const;
 
   //! \brief Computes the value at a given local coordinate.
-  //! \param[in] fe Finite element definition
-  virtual double valueFE(const FiniteElement& fe) const;
+  //! \param[in] x Local coordinate of evaluation point
+  virtual double valueFE(const ItgPoint& x) const;
 
   //! \brief Computes the value at a given global coordinate.
   //! \param[in] x Global/physical coordinate for point
   virtual double valueCoor(const Vec4& x) const;
 
   //! \brief Computes the gradient for a given local coordinate.
-  //! \param[in] fe Finite element
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] grad Gradient of solution in a given local coordinate
-  virtual bool gradFE(const FiniteElement& fe, Vector& grad) const;
+  virtual bool gradFE(const ItgPoint& x, Vector& grad) const;
 
   //! \brief Computes the hessian for a given local coordinate.
-  //! \param[in] fe Finite element quantities
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] H Hessian of solution in a given local coordinate
-  virtual bool hessianFE(const FiniteElement& fe, Matrix& H) const;
+  virtual bool hessianFE(const ItgPoint& x, Matrix& H) const;
 
 protected:
   const LR::LRSplineVolume* basis; //!< Spline basis description

--- a/src/ASM/LR/LRSplineFields2D.h
+++ b/src/ASM/LR/LRSplineFields2D.h
@@ -26,8 +26,8 @@ namespace LR {
 /*!
   \brief Class for LR spline-based finite element vector fields in 2D.
 
-  \details This class implements the methods required to evaluate a 2D
-  LR spline vector field at a given point in parametrical or physical coordinates.
+  \details This class implements the methods required to evaluate a 2D LR spline
+  vector field at a given point in parametrical or physical coordinates.
 */
 
 class LRSplineFields2D : public Fields
@@ -62,9 +62,9 @@ public:
   bool valueNode(size_t node, Vector& vals) const;
 
   //! \brief Computes the value at a given local coordinate.
-  //! \param[in] fe Finite element definition
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] vals Values in local point in given element
-  bool valueFE(const FiniteElement& fe, Vector& vals) const;
+  bool valueFE(const ItgPoint& x, Vector& vals) const;
 
   //! \brief Computes the value at a given global coordinate.
   //! \param[in] x Global/physical coordinate for point
@@ -72,14 +72,14 @@ public:
   bool valueCoor(const Vec4& x, Vector& vals) const;
 
   //! \brief Computes the gradient for a given local coordinate.
-  //! \param[in] fe Finite element
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] grad Gradient of solution in a given local coordinate
-  bool gradFE(const FiniteElement& fe, Matrix& grad) const;
+  bool gradFE(const ItgPoint& x, Matrix& grad) const;
 
   //! \brief Computes the hessian for a given local coordinate.
-  //! \param[in] fe Finite element quantities
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] H Hessian of solution in a given local coordinate
-  virtual bool hessianFE(const FiniteElement& fe, Matrix3D& H) const;
+  virtual bool hessianFE(const ItgPoint& x, Matrix3D& H) const;
 
 protected:
   const LR::LRSplineSurface* basis; //!< Spline basis description

--- a/src/ASM/LR/LRSplineFields2Dmx.C
+++ b/src/ASM/LR/LRSplineFields2Dmx.C
@@ -11,13 +11,13 @@
 //!
 //==============================================================================
 
+#include "LRSpline/LRSplineSurface.h"
+
 #include "LRSplineFields2Dmx.h"
 #include "ASMu2Dmx.h"
-#include "FiniteElement.h"
+#include "ItgPoint.h"
 #include "CoordinateMapping.h"
 #include "Utilities.h"
-
-#include "LRSpline/LRSplineSurface.h"
 
 
 LRSplineFields2Dmx::LRSplineFields2Dmx (const ASMu2Dmx* patch,
@@ -48,7 +48,7 @@ bool LRSplineFields2Dmx::valueNode (size_t node, Vector& vals) const
 }
 
 
-bool LRSplineFields2Dmx::valueFE (const FiniteElement& fe, Vector& vals) const
+bool LRSplineFields2Dmx::valueFE (const ItgPoint& x, Vector& vals) const
 {
   if (!surf) return false;
 
@@ -60,10 +60,10 @@ bool LRSplineFields2Dmx::valueFE (const FiniteElement& fe, Vector& vals) const
   for (const auto& it : bases) {
     const LR::LRSplineSurface* basis = surf->getBasis(it);
 
-    int iel = basis->getElementContaining(fe.u,fe.v);
+    int iel = basis->getElementContaining(x.u,x.v);
     auto elm = basis->getElement(iel);
     Go::BasisPtsSf spline;
-    basis->computeBasis(fe.u,fe.v,spline,iel);
+    basis->computeBasis(x.u,x.v,spline,iel);
 
     // Evaluate the solution field at the given point
 
@@ -81,16 +81,16 @@ bool LRSplineFields2Dmx::valueFE (const FiniteElement& fe, Vector& vals) const
 }
 
 
-bool LRSplineFields2Dmx::gradFE (const FiniteElement& fe, Matrix& grad) const
+bool LRSplineFields2Dmx::gradFE (const ItgPoint& x, Matrix& grad) const
 {
   if (!surf)  return false;
 
   // Evaluate the basis functions at the given point
   Go::BasisDerivsSf spline;
   const LR::LRSplineSurface* gsurf = surf->getBasis(ASMmxBase::geoBasis);
-  int iel = gsurf->getElementContaining(fe.u,fe.v);
+  int iel = gsurf->getElementContaining(x.u,x.v);
   auto elm = gsurf->getElement(iel);
-  gsurf->computeBasis(fe.u,fe.v,spline,iel);
+  gsurf->computeBasis(x.u,x.v,spline,iel);
 
   const size_t nen = elm->nBasisFunctions();
 
@@ -116,9 +116,9 @@ bool LRSplineFields2Dmx::gradFE (const FiniteElement& fe, Matrix& grad) const
   size_t row = 1;
   for (const auto& it : bases) {
     const LR::LRSplineSurface* basis = surf->getBasis(it);
-    int iel = basis->getElementContaining(fe.u,fe.v);
+    int iel = basis->getElementContaining(x.u,x.v);
     auto belm = basis->getElement(iel);
-    basis->computeBasis(fe.u,fe.v,spline,iel);
+    basis->computeBasis(x.u,x.v,spline,iel);
 
     const size_t nbf = belm->nBasisFunctions();
     dNdu.resize(nbf,2);

--- a/src/ASM/LR/LRSplineFields2Dmx.h
+++ b/src/ASM/LR/LRSplineFields2Dmx.h
@@ -27,8 +27,8 @@ namespace LR {
 /*!
   \brief Class for mixed LR spline-based finite element vector fields in 2D.
 
-  \details This class implements the methods required to evaluate a 2D
-  mixed LR spline vector field at a given point in parametrical or physical coordinates.
+  \details This class implements the methods required to evaluate a 2D LR spline
+  mixed vector field at a given point in parametrical or physical coordinates.
 */
 
 class LRSplineFields2Dmx : public Fields
@@ -53,18 +53,18 @@ public:
   bool valueNode(size_t node, Vector& vals) const;
 
   //! \brief Computes the value at a given local coordinate.
-  //! \param[in] fe Finite element definition
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] vals Values in local point in given element
-  bool valueFE(const FiniteElement& fe, Vector& vals) const;
+  bool valueFE(const ItgPoint& x, Vector& vals) const;
 
   //! \brief Computes the gradient for a given local coordinate.
-  //! \param[in] fe Finite element
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] grad Gradient of solution in a given local coordinate
-  bool gradFE(const FiniteElement& fe, Matrix& grad) const;
+  bool gradFE(const ItgPoint& x, Matrix& grad) const;
 
 protected:
   const ASMu2Dmx* surf; //!< Patch description
-  std::set<int> bases; //!< Bases to use
+  std::set<int>  bases; //!< Bases to use
 };
 
 #endif

--- a/src/ASM/LR/LRSplineFields3D.h
+++ b/src/ASM/LR/LRSplineFields3D.h
@@ -26,8 +26,8 @@ namespace LR {
 /*!
   \brief Class for LR spline-based finite element vector fields in 3D.
 
-  \details This class implements the methods required to evaluate a 3D
-  LR spline vector field at a given point in parametrical or physical coordinates.
+  \details This class implements the methods required to evaluate a 3D LR spline
+  vector field at a given point in parametrical or physical coordinates.
 */
 
 class LRSplineFields3D : public Fields
@@ -62,9 +62,9 @@ public:
   bool valueNode(size_t node, Vector& vals) const;
 
   //! \brief Computes the value at a given local coordinate.
-  //! \param[in] fe Finite element definition
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] vals Values in local point in given element
-  bool valueFE(const FiniteElement& fe, Vector& vals) const;
+  bool valueFE(const ItgPoint& x, Vector& vals) const;
 
   //! \brief Computes the value at a given global coordinate.
   //! \param[in] x Global/physical coordinate for point
@@ -72,14 +72,14 @@ public:
   bool valueCoor(const Vec4& x, Vector& vals) const;
 
   //! \brief Computes the gradient for a given local coordinate.
-  //! \param[in] fe Finite element
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] grad Gradient of solution in a given local coordinate
-  bool gradFE(const FiniteElement& fe, Matrix& grad) const;
+  bool gradFE(const ItgPoint& x, Matrix& grad) const;
 
   //! \brief Computes the hessian for a given local coordinate.
-  //! \param[in] fe Finite element quantities
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] H Hessian of solution in a given local coordinate
-  virtual bool hessianFE(const FiniteElement& fe, Matrix3D& H) const;
+  virtual bool hessianFE(const ItgPoint& x, Matrix3D& H) const;
 
 protected:
   const LR::LRSplineVolume* basis; //!< Spline basis description

--- a/src/ASM/LR/LRSplineFields3Dmx.C
+++ b/src/ASM/LR/LRSplineFields3Dmx.C
@@ -11,13 +11,13 @@
 //!
 //==============================================================================
 
+#include "LRSpline/LRSplineVolume.h"
+
 #include "LRSplineFields3Dmx.h"
 #include "ASMu3Dmx.h"
-#include "FiniteElement.h"
+#include "ItgPoint.h"
 #include "CoordinateMapping.h"
 #include "Utilities.h"
-
-#include "LRSpline/LRSplineVolume.h"
 
 
 LRSplineFields3Dmx::LRSplineFields3Dmx (const ASMu3Dmx* patch,
@@ -48,7 +48,7 @@ bool LRSplineFields3Dmx::valueNode (size_t node, Vector& vals) const
 }
 
 
-bool LRSplineFields3Dmx::valueFE (const FiniteElement& fe, Vector& vals) const
+bool LRSplineFields3Dmx::valueFE (const ItgPoint& x, Vector& vals) const
 {
   if (!vol) return false;
 
@@ -60,10 +60,10 @@ bool LRSplineFields3Dmx::valueFE (const FiniteElement& fe, Vector& vals) const
   for (const auto& it : bases) {
     const LR::LRSplineVolume* basis = vol->getBasis(it);
 
-    int iel = basis->getElementContaining(fe.u,fe.v,fe.w);
+    int iel = basis->getElementContaining(x.u,x.v,x.w);
     auto elm = basis->getElement(iel);
     Go::BasisPts spline;
-    basis->computeBasis(fe.u,fe.v,fe.w,spline,iel);
+    basis->computeBasis(x.u,x.v,x.w,spline,iel);
 
     // Evaluate the solution field at the given point
 
@@ -81,16 +81,16 @@ bool LRSplineFields3Dmx::valueFE (const FiniteElement& fe, Vector& vals) const
 }
 
 
-bool LRSplineFields3Dmx::gradFE (const FiniteElement& fe, Matrix& grad) const
+bool LRSplineFields3Dmx::gradFE (const ItgPoint& x, Matrix& grad) const
 {
   if (!vol)  return false;
 
   // Evaluate the basis functions at the given point
   Go::BasisDerivs spline;
   const LR::LRSplineVolume* gvol = vol->getBasis(ASMmxBase::geoBasis);
-  int iel = gvol->getElementContaining(fe.u,fe.v,fe.w);
+  int iel = gvol->getElementContaining(x.u,x.v,x.w);
   auto elm = gvol->getElement(iel);
-  gvol->computeBasis(fe.u,fe.v,fe.w,spline,iel);
+  gvol->computeBasis(x.u,x.v,x.w,spline,iel);
 
   const size_t nen = elm->nBasisFunctions();
   Matrix dNdu(nen,3), dNdX;
@@ -116,9 +116,9 @@ bool LRSplineFields3Dmx::gradFE (const FiniteElement& fe, Matrix& grad) const
   size_t row = 1;
   for (const auto& it : bases) {
     const LR::LRSplineVolume* basis = vol->getBasis(it);
-    int iel = basis->getElementContaining(fe.u,fe.v,fe.w);
+    int iel = basis->getElementContaining(x.u,x.v,x.w);
     auto belm = basis->getElement(iel);
-    basis->computeBasis(fe.u,fe.v,fe.w,spline,iel);
+    basis->computeBasis(x.u,x.v,x.w,spline,iel);
 
     const size_t nbf = belm->nBasisFunctions();
     dNdu.resize(nbf,3);

--- a/src/ASM/LR/LRSplineFields3Dmx.h
+++ b/src/ASM/LR/LRSplineFields3Dmx.h
@@ -27,8 +27,8 @@ namespace LR {
 /*!
   \brief Class for LR spline-based finite element vector fields in 3D.
 
-  \details This class implements the methods required to evaluate a 3D
-  LR spline vector field at a given point in parametrical or physical coordinates.
+  \details This class implements the methods required to evaluate a 3D LR spline
+  mixed vector field at a given point in parametrical or physical coordinates.
 */
 
 class LRSplineFields3Dmx : public Fields
@@ -53,14 +53,14 @@ public:
   bool valueNode(size_t node, Vector& vals) const;
 
   //! \brief Computes the value at a given local coordinate.
-  //! \param[in] fe Finite element definition
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] vals Values in local point in given element
-  bool valueFE(const FiniteElement& fe, Vector& vals) const;
+  bool valueFE(const ItgPoint& x, Vector& vals) const;
 
   //! \brief Computes the gradient for a given local coordinate.
-  //! \param[in] fe Finite element
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] grad Gradient of solution in a given local coordinate
-  bool gradFE(const FiniteElement& fe, Matrix& grad) const;
+  bool gradFE(const ItgPoint& x, Matrix& grad) const;
 
 protected:
   const ASMu3Dmx* vol; //!< Patch description

--- a/src/ASM/LagrangeField2D.h
+++ b/src/ASM/LagrangeField2D.h
@@ -48,13 +48,13 @@ public:
   double valueNode(size_t node) const;
 
   //! \brief Computes the value at a given local coordinate.
-  //! \param[in] fe Finite element definition
-  double valueFE(const FiniteElement& fe) const;
+  //! \param[in] x Local coordinate of evaluation point
+  double valueFE(const ItgPoint& x) const;
 
   //! \brief Computes the gradient for a given local coordinate.
-  //! \param[in] fe Finite element
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] grad Gradient of solution in a given local coordinate
-  bool gradFE(const FiniteElement& fe, Vector& grad) const;
+  bool gradFE(const ItgPoint& x, Vector& grad) const;
 
 protected:
   Matrix coord; //!< Matrix of nodal coordinates

--- a/src/ASM/LagrangeField3D.h
+++ b/src/ASM/LagrangeField3D.h
@@ -48,13 +48,13 @@ public:
   double valueNode(size_t node) const;
 
   //! \brief Computes the value at a given local coordinate.
-  //! \param[in] fe Finite element definition
-  double valueFE(const FiniteElement& fe) const;
+  //! \param[in] x Local coordinate of evaluation point
+  double valueFE(const ItgPoint& x) const;
 
   //! \brief Computes the gradient for a given local coordinate.
-  //! \param[in] fe Finite element
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] grad Gradient of solution in a given local coordinate
-  bool gradFE(const FiniteElement& fe, Vector& grad) const;
+  bool gradFE(const ItgPoint& x, Vector& grad) const;
 
 protected:
   Matrix coord; //!< Matrix of nodel coordinates

--- a/src/ASM/LagrangeFields2D.h
+++ b/src/ASM/LagrangeFields2D.h
@@ -48,14 +48,14 @@ public:
   bool valueNode(size_t node, Vector& vals) const;
 
   //! \brief Computes the value at a given local coordinate.
-  //! \param[in] fe Finite element definition
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] vals Values in local point in given element
-  bool valueFE(const FiniteElement& fe, Vector& vals) const;
+  bool valueFE(const ItgPoint& x, Vector& vals) const;
 
   //! \brief Computes the gradient for a given local coordinate.
-  //! \param[in] fe Finite element
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] grad Gradient of solution in a given local coordinate
-  bool gradFE(const FiniteElement& fe, Matrix& grad) const;
+  bool gradFE(const ItgPoint& x, Matrix& grad) const;
 
 protected:
   Matrix coord; //!< Matrix of nodal coordinates

--- a/src/ASM/LagrangeFields3D.h
+++ b/src/ASM/LagrangeFields3D.h
@@ -48,14 +48,14 @@ public:
   bool valueNode(size_t node, Vector& vals) const;
 
   //! \brief Computes the value at a given local coordinate.
-  //! \param[in] fe Finite element definition
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] vals Values in local point in given element
-  bool valueFE(const FiniteElement& fe, Vector& vals) const;
+  bool valueFE(const ItgPoint& x, Vector& vals) const;
 
   //! \brief Computes the gradient for a given local coordinate.
-  //! \param[in] fe Finite element
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] grad Gradient of solution in a given local coordinate
-  bool gradFE(const FiniteElement& fe, Matrix& grad) const;
+  bool gradFE(const ItgPoint& x, Matrix& grad) const;
 
 protected:
   Matrix coord; //!< Matrix of nodel coordinates

--- a/src/ASM/SplineField2D.h
+++ b/src/ASM/SplineField2D.h
@@ -37,7 +37,8 @@ public:
   //! \param[in] patch The spline patch on which the field is to be defined
   //! \param[in] v Array of control point field values
   //! \param[in] basis Basis to use from patch
-  //! \param[in] cmp Component to use from source field. Pass 0 to use vector as-is.
+  //! \param[in] cmp Component to use from source field.
+  //! Pass 0 to use vector as-is.
   //! \param[in] name Name of spline field
   SplineField2D(const ASMs2D* patch, const RealArray& v,
                 char basis = 1, char cmp = 1, const char* name = nullptr);
@@ -52,8 +53,8 @@ public:
   virtual double valueNode(size_t node) const;
 
   //! \brief Computes the value at a given local coordinate.
-  //! \param[in] fe Finite element definition
-  virtual double valueFE(const FiniteElement& fe) const;
+  //! \param[in] x Local coordinate of evaluation point
+  virtual double valueFE(const ItgPoint& x) const;
 
   //! \brief Computes the value at a given global coordinate.
   //! \param[in] x Global/physical coordinate for point
@@ -65,14 +66,14 @@ public:
   virtual bool valueGrid(RealArray& val, const int* npe) const;
 
   //! \brief Computes the gradient for a given local coordinate.
-  //! \param[in] fe Finite element
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] grad Gradient of solution in a given local coordinate
-  virtual bool gradFE(const FiniteElement& fe, Vector& grad) const;
+  virtual bool gradFE(const ItgPoint& x, Vector& grad) const;
 
   //! \brief Computes the hessian for a given local coordinate.
-  //! \param[in] fe Finite element quantities
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] H Hessian of solution in a given local coordinate
-  virtual bool hessianFE(const FiniteElement& fe, Matrix& H) const;
+  virtual bool hessianFE(const ItgPoint& x, Matrix& H) const;
 
 protected:
   const Go::SplineSurface* basis; //!< Spline basis description

--- a/src/ASM/SplineField3D.h
+++ b/src/ASM/SplineField3D.h
@@ -37,7 +37,8 @@ public:
   //! \param[in] patch The spline patch on which the field is to be defined
   //! \param[in] v Array of control point field values
   //! \param[in] basis Basis to use from patch
-  //! \param[in] cmp Component to use from source field. Pass 0 to use vector as-is.
+  //! \param[in] cmp Component to use from source field.
+  //! Pass 0 to use the vector as-is.
   //! \param[in] name Name of spline field
   SplineField3D(const ASMs3D* patch, const RealArray& v,
                 char basis = 1, char cmp = 1, const char* name = nullptr);
@@ -52,11 +53,11 @@ public:
   virtual double valueNode(size_t node) const;
 
   //! \brief Computes the value at a given local coordinate.
-  //! \param[in] fe Finite element definition
-  virtual double valueFE(const FiniteElement& fe) const;
+  //! \param[in] x Local coordinate of evaluation point
+  virtual double valueFE(const ItgPoint& x) const;
 
   //! \brief Computes the value at a given global coordinate.
-  //! \param[in] x Global/physical coordinate for point
+  //! \param[in] x Global/physical coordinate of evaluation point
   virtual double valueCoor(const Vec4& x) const;
 
   //! \brief Computes the value at a grid of visualization points.
@@ -65,14 +66,14 @@ public:
   virtual bool valueGrid(RealArray& val, const int* npe) const;
 
   //! \brief Computes the gradient for a given local coordinate.
-  //! \param[in] fe Finite element
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] grad Gradient of solution in a given local coordinate
-  virtual bool gradFE(const FiniteElement& fe, Vector& grad) const;
+  virtual bool gradFE(const ItgPoint& x, Vector& grad) const;
 
   //! \brief Computes the hessian for a given local coordinate.
-  //! \param[in] fe Finite element quantities
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] H Hessian of solution in a given local coordinate
-  virtual bool hessianFE(const FiniteElement& fe, Matrix& H) const;
+  virtual bool hessianFE(const ItgPoint& x, Matrix& H) const;
 
 protected:
   const Go::SplineVolume* basis; //!< Spline basis description

--- a/src/ASM/SplineFields1D.h
+++ b/src/ASM/SplineFields1D.h
@@ -46,19 +46,19 @@ public:
   //==============================
 
   //! \brief Computes the value for a given local coordinate.
-  //! \param[in] fe Finite element definition
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] vals Values at local point in given element
-  virtual bool valueFE(const FiniteElement& fe, Vector& vals) const;
+  virtual bool valueFE(const ItgPoint& x, Vector& vals) const;
 
   //! \brief Computes the gradient for a given local coordinate.
-  //! \param[in] fe Finite element definition
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] grad Gradient at local point in given element
-  virtual bool gradFE(const FiniteElement& fe, Matrix& grad) const;
+  virtual bool gradFE(const ItgPoint& x, Matrix& grad) const;
 
   //! \brief Computes the hessian for a given local coordinate.
-  //! \param[in] fe Finite element definition
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] H Hessian at local point in given element
-  virtual bool hessianFE(const FiniteElement& fe, Matrix3D& H) const;
+  virtual bool hessianFE(const ItgPoint& x, Matrix3D& H) const;
 
 protected:
   const Go::SplineCurve* curv; //!< Spline geometry description

--- a/src/ASM/SplineFields2D.h
+++ b/src/ASM/SplineFields2D.h
@@ -62,9 +62,9 @@ public:
   virtual bool valueNode(size_t node, Vector& vals) const;
 
   //! \brief Computes the value at a given local coordinate.
-  //! \param[in] fe Finite element definition
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] vals Values in local point in given element
-  virtual bool valueFE(const FiniteElement& fe, Vector& vals) const;
+  virtual bool valueFE(const ItgPoint& x, Vector& vals) const;
 
   //! \brief Computes the value at a given global coordinate.
   //! \param[in] x Global/physical coordinate for point
@@ -72,14 +72,14 @@ public:
   virtual bool valueCoor(const Vec4& x, Vector& vals) const;
 
   //! \brief Computes the gradient for a given local coordinate.
-  //! \param[in] fe Finite element
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] grad Gradient of solution in a given local coordinate
-  virtual bool gradFE(const FiniteElement& fe, Matrix& grad) const;
+  virtual bool gradFE(const ItgPoint& x, Matrix& grad) const;
 
   //! \brief Computes the hessian for a given local coordinate.
-  //! \param[in] fe Finite element quantities
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] H Hessian of solution in a given local coordinate
-  virtual bool hessianFE(const FiniteElement& fe, Matrix3D& H) const;
+  virtual bool hessianFE(const ItgPoint& x, Matrix3D& H) const;
 
 protected:
   const Go::SplineSurface* basis; //!< Spline basis description

--- a/src/ASM/SplineFields2Dmx.h
+++ b/src/ASM/SplineFields2Dmx.h
@@ -27,8 +27,8 @@ namespace Go {
 /*!
   \brief Class for mixed spline-based finite element vector fields in 2D.
 
-  \details This class implements the methods required to evaluate a 2D
-  mixed spline vector field at a given point in parametrical or physical coordinates.
+  \details This class implements the methods required to evaluate a 2D mixed
+  spline vector field at a given point in parametrical or physical coordinates.
 */
 
 class SplineFields2Dmx : public Fields
@@ -40,7 +40,7 @@ public:
   //! \param[in] basis Bases to use from patch
   //! \param[in] name Name of spline field
   SplineFields2Dmx(const ASMs2Dmx* patch, const RealArray& v,
-                  char basis = 12, const char* name = nullptr);
+                   char basis = 12, const char* name = nullptr);
   //! \brief Empty destructor.
   virtual ~SplineFields2Dmx() {}
 
@@ -53,18 +53,18 @@ public:
   bool valueNode(size_t node, Vector& vals) const;
 
   //! \brief Computes the value at a given local coordinate.
-  //! \param[in] fe Finite element definition
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] vals Values in local point in given element
-  bool valueFE(const FiniteElement& fe, Vector& vals) const;
+  bool valueFE(const ItgPoint& x, Vector& vals) const;
 
   //! \brief Computes the gradient for a given local coordinate.
-  //! \param[in] fe Finite element
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] grad Gradient of solution in a given local coordinate
-  bool gradFE(const FiniteElement& fe, Matrix& grad) const;
+  bool gradFE(const ItgPoint& x, Matrix& grad) const;
 
 protected:
   const ASMs2Dmx* surf; //!< Patch description
-  std::set<int> bases; //!< Bases to use
+  std::set<int>  bases; //!< Bases to use
 };
 
 #endif

--- a/src/ASM/SplineFields3D.h
+++ b/src/ASM/SplineFields3D.h
@@ -62,9 +62,9 @@ public:
   virtual bool valueNode(size_t node, Vector& vals) const;
 
   //! \brief Computes the value at a given local coordinate.
-  //! \param[in] fe Finite element definition
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] vals Values in local point in given element
-  virtual bool valueFE(const FiniteElement& fe, Vector& vals) const;
+  virtual bool valueFE(const ItgPoint& x, Vector& vals) const;
 
   //! \brief Computes the value at a given global coordinate.
   //! \param[in] x Global/physical coordinate for point
@@ -72,14 +72,14 @@ public:
   virtual bool valueCoor(const Vec4& x, Vector& vals) const;
 
   //! \brief Computes the gradient for a given local coordinate.
-  //! \param[in] fe Finite element
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] grad Gradient of solution in a given local coordinate
-  virtual bool gradFE(const FiniteElement& fe, Matrix& grad) const;
+  virtual bool gradFE(const ItgPoint& x, Matrix& grad) const;
 
   //! \brief Computes the hessian for a given local coordinate.
-  //! \param[in] fe Finite element quantities
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] H Hessian of solution in a given local coordinate
-  virtual bool hessianFE(const FiniteElement& fe, Matrix3D& H) const;
+  virtual bool hessianFE(const ItgPoint& x, Matrix3D& H) const;
 
 protected:
   const Go::SplineVolume* basis; //!< Spline basis description

--- a/src/ASM/SplineFields3Dmx.h
+++ b/src/ASM/SplineFields3Dmx.h
@@ -27,8 +27,8 @@ namespace Go {
 /*!
   \brief Class for mixed spline-based finite element vector fields in 3D.
 
-  \details This class implements the methods required to evaluate a 3D
-  mixed spline vector field at a given point in parametrical or physical coordinates.
+  \details This class implements the methods required to evaluate a 3D mixed
+  spline vector field at a given point in parametrical or physical coordinates.
 */
 
 class SplineFields3Dmx : public Fields
@@ -40,7 +40,7 @@ public:
   //! \param[in] basis Bases to use from patch
   //! \param[in] name Name of spline field
   SplineFields3Dmx(const ASMs3Dmx* patch, const RealArray& v,
-                  char basis = 12, const char* name = nullptr);
+                   char basis = 12, const char* name = nullptr);
   //! \brief Empty destructor.
   virtual ~SplineFields3Dmx() {}
 
@@ -53,18 +53,18 @@ public:
   bool valueNode(size_t node, Vector& vals) const;
 
   //! \brief Computes the value at a given local coordinate.
-  //! \param[in] fe Finite element definition
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] vals Values in local point in given element
-  bool valueFE(const FiniteElement& fe, Vector& vals) const;
+  bool valueFE(const ItgPoint& x, Vector& vals) const;
 
   //! \brief Computes the gradient for a given local coordinate.
-  //! \param[in] fe Finite element
+  //! \param[in] x Local coordinate of evaluation point
   //! \param[out] grad Gradient of solution in a given local coordinate
-  bool gradFE(const FiniteElement& fe, Matrix& grad) const;
+  bool gradFE(const ItgPoint& x, Matrix& grad) const;
 
 protected:
   const ASMs3Dmx* svol; //!< Patch description
-  std::set<int> bases; //!< Bases to use
+  std::set<int>  bases; //!< Bases to use
 };
 
 #endif

--- a/src/ASM/Test/ASMCube.h
+++ b/src/ASM/Test/ASMCube.h
@@ -1,0 +1,51 @@
+//==============================================================================
+//!
+//! \file ASMCube.h
+//!
+//! \date Oct 2 2019
+//!
+//! \author Knut Morten Okstad / SINTEF
+//!
+//! \brief Default tri-unit cube patch for unit-testing.
+//!
+//==============================================================================
+
+#ifndef _ASM_CUBE_H
+#define _ASM_CUBE_H
+
+#include "ASMs3Dmx.h"
+#include <sstream>
+
+static const char* cube = "700 1 0 0 3 0\n"
+                          "2 2 0 0 1 1\n"
+                          "2 2 0 0 1 1\n"
+                          "2 2 0 0 1 1\n"
+                          "0 0 0  1 0 0  0 1 0  1 1 0\n"
+                          "0 0 1  1 0 1  0 1 1  1 1 1\n";
+
+
+class ASMCube : public ASMs3D
+{
+public:
+  explicit ASMCube(unsigned char n_f = 3) : ASMs3D(n_f)
+  {
+    std::stringstream geo(cube);
+    this->read(geo);
+  }
+  virtual ~ASMCube() {}
+};
+
+
+class ASMmxCube : public ASMs3Dmx
+{
+public:
+  explicit ASMmxCube(const CharVec& n_f) : ASMs3Dmx(n_f)
+  {
+    std::stringstream geo(cube);
+    this->read(geo);
+    this->generateFEMTopology();
+  }
+  virtual ~ASMmxCube() {}
+};
+
+#endif

--- a/src/ASM/Test/ASMSquare.h
+++ b/src/ASM/Test/ASMSquare.h
@@ -1,0 +1,48 @@
+//==============================================================================
+//!
+//! \file ASMSquare.h
+//!
+//! \date Oct 2 2019
+//!
+//! \author Knut Morten Okstad / SINTEF
+//!
+//! \brief Default bi-unit square patch for unit-testing.
+//!
+//==============================================================================
+
+#ifndef ASM_SQUARE_H
+#define ASM_SQUARE_H
+
+#include "ASMs2Dmx.h"
+#include <sstream>
+
+static const char* square = "200 1 0 0 2 0\n"
+                            "2 2 0 0 1 1\n"
+                            "2 2 0 0 1 1\n"
+                            "0 0 1 0 0 1 1 1\n";
+
+class ASMSquare : public ASMs2D
+{
+public:
+  explicit ASMSquare(unsigned char n_f = 2) : ASMs2D(2,n_f)
+  {
+    std::stringstream geo(square);
+    this->read(geo);
+  }
+  virtual ~ASMSquare() {}
+};
+
+
+class ASMmxSquare : public ASMs2Dmx
+{
+public:
+  explicit ASMmxSquare(const CharVec& n_f) : ASMs2Dmx(2,n_f)
+  {
+    std::stringstream geo(square);
+    this->read(geo);
+    this->generateFEMTopology();
+  }
+  virtual ~ASMmxSquare() {}
+};
+
+#endif

--- a/src/ASM/Test/TestASMs2D.C
+++ b/src/ASM/Test/TestASMs2D.C
@@ -10,22 +10,10 @@
 //!
 //==============================================================================
 
-#include "ASMs2D.h"
+#include "ASMSquare.h"
 #include "SIM2D.h"
 
 #include "gtest/gtest.h"
-
-
-class ASMSquare : public ASMs2D
-{
-public:
-  ASMSquare()
-  {
-    std::stringstream geo("200 1 0 0\n2 0\n2 2\n0 0 1 1\n2 2\n0 0 1 1\n0 0\n1 0\n0 1\n1 1\n");
-    EXPECT_TRUE(this->read(geo));
-  }
-  virtual ~ASMSquare() {}
-};
 
 
 TEST(TestASMs2D, ElementConnectivities)

--- a/src/ASM/Test/TestASMs3D.C
+++ b/src/ASM/Test/TestASMs3D.C
@@ -10,23 +10,11 @@
 //!
 //==============================================================================
 
-#include "ASMs3D.h"
+#include "ASMCube.h"
 #include "SIM3D.h"
 #include <array>
 
 #include "gtest/gtest.h"
-
-
-class ASMCube : public ASMs3D
-{
-public:
-  ASMCube()
-  {
-    std::stringstream geo("700 1 0 0\n3 0\n2 2\n0 0 1 1\n2 2\n0 0 1 1\n2 2\n0 0 1 1\n0 0 0\n1 0 0\n0 1 0\n1 1 0\n0 0 1\n1 0 0\n0 1 1\n1 1 1\n");
-    EXPECT_TRUE(this->read(geo));
-  }
-  virtual ~ASMCube() {}
-};
 
 
 TEST(TestASMs3D, ElementConnectivities)

--- a/src/ASM/Test/TestSplineField.C
+++ b/src/ASM/Test/TestSplineField.C
@@ -11,9 +11,9 @@
 //==============================================================================
 
 #include "Field.h"
-#include "FiniteElement.h"
-#include "SIM2D.h"
-#include "SIM3D.h"
+#include "ItgPoint.h"
+#include "ASMSquare.h"
+#include "ASMCube.h"
 
 #include "gtest/gtest.h"
 #include <array>
@@ -21,53 +21,40 @@
 
 TEST(TestSplineField, Value2D)
 {
-  SIM2D sim(1);
-  sim.createDefaultModel();
-
+  ASMSquare patch(1);
   std::vector<double> sc = {0.0, 1.0, 1.0, 2.0}; // x + y
-  Field* fscalar = Field::create(sim.getPatch(1), sc);
+  Field* fscalar = Field::create(&patch,sc);
   static std::vector<std::array<double,3>> tests_scalar = {{{{0.5, 0.5, 1.0}},
                                                             {{1.0, 0.0, 1.0}},
                                                             {{0.0, 1.0, 1.0}},
                                                             {{1.0, 1.0, 2.0}}}};
-  for (const auto& it : tests_scalar) {
-    FiniteElement fe;
-    fe.u = it[0];
-    fe.v = it[1];
-    ASSERT_FLOAT_EQ(fscalar->valueFE(fe), it[2]);
-  }
+  for (const auto& it : tests_scalar)
+    EXPECT_FLOAT_EQ(fscalar->valueFE(ItgPoint(it[0],it[1])),it[2]);
 }
 
 TEST(TestSplineField, Grad2D)
 {
-  SIM2D sim(1);
-  sim.createDefaultModel();
-
+  ASMSquare patch(1);
   std::vector<double> sc = {0.0, 1.0, 1.0, 2.0}; // x + y
-  Field* fscalar = Field::create(sim.getPatch(1), sc);
+  Field* fscalar = Field::create(&patch,sc);
   static std::vector<std::array<double,2>> tests_scalar = {{{{0.5, 0.5}},
                                                             {{1.0, 0.0}},
                                                             {{0.0, 1.0}},
                                                             {{1.0, 1.0}}}};
   for (const auto& it : tests_scalar) {
-    FiniteElement fe;
-    fe.u = it[0];
-    fe.v = it[1];
     Vector v(2);
-    fscalar->gradFE(fe, v);
-    ASSERT_FLOAT_EQ(v(1), 1.0);
-    ASSERT_FLOAT_EQ(v(2), 1.0);
+    ASSERT_TRUE(fscalar->gradFE(ItgPoint(it[0],it[1]),v));
+    EXPECT_FLOAT_EQ(v(1),1.0);
+    EXPECT_FLOAT_EQ(v(2),1.0);
   }
 }
 
 
 TEST(TestSplineField, Value3D)
 {
-  SIM3D sim(1);
-  sim.createDefaultModel();
-
+  ASMCube patch(1);
   std::vector<double> sc = {0.0, 1.0, 1.0, 2.0, 1.0, 2.0, 2.0, 3.0}; // x + y + z
-  Field* fscalar = Field::create(sim.getPatch(1), sc);
+  Field* fscalar = Field::create(&patch,sc);
   static std::vector<std::array<double,4>> tests_scalar = {{{{0.5, 0.5, 0.5, 1.5}},
                                                             {{0.0, 0.0, 0.0, 0.0}},
                                                             {{1.0, 0.0, 0.0, 1.0}},
@@ -77,23 +64,15 @@ TEST(TestSplineField, Value3D)
                                                             {{1.0, 0.0, 1.0, 2.0}},
                                                             {{0.0, 1.0, 1.0, 2.0}},
                                                             {{1.0, 1.0, 1.0, 3.0}}}};
-  for (const auto& it : tests_scalar) {
-    FiniteElement fe;
-    fe.u = it[0];
-    fe.v = it[1];
-    fe.w = it[2];
-    ASSERT_FLOAT_EQ(fscalar->valueFE(fe), it[3]);
-  }
+  for (const auto& it : tests_scalar)
+    EXPECT_FLOAT_EQ(fscalar->valueFE(ItgPoint(it[0],it[1],it[2])),it[3]);
 }
-
 
 TEST(TestSplineField, Grad3D)
 {
-  SIM3D sim(1);
-  sim.createDefaultModel();
-
+  ASMCube patch(1);
   std::vector<double> sc = {0.0, 1.0, 1.0, 2.0, 1.0, 2.0, 2.0, 3.0}; // x + y + z
-  Field* fscalar = Field::create(sim.getPatch(1), sc);
+  Field* fscalar = Field::create(&patch,sc);
   static std::vector<std::array<double,3>> tests_scalar = {{{{0.5, 0.5, 0.5}},
                                                             {{0.0, 0.0, 0.0}},
                                                             {{1.0, 0.0, 0.0}},
@@ -104,14 +83,10 @@ TEST(TestSplineField, Grad3D)
                                                             {{0.0, 1.0, 1.0}},
                                                             {{1.0, 1.0, 1.0}}}};
   for (const auto& it : tests_scalar) {
-    FiniteElement fe;
-    fe.u = it[0];
-    fe.v = it[1];
-    fe.w = it[2];
     Vector v(3);
-    fscalar->gradFE(fe, v);
-    ASSERT_FLOAT_EQ(v(1), 1.0);
-    ASSERT_FLOAT_EQ(v(2), 1.0);
-    ASSERT_FLOAT_EQ(v(3), 1.0);
+    ASSERT_TRUE(fscalar->gradFE(ItgPoint(it[0],it[1],it[2]),v));
+    EXPECT_FLOAT_EQ(v(1),1.0);
+    EXPECT_FLOAT_EQ(v(2),1.0);
+    EXPECT_FLOAT_EQ(v(3),1.0);
   }
 }

--- a/src/ASM/Test/TestSplineFields.C
+++ b/src/ASM/Test/TestSplineFields.C
@@ -12,39 +12,34 @@
 
 #include "Field.h"
 #include "Fields.h"
-#include "FiniteElement.h"
-#include "ASMmxBase.h"
-#include "SIM2D.h"
-#include "SIM3D.h"
+#include "ItgPoint.h"
+#include "ASMSquare.h"
+#include "ASMCube.h"
 
 #include "gtest/gtest.h"
 #include <array>
-#include <vector>
 
 
 TEST(TestSplineFields, Value2D)
 {
-  SIM2D sim(2);
-  ASSERT_TRUE(sim.createDefaultModel());
+  ASMSquare patch;
 
   // {x+y+x*y, x-y+x*y}
   std::vector<double> vc = {0.0,  0.0,
                             1.0,  1.0,
                             1.0, -1.0,
                             3.0, 1.0};
-  Fields* fvector = Fields::create(sim.getPatch(1), vc);
-  Field* fscalar = Field::create(sim.getPatch(1), vc, 1, 2);
+  Fields* fvector = Fields::create(&patch,vc);
+  Field* fscalar = Field::create(&patch,vc,1,2);
   static std::vector<std::array<double,4>> tests_vector =
         {{{{0.5, 0.5, 1.25, 0.25}},
           {{1.0, 0.0, 1.0,  1.0}},
           {{0.0, 1.0, 1.0, -1.0}},
           {{1.0, 1.0, 3.0,  1.0}}}};
   for (const auto& it : tests_vector) {
-    FiniteElement fe;
-    fe.u = it[0];
-    fe.v = it[1];
+    ItgPoint fe(it[0],it[1]);
     Vector v(2);
-    fvector->valueFE(fe, v);
+    ASSERT_TRUE(fvector->valueFE(fe,v));
     EXPECT_FLOAT_EQ(v(1), it[2]);
     EXPECT_FLOAT_EQ(v(2), it[3]);
     EXPECT_FLOAT_EQ(fscalar->valueFE(fe), it[3]);
@@ -55,9 +50,7 @@ TEST(TestSplineFields, Value2D)
 TEST(TestSplineFields, Value2Dmx)
 {
   ASMmxBase::Type = ASMmxBase::DIV_COMPATIBLE;
-  SIM2D sim({1,1,1});
-  ASSERT_TRUE(sim.createDefaultModel());
-  ASSERT_TRUE(sim.createFEMmodel());
+  ASMmxSquare patch({1,1,1});
 
   // {x+y+x*y, x-y+x*y}
   std::vector<double> vc = {0.0,
@@ -75,19 +68,17 @@ TEST(TestSplineFields, Value2Dmx)
                             1.0,
                             // p
                             0.0, 1.0, 1.0, 2.0}; // x + y
-  Fields* fvector = Fields::create(sim.getPatch(1), vc, 12);
-  Field* fscalar = Field::create(sim.getPatch(1), vc, 3, 1);
+  Fields* fvector = Fields::create(&patch,vc,12);
+  Field* fscalar = Field::create(&patch,vc,3,1);
   static std::vector<std::array<double,5>> tests_vector =
                           {{{{0.5, 0.5, 1.25, 0.25, 1.0}},
                             {{1.0, 0.0, 1.0,  1.0,  1.0}},
                             {{0.0, 1.0, 1.0, -1.0,  1.0}},
                             {{1.0, 1.0, 3.0,  1.0,  2.0}}}};
   for (const auto& it : tests_vector) {
-    FiniteElement fe;
-    fe.u = it[0];
-    fe.v = it[1];
     Vector v(2);
-    fvector->valueFE(fe, v);
+    ItgPoint fe(it[0],it[1]);
+    ASSERT_TRUE(fvector->valueFE(fe,v));
     EXPECT_FLOAT_EQ(v(1), it[2]);
     EXPECT_FLOAT_EQ(v(2), it[3]);
     EXPECT_FLOAT_EQ(fscalar->valueFE(fe), it[4]);
@@ -97,23 +88,19 @@ TEST(TestSplineFields, Value2Dmx)
 
 TEST(TestSplineFields, Grad2D)
 {
-  SIM2D sim(2);
-  ASSERT_TRUE(sim.createDefaultModel());
+  ASMSquare patch;
 
   // {x+y+x*y, x-y+x*y}
   std::vector<double> vc = {0.0, 0.0, 1.0, 1.0, 1.0, -1.0, 3.0, 1.0};
-  Fields* fvector = Fields::create(sim.getPatch(1), vc);
+  Fields* fvector = Fields::create(&patch,vc);
   static std::vector<std::array<double,6>> tests_vector =
         {{{{0.5, 0.5, 1.5, 1.5, 1.5, -0.5}},
           {{1.0, 0.0, 1.0, 2.0, 1.0, 0.0}},
           {{0.0, 1.0, 2.0, 1.0, 2.0, -1.0}},
           {{1.0, 1.0, 2.0, 2.0, 2.0, 0.0}}}};
   for (const auto& it : tests_vector) {
-    FiniteElement fe;
-    fe.u = it[0];
-    fe.v = it[1];
     Matrix gradu(2,2);
-    fvector->gradFE(fe, gradu);
+    ASSERT_TRUE(fvector->gradFE(ItgPoint(it[0],it[1]),gradu));
     EXPECT_FLOAT_EQ(gradu(1,1), it[2]);
     EXPECT_FLOAT_EQ(gradu(1,2), it[3]);
     EXPECT_FLOAT_EQ(gradu(2,1), it[4]);
@@ -124,8 +111,7 @@ TEST(TestSplineFields, Grad2D)
 
 TEST(TestSplineFields, Value3D)
 {
-  SIM3D sim(3);
-  ASSERT_TRUE(sim.createDefaultModel());
+  ASMCube patch;
 
   // {x+y+z, x+y-z, x-y+z}
   std::vector<double> vc = {0.0,  0.0,  0.0,
@@ -136,8 +122,8 @@ TEST(TestSplineFields, Value3D)
                             2.0,  0.0,  2.0,
                             2.0,  0.0,  0.0,
                             3.0,  1.0,  1.0};
-  Fields* fvector = Fields::create(sim.getPatch(1), vc);
-  Field* fscalar = Field::create(sim.getPatch(1), vc, 1, 2);
+  Fields* fvector = Fields::create(&patch,vc);
+  Field* fscalar = Field::create(&patch,vc,1,2);
   static std::vector<std::array<double,6>> tests_scalar =
       {{{{0.5, 0.5, 0.5, 1.5,  0.5,  0.5}},
         {{0.0, 0.0, 0.0, 0.0,  0.0,  0.0}},
@@ -149,12 +135,9 @@ TEST(TestSplineFields, Value3D)
         {{0.0, 1.0, 1.0, 2.0,  0.0,  0.0}},
         {{1.0, 1.0, 1.0, 3.0,  1.0,  1.0}}}};
   for (const auto& it : tests_scalar) {
-    FiniteElement fe;
-    fe.u = it[0];
-    fe.v = it[1];
-    fe.w = it[2];
+    ItgPoint fe(it.data());
     Vector v(3);
-    fvector->valueFE(fe, v);
+    ASSERT_TRUE(fvector->valueFE(fe,v));
     EXPECT_FLOAT_EQ(v(1), it[3]);
     EXPECT_FLOAT_EQ(v(2), it[4]);
     EXPECT_FLOAT_EQ(v(3), it[5]);
@@ -165,8 +148,7 @@ TEST(TestSplineFields, Value3D)
 
 TEST(TestSplineFields, Grad3D)
 {
-  SIM3D sim(3);
-  ASSERT_TRUE(sim.createDefaultModel());
+  ASMCube patch;
 
   // {x+y+z+x*y*z, x+y-z+x*y*z, x-y+z+x*y*z}
   std::vector<double> vc = {0.0,  0.0,  0.0,
@@ -177,7 +159,7 @@ TEST(TestSplineFields, Grad3D)
                             2.0,  0.0,  2.0,
                             2.0,  0.0,  0.0,
                             4.0,  2.0,  2.0};
-  Fields* fvector = Fields::create(sim.getPatch(1), vc);
+  Fields* fvector = Fields::create(&patch,vc);
   static std::vector<std::pair<std::array<double,3>,
                                std::array<double,9>>> tests_vector =
     {{{{{0.5, 0.5, 0.5}}, {{1.25,  1.25,  1.25,
@@ -208,12 +190,8 @@ TEST(TestSplineFields, Grad3D)
                             2.0,  2.0,  0.0,
                             2.0,  0.0,  2.0}}}}};
   for (const auto& it : tests_vector) {
-    FiniteElement fe;
-    fe.u = it.first[0];
-    fe.v = it.first[1];
-    fe.w = it.first[2];
     Matrix gradu(3,3);
-    fvector->gradFE(fe, gradu);
+    ASSERT_TRUE(fvector->gradFE(ItgPoint(it.first.data()),gradu));
     for (size_t i = 0; i < 3; ++i)
       for (size_t j = 0; j <3; ++j)
         EXPECT_FLOAT_EQ(gradu(i+1,j+1), it.second[i*3+j]);
@@ -224,9 +202,7 @@ TEST(TestSplineFields, Grad3D)
 TEST(TestSplineFields, Value3Dmx)
 {
   ASMmxBase::Type = ASMmxBase::DIV_COMPATIBLE;
-  SIM3D sim({1,1,1,1});
-  ASSERT_TRUE(sim.createDefaultModel());
-  ASSERT_TRUE(sim.createFEMmodel());
+  ASMmxCube patch({1,1,1,1});
 
   // {x+y+z+x*y*z, x+y-z+x*y*z, x-y+z+x*y*z}
   std::vector<double> vc = {0.0, 0.5, 1.0,
@@ -249,8 +225,8 @@ TEST(TestSplineFields, Value3Dmx)
                             0.0, 2.0,
                             // p
                             0.0, 1.0, 1.0, 2.0, 1.0, 2.0, 2.0, 3.0};
-  Fields* fvector = Fields::create(sim.getPatch(1), vc, 123);
-  Field* fscalar = Field::create(sim.getPatch(1), vc, 4, 1);
+  Fields* fvector = Fields::create(&patch,vc,123);
+  Field* fscalar = Field::create(&patch,vc,4,1);
   static std::vector<std::array<double,7>> tests_vector =
                          {{{{0.5, 0.5, 0.5, 1.625, 0.625, 0.625, 1.5}},
                            {{0.0, 0.0, 0.0,   0.0,   0.0,   0.0, 0.0}},
@@ -262,12 +238,9 @@ TEST(TestSplineFields, Value3Dmx)
                            {{0.0, 1.0, 1.0,   2.0,   0.0,   0.0, 2.0}},
                            {{1.0, 1.0, 1.0,   4.0,   2.0,   2.0, 3.0}}}};
   for (const auto& it : tests_vector) {
-    FiniteElement fe;
-    fe.u = it[0];
-    fe.v = it[1];
-    fe.w = it[2];
+    ItgPoint fe(it.data());
     Vector v(3);
-    fvector->valueFE(fe, v);
+    ASSERT_TRUE(fvector->valueFE(fe,v));
     EXPECT_FLOAT_EQ(v(1), it[3]);
     EXPECT_FLOAT_EQ(v(2), it[4]);
     EXPECT_FLOAT_EQ(v(3), it[5]);


### PR DESCRIPTION
All the field classes do not need to relate to the basis function arrays, etc., stored in the FiniteElement object. They only need the spline parameters (or xi, eta for Lagrange), to operate. Therefore I created the class ItgPoint as a parent for FiniteElement, to simplify the valueFE invokations.