### PR TITLE
changed: use L2 projection instead of Greville with LR splines

### DIFF
--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -2155,7 +2155,9 @@ bool ASMu2D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
   if (project == 'S')
     s = this->scRecovery(integrand);
   else if (project == 'D' || !npe)
-    s = this->projectSolution(integrand);
+    // LR splines use L2-projection by default since Greville points
+    // are often not unique.
+    return this->globalL2projection(sField,integrand,true);
 
   if (npe)
   {


### PR DESCRIPTION
the Greville points are often not unique for locally refined
splines. thus L2 is a better default as it will always work.