### PR TITLE
Changed: Let IntegrandBase::parse() return false by default

### DIFF
--- a/src/ASM/IntegrandBase.h
+++ b/src/ASM/IntegrandBase.h
@@ -49,7 +49,7 @@ public:
   virtual ~IntegrandBase() {}
 
   //! \brief Parses a data section from an XML element.
-  virtual bool parse(const TiXmlElement*) { return true; }
+  virtual bool parse(const TiXmlElement*) { return false; }
 
   //! \brief Prints out the problem definition to the log stream.
   virtual void printLog() const {}


### PR DESCRIPTION
To ensure consistent behavior when parsing app-specific input