### PR TITLE
Fixed: std::iota declared in numeric header

### DIFF
--- a/src/ASM/ASMsupel.C
+++ b/src/ASM/ASMsupel.C
@@ -11,6 +11,8 @@
 //!
 //==============================================================================
 
+#include <numeric>
+
 #include "ASMsupel.h"
 #include "GlobalIntegral.h"
 #include "ElementBlock.h"


### PR DESCRIPTION
At least, I'm unable to compile without this.