### PR TITLE
Added: Overload the constrain methods for mixed

### DIFF
--- a/src/ASM/ASMmxBase.C
+++ b/src/ASM/ASMmxBase.C
@@ -12,6 +12,7 @@
 //==============================================================================
 
 #include "ASMmxBase.h"
+#include "Utilities.h"
 #include "GoTools/geometry/SplineSurface.h"
 #include "GoTools/geometry/SurfaceInterpolator.h"
 #include "GoTools/trivariate/SplineVolume.h"
@@ -250,8 +251,8 @@ ASMmxBase::SurfaceVec ASMmxBase::establishBases (Go::SplineSurface* surf,
 }
 
 
-ASMmxBase::VolumeVec ASMmxBase::establishBases(Go::SplineVolume* svol,
-                                               MixedType type)
+ASMmxBase::VolumeVec ASMmxBase::establishBases (Go::SplineVolume* svol,
+                                                MixedType type)
 {
   VolumeVec result(2);
   // With mixed methods we need two separate spline spaces
@@ -499,4 +500,22 @@ Go::SplineVolume* ASMmxBase::raiseBasis (Go::SplineVolume* svol)
   svol->gridEvaluator(ug[0],ug[1],ug[2],XYZ);
   // Project the coordinates onto the new basis (the 2nd XYZ is dummy here)
   return Go::VolumeInterpolator::regularInterpolation(basis[0],basis[1],basis[2],ug[0],ug[1],ug[2],XYZ,ndim,false,XYZ);
+}
+
+
+int ASMmxBase::maskDOFs (int dofs, char basis) const
+{
+  unsigned char ofs = std::accumulate(nfx.begin(),nfx.begin()+basis-1,0u);
+  std::set<int> allDofs = utl::getDigits(dofs);
+  dofs = 0;
+
+  // Convert the DOF digits to local values of this basis,
+  // and mask off those not residing on this basis
+  for (int dof : allDofs)
+  {
+    dofs *= 10;
+    if (dof > ofs && dof <= ofs+nfx[basis-1])
+      dofs += dof - ofs;
+  }
+  return dofs;
 }

--- a/src/ASM/ASMmxBase.h
+++ b/src/ASM/ASMmxBase.h
@@ -76,8 +76,10 @@ public:
   static char  geoBasis; //!< 1-based index of basis representing the geometry
 
 protected:
-  typedef std::vector<std::shared_ptr<Go::SplineSurface>> SurfaceVec; //!< Convenience type
-  typedef std::vector<std::shared_ptr<Go::SplineVolume>> VolumeVec; //!< Convenience type
+  typedef std::shared_ptr<Go::SplineSurface> SurfacePtr; //!< Pointer to spline
+  typedef std::shared_ptr<Go::SplineVolume>  VolumePtr;  //!< Pointer to spline
+  typedef std::vector<SurfacePtr> SurfaceVec; //!< Convenience type
+  typedef std::vector<VolumePtr>  VolumeVec;  //!< Convenience type
 
   //! \brief Establish mixed bases in 2D.
   //! \param[in] surf The base basis to use
@@ -95,6 +97,12 @@ protected:
   static Go::SplineSurface* raiseBasis(Go::SplineSurface* surf);
   //! \brief Returns a C^p-1 basis of one degree higher than \a *svol.
   static Go::SplineVolume*  raiseBasis(Go::SplineVolume* svol);
+
+  //! \brief Mask off DOFs not residing on the specified basis
+  //! \param[in] dofs Encoded DOF indices (like 123456 meaning dofs 1 to 6)
+  //! \param[in] basis Which basis to return DOF indices for
+  //! \return Encoded DOF indices related to the specified basis only
+  int maskDOFs(int dofs, char basis) const;
 
 private:
   std::vector<int> MADOF; //!< Matrix of accumulated DOFs for this patch

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -341,6 +341,32 @@ bool ASMs2Dmx::generateFEMTopology ()
 }
 
 
