### PR TITLE
added: (non-internal) L2 projection support for functions

### DIFF
--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -33,6 +33,7 @@ class Fields;
 class GlobalIntegral;
 class IntegrandBase;
 class Integrand;
+class L2Integrand;
 class ASMbase;
 class SparseMatrix;
 class StdVector;
@@ -601,8 +602,8 @@ public:
   //! \param[in] integrand Object with problem-specific data and methods
   //! \param[in] continuous If \e true, a continuous L2-projection is used
   virtual bool globalL2projection(Matrix& sField,
-				  const IntegrandBase& integrand,
-				  bool continuous = false) const;
+                                  const L2Integrand& integrand,
+                                  bool continuous = false) const;
 
   //! \brief Projects the secondary solution using a continuous global L2-fit.
   //! \param[out] sField Secondary solution field control point values
@@ -758,10 +759,10 @@ protected:
   //! \brief Assembles L2-projection matrices for the secondary solution.
   //! \param[out] A Left-hand-side matrix
   //! \param[out] B Right-hand-side vectors
-  //! \param[in] integrand Object with problem-specific data and methods
+  //! \param[in] obj Wrapper object for integrand/function
   //! \param[in] continuous If \e false, a discrete L2-projection is used
   virtual bool assembleL2matrices(SparseMatrix& A, StdVector& B,
-                                  const IntegrandBase& integrand,
+                                  const L2Integrand& obj,
                                   bool continuous) const = 0;
 
 public:

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -23,6 +23,7 @@
 #include "IntegrandBase.h"
 #include "CoordinateMapping.h"
 #include "GaussQuadrature.h"
+#include "GlbL2projector.h"
 #include "SparseMatrix.h"
 #include "SplineFields1D.h"
 #include "ElementBlock.h"
