### PR TITLE
added: support for saving the local-to-global node mapping in HDF5

### DIFF
--- a/src/Utility/DataExporter.h
+++ b/src/Utility/DataExporter.h
@@ -46,14 +46,15 @@ public:
 
   //! \brief An enum used to describe the results to write from a SIM
   enum Results {
-    PRIMARY      = 1,   //!< Storage of primary solutions
-    DISPLACEMENT = 2,   //!< Storage of vector fields as displacements
-    SECONDARY    = 4,   //!< Storage of secondary field
-    NORMS        = 8,   //!< Storage of norms
-    EIGENMODES   = 16,  //!< Storage of eigenmodes
-    ONCE         = 32,  //!< Only write field once
+    PRIMARY      = 1, //!< Storage of primary solutions
+    DISPLACEMENT = 2, //!< Storage of vector fields as displacements
+    SECONDARY    = 4, //!< Storage of secondary field
+    NORMS        = 8, //!< Storage of norms
+    EIGENMODES   = 16, //!< Storage of eigenmodes
+    ONCE         = 32, //!< Only write field once
     GRID         = 128, //!< Always store an updated grid
-    REDUNDANT    = 256  //!< Field is redundantly calculated on all processes
+    REDUNDANT    = 256, //!< Field is redundantly calculated on all processes
+    L2G_NODE     = 512 //!< Store local-to-global node mapping
   };
 
   //! \brief A structure holding information about registered fields

--- a/src/Utility/HDF5Writer.h
+++ b/src/Utility/HDF5Writer.h
@@ -110,8 +110,10 @@ protected:
   //! \param[in] basis 1/2 Write primary or secondary basis from SIM
   //! \param[in] level The time level to write the basis at
   //! \param[in] redundant Whether or not basis is redundant across processes
+  //! \param[in] l2g True to write local-to-global node numbers
   void writeBasis(const SIMbase* SIM, const std::string& name,
-                  int basis, int level, bool redundant = false);
+                  int basis, int level, bool redundant = false,
+                  bool l2g = false);
 
 private:
   unsigned int m_flag; //!< The file flags to open HDF5 file with


### PR DESCRIPTION
this is on a per-basis level, ie, not interleaved on a per-patch
basis as used in IFEM