### PR TITLE
Input stream operators for matrices and vectors and congruence transformation fix

### DIFF
--- a/src/LinAlg/MatVec.C
+++ b/src/LinAlg/MatVec.C
@@ -80,19 +80,19 @@ Matrix utl::operator* (const Matrix& A, const Matrix& B)
 
 /*!
   The following matrix multiplication is performed by this function:
-  \f[ {\bf A} = {\bf T}^T{\bf A}{\bf T} \f]
+  \f[ {\bf A} = {\bf T}{\bf A}{\bf T}^T \f]
   where \b A is a full, symmetric matrix, and \b T is an identity matrix
   with the nodal sub-matrix \b Tn inserted on the diagonal.
 */
 
-bool utl::transform (Matrix& A, const Matrix& T, size_t K)
+bool utl::transform (Matrix& A, const Matrix& Tn, size_t K)
 {
   size_t M = A.rows();
-  size_t N = T.rows();
-  if (M < A.cols() || N < T.cols()) return false;
+  size_t N = Tn.rows();
+  if (M < A.cols() || N < Tn.cols()) return false;
   if (K < 1 || K+N-1 > M || N > 3) return false;
 
-  Real WA[3] = {};
+  Real WA[N];
   size_t i, ii, j, jj, l, KN = K+N-1;
   for (jj = K; jj <= M; jj++)
   {
@@ -100,7 +100,7 @@ bool utl::transform (Matrix& A, const Matrix& T, size_t K)
     {
       WA[i-1] = Real(0);
       for (l = 1, ii = K; l <= N; l++, ii++)
-	WA[i-1] += T(l,i)*A(ii,jj);
+        WA[i-1] += Tn(i,l)*A(ii,jj);
     }
     ii = K;
     for (i = 1; i <= N; i++, ii++)
@@ -117,7 +117,7 @@ bool utl::transform (Matrix& A, const Matrix& T, size_t K)
     {
       WA[j-1] = Real(0);
       for (l = 1, jj = K; l <= N; l++, jj++)
-	WA[j-1] += A(ii,jj)*T(l,j);
+        WA[j-1] += A(ii,jj)*Tn(j,l);
     }
     jj = ii > K ? ii : K;
     for (j = JS; j <= N; j++, jj++)
@@ -140,21 +140,21 @@ bool utl::transform (Matrix& A, const Matrix& T, size_t K)
   the identity matrix with the nodal sub-matrix \b Tn inserted on the diagonal.
 */
 
-bool utl::transform (Vector& V, const Matrix& T, size_t K, bool transpose)
+bool utl::transform (Vector& V, const Matrix& Tn, size_t K, bool transpose)
 {
   size_t M = V.size();
-  size_t N = T.rows();
-  if (N < T.cols()) return false;
+  size_t N = Tn.rows();
+  if (N < Tn.cols()) return false;
   if (K < 1 || K+N-1 > M || N > 3) return false;
 
-  Real WA[3] = {};
+  Real WA[N];
   size_t i, ii, j;
   if (transpose)
     for (i = 1; i <= N; i++)
     {
       WA[i-1] = Real(0);
       for (j = 1, ii = K; j <= N; j++, ii++)
-	WA[i-1] += T(j,i)*V(ii);
+        WA[i-1] += Tn(j,i)*V(ii);
     }
 
   else
@@ -162,7 +162,7 @@ bool utl::transform (Vector& V, const Matrix& T, size_t K, bool transpose)
     {
       WA[i-1] = Real(0);
       for (j = 1, ii = K; j <= N; j++, ii++)
-	WA[i-1] += T(i,j)*V(ii);
+        WA[i-1] += Tn(i,j)*V(ii);
     }
 
   for (i = 0, ii = K; i < N; i++, ii++)

--- a/src/LinAlg/MatVec.h
+++ b/src/LinAlg/MatVec.h
@@ -82,16 +82,16 @@ namespace utl
 
   //! \brief Congruence transformation of a symmetric matrix.
   //! \param A The matrix to be transformed
-  //! \param[in] T Nodal transformation matrix
-  //! \param[in] K Index telling where to insert \b T on the diagonal
-  bool transform(Matrix& A, const Matrix& T, size_t K);
+  //! \param[in] Tn Nodal transformation matrix
+  //! \param[in] K Index telling where to insert \b Tn on the diagonal
+  bool transform(Matrix& A, const Matrix& Tn, size_t K);
 
   //! \brief Congruence transformation of a vector.
   //! \param V The vector to be transformed
-  //! \param[in] T Nodal transformation matrix
-  //! \param[in] K Index telling where to insert \b T on the diagonal
+  //! \param[in] Tn Nodal transformation matrix
+  //! \param[in] K Index telling where to insert \b Tn on the diagonal
   //! \param[in] transpose If \e true, the transpose of \b T is used instead
-  bool transform(Vector& V, const Matrix& T, size_t K, bool transpose = false);
+  bool transform(Vector& V, const Matrix& Tn, size_t K, bool transpose = false);
 
   //! \brief Inverts the square matrix \b A.
   bool invert(Matrix& A);

--- a/src/LinAlg/Test/TestMatrix.C
+++ b/src/LinAlg/Test/TestMatrix.C
@@ -112,6 +112,90 @@ TEST(TestMatrix, Norm)
 }
 
 
+TEST(TestMatrix, Read)
+{
+  utl::vector<double> a(26);
+  utl::matrix<double> A(2,3);
+  std::iota(a.begin(),a.end(),1.0);
+  std::iota(A.begin(),A.end(),1.0);
+  std::cout <<"a:"<< a;
+  std::cout <<"A:"<< A;
+
+  auto&& checkVector = [&a](const char* fname)
+  {
+    std::ifstream is(fname,std::ios::in);
+    utl::vector<double> b;
+    is >> b;
+    std::cout <<"b:"<< b;
+    ASSERT_EQ(a.size(),b.size());
+    for (size_t i = 1; i <= a.size(); i++)
+      EXPECT_NEAR(a(i), b(i), 1.0e-13);
+  };
+
+  auto&& checkMatrix = [&A](const char* fname)
+  {
+    std::ifstream is(fname,std::ios::in);
+    utl::matrix<double> B;
+    is >> B;
+    std::cout <<"B:"<< B;
+    ASSERT_EQ(A.rows(),B.rows());
+    ASSERT_EQ(A.cols(),B.cols());
+    for (size_t i = 1; i <= A.rows(); i++)
+      for (size_t j = 1; j <= A.cols(); j++)
+        EXPECT_NEAR(A(i,j), B(i,j), 1.0e-13);
+  };
+
+  const char* fname0 = "/tmp/testVector.dat";
+  const char* fname1 = "/tmp/testMatrix1.dat";
+  const char* fname2 = "/tmp/testMatrix2.dat";
+  const char* fname3 = "/tmp/testMatrix3.dat";
+  const char* fname4 = "/tmp/testMatrix4.dat";
+
+  std::ofstream os(fname0);
+  os << a.size() << a;
+  os.close();
+
+  os.open(fname1);
+  os << A.rows() <<' '<< A.cols() << A;
+  os.close();
+
+  os.open(fname2);
+  os << A.rows() <<' '<< A.cols();
+  for (size_t i = 1; i <= A.rows(); i++)
+    for (size_t j = 1; j <= A.cols(); j++)
+      os << (j == 1 ? '\n' : ' ') << A(i,j);
+  os <<'\n';
+  os.close();
+
+  checkVector(fname0);
+  checkMatrix(fname1);
+  checkMatrix(fname2);
+
+  double value = 0.0;
+  A.resize(6,6);
+  for (size_t i = 1; i <= A.rows(); i++)
+    for (size_t j = i; j <= A.cols(); j++)
+      A(i,j) = A(j,i) = ++value;
+  std::cout <<"Symmetric A:"<< A;
+
+  os.open(fname3);
+  os <<"Symmetric: "<< A.rows() << A;
+  os.close();
+
+  checkMatrix(fname3);
+
+  std::iota(A.begin(),A.end(),1.0);
+  std::cout <<"Non-symmetric A:"<< A;
+  os.open(fname4);
+  os <<"Column-oriented: "<< A.rows() <<" "<< A.cols();
+  for (double v : A) os <<"\n"<< v;
+  os <<"\n";
+  os.close();
+
+  checkMatrix(fname4);
+}
+
+
 TEST(TestMatrix3D, Trace)
 {
   utl::matrix3d<double> a(4,3,3);


### PR DESCRIPTION
The first commit is to be used for input of superelement matrices (reduced-order-models).
The second commit fixes the local-to-global transformation of beam element matrices in IFEM-Elasticity.