+void ASMs2Dmx::constrainEdge (int dir, bool open, int dof, int code, char basis)
+{
+  if (basis > 0)
+    this->ASMs2D::constrainEdge(dir,open,dof,code,basis);
+  else for (basis = 1; basis <= (char)nfx.size(); basis++)
+  {
+    int basisDofs = this->maskDOFs(dof,basis);
+    if (basisDofs > 0)
+      this->ASMs2D::constrainEdge(dir,open,basisDofs,code,basis);
+  }
+}
+
+
+void ASMs2Dmx::constrainCorner (int I, int J, int dof, int code, char basis)
+{
+  if (basis > 0)
+    this->ASMs2D::constrainCorner(I,J,dof,code,basis);
+  else for (basis = 1; basis <= (char)nfx.size(); basis++)
+  {
+    int basisDofs = this->maskDOFs(dof,basis);
+    if (basisDofs > 0)
+      this->ASMs2D::constrainCorner(I,J,basisDofs,code,basis);
+  }
+}
+
+
 bool ASMs2Dmx::connectPatch (int edge, ASM2D& neighbor, int nedge, bool revers,
                              int basis, bool coordCheck, int thick)
 {

--- a/src/ASM/ASMs3Dmx.C
+++ b/src/ASM/ASMs3Dmx.C
@@ -355,6 +355,47 @@ bool ASMs3Dmx::generateFEMTopology ()
 }
 
 
+void ASMs3Dmx::constrainFace (int dir, bool open, int dof, int code, char basis)
+{
+  if (basis > 0)
+    this->ASMs3D::constrainFace(dir,open,dof,code,basis);
+  else for (basis = 1; basis <= (char)nfx.size(); basis++)
+  {
+    int basisDofs = this->maskDOFs(dof,basis);
+    if (basisDofs > 0)
+      this->ASMs3D::constrainFace(dir,open,basisDofs,code,basis);
+  }
+}
+
+
+void ASMs3Dmx::constrainEdge (int lEdge, bool open, int dof,
+                              int code, char basis)
+{
+  if (basis > 0)
+    this->ASMs3D::constrainEdge(lEdge,open,dof,code,basis);
+  else for (basis = 1; basis <= (char)nfx.size(); basis++)
+  {
+    int basisDofs = this->maskDOFs(dof,basis);
+    if (basisDofs > 0)
+      this->ASMs3D::constrainEdge(lEdge,open,basisDofs,code,basis);
+  }
+}
+
+
+void ASMs3Dmx::constrainCorner (int I, int J, int K, int dof,
+                                int code, char basis)
+{
+  if (basis > 0)
+    this->ASMs3D::constrainCorner(I,J,K,dof,code,basis);
+  else for (basis = 1; basis <= (char)nfx.size(); basis++)
+  {
+    int basisDofs = this->maskDOFs(dof,basis);
+    if (basisDofs > 0)
+      this->ASMs3D::constrainCorner(I,J,K,basisDofs,code,basis);
+  }
+}
+
+
 bool ASMs3Dmx::connectPatch (int face, ASM3D& neighbor, int nface, int norient,
                              int basis, bool coordCheck, int thick)
 {
@@ -476,6 +517,79 @@ bool ASMs3Dmx::getSize (int& n1, int& n2, int& n3, int basis) const
   n2 = m_basis[basis-1]->numCoefs(1);
   n3 = m_basis[basis-1]->numCoefs(2);
   return true;
+}
+
+
+#define DERR -999.99
+
+double ASMs3Dmx::getParametricVolume (int iel) const
+{
+#ifdef INDEX_CHECK
+  if (iel < 1 || (size_t)iel > MNPC.size())
+  {
+    std::cerr <<" *** ASMs3Dmx::getParametricVolume: Element index "<< iel
+	      <<" out of range [1,"<< MNPC.size() <<"]."<< std::endl;
+    return DERR;
+  }
+#endif
+  if (MNPC[iel-1].empty())
+    return 0.0;
+
+  int inod1 = MNPC[iel-1][std::accumulate(elem_size.begin(),
+                                          elem_size.begin()+geoBasis, -1)];
+#ifdef INDEX_CHECK
+  if (inod1 < 0 || (size_t)inod1 >= nnod)
+  {
+    std::cerr <<" *** ASMs3Dmx::getParametricVolume: Node index "<< inod1
+	      <<" out of range [0,"<< nnod <<">."<< std::endl;
+    return DERR;
+  }
+#endif
+
+  double du = svol->knotSpan(0,nodeInd[inod1].I);
+  double dv = svol->knotSpan(1,nodeInd[inod1].J);
+  double dw = svol->knotSpan(2,nodeInd[inod1].K);
+  return du*dv*dw;
+}
+
+
+double ASMs3Dmx::getParametricArea (int iel, int dir) const
+{
+#ifdef INDEX_CHECK
+  if (iel < 1 || (size_t)iel > MNPC.size())
+  {
+    std::cerr <<" *** ASMs3Dmx::getParametricArea: Element index "<< iel
+	      <<" out of range [1,"<< MNPC.size() <<"]."<< std::endl;
+    return DERR;
+  }
+#endif
+  if (MNPC[iel-1].empty())
+    return 0.0;
+
+  int inod1 = MNPC[iel-1][std::accumulate(elem_size.begin(),
+                                          elem_size.begin()+geoBasis, -1)];
+#ifdef INDEX_CHECK
+  if (inod1 < 0 || (size_t)inod1 >= nnod)
+  {
+    std::cerr <<" *** ASMs3Dmx::getParametricArea: Node index "<< inod1
+	      <<" out of range [0,"<< nnod <<">."<< std::endl;
+    return DERR;
+  }
+#endif
+
+  const int ni = nodeInd[inod1].I;
+  const int nj = nodeInd[inod1].J;
+  const int nk = nodeInd[inod1].K;
+  switch (dir)
+    {
+    case 1: return svol->knotSpan(1,nj)*svol->knotSpan(2,nk);
+    case 2: return svol->knotSpan(0,ni)*svol->knotSpan(2,nk);
+    case 3: return svol->knotSpan(0,ni)*svol->knotSpan(1,nj);
+    }
+
+  std::cerr <<" *** ASMs3Dmx::getParametricArea: Invalid face direction "
+	    << dir << std::endl;
+  return DERR;
 }
 
 
