### PR TITLE
fixed: TestPETScMatrix.Assemble

### DIFF
--- a/src/LinAlg/Test/TestPETScMatrix.C
+++ b/src/LinAlg/Test/TestPETScMatrix.C
@@ -30,6 +30,8 @@ TEST(TestPETScMatrix, Assemble)
   PETScMatrix* myMat = dynamic_cast<PETScMatrix*>(sim.getLHSmatrix());
   ASSERT_TRUE(myMat != nullptr);
 
+  myMat->init();
+
   Matrix stencil(4,4);
   stencil.diag(1.0);
 


### PR DESCRIPTION
for some reason newer PETSc requires an explicit call to zero out the
matrix.