### PR TITLE
Fixed: Processing of chained MPCs for time-dependent problems

### DIFF
--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -388,13 +388,10 @@ public:
 
   //! \brief Resolves (possibly multi-level) chaining in MPC equations.
   //! \param[in] allMPCs All multi-point constraint equations in the model
+  //! \param[in] model All spline patches in the model
   //! \param[in] setPtrOnly If \e true, only set pointer to next MPC in chain
-  //!
-  //! \details If a master DOF in one MPC (multi-point constraint) equation
-  //! is specified as slave by another MPC, it is replaced by the master(s) of
-  //! that other equation. Since an MPC-equation may couple nodes belonging to
-  //! different patches, this method must have access to all patches.
-  static void resolveMPCchains(const MPCSet& allMPCs, bool setPtrOnly = false);
+  static void resolveMPCchains(const MPCSet& allMPCs,
+                               const ASMVec& model, bool setPtrOnly = false);
 
   //! \brief Initializes the multi-point constraint coefficients.
   virtual bool initConstraints() { return true; }
@@ -813,12 +810,6 @@ protected:
   //! \details The global node number of the node with the highest number
   //! is changed into the number of the other node.
   static bool collapseNodes(ASMbase& pch1, int node1, ASMbase& pch2, int node2);
-
-private:
-  //! \brief Recursive method used by resolveMPCchains().
-  //! \param[in] allMPCs All multi-point constraint equations in the model
-  //! \param mpc Pointer to the multi-point constraint equation to resolve
-  static bool resolveMPCchain(const MPCSet& allMPCs, MPC* mpc);
 
 public:
   static bool fixHomogeneousDirichlet; //!< If \e true, pre-eliminate fixed DOFs

--- a/src/ASM/SAMpatch.h
+++ b/src/ASM/SAMpatch.h
@@ -15,7 +15,6 @@
 #define _SAM_PATCH_H
 
 #include "SAM.h"
-#include "MPC.h"
 
 class ASMbase;
 
@@ -62,13 +61,6 @@ protected:
   bool initConstraintEqs();
 
 private:
-  //! \brief Recursive helper method used by \a initConstraintEqs.
-  bool initConstraintEqMaster(const MPC::DOF& master, const MPC::DOF& slave,
-                              Real& offset, int ip, Real scale = Real(1));
-  //! \brief Recursive helper method used by \a updateConstraintEqs.
-  void updateConstraintEqMaster(const MPC::DOF& master,
-                                Real& offset, int& ipeq, Real scale = 1.0);
-
   std::vector<ASMbase*> model; //!< The spline patches of the model
 };
 

--- a/src/ASM/SAMpatch.h
+++ b/src/ASM/SAMpatch.h
@@ -35,36 +35,31 @@ public:
   virtual ~SAMpatch() {}
 
   //! \brief Allocates the dynamic arrays and populates them with data.
-  //! \param[in] model All spline patches in the model
+  //! \param[in] patches All spline patches in the model
   //! \param[in] numNod Total number of unique nodes in the model
   //! \param[in] dTypes Nodal DOF type flags
-  virtual bool init(const std::vector<ASMbase*>& model, int numNod,
-                    const std::vector<char>& dTypes);
+  bool init(const std::vector<ASMbase*>& patches, int numNod,
+            const std::vector<char>& dTypes);
 
   //! \brief Updates the multi-point constraint array \a TTCC.
-  //! \param[in] model All spline patches in the model
   //! \param[in] prevSol Previous primary solution vector in DOF-order
-  bool updateConstraintEqs(const std::vector<ASMbase*>& model,
-                           const Vector* prevSol = 0);
+  bool updateConstraintEqs(const Vector* prevSol = nullptr);
 
-  //! \brief Start iterator for patches
-  std::vector<ASMbase*>::const_iterator begin() const { return patches.begin(); }
-  //! \brief End iterator for patches
-  std::vector<ASMbase*>::const_iterator end() const { return patches.end(); }
-  //! \brief Number of patches in model
-  size_t getNoPatches() const { return patches.size(); }
+  //! \brief Returns the start iterator of the patch container.
+  std::vector<ASMbase*>::const_iterator begin() const { return model.begin(); }
+  //! \brief Returns the end iterator of the patch container.
+  std::vector<ASMbase*>::const_iterator end() const { return model.end(); }
+  //! \brief Returns the number of patches in model.
+  size_t getNoPatches() const { return model.size(); }
 
 protected:
   //! \brief Initializes the nodal arrays \a MINEX, \a MADOF and \a MSC.
-  bool initNodeDofs(const std::vector<ASMbase*>& model,
-                    const std::vector<char>& dTypes);
+  bool initNodeDofs(const std::vector<char>& dTypes);
   //! \brief Initializes the element topology arrays \a MPMNPC and \a MMNPC.
-  bool initElementConn(const std::vector<ASMbase*>& model);
-  //! \brief Initializes the multi-point constraint arrays.
+  bool initElementConn();
+  //! \brief Initializes the multi-point constraint arrays
   //! \a MPMCEQ, \a MMCEQ and \a TTCC.
