### PR TITLE
Fixed: Result point evaluation for multi-patch models

### DIFF
--- a/src/IFEM.h.in
+++ b/src/IFEM.h.in
@@ -19,7 +19,6 @@
 #define IFEM_VERSION_PATCH @IFEM_VERSION_PATCH@ //!< Patch library version
 
 #include "SIMoptions.h"
-#include "ControlFIFO.h"
 #include "LogStream.h"
 
 #ifndef NDEBUG
@@ -30,6 +29,9 @@
 #define SCOPED_LOG
 #endif
 
+class ControlFIFO;
+class ControlCallback;
+
 
 /*!
   \brief Class holding global IFEM configuration.
@@ -39,11 +41,13 @@ class IFEM
 {
 public:
   //! \brief Initializes the IFEM library.
-  //! \param arg_c The number of command-line arguments
-  //! \param arg_v The command-line arguments
-  //! \param title The title of the IFEM simulator
+  //! \param[in] arg_c The number of command-line arguments
+  //! \param[in] arg_v The command-line arguments
+  //! \param[in] title The title of the IFEM simulator
   //! \return The MPI process ID
   static int Init(int arg_c, char** arg_v, const char* title = nullptr);
+  //! \brief Closes the IFEM library.
+  static void Close();
 
   //! \brief Applies command-line argument values to the general input options.
   static void applyCommandLineOptions(SIMoptions& opt);
@@ -51,13 +55,9 @@ public:
   static SIMoptions& getOptions() { return cmdOptions; }
 
   //! \brief Registers a fifo instruction callback.
-  static void registerCallback(ControlCallback& callback)
-  {
-    fifo.registerCallback(callback);
-  }
-
+  static void registerCallback(ControlCallback& cb);
   //! \brief Polls the control fifo for instructions.
-  static void pollControllerFifo() { fifo.poll(); }
+  static bool pollControllerFifo();
 
   static utl::LogStream cout; //!< Combined standard out for parallel processes
 
@@ -65,7 +65,7 @@ private:
   static SIMoptions cmdOptions; //!< General input options
   static int argc;              //!< The number of command-line arguments
   static char** argv;           //!< The command-line arguments
-  static ControlFIFO fifo;      //!< Control fifo helper class
+  static ControlFIFO* fifo;     //!< Control fifo helper
 };
 
 #endif

--- a/src/SIM/SIMoptions.C
+++ b/src/SIM/SIMoptions.C
@@ -44,9 +44,7 @@ SIMoptions::SIMoptions ()
   format  = -1;
   saveInc =  1;
   dtSave  =  0.0;
-  pSolOnly = false;
-  saveNorms = false;
-  enableController = false;
+  pSolOnly = saveNorms = false;
   restartInc = 0;
   restartStep = -1;
 
@@ -339,7 +337,7 @@ bool SIMoptions::parseOldOptions (int argc, char** argv, int& i)
   else if (!strcmp(argv[i],"-shift") && i < argc-1)
     shift = atof(argv[++i]);
   else if (!strcasecmp(argv[i],"-controller"))
-    enableController = true;
+    return true; // Silently ignore here, processed by IFEM::Init()
   else if (argv[i][0] == '-')
     return this->parseProjectionMethod(argv[i]+1);
   else

--- a/src/SIM/SIMoptions.h
+++ b/src/SIM/SIMoptions.h
@@ -92,14 +92,12 @@ public:
   bool saveNorms;//!< If \e true, save element norms
 
   std::string hdf5; //!< Prefix for HDF5-file
-  std::string vtf; //!< Prefix for VTF file
+  std::string vtf;  //!< Prefix for VTF-file
 
   // Restart options
   int         restartInc;  //!< Number of increments between each restart output
   int         restartStep; //!< Index to the actual state to restart from
   std::string restartFile; //!< File to read restart state data from
-
-  bool enableController; //!< Whether or not to enable external program control
 
   int         printPid;   //!< PID to print info to screen for
   std::string log_prefix; //!< Prefix for process log files


### PR DESCRIPTION
This (the SIMoutput fix) is needed for the digital-twin model, for instance, when there are more than one result points and not all one the same patch. The other commit is more cosmetic, but enables the possibility run without the -controller also (for debugging, etc.)