### PR TITLE
Fixed: Clear all (including shared) FE arrays after refinement

### DIFF
--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -149,6 +149,11 @@ void ASMbase::clear (bool retainGeometry)
     // Clear all FE structures, including the elements
     myMLGE.clear();
     myMNPC.clear();
+    if (shareFE == 'F')
+    {
+      const_cast<IntVec&>(MLGE).clear();
+      const_cast<IntMat&>(MNPC).clear();
+    }
   }
   else // Don't erase the elements, but set them to have zero nodes
     for (IntVec& mnpc : myMNPC)
@@ -163,6 +168,9 @@ void ASMbase::clear (bool retainGeometry)
   myRmaster.clear();
 
   myMLGN.clear();
+  if (shareFE == 'F')
+    const_cast<IntVec&>(MLGN).clear();
+
   BCode.clear();
   dCode.clear();
   mpcs.clear();

--- a/src/ASM/LR/ASMLRSpline.C
+++ b/src/ASM/LR/ASMLRSpline.C
@@ -304,6 +304,7 @@ bool ASMLRSpline::doRefine (const LR::RefineData& prm, LR::LRSpline* lrspline)
     lrspline->refineElement(prm.elements);
 
   lrspline->generateIDs();
+  this->clear(true);
 
   return doRefine;
 }


### PR DESCRIPTION
This replaces the temporary fix OPM/IFEM-OpenFrac#55.

Whenever the mesh is refined, the existing FE topology structures are no longer valid and should be cleared.
For shared patches, one must also clear the shared arrays (MLGN, MLGE and MNPC).