### PR TITLE
Output of lagrangian mesh for superelement patches to HDF5

### DIFF
--- a/Apps/Common/SIMSolverAdap.h
+++ b/Apps/Common/SIMSolverAdap.h
@@ -85,18 +85,11 @@ public:
     if (!aSim.initAdaptor())
       return 1;
 
-    if (SIMSolverStat<T1>::exporter) {
+    if (SIMSolverStat<T1>::exporter)
       SIMSolverStat<T1>::exporter->setFieldValue(exporterName, &this->S1,
                                                  &aSim.getSolution(),
                                                  &aSim.getProjections(),
                                                  &aSim.getEnorm());
-      if (!this->S1.opt.project.empty()) {
-        std::vector<std::string> pref;
-        for (const auto& it : this->S1.opt.project)
-          pref.push_back(it.second);
-        SIMSolverStat<T1>::exporter->setNormPrefixes(pref);
-      }
-    }
 
     for (int iStep = 1; aSim.adaptMesh(iStep); iStep++)
       if (!aSim.solveStep(infile,iStep))
@@ -152,11 +145,6 @@ public:
     if (!this->S1.initAdapPrm())
       return 1;
 
-    std::vector<std::string> prefix = this->S1.getNormPrefixes();
-
-    if (this->exporter)
-      this->exporter->setNormPrefixes(prefix);
-
     int geoBlk = 0, nBlock = 0;
     for (int iStep = 1; this->S1.adaptMesh(iStep); iStep++) {
       IFEM::cout <<"\nAdaptive step "<< iStep << std::endl;
@@ -164,7 +152,7 @@ public:
         return 1;
       else if (!this->S1.projectNorms(iStep))
         return 2;
-      else if (!this->saveState(geoBlk,nBlock,iStep,infile,prefix))
+      else if (!this->saveState(geoBlk,nBlock,iStep,infile))
         return 3;
     }
 
@@ -179,8 +167,7 @@ public:
 
 protected:
   //! \brief Saves geometry and results to VTF and HDF5 for current time step.
-  bool saveState(int& geoBlk, int& nBlock, int iStep, char* infile,
-                 const std::vector<std::string>& prefix)
+  bool saveState(int& geoBlk, int& nBlock, int iStep, char* infile)
   {
     if (!this->S1.saveModel(iStep == 1 ? infile : nullptr,geoBlk,nBlock))
       return false;
@@ -188,10 +175,10 @@ protected:
     TimeStep tp;
     tp.step = iStep;
 
-    if (!this->S1.saveElmNorms(iStep,nBlock,prefix))
+    if (!this->S1.saveElmNorms(iStep,nBlock))
       return false;
 
-    if (!this->S1.saveProjections(iStep,nBlock,prefix))
+    if (!this->S1.saveProjections(iStep,nBlock))
       return false;
 
     if (!this->S1.saveStep(tp,nBlock))

--- a/src/ASM/ASMsupel.h
+++ b/src/ASM/ASMsupel.h
@@ -39,8 +39,8 @@ public:
 
   //! \brief Creates an instance by reading the given input stream.
   virtual bool read(std::istream& is);
-  //! \brief Dummy method (basis is unknown).
-  virtual bool write(std::ostream&, int) const { return false; }
+  //! \brief Writes the geometry of the patch to the given stream.
+  virtual bool write(std::ostream&, int) const;
   //! \brief Generates the finite element topology data for this patch.
   virtual bool generateFEMTopology();
   //! \brief Checks if this patch is empty.
@@ -54,7 +54,8 @@ public:
   virtual IntVec& getNodeSet(const std::string& setName);
 
   //! \brief Returns the global coordinates for the given node.
-  //! \param[in] inod 1-based node index local to current patch
+  //! \param[in] inod 1-based node index local to current patch.
+  //! If \a inod is 0, the centroid of the patch is returned.
   virtual Vec3 getCoord(size_t inod) const;
   //! \brief Returns a matrix with all nodal coordinates within the patch.
   //! \param[out] X nsd\f$\times\f$n-matrix, where \a n is the number of nodes

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -2157,7 +2157,7 @@ size_t SIMbase::extractPatchSolution (const Vector& sol, Vector& vec,
     const IntVec& madof = this->getMADOF(basis,nndof);
     pch->extractNodalVec(sol,vec,madof.data(),madof.size());
   }
-  else if (mySam && mySam->getNoNodes('X') > 0)
+  else if (mySam && (mySam->getNoNodes('X') > 0 || this->getMDflag() > 0))
     // Excluding the extraordinary DOFs
     pch->extractNodalVec(sol,vec,mySam->getMADOF(),-2);
   else

--- a/src/SIM/SIMsupel.h
+++ b/src/SIM/SIMsupel.h
@@ -38,6 +38,9 @@ public:
   //! \param[in] resetNumb If \e 'y', start element and node numbers from zero
   virtual bool createFEMmodel(char resetNumb);
 
+  //! \brief Returns the name of this simulator.
+  virtual std::string getName() const { return "SIMsupel"; }
+
 protected:
   using SIMdummy<SIMgeneric>::parse;
   //! \brief Parses a data section from an XML element

--- a/src/Utility/DataExporter.C
+++ b/src/Utility/DataExporter.C
@@ -159,13 +159,6 @@ bool DataExporter::dumpTimeLevel (const TimeStep* tp, bool geoUpd, bool doLog)
 }
 
 
