### PR TITLE
Fixed: Avoid writing unnecessary restart file

### DIFF
--- a/Apps/Common/scripts/regtest.sh.in
+++ b/Apps/Common/scripts/regtest.sh.in
@@ -41,6 +41,7 @@ then
 fi
 if test -n "$4"
 then
+  MAPFILE=`echo $MAPFILE | sed 's/ -restartInc [1-9][0-9]*//'`
   $mysim $MAPFILE -restart @CMAKE_BINARY_DIR@/Testing/$3_restart.hdf5 $4 2>&1 | tee $tmplog
 fi
 appres=$?


### PR DESCRIPTION
In the restart regression tests, a restart hdf5-file is written in both the original execution, and in the restart. It is not needed in the latter, and it ends up in the source code tree where it does not belong.