@@ -1267,79 +1381,6 @@ void ASMs3Dmx::generateThreadGroups (const Integrand& integrand, bool silence,
 
   this->ASMs3D::generateThreadGroups(p[0]-1, p[1]-1, p[2]-1,
                                      silence, ignoreGlobalLM);
-}
-
-
-#define DERR -999.99
-
-double ASMs3Dmx::getParametricVolume (int iel) const
-{
-#ifdef INDEX_CHECK
-  if (iel < 1 || (size_t)iel > MNPC.size())
-  {
-    std::cerr <<" *** ASMs3Dmx::getParametricVolume: Element index "<< iel
-	      <<" out of range [1,"<< MNPC.size() <<"]."<< std::endl;
-    return DERR;
-  }
-#endif
-  if (MNPC[iel-1].empty())
-    return 0.0;
-
-  int inod1 = MNPC[iel-1][std::accumulate(elem_size.begin(),
-                                          elem_size.begin()+geoBasis, -1)];
-#ifdef INDEX_CHECK
-  if (inod1 < 0 || (size_t)inod1 >= nnod)
-  {
-    std::cerr <<" *** ASMs3Dmx::getParametricVolume: Node index "<< inod1
-	      <<" out of range [0,"<< nnod <<">."<< std::endl;
-    return DERR;
-  }
-#endif
-
-  double du = svol->knotSpan(0,nodeInd[inod1].I);
-  double dv = svol->knotSpan(1,nodeInd[inod1].J);
-  double dw = svol->knotSpan(2,nodeInd[inod1].K);
-  return du*dv*dw;
-}
-
-
-double ASMs3Dmx::getParametricArea (int iel, int dir) const
-{
-#ifdef INDEX_CHECK
-  if (iel < 1 || (size_t)iel > MNPC.size())
-  {
-    std::cerr <<" *** ASMs3Dmx::getParametricArea: Element index "<< iel
-	      <<" out of range [1,"<< MNPC.size() <<"]."<< std::endl;
-    return DERR;
-  }
-#endif
-  if (MNPC[iel-1].empty())
-    return 0.0;
-
-  int inod1 = MNPC[iel-1][std::accumulate(elem_size.begin(),
-                                          elem_size.begin()+geoBasis, -1)];
-#ifdef INDEX_CHECK
-  if (inod1 < 0 || (size_t)inod1 >= nnod)
-  {
-    std::cerr <<" *** ASMs3Dmx::getParametricArea: Node index "<< inod1
-	      <<" out of range [0,"<< nnod <<">."<< std::endl;
-    return DERR;
-  }
-#endif
-
-  const int ni = nodeInd[inod1].I;
-  const int nj = nodeInd[inod1].J;
-  const int nk = nodeInd[inod1].K;
-  switch (dir)
-    {
-    case 1: return svol->knotSpan(1,nj)*svol->knotSpan(2,nk);
-    case 2: return svol->knotSpan(0,ni)*svol->knotSpan(2,nk);
-    case 3: return svol->knotSpan(0,ni)*svol->knotSpan(1,nj);
-    }
-
-  std::cerr <<" *** ASMs3Dmx::getParametricArea: Invalid face direction "
-	    << dir << std::endl;
-  return DERR;
 }
 
 

