### PR TITLE
Fixed: Using direction-dependent Gauss quadrature on face integrals

### DIFF
--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -187,6 +187,10 @@ void ASMs2D::clear (bool retainGeometry)
   myNodeInd.clear();
   xnMap.clear();
   nxMap.clear();
+
+  // Erase threading group data
+  threadGroups[0].clear();
+  threadGroups[1].clear();
 }
 
 

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -157,6 +157,11 @@ void ASMs3D::clear (bool retainGeometry)
   myNodeInd.clear();
   xnMap.clear();
   nxMap.clear();
+
+  // Erase threading group data
+  threadGroupsVol[0].clear();
+  threadGroupsVol[1].clear();
+  threadGroupsFace.clear();
 }
 
 

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -672,13 +672,6 @@ protected:
                        std::vector<utl::Point>& XC) const;
 
   //! \brief Generates element groups for multi-threading of interior integrals.
-  //! \param[in] integrand Object with problem-specific data and methods
-  //! \param[in] silence If \e true, suppress threading group outprint
-  //! \param[in] ignoreGlobalLM Sanity check option
-  virtual void generateThreadGroups(const Integrand& integrand, bool silence,
-                                    bool ignoreGlobalLM);
-
-  //! \brief Generates element groups for multi-threading of interior integrals.
   //! \param[in] strip1 Strip width in first direction
   //! \param[in] strip2 Strip width in second direction
   //! \param[in] strip3 Strip width in third direction
@@ -686,6 +679,14 @@ protected:
   //! \param[in] ignoreGlobalLM Sanity check option
   void generateThreadGroups(size_t strip1, size_t strip2, size_t strip3,
                             bool silence, bool ignoreGlobalLM);
+
+public:
+  //! \brief Generates element groups for multi-threading of interior integrals.
+  //! \param[in] integrand Object with problem-specific data and methods
+  //! \param[in] silence If \e true, suppress threading group outprint
+  //! \param[in] ignoreGlobalLM Sanity check option
+  virtual void generateThreadGroups(const Integrand& integrand, bool silence,
+                                    bool ignoreGlobalLM);
 
   //! \brief Generates element groups for multi-threading of boundary integrals.
   //! \param[in] lIndex Local index [1,6] of the boundary face
@@ -695,7 +696,6 @@ protected:
   //! \brief Generates element groups from a partition.
   virtual void generateThreadGroupsFromElms(const IntVec& elms);
 
-public:
   //! \brief Auxilliary function for computation of basis function indices.
   static void scatterInd(int n1, int n2, int n3, int p1, int p2, int p3,
 			 const int* start, IntVec& index);

--- a/src/ASM/LR/ASMLRSpline.h
+++ b/src/ASM/LR/ASMLRSpline.h
@@ -178,6 +178,9 @@ public:
   //! \brief Returns the coordinates of the element center.
   virtual Vec3 getElementCenter(int iel) const;
 
+  //! \brief Computes the total number of integration points in this patch.
+  virtual void getNoIntPoints(size_t& nPt, size_t& nIPt);
+
 protected:
   //! \brief Refines the mesh adaptively.
   //! \param[in] prm Input data used to control the mesh refinement
@@ -188,15 +191,15 @@ protected:
   virtual int evalPoint(int iel, const double* param, Vec3& X) const = 0;
 
   //! \brief Santity check thread groups.
-  //! \param groups The generated thread groups
-  //! \param bases The bases to check for
-  //! \param threadBasis The LRSpline the element groups are derived from
+  //! \param[in] groups The generated thread groups
+  //! \param[in] bases The bases to check for
+  //! \param[in] threadBasis The LRSpline the element groups are derived from
   static bool checkThreadGroups(const IntMat& groups,
-                                const std::vector<const LR::LRSpline*> bases,
+                                const std::vector<const LR::LRSpline*>& bases,
                                 const LR::LRSpline* threadBasis);
 
   //! \brief Analyze and print thread group statistics.
-  //! \param groups The generated thread groups
+  //! \param[in] groups The generated thread groups
   static void analyzeThreadGroups(const IntMat& groups);
 
   LR::LRSpline* geo; //!< Pointer to the actual spline geometry object

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -1982,6 +1982,30 @@ int ASMu3D::getCorner(int I, int J, int K, int basis) const
 }
 
 
+void ASMu3D::getNoBouPoints (size_t& nPt, char ldim, char lindx)
+{
+  size_t nGp = 1;
+  if (nGauss > 0 && nGauss <= 10)
+    for (char d = 0; d < ldim; d++)
+      nGp *= nGauss;
+  else if (ldim == 2)
+  {
+    // Use polynomial order to define number of quadrature points
+    int p[3] = { 0, 0, 0 };
+    this->getOrder(p[0],p[1],p[2]);
+    p[(lindx-1)/2] = 1;
+    int nG = std::max(std::max(p[0],p[1]),p[2]);
+    nGp = nG*nG;
+  }
+  else
+    nGp = 0;
+
+  firstBp[lindx] = nPt;
+
+  nPt += this->getNoBoundaryElms(lindx,ldim)*nGp;
+}
+
+
 void ASMu3D::generateThreadGroups (const Integrand& integrand, bool silence,
                                    bool ignoreGlobalLM)
 {

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -277,6 +277,9 @@ public:
   // These are the main computational methods of the ASM class hierarchy.
   // ====================================================================
 
+  //! \brief Computes the number of boundary integration points in this patch.
+  virtual void getNoBouPoints(size_t& nPt, char ldim, char lindx);
+
   //! \brief Evaluates an integral over the interior patch domain.
   //! \param integrand Object with problem-specific data and methods
   //! \param glbInt The integrated quantity


### PR DESCRIPTION
This is needed for `<nGauss default="0"/>` to work properly when we have neumann conditions on 3D elements with different polynomial orders in the three parameter direction. Mostly for enabling correct export of traction vector arrows to VTF.