### PR TITLE
Fixed: Incorrect sanity check correction

### DIFF
--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -754,11 +754,14 @@ bool ASMs1D::updateCoords (const Vector& displ)
   if (!curv) return true; // silently ignore empty patches
   if (shareFE) return true;
 
-  if (displ.size() < nsd*MLGN.size())
+  size_t nno = curv->numCoefs();
+  if (displ.size() != nsd*nno && displ.size() != nsd*MLGN.size())
   {
     std::cerr <<" *** ASMs1D::updateCoords: Invalid dimension "
-	      << displ.size() <<" on displ, should be "
-	      << nsd*MLGN.size() << std::endl;
+              << displ.size() <<" on displacement vector, should be ";
+    if (nno != MLGN.size())
+      std::cerr <<"either "<< nsd*MLGN.size() <<" or ";
+    std::cerr << nsd*nno << std::endl;
     return false;
   }
 

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -1364,11 +1364,14 @@ bool ASMs2D::updateCoords (const Vector& displ)
   if (!surf) return true; // silently ignore empty patches
   if (shareFE) return true;
 
-  if (displ.size() < nsd*MLGN.size())
+  size_t nno = surf->numCoefs_u()*surf->numCoefs_v();
+  if (displ.size() != nsd*nno && displ.size() != nsd*MLGN.size())
   {
     std::cerr <<" *** ASMs2D::updateCoords: Invalid dimension "
-	      << displ.size() <<" on displacement vector, should be "
-	      << nsd*MLGN.size() << std::endl;
+              << displ.size() <<" on displacement vector, should be ";
+    if (nno != MLGN.size())
+      std::cerr <<"either "<< nsd*MLGN.size() <<" or ";
+    std::cerr << nsd*nno << std::endl;
     return false;
   }
 

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -1653,11 +1653,14 @@ bool ASMs3D::updateCoords (const Vector& displ)
   if (!svol) return true; // silently ignore empty patches
   if (shareFE) return true;
 
-  if (displ.size() < 3*MLGN.size())
+  size_t nno = svol->numCoefs(0)*svol->numCoefs(1)*svol->numCoefs(2);
+  if (displ.size() != 3*nno && displ.size() != 3*MLGN.size())
   {
     std::cerr <<" *** ASMs3D::updateCoords: Invalid dimension "
-	      << displ.size() <<" on displacement vector, should be "
-	      << 3*MLGN.size() << std::endl;
+              << displ.size() <<" on displacement vector, should be ";
+    if (nno != MLGN.size())
+      std::cerr <<"either "<< 3*MLGN.size() <<" or ";
+    std::cerr << 3*nno << std::endl;
     return false;
   }
 


### PR DESCRIPTION
It turns out I was wrong in e3da110cb9ea7f4fa3634257f64abcdf531782eb (see my review in #371).
The check should instead use the number of coefficient in the patch, which will work both for mixed and regular problems. The check against `MLGN.size()` is still needed as a secondary condition, in case of Dirichlet conditions in local axes (with extra nodes around).