### PR TITLE
simplification in DataExporter

### DIFF
--- a/src/Utility/DataExporter.C
+++ b/src/Utility/DataExporter.C
@@ -77,11 +77,6 @@ bool DataExporter::registerWriter (DataWriter* writer, bool info, bool data)
 {
   m_writers.push_back(writer);
 
-  if (info)
-    m_infoReader = writer;
-  if (data)
-    m_dataReader = writer;
-
   return true;
 }
 
@@ -124,33 +119,31 @@ bool DataExporter::dumpTimeLevel (const TimeStep* tp, bool geometryUpdated)
   if (m_level == -1)
     m_level = this->getWritersTimeLevel()+1;
 
-  std::map<std::string,FileEntry>::iterator it;
   for (DataWriter* writer : m_writers) {
     writer->openFile(m_level);
-    for (it = m_entry.begin(); it != m_entry.end(); ++it) {
-      if (!it->second.data)
+    for (const DataEntry& it : m_entry) {
+      if (!it.second.data)
         return false;
-      switch (it->second.field) {
+      switch (it.second.field) {
         case INTVECTOR:
         case VECTOR:
-          writer->writeVector(m_level,*it);
+          writer->writeVector(m_level,it);
           break;
         case SIM:
-          if (writeData)
-            writer->writeSIM(m_level,*it,geometryUpdated,it->second.prefix);
+          writer->writeSIM(m_level,it,geometryUpdated,it.second.prefix);
           break;
         case NODALFORCES:
-          writer->writeNodalForces(m_level,*it);
+          writer->writeNodalForces(m_level,it);
           break;
         case KNOTSPAN:
-          writer->writeKnotspan(m_level,*it,it->second.prefix);
+          writer->writeKnotspan(m_level,it,it.second.prefix);
           break;
         case BASIS:
-          writer->writeBasis(m_level,*it,it->second.prefix);
+          writer->writeBasis(m_level,it,it.second.prefix);
           break;
         default:
           std::cerr <<"  ** DataExporter: Invalid field type registered "
-                    << it->second.field <<", skipping"<< std::endl;
+                    << it.second.field <<", skipping"<< std::endl;
           break;
       }
     }
@@ -162,9 +155,9 @@ bool DataExporter::dumpTimeLevel (const TimeStep* tp, bool geometryUpdated)
   m_level++;
 
   // disable fields marked as once
-  for (it = m_entry.begin(); it != m_entry.end(); ++it)
-    if (abs(it->second.results) & ONCE)
-      it->second.enabled = false;
+  for (auto& it : m_entry)
+    if (abs(it.second.results) & ONCE)
+      it.second.enabled = false;
 
   return true;
 }

--- a/src/Utility/DataExporter.h
+++ b/src/Utility/DataExporter.h
@@ -81,7 +81,7 @@ public:
   //! \param[in] ndump Interval between dumps
   DataExporter(bool dynWriters = false, int ndump=1) :
     m_delete(dynWriters), m_level(-1), m_ndump(ndump),
-    m_last_step(-1), m_infoReader(0), m_dataReader(0) {}
+    m_last_step(-1) {}
 
   //! \brief The destructor deletes the writers if \a dynWriters was \e true.
   virtual ~DataExporter();
@@ -154,9 +154,6 @@ protected:
   int  m_level;     //!< Current time level
   int  m_ndump;     //!< Time level stride for dumping
   int  m_last_step; //!< Last time step we dumped for
-
-  DataWriter* m_infoReader; //!< DataWriter to read data information from
-  DataWriter* m_dataReader; //!< DataWriter to read numerical data from
 };
 
 //! \brief Convenience type


### PR DESCRIPTION
- remove unused members
- use ranged for
- remove unnecessary if (we return early if writeData is false)