### PR TITLE
Fixed: Account for boundary MPC couplings when choosing stripe direction

### DIFF
--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -717,8 +717,9 @@ public:
   //! \param[in] Xmaster Position of the master nodal point
   //! \param[in] extraPt If \e true, the master point is not a patch node
   //! \return \e true if a new global node was added, otherwise \e false
-  bool addRigidCpl(int lindx, int ldim, int basis,
-                   int& gMaster, const Vec3& Xmaster, bool extraPt = true);
+  virtual bool addRigidCpl(int lindx, int ldim, int basis,
+                           int& gMaster, const Vec3& Xmaster,
+                           bool extraPt = true);
 
 protected:
 

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -313,6 +313,17 @@ public:
   //! \param[in] basis Which basis to collapse edge for
   virtual bool collapseEdge(int dir, int basis = 1);
 
+  //! \brief Adds MPCs representing a rigid coupling to this patch.
+  //! \param[in] lindx Local index of the boundary item that should be rigid
+  //! \param[in] ldim Dimension of the boundary item that should be rigid
+  //! \param[in] basis Which basis to add rigid coupling for (mixed methods)
+  //! \param gMaster Global node number of the master node
+  //! \param[in] Xmaster Position of the master nodal point
+  //! \param[in] extraPt If \e true, the master point is not a patch node
+  //! \return \e true if a new global node was added, otherwise \e false
+  virtual bool addRigidCpl(int lindx, int ldim, int basis,
+                           int& gMaster, const Vec3& Xmaster, bool extraPt);
+
   //! \brief Sets the global node numbers for this patch.
   //! \param[in] nodes Vector of global node numbers (zero-based)
   virtual void setNodeNumbers(const IntVec& nodes);

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -377,6 +377,17 @@ public:
   //! \param[in] basis Which basis to collapse face for
   virtual bool collapseFace(int face, int edge = 0, int basis = 1);
 
+  //! \brief Adds MPCs representing a rigid coupling to this patch.
+  //! \param[in] lindx Local index of the boundary item that should be rigid
+  //! \param[in] ldim Dimension of the boundary item that should be rigid
+  //! \param[in] basis Which basis to add rigid coupling for (mixed methods)
+  //! \param gMaster Global node number of the master node
+  //! \param[in] Xmaster Position of the master nodal point
+  //! \param[in] extraPt If \e true, the master point is not a patch node
+  //! \return \e true if a new global node was added, otherwise \e false
+  virtual bool addRigidCpl(int lindx, int ldim, int basis,
+                           int& gMaster, const Vec3& Xmaster, bool extraPt);
+
   //! \brief Sets the global node numbers for this patch.
   //! \param[in] nodes Vector of global node numbers (zero-based)
   virtual void setNodeNumbers(const IntVec& nodes);

--- a/src/Utility/Test/TestThreadGroups.C
+++ b/src/Utility/Test/TestThreadGroups.C
@@ -59,7 +59,7 @@ TEST(TestThreadGroups, Groups2D)
   std::vector<bool> b24(4, true);
 
   for (int i = 0; i < 2; ++i) {
-    ThreadGroups group((ThreadGroups::StripDirection)i);
+    ThreadGroups group((ThreadGroups::StripDirection)(i+1));
     group.calcGroups(b14, b24, 1, 1);
 #ifdef USE_OPENMP
     const int ref1[4][4] = {{0,4,8,12}, {2,6,10,14},

--- a/src/Utility/ThreadGroups.h
+++ b/src/Utility/ThreadGroups.h
@@ -30,7 +30,7 @@ class ThreadGroups
 
 public:
   //! Directions to consider for element stripes.
-  enum StripDirection { U, V, W, ANY };
+  enum StripDirection { NONE, U, V, W, ANY };
 
   //! \brief Default constructor.
   explicit ThreadGroups(StripDirection dir = ANY) : stripDir(dir) {}
@@ -83,8 +83,7 @@ public:
   //! \brief Indexing operator.
   IntMat& operator[](int i) { return tg[i]; }
 
-  //! \brief Filter current threadgroups through a white list of elements.
-  //! \param[in] elmList The white list of elements
+  //! \brief Filters current threading groups through a white-list of elements.
   ThreadGroups filter(const IntVec& elmList) const;
 
 protected:


### PR DESCRIPTION
With this the K-joint model with rigid couplings at the ends also works when using multi-threading.