-void DataExporter::setNormPrefixes(const std::vector<std::string>& prefix)
-{
-  for (DataWriter* writer : m_writers)
-    writer->setNormPrefixes(prefix);
-}
-
-
 void DataExporter::OnControl(const TiXmlElement* context)
 {
   const TiXmlElement* child = context->FirstChildElement();

--- a/src/Utility/DataExporter.h
+++ b/src/Utility/DataExporter.h
@@ -119,9 +119,6 @@ public:
   bool dumpTimeLevel(const TimeStep* tp = nullptr,
                      bool geoUpd = false, bool doLog = false);
 
-  //! \brief Sets the prefices used for norm output.
-  void setNormPrefixes(const std::vector<std::string>& prefixes);
-
   //! \brief Callback on receiving a XML control block from external controller.
   virtual void OnControl(const TiXmlElement* context);
   //! \brief Returns context name for callback for external controller.
@@ -222,15 +219,11 @@ public:
   //! \param name Name of log
   virtual bool writeLog(const std::string& data, const std::string& name) = 0;
 
-  //! \brief Sets the prefices used for norm output.
-  void setNormPrefixes(const std::vector<std::string>& prefix) { m_prefix = prefix; }
-
   //! \brief Returns the name of the file
   const std::string& getName() const { return m_name; }
 
 protected:
-  std::string  m_name;   //!< File name
-  std::vector<std::string> m_prefix; //!< The norm prefixes
+  std::string m_name; //!< File name
 
   int m_size; //!< Number of MPI nodes (processors)
   int m_rank; //!< MPI rank (processor ID)

--- a/src/Utility/HDF5Writer.C
+++ b/src/Utility/HDF5Writer.C
@@ -14,7 +14,7 @@
 #include "HDF5Writer.h"
 #include "GlbForceVec.h"
 #include "SIMbase.h"
-#include "ASMbase.h"
+#include "ASMsupel.h"
 #include "IntegrandBase.h"
 #include "TimeStep.h"
 #include "Vec3.h"
@@ -356,6 +356,16 @@ void HDF5Writer::writeSIM (int level, const DataEntry& entry,
       if (results & DataExporter::PRIMARY && !sol->empty()) {
         size_t ndof1 = sim->extractPatchSolution(*sol,psol,pch,entry.second.ncmps,
                                                  usedescription ? 1 : 0);
+        if (dynamic_cast<ASMsupel*>(pch))
+        {
+          // Hack for superelement patches: Expand to include the center node
+          Matrix sField;
+          if (pch->evalSolution(sField,psol,nullptr,0))
+          {
+            psol = sField;
+            ndof1 = psol.size();
+          }
+        }
         const double* data = psol.ptr();
         if (usedescription)
           // Field assumed to be on basis 1 for now


### PR DESCRIPTION
In addition (see second commit), the element norm prefixes are now extracted from the SIM objects instead of storing them separately in the writer class. This is to simplify the HDF5 setup, especially for the multi-dimensional coupled elasticity simulator (see OPM/IFEM-Elasticity#112).

Included here (third commit) is also #469.