@@ -1751,7 +1752,7 @@ bool ASMs1D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
 
 
 bool ASMs1D::assembleL2matrices (SparseMatrix& A, StdVector& B,
-                                 const IntegrandBase& integrand,
+                                 const L2Integrand& integrand,
                                  bool continuous) const
 {
   const size_t nnod = this->getNoProjectionNodes();
@@ -1768,7 +1769,7 @@ bool ASMs1D::assembleL2matrices (SparseMatrix& A, StdVector& B,
   // and evaluate the secondary solution at all integration points
   Matrix gp, sField;
   RealArray gpar = this->getGaussPointParameters(gp,ng,xg,proj,true);
-  if (!this->evalSolution(sField,integrand,&gpar))
+  if (!integrand.evaluate(sField,&gpar))
   {
     std::cerr <<" *** ASMs1D::assembleL2matrices: Failed for patch "<< idx+1
               <<" nPoints="<< gpar.size() << std::endl;

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -352,7 +352,7 @@ protected:
   //! \param[in] integrand Object with problem-specific data and methods
   //! \param[in] continuous If \e false, a discrete L2-projection is used
   virtual bool assembleL2matrices(SparseMatrix& A, StdVector& B,
-                                  const IntegrandBase& integrand,
+                                  const L2Integrand& integrand,
                                   bool continuous) const;
 
   //! \brief Initializes the local element axes for a patch of beam elements.

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -514,7 +514,7 @@ protected:
   //! \param[in] integrand Object with problem-specific data and methods
   //! \param[in] continuous If \e false, a discrete L2-projection is used
   virtual bool assembleL2matrices(SparseMatrix& A, StdVector& B,
-                                  const IntegrandBase& integrand,
+                                  const L2Integrand& integrand,
                                   bool continuous) const;
 
   //! \brief Connects all matching nodes on two adjacent boundary edges.

--- a/src/ASM/ASMs2Drecovery.C
+++ b/src/ASM/ASMs2Drecovery.C
@@ -20,6 +20,7 @@
 #include "IntegrandBase.h"
 #include "CoordinateMapping.h"
 #include "GaussQuadrature.h"
+#include "GlbL2projector.h"
 #include "SparseMatrix.h"
 #include "DenseMatrix.h"
 #include "SplineUtils.h"
@@ -160,7 +161,7 @@ Go::GeomObject* ASMs2D::evalSolution (const IntegrandBase& integrand) const
 
 
 bool ASMs2D::assembleL2matrices (SparseMatrix& A, StdVector& B,
-                                 const IntegrandBase& integrand,
+                                 const L2Integrand& integrand,
                                  bool continuous) const
 {
   const size_t nnod = this->getNoProjectionNodes();
@@ -202,7 +203,7 @@ bool ASMs2D::assembleL2matrices (SparseMatrix& A, StdVector& B,
 
   // Evaluate the secondary solution at all integration points
   Matrix sField;
-  if (!this->evalSolution(sField,integrand,gpar.data()))
+  if (!integrand.evaluate(sField,gpar.data()))
   {
     std::cerr <<" *** ASMs2D::assembleL2matrices: Failed for patch "<< idx+1
               <<" nPoints="<< gpar[0].size()*gpar[1].size() << std::endl;

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -582,7 +582,7 @@ protected:
   //! \param[in] integrand Object with problem-specific data and methods
   //! \param[in] continuous If \e false, a discrete L2-projection is used
   virtual bool assembleL2matrices(SparseMatrix& A, StdVector& B,
-                                  const IntegrandBase& integrand,
+                                  const L2Integrand& integrand,
                                   bool continuous) const;
 
   //! \brief Connects all matching nodes on two adjacent boundary faces.

--- a/src/ASM/ASMs3Drecovery.C
+++ b/src/ASM/ASMs3Drecovery.C
@@ -19,6 +19,7 @@
 #include "Field.h"
 #include "CoordinateMapping.h"
 #include "GaussQuadrature.h"
+#include "GlbL2projector.h"
 #include "SparseMatrix.h"
 #include "SplineUtils.h"
 #include "Utilities.h"
@@ -160,7 +161,7 @@ Go::GeomObject* ASMs3D::evalSolution (const IntegrandBase& integrand) const
 
 
 bool ASMs3D::assembleL2matrices (SparseMatrix& A, StdVector& B,
-                                 const IntegrandBase& integrand,
+                                 const L2Integrand& integrand,
                                  bool continuous) const
 {
   const size_t nnod = this->getNoProjectionNodes();
@@ -211,7 +212,7 @@ bool ASMs3D::assembleL2matrices (SparseMatrix& A, StdVector& B,
 
   // Evaluate the secondary solution at all integration points
   Matrix sField;
-  if (!this->evalSolution(sField,integrand,gpar.data()))
+  if (!integrand.evaluate(sField,gpar.data()))
   {
     std::cerr <<" *** ASMs3D::assembleL2matrices: Failed for patch "<< idx+1
               <<" nPoints="<< gpar[0].size()*gpar[1].size()*gpar[2].size()

--- a/src/ASM/GlbL2projector.h
+++ b/src/ASM/GlbL2projector.h
@@ -18,6 +18,7 @@
 #include "LinAlgenums.h"
 #include "MatVec.h"
 
+class ASMbase;
 class IntegrandBase;
 class FunctionBase;
 class LinSolParams;
@@ -28,6 +29,75 @@ class ProcessAdm;
 typedef std::vector<int>           IntVec;      //!< Vector of integers
 typedef std::vector<size_t>        uIntVec;     //!< Vector of unsigned integers
 typedef std::vector<FunctionBase*> FunctionVec; //!< Vector of functions
+
+/*!
+  \brief Abstract class for evaluating integrand or function.
+*/
+
+class L2Integrand {
+public:
+  //! \brief Constructor.
+  //! \param patch ASM holding geometry to evaluate on
+  L2Integrand(const ASMbase& patch) : m_patch(patch) {}
+
+  //! \brief Evaluates the entity in a set of points.
+  //! \param sField Matrix with results
+  //! \param gpar Points to evaluate in
+  virtual bool evaluate(Matrix& sField, const RealArray* gpar) const = 0;
+
+  //! \brief Returns dimension of entity to evaluate.
+  virtual size_t dim() const = 0;
+
+protected:
+  const ASMbase& m_patch; //!< Reference to ASM holding geometry
+};
+
+/*!
+  \brief Evaluation class for secondary solutions of an integrand.
+*/
+
+class L2ProbIntegrand : public L2Integrand {
+public:
+  //! \brief Constructor.
+  //! \param patch ASM holding geometry to evaluate on
+  //! \param itg Integrand to evaluate
+  L2ProbIntegrand(const ASMbase& patch, const IntegrandBase& itg);
+
+  //! \brief Evaluates the secondary solutions in a set of points.
+  //! \param sField Matrix with results
+  //! \param gpar Points to evaluate in
+  bool evaluate(Matrix& sField, const RealArray* gpar) const override;
+
+  //! \brief Returns number of secondary solutions.
+  size_t dim() const override;
+
+private:
+  const IntegrandBase& m_itg; //!< Reference to integrand
+};
+
+
+/*!
+  \brief Evaluation class for functions.
+*/
+
+class L2FuncIntegrand : public L2Integrand {
+public:
+  //! \brief Constructor.
+  //! \param patch ASM holding geometry to evaluate on
+  //! \param func Function to evaluate
+  L2FuncIntegrand(const ASMbase& patch, const FunctionBase& func);
+
+  //! \brief Evaluates the function in a set of points.
+  //! \param sField Matrix with results
+  //! \param gpar Points to evaluate in
+  bool evaluate(Matrix& sField, const RealArray* gpar) const override;
+
+  //! \brief Returns number of function components.
+  size_t dim() const override;
+
+private:
+  const FunctionBase& m_func; //!< Reference to function
+};
 
 
 /*!

--- a/src/ASM/LR/ASMLRSpline.C
+++ b/src/ASM/LR/ASMLRSpline.C
@@ -493,3 +493,39 @@ void ASMLRSpline::analyzeThreadGroups(const IntMat& groups)
              << ").\n";
 
 }
+
+
+bool ASMLRSpline::getParameterDomain(Real2DMat& u, IntVec* corners) const
+{
+  u.resize(geo->nVariate(),RealArray(2));
+  for (int i = 0; i < geo->nVariate(); ++i) {
+    u[i][0] = geo->startparam(i);
+    u[i][1] = geo->endparam(i);
+  }
+
+  if (corners) {
+    if (geo->nVariate() == 2) {
+      for (int J = 0; J < 2; ++J)
+        for (int I = 0; I < 2; ++I) {
+          std::vector<LR::Basisfunction*> funcs;
+          int dir = (I > 0 ? LR::EAST : LR::WEST) |
+                    (J > 0 ? LR::NORTH : LR::SOUTH);
+          geo->getEdgeFunctions(funcs, static_cast<LR::parameterEdge>(dir));
+          corners->push_back(funcs.front()->getId()+1);
+        }
+    } else if (geo->nVariate() == 3) {
+      for (int K = 0; K < 2; ++K)
+        for (int J = 0; J < 2; ++J)
+          for (int I = 0; I < 2; ++I) {
+            std::vector<LR::Basisfunction*> funcs;
+            int dir = (I > 0 ? LR::EAST  : LR::WEST)  |
+                      (J > 0 ? LR::NORTH : LR::SOUTH) |
+                      (K > 0 ? LR::TOP   : LR::BOTTOM);
+            geo->getEdgeFunctions(funcs, static_cast<LR::parameterEdge>(dir));
+            corners->push_back(funcs.front()->getId()+1);
+          }
+    }
+  }
+
+  return true;
+}

--- a/src/ASM/LR/ASMLRSpline.h
+++ b/src/ASM/LR/ASMLRSpline.h
@@ -88,7 +88,7 @@ public:
   virtual bool empty() const { return geo == nullptr; }
 
   //! \brief Returns parameter values and node numbers of the domain corners.
-  virtual bool getParameterDomain(Real2DMat&, IntVec*) const { return false; }
+  virtual bool getParameterDomain(Real2DMat&, IntVec*) const;
 
   //! \brief Refines the mesh adaptively.
   //! \param[in] prm Input data used to control the mesh refinement

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -522,7 +522,7 @@ protected:
   //! \param[in] integrand Object with problem-specific data and methods
   //! \param[in] continuous If \e false, a discrete L2-projection is used
   virtual bool assembleL2matrices(SparseMatrix& A, StdVector& B,
-                                  const IntegrandBase& integrand,
+                                  const L2Integrand& integrand,
                                   bool continuous) const;
 
   //! \brief Connects all matching nodes on two adjacent boundary edges.

--- a/src/ASM/LR/ASMu2Drecovery.C
+++ b/src/ASM/LR/ASMu2Drecovery.C
@@ -18,6 +18,7 @@
 #include "IntegrandBase.h"
 #include "CoordinateMapping.h"
 #include "GaussQuadrature.h"
+#include "GlbL2projector.h"
 #include "SparseMatrix.h"
 #include "DenseMatrix.h"
 #include "SplineUtils.h"
@@ -99,7 +100,7 @@ LR::LRSpline* ASMu2D::evalSolution (const IntegrandBase& integrand) const
 
 
 bool ASMu2D::assembleL2matrices (SparseMatrix& A, StdVector& B,
-                                 const IntegrandBase& integrand,
+                                 const L2Integrand& integrand,
                                  bool continuous) const
 {
   size_t nnod = this->getNoProjectionNodes();
@@ -166,7 +167,7 @@ bool ASMu2D::assembleL2matrices (SparseMatrix& A, StdVector& B,
 
       // Evaluate the secondary solution at all integration points
       Matrix sField;
-      if (!this->evalSolution(sField,integrand,unstrGpar.data())) {
+      if (!integrand.evaluate(sField,unstrGpar.data())) {
         ok = false;
         continue;
       }

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -506,7 +506,7 @@ protected:
   //! \param[in] integrand Object with problem-specific data and methods
   //! \param[in] continuous If \e false, a discrete L2-projection is used
   virtual bool assembleL2matrices(SparseMatrix& A, StdVector& B,
-                                  const IntegrandBase& integrand,
+                                  const L2Integrand& integrand,
                                   bool continuous) const;
 
   //! \brief Connects all matching nodes on two adjacent boundary faces.

--- a/src/ASM/LR/ASMu3Drecovery.C
+++ b/src/ASM/LR/ASMu3Drecovery.C
@@ -18,6 +18,7 @@
 #include "IntegrandBase.h"
 #include "CoordinateMapping.h"
 #include "GaussQuadrature.h"
+#include "GlbL2projector.h"
 #include "SparseMatrix.h"
 #include "DenseMatrix.h"
 #include "SplineUtils.h"
@@ -103,7 +104,7 @@ LR::LRSpline* ASMu3D::evalSolution (const IntegrandBase& integrand) const
 
 
 bool ASMu3D::assembleL2matrices (SparseMatrix& A, StdVector& B,
-                                 const IntegrandBase& integrand,
+                                 const L2Integrand& integrand,
                                  bool continuous) const
 {
   size_t nnod = this->getNoProjectionNodes();
@@ -174,7 +175,7 @@ bool ASMu3D::assembleL2matrices (SparseMatrix& A, StdVector& B,
 
       // Evaluate the secondary solution at all integration points
       Matrix sField;
-      if (!this->evalSolution(sField,integrand,unstrGpar.data())) {
+      if (!integrand.evaluate(sField,unstrGpar.data())) {
         ok = false;
         continue;
       }


### PR DESCRIPTION
I need this in the Stokes application (to use projected source functions). And since I have separate projection bases there, the current support does not cut it.

@kmokstad I am sure you have some opinion here. I can do it however you see fit, this does the job...