### PR TITLE
Quasi-static modal simulation when beta=0

### DIFF
--- a/src/SIM/NewmarkSIM.h
+++ b/src/SIM/NewmarkSIM.h
@@ -66,7 +66,7 @@ protected:
                              std::streamsize outPrec = 0);
 
   //! \brief Checks whether the corrector iterations have converged or diverged.
-  SIM::ConvStatus checkConvergence(TimeStep& param);
+  virtual SIM::ConvStatus checkConvergence(TimeStep& param);
   //! \brief Calculates predicted velocities and accelerations.
   virtual bool predictStep(TimeStep& param);
   //! \brief Updates configuration variables (solution vector) in an iteration.
@@ -105,6 +105,7 @@ protected:
   double rTol;      //!< Relative convergence tolerance
   double aTol;      //!< Absolute convergence tolerance
   double divgLim;   //!< Relative divergence limit
+
   unsigned short int cNorm; //!< Option for which convergence norm to use
 
 public:

--- a/src/SIM/SIMmodal.h
+++ b/src/SIM/SIMmodal.h
@@ -16,7 +16,7 @@
 
 #include "SIMbase.h"
 
-class NewmarkMats;
+class ElmMats;
 
 
 /*!
@@ -77,7 +77,7 @@ protected:
 private:
   AlgEqSystem* modalSys; //!< The modal equation system
   SAM*         modalSam; //!< Auxiliary data for FE assembly management
-  NewmarkMats* myElmMat; //!< Nodal (single-DOF) element matrices
+  ElmMats*     myElmMat; //!< Nodal (single-DOF) element matrices
 };
 
 #endif


### PR DESCRIPTION
This enables the possibility to run NewmarkSIM with SIMmodal in quasi-static mode,
by setting beta to zero, in which case there are no velocity and acceleration vectors around.