### PR TITLE
Fixed output of projected fields to HDF5

### DIFF
--- a/src/Utility/HDF5Base.h
+++ b/src/Utility/HDF5Base.h
@@ -15,12 +15,9 @@
 #define _HDF5_BASE_H
 
 #include <string>
-#include <vector>
-
 #ifdef HAS_HDF5
 #include <hdf5.h>
 #endif
-
 
 class ProcessAdm;
 
@@ -32,36 +29,32 @@ class ProcessAdm;
 class HDF5Base
 {
 public:
-#ifndef HAS_HDF5
-  using hid_t = int; //!< Type alias providing hid_t without the hdf5 library
-  using herr_t = int; //!< Type alias providing herr_t without the hdf5 library
-#endif
   //! \brief The constructor opens a named HDF5-file.
   //! \param[in] name The name (without extension) of the data file
   //! \param[in] adm The process administrator
   HDF5Base(const std::string& name, const ProcessAdm& adm);
-
   //! \brief The destructor closes the file.
-  virtual ~HDF5Base();
+  virtual ~HDF5Base() { this->closeFile(); }
 
 protected:
-  //! \brief Open the HDF5 file.
-  //!\ param flag Mode to open file using
-  bool openFile (unsigned flag);
-
-  //! \brief Close the HDF5 file.
+  //! \brief Opens the HDF5 file.
+  //! \param[in] flag Mode to open file using
+  bool openFile(unsigned int flag);
+  //! \brief Closes the HDF5 file.
   void closeFile();
 
+#ifdef HAS_HDF5
   //! \brief Internal helper function checking if a group exists in the file.
   //! \param[in] parent The HDF5 group of the parent
   //! \param[in] path Path of dataset
   //! \return \e true if group exists, otherwise \e false
-  bool checkGroupExistence (hid_t parent, const char* path);
+  static bool checkGroupExistence(hid_t parent, const char* path);
 
-  hid_t        m_file; //!< The HDF5 handle for our file
+  hid_t        m_file;      //!< The HDF5 handle for our file
+#endif
   std::string  m_hdf5_name; //!< The file name of the HDF5 file
 #ifdef HAVE_MPI
-  const ProcessAdm& m_adm;   //!< Pointer to process adm in use
+  const ProcessAdm& m_adm;  //!< Pointer to process administrator in use
 #endif
 };
 

--- a/src/Utility/HDF5Restart.h
+++ b/src/Utility/HDF5Restart.h
@@ -15,12 +15,8 @@
 #define _HDF5_RESTART_H
 
 #include "HDF5Base.h"
-
 #include <map>
-#include <string>
 
-
-class ProcessAdm;
 class TimeStep;
 
 
@@ -35,7 +31,7 @@ class TimeStep;
 class HDF5Restart : public HDF5Base
 {
 public:
-  typedef std::map<std::string, std::string> SerializeData; //!< Convenience typedef
+  typedef std::map<std::string,std::string> SerializeData; //!< Convenience type
 
   //! \brief The constructor opens a named HDF5-file.
   //! \param[in] name The name (without extension) of the data file
@@ -44,7 +40,7 @@ public:
   HDF5Restart(const std::string& name, const ProcessAdm& adm, int stride);
 
   //! \brief Returns whether or not restart data should be output.
-  //! \param tp Time stepping parameter
+  //! \param[in] tp Time stepping information
   bool dumpStep(const TimeStep& tp);
 
   //! \brief Writes restart data to file.
@@ -58,28 +54,8 @@ public:
   //! \returns Negative value on error, else restart level loaded
   int readData(SerializeData& data, int level = -1);
 
-protected:
-  //! \brief Internal helper function reading into an array of chars.
-  //! \param[in] group The HDF5 dataset to read data from
-  //! \param[in] name The name of the array
-  //! \param[out] len The length of the data read
-  //! \param[out] data The array to read data into
-  void readArray(hid_t group, const std::string& name, int& len, char*& data);
-
-  //! \brief Internal helper function writing a data array to file.
-  //! \param[in] group The HDF5 group to write data into
-  //! \param[in] name The name of the array
-  //! \param[in] len The length of the array
-  //! \param[in] data The array to write
-  //! \param[in] type The HDF5 type for the data (see H5T)
-  void writeArray(hid_t group, const std::string& name,
-                  int len, const void* data, hid_t type);
-
-  //! \brief Static helper used for reading data.
-  static herr_t read_restart_data(hid_t group_id, const char* member_name, void* data);
-
 private:
-  int m_stride;        //!< Stride between outputs
+  int m_stride; //!< Stride between outputs
 };
 
 #endif