-  virtual bool initConstraintEqs(const std::vector<ASMbase*>& model);
-
-  std::vector<ASMbase*> patches; //!< The spline patches
+  bool initConstraintEqs();
 
 private:
   //! \brief Recursive helper method used by \a initConstraintEqs.
@@ -73,6 +68,8 @@ private:
   //! \brief Recursive helper method used by \a updateConstraintEqs.
   void updateConstraintEqMaster(const MPC::DOF& master,
                                 Real& offset, int& ipeq, Real scale = 1.0);
+
+  std::vector<ASMbase*> model; //!< The spline patches of the model
 };
 
 #endif

--- a/src/ASM/SAMpatchPETSc.C
+++ b/src/ASM/SAMpatchPETSc.C
@@ -17,15 +17,15 @@
 #include "ProcessAdm.h"
 
 
-SAMpatchPETSc::SAMpatchPETSc(const std::map<int,int>& g2ln,
-                             const ProcessAdm& padm) : adm(padm)
+SAMpatchPETSc::SAMpatchPETSc (const std::map<int,int>& g2ln,
+                              const ProcessAdm& padm) : adm(padm)
 {
   nProc = adm.getNoProcs();
   LinAlgInit::increfs();
 }
 
 
-SAMpatchPETSc::~SAMpatchPETSc()
+SAMpatchPETSc::~SAMpatchPETSc ()
 {
 #ifdef HAVE_MPI
   for (auto& it : dofIS) {
@@ -39,14 +39,6 @@ SAMpatchPETSc::~SAMpatchPETSc()
     ISDestroy(&glob2LocEq);
 #endif
   LinAlgInit::decrefs();
-}
-
-
-bool SAMpatchPETSc::init (const std::vector<ASMbase*>& model, int numNod,
-                          const std::vector<char>& dTypes)
-{
-  patch = model;
-  return this->SAMpatch::init(model,numNod,dTypes);
 }
 
 
@@ -181,8 +173,8 @@ SAMpatchPETSc::DofIS& SAMpatchPETSc::getIS (char dofType) const
 #endif
 
 
-bool SAMpatchPETSc::expandSolution(const SystemVector& solVec,
-                                   Vector& dofVec, Real scaleSD) const
+bool SAMpatchPETSc::expandSolution (const SystemVector& solVec,
+                                    Vector& dofVec, Real scaleSD) const
 {
   PETScVector* Bptr = const_cast<PETScVector*>(dynamic_cast<const PETScVector*>(&solVec));
   if (!Bptr)

--- a/src/ASM/SAMpatchPETSc.h
+++ b/src/ASM/SAMpatchPETSc.h
@@ -35,13 +35,6 @@ public:
   //! \brief The destructor destroys the index set arrays.
   virtual ~SAMpatchPETSc();
 
-  //! \brief Allocates the dynamic arrays and populates them with data.
-  //! \param[in] model All spline patches in the model
-  //! \param[in] numNod Total number of unique nodes in the model
-  //! \param[in] dTypes Nodal DOF type flags
-  virtual bool init(const std::vector<ASMbase*>& model, int numNod,
-                    const std::vector<char>& dTypes);
-
   //! \brief Computes the dot-product of two vectors.
   //! \param[in] x First vector in dot-product
   //! \param[in] y Second vector in dot-product
@@ -71,9 +64,6 @@ public:
   //! for parallel vectors the ghost entries are also included.
   virtual Real normInf(const Vector& x, size_t& comp, char dofType = 'D') const;
 
-  //! \brief Returns the patch vector.
-  const std::vector<ASMbase*> getPatches() const { return patch; }
-
   //! \brief Expands a solution vector from equation-ordering to DOF-ordering.
   //! \param[in] solVec Solution vector, length = NEQ
   //! \param[out] dofVec Degrees of freedom vector, length = NDOF
@@ -85,8 +75,8 @@ public:
   //! That is, all fixed or constrained (slave) DOFs are not present.
   //! Before we can compute derived element quantities we therefore need to
   //! extract the resulting solution values also for the constrained DOFs.
-  virtual bool expandSolution(const SystemVector& solVec, Vector& dofVec,
-                              Real scaleSD = 1.0) const;
+  virtual bool expandSolution(const SystemVector& solVec,
+                              Vector& dofVec, Real scaleSD) const;
 
 private:
   // Parameters for parallel computing
@@ -95,9 +85,6 @@ private:
   IntVec l2gn;       //!< Local-to-global node numbers for this processor
 
   const ProcessAdm& adm; //!< Parallel process administrator
-
-  // For domain decomposition preconditioner
-  std::vector<ASMbase*> patch; //!< The spline patches
 
 #ifdef HAVE_MPI
   mutable IS glob2LocEq = nullptr; //!< Index set for global-to-local equations

--- a/src/LinAlg/SAM.h
+++ b/src/LinAlg/SAM.h
@@ -82,8 +82,8 @@ public:
   //! \details This method must be called once before the first call to
   //! \a assembleSystem for a given load case or time step.
   bool initForAssembly(SystemMatrix& sysK, SystemVector& sysRHS,
-		       Vector* reactionForces = nullptr,
-		       bool dontLockSP = false) const;
+                       Vector* reactionForces = nullptr,
+                       bool dontLockSP = false) const;
 
   //! \brief Initializes a system matrix prior to the element assembly.
   //! \param sysM The system left-hand-side matrix to be initialized
@@ -111,16 +111,15 @@ public:
   //! \details When multi-point constraints are present, contributions from
   //! these are also added into the right-hand-side system load vector.
   bool assembleSystem(SystemMatrix& sysK, SystemVector& sysRHS,
-		      const Matrix& eK, int iel = 0,
-		      Vector* reactionForces = nullptr) const;
+                      const Matrix& eK, int iel = 0,
+                      Vector* reactionForces = nullptr) const;
 
   //! \brief Adds an element matrix into the corresponding system matrix.
   //! \param sysM    The left-hand-side system matrix
   //! \param[in] eM  The element matrix
   //! \param[in] iel Identifier for the element that \a eM belongs to
   //! \return \e true on successful assembly, otherwise \e false
