### PR TITLE
added: flag to suppress simulator norm output in AdaptiveSetup::printNorms()

### DIFF
--- a/src/SIM/AdaptiveSetup.C
+++ b/src/SIM/AdaptiveSetup.C
@@ -439,9 +439,10 @@ int AdaptiveSetup::calcRefinement (LR::RefineData& prm, int iStep,
 
 
 void AdaptiveSetup::printNorms (const Vectors& gNorm, const Vectors& dNorm,
-                                const Matrix& eNorm, size_t w) const
+                                const Matrix& eNorm, size_t w, bool printModelNorms) const
 {
-  model.printNorms(gNorm,w);
+  if (printModelNorms)
+    model.printNorms(gNorm,w);
 
   // Print out the norm used for mesh adaptation
   if (adaptor > 0 && adaptor < gNorm.size())

--- a/src/SIM/AdaptiveSetup.h
+++ b/src/SIM/AdaptiveSetup.h
@@ -72,8 +72,10 @@ public:
   //! \param[in] dNorm Global dual norms
   //! \param[in] eNorm Element norms
   //! \param[in] w Field width for global norm labels
+  //! \param[in] printModelNorms True to print norms for model
   void printNorms(const Vectors& gNorm, const Vectors& dNorm,
-                  const Matrix& eNorm, size_t w = 36) const;
+                  const Matrix& eNorm, size_t w = 36,
+                  bool printModelNorms = true) const;
 
   //! \brief Dumps current mesh to external file(s) for inspection.
   //! \param[in] iStep Current refinement step (1=initial grid)


### PR DESCRIPTION
needed for (staggered) simulators where we want to handle the
printout ourself