--- a/src/ASM/ASMs3Dmx.h
+++ b/src/ASM/ASMs3Dmx.h
@@ -16,7 +16,6 @@
 
 #include "ASMs3D.h"
 #include "ASMmxBase.h"
-#include <memory>
 
 
 /*!
@@ -35,7 +34,7 @@ public:
   //! \brief The constructor initializes the dimension of each basis.
   explicit ASMs3Dmx(const CharVec& n_f);
   //! \brief Copy constructor.
-  ASMs3Dmx(const ASMs3Dmx& patch, const CharVec& n_f = CharVec(2,0));
+  ASMs3Dmx(const ASMs3Dmx& patch, const CharVec& n_f);
   //! \brief Destructor.
   virtual ~ASMs3Dmx();
 
@@ -52,7 +51,7 @@ public:
 
   //! \brief Generates the finite element topology data for the patch.
   //! \details The data generated are the element-to-node connectivity array,
-  //! the node-to-IJ-index array, as well as global node and element numbers.
+  //! the node-to-IJK-index array, as well as global node and element numbers.
   virtual bool generateFEMTopology();
 
   //! \brief Clears the contents of the patch, making it empty.
@@ -90,6 +89,32 @@ public:
 
   //! \brief Initializes the patch level MADOF array for mixed problems.
   virtual void initMADOF(const int* sysMadof);
+
+  //! \brief Constrains all DOFs on a given boundary face.
+  //! \param[in] dir Parameter direction defining the face to constrain
+  //! \param[in] open If \e true, exclude all points along the face boundary
+  //! \param[in] dof Which DOFs to constrain at each node on the face
+  //! \param[in] code Inhomogeneous dirichlet condition code
+  //! \param[in] basis Which basis to constrain face for (0 means check all)
+  virtual void constrainFace(int dir, bool open, int dof,
+                             int code, char basis);
+  //! \brief Constrains all DOFs on a given boundary edge.
+  //! \param[in] lEdge Local index [1,12] of the edge to constrain
+  //! \param[in] open If \e true, exclude the end points of the edge
+  //! \param[in] dof Which DOFs to constrain at each node along the edge
+  //! \param[in] code Inhomogeneous dirichlet condition code
+  //! \param[in] basis Which basis to constrain edge for (0 means check all)
+  virtual void constrainEdge(int lEdge, bool open, int dof,
+                             int code, char basis);
+  //! \brief Constrains a corner node identified by the three parameter indices.
+  //! \param[in] I Parameter index in u-direction
+  //! \param[in] J Parameter index in v-direction
+  //! \param[in] K Parameter index in w-direction
+  //! \param[in] dof Which DOFs to constrain at the node
+  //! \param[in] code Inhomogeneous dirichlet condition code
+  //! \param[in] basis Which basis to constrain node for (0 means check all)
+  virtual void constrainCorner(int I, int J, int K, int dof,
+                               int code, char basis);
 
   //! \brief Connects all matching nodes on two adjacent boundary faces.
   //! \param[in] face Local face index of this patch, in range [1,6]
@@ -132,7 +157,9 @@ public:
   //! \param[in] time Parameters for nonlinear/time-dependent simulations
   //! \param[in] iChk Object checking if an element interface has contributions
   virtual bool integrate(Integrand& integrand, GlobalIntegral& glbInt,
-                         const TimeDomain& time, const ASM::InterfaceChecker& iChk);
+                         const TimeDomain& time,
+                         const ASM::InterfaceChecker& iChk);
+
 
   // Post-processing methods
   // =======================
@@ -159,7 +186,7 @@ public:
   //! \param[in] gpar Parameter values of the result sampling points
   //! \param[in] regular Flag indicating how the sampling points are defined
   //! \param[in] deriv Derivative order to return
-  //! \param[in] nf If non-zero evaluates nf fields on first basis
+  //! \param[in] nf If nonzero, evaluate nf fields on first basis
   //!
   //! \details When \a regular is \e true, it is assumed that the parameter
   //! value array \a gpar forms a regular tensor-product point grid of dimension
@@ -206,7 +233,7 @@ public:
   //! \brief Generates element groups for multi-threading of interior integrals.
   //! \param[in] integrand Object with problem-specific data and methods
   //! \param[in] silence If \e true, suppress threading group outprint
-  //! \param[in] ignoreGlobalLM If \e true ignore global multipliers in sanity check
+  //! \param[in] ignoreGlobalLM Sanity check option
   virtual void generateThreadGroups(const Integrand& integrand, bool silence,
                                     bool ignoreGlobalLM);
 
@@ -223,7 +250,7 @@ protected:
   virtual double getParametricVolume(int iel) const;
   //! \brief Returns boundary face area in the parameter space for an element.
   //! \param[in] iel Element index
-  //! \param[in] dir Local face index of the boundary face
+  //! \param[in] dir Local index of the boundary face
   double getParametricArea(int iel, int dir) const;
 
   //! \brief Finds the global (or patch-local) node numbers on a patch boundary.

--- a/src/ASM/LR/ASMu2Dmx.C
+++ b/src/ASM/LR/ASMu2Dmx.C
@@ -312,6 +312,32 @@ bool ASMu2Dmx::generateFEMTopology ()
 }
 
 
+void ASMu2Dmx::constrainEdge (int dir, bool open, int dof, int code, char basis)
+{
+  if (basis > 0)
+    this->ASMu2D::constrainEdge(dir,open,dof,code,basis);
+  else for (basis = 1; basis <= (char)nfx.size(); basis++)
+  {
+    int basisDofs = this->maskDOFs(dof,basis);
+    if (basisDofs > 0)
+      this->ASMu2D::constrainEdge(dir,open,basisDofs,code,basis);
+  }
+}
+
+
+void ASMu2Dmx::constrainCorner (int I, int J, int dof, int code, char basis)
+{
+  if (basis > 0)
+    this->ASMu2D::constrainCorner(I,J,dof,code,basis);
+  else for (basis = 1; basis <= (char)nfx.size(); basis++)
+  {
+    int basisDofs = this->maskDOFs(dof,basis);
+    if (basisDofs > 0)
+      this->ASMu2D::constrainCorner(I,J,basisDofs,code,basis);
+  }
+}
+
+
 bool ASMu2Dmx::integrate (Integrand& integrand,
                           GlobalIntegral& glInt,
                           const TimeDomain& time)

--- a/src/ASM/LR/ASMu2Dmx.h
+++ b/src/ASM/LR/ASMu2Dmx.h
@@ -81,6 +81,21 @@ public:
   //! \brief Initializes the patch level MADOF array for mixed problems.
   virtual void initMADOF(const int* sysMadof);
 
+  //! \brief Constrains all DOFs on a given boundary edge.
+  //! \param[in] dir Parameter direction defining the edge to constrain
+  //! \param[in] open If \e true, exclude the end points of the edge
+  //! \param[in] dof Which DOFs to constrain at each node along the edge
+  //! \param[in] code Inhomogeneous dirichlet condition code
+  //! \param[in] basis Which basis to constrain edge for (0 means check all)
+  virtual void constrainEdge(int dir, bool open, int dof, int code, char basis);
+  //! \brief Constrains a corner node identified by the two parameter indices.
+  //! \param[in] I Parameter index in u-direction
+  //! \param[in] J Parameter index in v-direction
+  //! \param[in] dof Which DOFs to constrain at the node
+  //! \param[in] code Inhomogeneous dirichlet condition code
+  //! \param[in] basis Which basis to constrain node for (0 means check all)
+  virtual void constrainCorner(int I, int J, int dof, int code, char basis);
+
   // Methods for integration of finite element quantities.
   // These are the main computational methods of the ASM class hierarchy.
   // ====================================================================

--- a/src/ASM/LR/ASMu3Dmx.C
+++ b/src/ASM/LR/ASMu3Dmx.C
@@ -315,6 +315,47 @@ bool ASMu3Dmx::generateFEMTopology ()
 }
 
 
+void ASMu3Dmx::constrainFace (int dir, bool open, int dof, int code, char basis)
+{
+  if (basis > 0)
+    this->ASMu3D::constrainFace(dir,open,dof,code,basis);
+  else for (basis = 1; basis <= (char)nfx.size(); basis++)
+  {
+    int basisDofs = this->maskDOFs(dof,basis);
+    if (basisDofs > 0)
+      this->ASMu3D::constrainFace(dir,open,basisDofs,code,basis);
+  }
+}
+
+
+void ASMu3Dmx::constrainEdge (int lEdge, bool open, int dof,
+                              int code, char basis)
+{
+  if (basis > 0)
+    this->ASMu3D::constrainEdge(lEdge,open,dof,code,basis);
+  else for (basis = 1; basis <= (char)nfx.size(); basis++)
+  {
+    int basisDofs = this->maskDOFs(dof,basis);
+    if (basisDofs > 0)
+      this->ASMu3D::constrainEdge(lEdge,open,basisDofs,code,basis);
+  }
+}
+
+
+void ASMu3Dmx::constrainCorner (int I, int J, int K, int dof,
+                                int code, char basis)
+{
+  if (basis > 0)
+    this->ASMu3D::constrainCorner(I,J,K,dof,code,basis);
+  else for (basis = 1; basis <= (char)nfx.size(); basis++)
+  {
+    int basisDofs = this->maskDOFs(dof,basis);
+    if (basisDofs > 0)
+      this->ASMu3D::constrainCorner(I,J,K,basisDofs,code,basis);
+  }
+}
+
+
 bool ASMu3Dmx::integrate (Integrand& integrand,
                           GlobalIntegral& glInt,
                           const TimeDomain& time)

--- a/src/ASM/LR/ASMu3Dmx.h
+++ b/src/ASM/LR/ASMu3Dmx.h
@@ -81,6 +81,33 @@ public:
   //! \brief Initializes the patch level MADOF array for mixed problems.
   virtual void initMADOF(const int* sysMadof);
 
+  //! \brief Constrains all DOFs on a given boundary face.
+  //! \param[in] dir Parameter direction defining the face to constrain
+  //! \param[in] open If \e true, exclude all points along the face boundary
+  //! \param[in] dof Which DOFs to constrain at each node on the face
+  //! \param[in] code Inhomogeneous dirichlet condition code
+  //! \param[in] basis Which basis to constrain face for (0 means check all)
+  virtual void constrainFace(int dir, bool open, int dof,
+                             int code, char basis);
+  //! \brief Constrains all DOFs on a given boundary edge.
+  //! \param[in] lEdge Local index [1,12] of the edge to constrain
+  //! \param[in] open If \e true, exclude the end points of the edge
+  //! \param[in] dof Which DOFs to constrain at each node along the edge
+  //! \param[in] code Inhomogeneous dirichlet condition code
+  //! \param[in] basis Which basis to constrain edge for (0 means check all)
+  virtual void constrainEdge(int lEdge, bool open, int dof,
+                             int code, char basis);
+  //! \brief Constrains a corner node identified by the three parameter indices.
+  //! \param[in] I Parameter index in u-direction
+  //! \param[in] J Parameter index in v-direction
+  //! \param[in] K Parameter index in w-direction
+  //! \param[in] dof Which DOFs to constrain at the node
+  //! \param[in] code Inhomogeneous dirichlet condition code
+  //! \param[in] basis Which basis to constrain node for (0 means check all)
+  virtual void constrainCorner(int I, int J, int K, int dof,
+                               int code, char basis);
+
+
   // Methods for integration of finite element quantities.
   // These are the main computational methods of the ASM class hierarchy.
   // ====================================================================

--- a/src/SIM/SIMinput.C
+++ b/src/SIM/SIMinput.C
@@ -508,7 +508,7 @@ bool SIMinput::parseBCTag (const TiXmlElement* elem)
   else if (!strcasecmp(elem->Value(),"dirichlet") && !ignoreDirichlet)
   {
     const TiXmlNode* dval = nullptr;
-    int comp = 0, symm = 0, basis = 1;
+    int comp = 0, symm = 0, basis = 0;
     std::string set, type, axes;
     utl::getAttribute(elem,"set",set);
     utl::getAttribute(elem,"type",type,true);


### PR DESCRIPTION
To allow specifying DOFs to constrain for all bases (when invoked with basis=0).

This used to be the last commit in #289, which now is closed. It is not related to the original issue of that PR, so opening a separate one instead - just in case there is something here to pick up later.