### PR TITLE
changed: log multithreading info to IFEM::cout

### DIFF
--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -21,6 +21,7 @@
 #include "TimeDomain.h"
 #include "FiniteElement.h"
 #include "GlobalIntegral.h"
+#include "IFEM.h"
 #include "LocalIntegral.h"
 #include "IntegrandBase.h"
 #include "CoordinateMapping.h"
@@ -2989,16 +2990,16 @@ void ASMs2D::generateThreadGroups (size_t strip1, size_t strip2,
   threadGroups.calcGroups(el1,el2,strip1,strip2);
   if (silence || threadGroups.size() < 2) return;
 
-  std::cout <<"\nMultiple threads are utilized during element assembly.";
+  IFEM::cout <<"\nMultiple threads are utilized during element assembly.";
   for (size_t i = 0; i < threadGroups.size(); i++)
   {
     std::vector< std::set<int> > nodes(threadGroups[i].size());
 
-    std::cout <<"\n Thread group "<< i+1;
+    IFEM::cout <<"\n Thread group "<< i+1;
     for (size_t j = 0; j < threadGroups[i].size(); j++)
     {
-      std::cout <<"\n\tthread "<< j+1
-                << ": "<< threadGroups[i][j].size() <<" elements";
+      IFEM::cout <<"\n\tthread "<< j+1
+                 << ": "<< threadGroups[i][j].size() <<" elements";
       size_t k, l, nzeroar = 0;
       for (k = 0; k < threadGroups[i][j].size(); k++)
       {
@@ -3010,13 +3011,13 @@ void ASMs2D::generateThreadGroups (size_t strip1, size_t strip2,
           nzeroar++;
       }
       if (nzeroar > 0)
-        std::cout <<" ("<< threadGroups[i][j].size() - nzeroar <<" real)";
+        IFEM::cout <<" ("<< threadGroups[i][j].size() - nzeroar <<" real)";
 
       // Verify that the nodes on this thread are not present on the others
       this->checkThreadGroups(nodes, j, ignoreGlobalLM);
     }
   }
-  std::cout << std::endl;
+  IFEM::cout << std::endl;
 }
 
 

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -20,6 +20,7 @@
 #include "TimeDomain.h"
 #include "FiniteElement.h"
 #include "GlobalIntegral.h"
+#include "IFEM.h"
 #include "LocalIntegral.h"
 #include "IntegrandBase.h"
 #include "CoordinateMapping.h"
@@ -3366,16 +3367,16 @@ void ASMs3D::generateThreadGroups (size_t strip1, size_t strip2, size_t strip3,
   threadGroupsVol.calcGroups(el1,el2,el3,strip1,strip2,strip3);
   if (silence || threadGroupsVol.size() < 2) return;
 
-  std::cout <<"\nMultiple threads are utilized during element assembly.";
+  IFEM::cout <<"\nMultiple threads are utilized during element assembly.";
   for (size_t i = 0; i < threadGroupsVol.size(); i++)
   {
     std::vector< std::set<int> > nodes(threadGroupsVol[i].size());
 
-    std::cout <<"\n Thread group "<< i+1;
+    IFEM::cout <<"\n Thread group "<< i+1;
     for (size_t j = 0; j < threadGroupsVol[i].size(); j++)
     {
-      std::cout <<"\n\tthread "<< j+1
-                << ": "<< threadGroupsVol[i][j].size() <<" elements";
+      IFEM::cout <<"\n\tthread "<< j+1
+                 << ": "<< threadGroupsVol[i][j].size() <<" elements";
       size_t k, l, nzerovol = 0;
       for (k = 0; k < threadGroupsVol[i][j].size(); k++)
       {
@@ -3387,13 +3388,13 @@ void ASMs3D::generateThreadGroups (size_t strip1, size_t strip2, size_t strip3,
           nzerovol++;
       }
       if (nzerovol)
-        std::cout <<" ("<< threadGroupsVol[i][j].size() - nzerovol <<" real)";
+        IFEM::cout <<" ("<< threadGroupsVol[i][j].size() - nzerovol <<" real)";
 
       // Verify that the nodes on this thread are not present on the others
       this->checkThreadGroups(nodes, j, ignoreGlobalLM);
     }
   }
-  std::cout << std::endl;
+  IFEM::cout << std::endl;
 }
 
 

--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -2606,12 +2606,12 @@ void ASMu2D::generateThreadGroups (const Integrand& integrand, bool silence,
     LR::generateThreadGroups(projThreadGroups, projBasis.get());
   if (silence || threadGroups[0].size() < 2) return;
 
-  std::cout <<"\nMultiple threads are utilized during element assembly.";
+  IFEM::cout <<"\nMultiple threads are utilized during element assembly.";
 #ifdef SP_DEBUG
   for (size_t i = 0; i < threadGroups[0].size(); i++)
-    std::cout <<"\n Color "<< i+1 <<": "
-              << threadGroups[0][i].size() <<" elements";
-  std::cout << std::endl;
+    IFEM::cout <<"\n Color "<< i+1 <<": "
+               << threadGroups[0][i].size() <<" elements";
+  IFEM::cout << std::endl;
 #else
   this->analyzeThreadGroups(threadGroups[0]);
 #endif

--- a/src/ASM/LR/ASMu2Dmx.C
+++ b/src/ASM/LR/ASMu2Dmx.C
@@ -24,6 +24,7 @@
 #include "TimeDomain.h"
 #include "FiniteElement.h"
 #include "GlobalIntegral.h"
+#include "IFEM.h"
 #include "LocalIntegral.h"
 #include "IntegrandBase.h"
 #include "CoordinateMapping.h"
@@ -1091,11 +1092,12 @@ void ASMu2Dmx::generateThreadGroups (const Integrand& integrand, bool silence,
 
   this->checkThreadGroups(threadGroups[0], bases, threadBasis);
 
-  std::cout <<"\nMultiple threads are utilized during element assembly.";
+  IFEM::cout <<"\nMultiple threads are utilized during element assembly.";
 #ifdef SP_DEBUG
   for (size_t i = 0; i < threadGroups[0].size(); i++)
-    std::cout <<"\n Color "<< i+1 <<": "
-              << threadGroups[0][i].size() <<" elements";
+    IFEM::cout <<"\n Color "<< i+1 <<": "
+               << threadGroups[0][i].size() <<" elements";
+  IFEM::cout << std::endl;
 #else
   this->analyzeThreadGroups(threadGroups[0]);
 #endif

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -21,6 +21,7 @@
 #include "TimeDomain.h"
 #include "FiniteElement.h"
 #include "GlobalIntegral.h"
+#include "IFEM.h"
 #include "LocalIntegral.h"
 #include "IntegrandBase.h"
 #include "CoordinateMapping.h"
@@ -1973,11 +1974,12 @@ void ASMu3D::generateThreadGroups (const Integrand& integrand, bool silence,
     LR::generateThreadGroups(projThreadGroups, projBasis.get());
   if (silence || threadGroups[0].size() < 2) return;
 
-  std::cout <<"\nMultiple threads are utilized during element assembly.";
+  IFEM::cout <<"\nMultiple threads are utilized during element assembly.";
 #if SP_DEBUG
   for (size_t i = 0; i < threadGroups[0].size(); i++)
-    std::cout <<"\n Color "<< i+1 <<": "
-              << threadGroups[0][i].size() <<" elements";
+    IFEM::cout <<"\n Color "<< i+1 <<": "
+               << threadGroups[0][i].size() <<" elements";
+  IFEM::cout << std::endl;
 #else
   this->analyzeThreadGroups(threadGroups[0]);
 #endif

--- a/src/ASM/LR/ASMu3Dmx.C
+++ b/src/ASM/LR/ASMu3Dmx.C
@@ -23,6 +23,7 @@
 #include "TimeDomain.h"
 #include "FiniteElement.h"
 #include "GlobalIntegral.h"
+#include "IFEM.h"
 #include "LocalIntegral.h"
 #include "IntegrandBase.h"
 #include "CoordinateMapping.h"
@@ -1075,11 +1076,12 @@ void ASMu3Dmx::generateThreadGroups (const Integrand& integrand, bool silence,
 
   this->checkThreadGroups(threadGroups[0], bases, threadBasis);
 
-  std::cout <<"\nMultiple threads are utilized during element assembly.";
+  IFEM::cout <<"\nMultiple threads are utilized during element assembly.";
 #ifdef SP_DEBUG
   for (size_t i = 0; i < threadGroups[0].size(); i++)
-    std::cout <<"\n Color "<< i+1 <<": "
-              << threadGroups[0][i].size() <<" elements";
+    IFEM::cout <<"\n Color "<< i+1 <<": "
+               << threadGroups[0][i].size() <<" elements";
+  IFEM::cout << std::endl;
 #else
   this->analyzeThreadGroups(threadGroups[0]);
 #endif


### PR DESCRIPTION
Since multithreading and MPI (now) is usable at the same time, this creates a lot of terminal noise in parallel simulations.