### PR TITLE
fixed: remove unnecessary myElms member in ASMu3D

### DIFF
--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -631,7 +631,6 @@ protected:
 
   ThreadGroups threadGroups; //!< Element groups for multi-threaded assembly
   ThreadGroups projThreadGroups; //!< Element groups for multi-threaded assembly - projection basis
-  IntVec       myElms;       //!< Elements on patch - used with partitioning
 
   const Matrices& bezierExtract; //!< Bezier extraction matrices
   Matrices      myBezierExtract; //!< Bezier extraction matrices


### PR DESCRIPTION
this was forgotten in the original commit. after a review
comment myElms were added to ASMbase, and I forgot
to remove it in ASMu3D.