--- a/src/Utility/HDF5Writer.C
+++ b/src/Utility/HDF5Writer.C
@@ -86,10 +86,10 @@ int HDF5Writer::getLastTimeLevel ()
 
 void HDF5Writer::openFile(int level)
 {
+#ifdef HAS_HDF5
   if (m_file != -1)
     return;
 
-#ifdef HAS_HDF5
   if (m_flag == H5F_ACC_RDWR) {
     struct stat buffer;
     if (stat(m_name.c_str(),&buffer) != 0)
@@ -133,10 +133,10 @@ void HDF5Writer::closeFile(int level)
 }
 
 
+#ifdef HAS_HDF5
 void HDF5Writer::writeArray(hid_t group, const std::string& name, int patch,
                             int len, const void* data, hid_t type)
 {
-#ifdef HAS_HDF5
 #ifdef HAVE_MPI
   int lens[m_size], lens2[m_size];
   std::fill(lens,lens+m_size,len);
@@ -178,10 +178,8 @@ void HDF5Writer::writeArray(hid_t group, const std::string& name, int patch,
   H5Sclose(space);
   if (group1 != -1)
     H5Gclose(group1);
-#else
-  std::cout << "HDF5Writer: compiled without HDF5 support, no data written" << std::endl;
-#endif
 }
+#endif
 
 
 void HDF5Writer::writeVector(int level, const DataEntry& entry)
@@ -219,10 +217,13 @@ void HDF5Writer::writeBasis (int level, const DataEntry& entry,
   if (!entry.second.enabled || !entry.second.data)
     return;
 
+#ifdef HAS_HDF5
   const SIMbase* sim = static_cast<const SIMbase*>(entry.second.data);
-
   this->writeBasis(sim, prefix+sim->getName()+"-1", 1, level,
                    entry.second.results & DataExporter::REDUNDANT);
+#else
+  std::cout <<"HDF5Writer: Compiled without HDF5 support, no data written."<< std::endl;
+#endif
 }
 
 
@@ -530,10 +531,10 @@ void HDF5Writer::writeKnotspan (int level, const DataEntry& entry,
 }
 
 
+#ifdef HAS_HDF5
 void HDF5Writer::writeBasis (const SIMbase* sim, const std::string& name,
                              int basis, int level, bool redundant)
 {
-#ifdef HAS_HDF5
   std::stringstream str;
   str << "/" << level << '/' << name;
   hid_t group;
@@ -561,8 +562,8 @@ void HDF5Writer::writeBasis (const SIMbase* sim, const std::string& name,
     }
   }
   H5Gclose(group);
-#endif
 }
+#endif
 
 
 // TODO: implement for variable time steps.

--- a/src/Utility/HDF5Writer.h
+++ b/src/Utility/HDF5Writer.h
@@ -92,6 +92,7 @@ public:
   //! \param[in] tp The current time stepping info
   virtual bool writeTimeInfo(int level, int interval, const TimeStep& tp);
 
+#ifdef HAS_HDF5
 protected:
   //! \brief Internal helper function writing a data array to file.
   //! \param[in] group The HDF5 group to write data into
@@ -113,7 +114,6 @@ protected:
                   int basis, int level, bool redundant = false);
 
 private:
-#ifdef HAS_HDF5
   unsigned int m_flag; //!< The file flags to open HDF5 file with
 #endif
 };


### PR DESCRIPTION
This (i.e., the last commit, the others of more cosmetic character), should fix the issue with bullshit projected stress fields from the LinearElasticity app. The problem was that the LinEl registers the projected fields in a separate loop (since there in theory can be more than one of them). But inside the HDF5Writer they are treated as the primary solution and projected once again. The result then became of order O(2n) of instead of O(n) (E+18 instead of E+9, etc.)

You need to very this comparing with direct VTF output before approving.