-  bool assembleSystem(SystemMatrix& sysM,
-		      const Matrix& eM, int iel = 0) const;
+  bool assembleSystem(SystemMatrix& sysM, const Matrix& eM, int iel = 0) const;
 
   //! \brief Adds element stiffness contributions to the system load vector.
   //! \param sysRHS  The right-hand-side system load vector
@@ -219,8 +218,8 @@ public:
   //! That is, all fixed or constrained (slave) DOFs are not present.
   //! Before we can compute derived element quantities we therefore need to
   //! extract the resulting solution values also for the constrained DOFs.
-  virtual bool expandSolution(const SystemVector& solVec, Vector& dofVec,
-			      Real scaleSD = 1.0) const;
+  virtual bool expandSolution(const SystemVector& solVec,
+                              Vector& dofVec, Real scaleSD = Real(1)) const;
 
   //! \brief Expands a solution vector from equation-ordering to DOF-ordering.
   //! \param[in] solVec Solution vector, length = NEQ
@@ -302,6 +301,11 @@ protected:
   //! \param[out] dofVec Degrees of freedom vector, length = NDOF
   //! \param[in] scaleSD Scaling factor for specified (slave) DOFs
   bool expandVector(const Real* solVec, Vector& dofVec, Real scaleSD) const;
+
+  //! \brief Prints out the DOF status codes to the given stream.
+  void printStatusCodes(std::ostream& os) const;
+  //! \brief Prints out a constraint equation to the given stream.
+  void printCEQ(std::ostream& os, int iceq) const;
 
 private:
   int mpar[50]; //!< Matrix of parameters

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -703,7 +703,7 @@ bool SIMbase::updateDirichlet (double time, const Vector* prevSol)
         return false;
 
   SAMpatch* pSam = dynamic_cast<SAMpatch*>(mySam);
-  return pSam ? pSam->updateConstraintEqs(myModel,prevSol) : true;
+  return pSam ? pSam->updateConstraintEqs(prevSol) : true;
 }
 
 

--- a/src/Utility/MPC.h
+++ b/src/Utility/MPC.h
@@ -88,11 +88,12 @@ public:
   //! \brief Constructor creating a constraint for a specified slave DOF.
   //! \param[in] n The node number of the slave DOF (1...NNOD)
   //! \param[in] d The local DOF number of the slave DOF (1...3)
+  //! \param[in] s Associated constrained value
   //!
   //! \details The created constraint equation will by default constrain the
   //! specified slave DOF to zero. To constrain to a non-zero value, the method
   //! setSlaveCoeff has to be invoked with the desired value.
-  MPC(int n, int d) : slave(n,d,Real(0)) { iceq = -1; }
+  MPC(int n, int d, Real s = Real(0)) : slave(n,d,s) { iceq = -1; }
 
   //! \brief Adds a master DOF to the constraint equation.
   //! \param[in] dof The the master DOF and associated coefficient to be added
@@ -130,6 +131,14 @@ public:
       master.erase(master.begin()+pos);
   }
 
+  //! \brief Returns \e true if this MPC is chained.
+  bool isChained() const
+  {
+    for (const DOF& mdof : master)
+      if (mdof.nextc) return true;
+    return false;
+  }
+
   //! \brief Merges the given MPC equation into this one.
   bool merge(const MPC* mpc);
 
@@ -156,6 +165,11 @@ public:
   //! \brief Global stream operator printing a constraint equation.
   friend std::ostream& operator<<(std::ostream& s, const MPC& mpc);
 
+protected:
+  //! \brief Prints out the master(s) of this constraint equation.
+  void printMaster(std::ostream& os) const;
+
+public:
   int iceq; //!< Global constraint equation identifier
 
 private:


### PR DESCRIPTION
Fixes #263 (I think).
The problem was incorrect resolving of the chained MPC-equations for time-dependent simulations, for instance for KL shell models with symmetry BC's resulting in constraints on the boundary tangent, and inhomogeneous dirichlet conditions at adjacent boundaries.
This now works, at least the test-model attached in #263 runs.