### PR TITLE
fixed: we have to specify basis 1 when extracting projections

### DIFF
--- a/src/Utility/HDF5Writer.C
+++ b/src/Utility/HDF5Writer.C
@@ -370,7 +370,7 @@ void HDF5Writer::writeSIM (int level, const DataEntry& entry,
             if (p == proj->size()-1)
               projOfs += ndof;
           } else
-            sim->extractPatchSolution(proj->at(p),locvec,pch,prob->getNoFields(2));
+            sim->extractPatchSolution(proj->at(p),locvec,pch,prob->getNoFields(2),1);
 
           Matrix field;
           field.resize(prob->getNoFields(2),locvec.size()/prob->getNoFields(2));


### PR DESCRIPTION
if not, things do not work well with mixed simulations