### PR TITLE
Restart for time-slab adaptive simulations

### DIFF
--- a/Apps/Common/ISolver.h
+++ b/Apps/Common/ISolver.h
@@ -14,6 +14,7 @@
 #ifndef _I_SOLVER_H_
 #define _I_SOLVER_H_
 
+class ProcessAdm;
 class TimeStep;
 
 
@@ -25,6 +26,9 @@ class TimeStep;
 class ISolver
 {
 public:
+  //! \brief Returns the parallel process administrator.
+  virtual const ProcessAdm& getProcessAdm() const = 0;
+
   //! \brief Opens a new VTF-file and writes the model geometry to it.
   //! \param[in] fileName File name used to construct the VTF-file name from
   //! \param[out] geoBlk Running geometry block counter

--- a/Apps/Common/SIMCoupled.h
+++ b/Apps/Common/SIMCoupled.h
@@ -14,12 +14,13 @@
 #ifndef _SIM_COUPLED_H_
 #define _SIM_COUPLED_H_
 
-#include "Function.h"
 #include "Property.h"
 
 class SIMdependency;
 class ASMbase;
+class ProcessAdm;
 class DataExporter;
+class VecFunc;
 class TimeStep;
 class VTF;
 
@@ -45,6 +46,9 @@ public:
   {
     return S1.preprocess() && S2.preprocess();
   }
+
+  //! \brief Returns the parallel process administrator.
+  const ProcessAdm& getProcessAdm() const { return S1.getProcessAdm(); }
 
   //! \brief Advances the time step one step forward.
   virtual bool advanceStep(TimeStep& tp)

--- a/Apps/Common/SIMCoupled.h
+++ b/Apps/Common/SIMCoupled.h
@@ -50,6 +50,20 @@ public:
   //! \brief Returns the parallel process administrator.
   const ProcessAdm& getProcessAdm() const { return S1.getProcessAdm(); }
 
+  //! \brief Returns current refinement status.
+  int getRefined() const { return S1.getRefined(); }
+
+  //! \brief Returns the name of this (or a substep) simulator.
+  std::string getName(int substep = 1) const
+  {
+    if (substep == 1)
+      return S1.getName();
+    else if (substep == 2)
+      return S2.getName();
+
+    return "SIMCoupled<" + S1.getName() +","+ S2.getName() +">";
+  }
+
   //! \brief Advances the time step one step forward.
   virtual bool advanceStep(TimeStep& tp)
   {

--- a/Apps/Common/SIMExplicitLMM.h
+++ b/Apps/Common/SIMExplicitLMM.h
@@ -56,9 +56,13 @@ public:
   //! \brief Destructor frees up the load vectors.
   ~SIMExplicitLMM()
   {
-    for (auto& v : loads)
+    for (SystemVector*& v : loads)
       delete v;
   }
+
+  //! \brief Returns the parallel process administrator.
+  //! \copydoc ISolver::getProcessAdm
+  const ProcessAdm& getProcessAdm() const { return solver.getProcessAdm(); }
 
   //! \copydoc ISolver::solveStep(TimeStep&)
   bool solveStep(TimeStep& tp)

--- a/Apps/Common/SIMExplicitRK.h
+++ b/Apps/Common/SIMExplicitRK.h
@@ -83,6 +83,10 @@ public:
       RK.order = 0;
   }
 
+  //! \brief Returns the parallel process administrator.
+  //! \copydoc ISolver::getProcessAdm
+  const ProcessAdm& getProcessAdm() const { return solver.getProcessAdm(); }
+
   //! \copydoc ISolver::solveStep(TimeStep&)
   virtual bool solveStep(TimeStep& tp)
   {

--- a/Apps/Common/SIMImplicitLMM.h
+++ b/Apps/Common/SIMImplicitLMM.h
@@ -56,9 +56,13 @@ public:
   //! \brief Destructor frees up the load vectors.
   ~SIMImplicitLMM()
   {
-    for (auto& v : loads)
+    for (SystemVector* v : loads)
       delete v;
   }
+
+  //! \brief Returns the parallel process administrator.
+  //! \copydoc ISolver::getProcessAdm
+  const ProcessAdm& getProcessAdm() const { return solver.getProcessAdm(); }
 
   //! \copydoc ISolver::solveStep(TimeStep&)
   bool solveStep(TimeStep& tp)

--- a/Apps/Common/SIMSolverTS.h
+++ b/Apps/Common/SIMSolverTS.h
@@ -80,7 +80,7 @@ public:
     this->printHeading(heading);
 
     // Pre-adaptive loop, solve for a certain time period on the initial mesh
-    while (this->tp.time.t < aStart && this->advanceStep())
+    while (this->tp.time.t < aStart-1.0e-12 && this->advanceStep())
       if (!this->S1.solveStep(this->tp))
         return 3;
       else if (!this->saveState(geoBlk,nBlock))
@@ -214,6 +214,8 @@ protected:
         maxPred = atoi(value);
       else if ((value = utl::getValue(child,"min_frac")))
         minFrac = atof(value);
+      else if (this->S1.getRefined())
+        continue; // ignore pre-refinement tags if mesh already refined
       else if ((value = utl::getValue(child,"prerefine")))
       {
         if (utl::getAttribute(child,"levels",preRef))

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -165,8 +165,10 @@ public:
   //! It must be invoked only before SIMbase::preprocess() is invoked.
   void setNoFields(unsigned char n) { nf = n; }
 
+  //! \brief Sets the minimum element size for adaptive refinement.
+  virtual void setMinimumSize(double) {}
   //! \brief Defines the minimum element size for adaptive refinement.
-  virtual double getMinimumSize(int) const { return 0.0; }
+  virtual double getMinimumSize(int = 0) const { return 0.0; }
   //! \brief Checks if the specified element is larger than the minimum size.
   virtual bool checkElementSize(int, bool = true) const { return false; }
 

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -203,6 +203,8 @@ public:
   //! \brief Creates a separate projection basis for this patch.
   virtual bool createProjectionBasis(bool init);
 
+  //! \brief Sets the minimum element area for adaptive refinement.
+  virtual void setMinimumSize(double size) { aMin = size; }
   //! \brief Defines the minimum element area for adaptive refinement.
   //! \param[in] nrefinements Maximum number of adaptive refinement levels
   virtual double getMinimumSize(int nrefinements) const;

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -168,6 +168,8 @@ public:
   //! \brief Creates a separate projection basis for this patch.
   virtual bool createProjectionBasis(bool init);
 
+  //! \brief Sets the minimum element volume for adaptive refinement.
+  virtual void setMinimumSize(double size) { vMin = size; }
   //! \brief Defines the minimum element volume for adaptive refinement.
   //! \param[in] nrefinements Maximum number of adaptive refinement levels
   virtual double getMinimumSize(int nrefinements) const;

--- a/src/SIM/MultiStepSIM.C
+++ b/src/SIM/MultiStepSIM.C
@@ -173,12 +173,18 @@ bool MultiStepSIM::saveStep (int iStep, int& rBlock, const char* vecName)
 
 bool MultiStepSIM::serialize (SerializeMap& data) const
 {
+  data["MultiStepSIM::refNorm"] = SIMsolution::serialize(&refNorm,1);
+
   return this->saveSolution(data,model.getName());
 }
 
 
 bool MultiStepSIM::deSerialize (const SerializeMap& data)
 {
+  SerializeMap::const_iterator sit = data.find("MultiStepSIM::refNorm");
+  if (sit != data.end())
+    SIMsolution::deSerialize(sit->second,&refNorm,1);
+
   return this->restoreSolution(data,model.getName());
 }
 

--- a/src/SIM/MultiStepSIM.C
+++ b/src/SIM/MultiStepSIM.C
@@ -259,8 +259,8 @@ bool MultiStepSIM::checkForRestart ()
     return true; // No restart
 
   HDF5Restart::SerializeData data;
-  HDF5Restart hdf(opt.restartFile,adm,1);
-  int restartStep = hdf.readData(data,opt.restartStep);
+  HDF5Restart hdf(opt.restartFile,adm);
+  int restartStep = hdf.readData(data,opt.restartStep-1);
   if (restartStep < 0 || !this->deSerialize(data))
   {
     std::cerr <<" *** Failed to read restart data."<< std::endl;
@@ -269,6 +269,6 @@ bool MultiStepSIM::checkForRestart ()
 
   IFEM::cout <<"\n === Restarting from a serialized state ==="
              <<"\n     file = "<< opt.restartFile
-             <<"\n     step = "<< restartStep << std::endl;
+             <<"\n     step = "<< restartStep+1 << std::endl;
   return true;
 }

--- a/src/SIM/MultiStepSIM.h
+++ b/src/SIM/MultiStepSIM.h
@@ -184,6 +184,11 @@ public:
   //! The default implementation is the same as SIMsolution::theSolutions().
   virtual const Vectors& realSolutions() { return solution; }
 
+  //! \brief Returns a pointer to the reference norm variable.
+  double* theRefNorm() { return &refNorm; }
+  //! \brief Returns const a pointer to the reference norm variable.
+  const double* getRefNorm() const { return &refNorm; }
+
 protected:
   SIMoutput& model;    //!< The isogeometric FE model
   Vector     residual; //!< Residual force vector

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -256,6 +256,12 @@ public:
   //! \param[in] field Name of the displacement increment field to update with
   bool updateGrid(const std::string& field);
 
+  //! \brief Sets the refinement status (for restart of adaptive simulations).
+  //! \param[in] nref Number of refinement levels so far
+  void setRefined(int nref) { isRefined = nref; }
+  //! \brief Returns current refinement status.
+  int getRefined() const { return isRefined; }
+
 
   // Computational methods
   // =====================

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -718,6 +718,11 @@ protected:
   //! \param[in] other If \e true, include other bases in MADOF as well
   bool addMADOF(unsigned char basis, unsigned char nndof, bool other = true);
 
+  //! \brief Returns a pointer to the external energy path integral value.
+  double* theExtEnerg() { return &extEnergy; }
+  //! \brief Returns a const pointer to the external energy path integral value.
+  const double* getExtEnerg() const { return &extEnergy; }
+
 private:
   //! \brief Returns an extraordinary MADOF array.
   //! \param[in] basis The basis to specify number of DOFs for

--- a/src/SIM/SIMinput.h
+++ b/src/SIM/SIMinput.h
@@ -238,7 +238,25 @@ protected:
   //! \param[in] coordCheck If \e false, do not check for matching coordinates
   virtual bool connectPatches(const ASM::Interface& ifc, bool coordCheck) = 0;
 
+  typedef std::map<std::string,std::string> SerializeMap; //!< Convenience type
+
+  //! \brief Writes current basis to a serialization container.
+  //! \param data Container for serialized data
+  bool saveBasis(SerializeMap& data) const;
+
+  //! \brief Restores the basis from a serialization container.
+  //! \param[in] data Container for serialized data
+  bool restoreBasis(const SerializeMap& data);
+
 public:
+  //! \brief Handles application restarts by reading a serialized basis.
+  //! \param[in] restartFile File to read restart basis from
+  //! \param[in] restartStep Index of the time step to read restart basis for
+  //! \return One-based index of the first time step to solve after restart.
+  //! If zero, no restart specified. If one, no serialized basis stored.
+  //! If negative, read failure.
+  int restartBasis(const std::string& restartFile, int restartStep);
+
   //! \brief Creates the computational FEM model from the spline patches.
   //! \param[in] resetNumb If \e 'y', start element and node numbers from zero
   virtual bool createFEMmodel(char resetNumb = 'y');
@@ -255,7 +273,7 @@ public:
   bool setInitialConditions(SIMdependency* fieldHolder = nullptr);
 
   //! \brief Deserialization support (for simulation restart).
-  virtual bool deSerialize(const std::map<std::string,std::string>&);
+  virtual bool deSerialize(const SerializeMap&);
 
   //! \brief Returns reference to a named topology entity.
   const TopEntity& getEntity(const std::string& name) const;

--- a/src/SIM/SIMinput.h
+++ b/src/SIM/SIMinput.h
@@ -313,6 +313,7 @@ protected:
 
 private:
   bool isReading; //!< If \e true, we are reading multiple patch tags
+  bool isSaved;   //!< If \e true, the basis has been serialized
 };
 
 #endif

--- a/src/SIM/TimeStep.C
+++ b/src/SIM/TimeStep.C
@@ -208,7 +208,8 @@ bool TimeStep::reset (int istep)
   }
   lstep = step = 0;
   stepIt = mySteps.begin();
-  stopTime = mySteps.back().second;
+  if (istep == 0)
+    stopTime = mySteps.back().second;
   time.dt = mySteps.front().first.front();
   time.dtn = time.t = time.CFL = 0.0;
   for (int i = 0; i < istep; i++)
@@ -375,7 +376,7 @@ bool TimeStep::deSerialize (const std::map<std::string,std::string>& data)
     std::stringstream str(it->second);
     cereal::BinaryInputArchive ar(str);
     doSerializeOps(ar,*this);
-    return true;
+    return this->reset(step);
   }
 #endif
   return false;

--- a/src/Utility/DataExporter.C
+++ b/src/Utility/DataExporter.C
@@ -95,19 +95,23 @@ bool DataExporter::setFieldValue (const std::string& name,
 bool DataExporter::dumpTimeLevel (const TimeStep* tp, bool geoUpd, bool doLog)
 {
   if (tp) {
-    if (tp->step == m_last_step)
-      return true; // ignore multiple calls for the same time step
-    else if (tp->step % m_ndump > 0)
+    if (tp->step > 0 && tp->step < std::max(0,m_last_step) + m_ndump)
       return true; // write only every m_ndump step
+
+    if (m_last_step < 0)
+      geoUpd = true; // always write geometry basis on first time level
 
     m_last_step = tp->step;
   }
   else if (m_level < 0)
+  {
+    geoUpd = true; // always write geometry basis on first time level
     for (DataWriter* writer : m_writers) {
       int lastLevel = writer->getLastTimeLevel();
       if (lastLevel < m_level || m_level < 0)
         m_level = lastLevel;
     }
+  }
 
   PROFILE1("DataExporter::dumpTimeLevel");
 

--- a/src/Utility/DataExporter.h
+++ b/src/Utility/DataExporter.h
@@ -127,6 +127,8 @@ public:
   //! \brief Returns name from (first) data writer.
   std::string getName() const;
 
+  //! \brief Returns current time level of the exporter.
+  int getTimeLevel() const { return m_level; }
   //! \brief Returns the data dump stride.
   int getStride() const { return m_ndump; }
 

--- a/src/Utility/HDF5Restart.h
+++ b/src/Utility/HDF5Restart.h
@@ -23,7 +23,7 @@ class TimeStep;
 /*!
   \brief Write and read restart data using a HDF5 file.
 
-  \details The HDF5 restart hanlder writes and reads data using a HDF5 file.
+  \details The HDF5 restart handler writes and reads data using a HDF5 file.
   It supports parallel I/O, and can be used to add restart capability
   to applications.
 */
@@ -37,7 +37,7 @@ public:
   //! \param[in] name The name (without extension) of the data file
   //! \param[in] adm The process administrator
   //! \param[in] stride Restart data output stride
-  HDF5Restart(const std::string& name, const ProcessAdm& adm, int stride);
+  HDF5Restart(const std::string& name, const ProcessAdm& adm, int stride = 1);
 
   //! \brief Returns whether or not restart data should be output.
   //! \param[in] tp Time stepping information
@@ -51,8 +51,9 @@ public:
   //! \brief Reads restart data from file.
   //! \param[out] data The map to store data in
   //! \param[in] level Level to read (-1 to read last level in file)
+  //! \param[in] basis If \e true, read basis instead of data
   //! \returns Negative value on error, else restart level loaded
-  int readData(SerializeData& data, int level = -1);
+  int readData(SerializeData& data, int level = -1, bool basis = false);
 
 private:
   int m_stride; //!< Stride between outputs

--- a/src/Utility/HDF5Restart.h
+++ b/src/Utility/HDF5Restart.h
@@ -37,16 +37,17 @@ public:
   //! \param[in] name The name (without extension) of the data file
   //! \param[in] adm The process administrator
   //! \param[in] stride Restart data output stride
-  HDF5Restart(const std::string& name, const ProcessAdm& adm, int stride = 1);
+  //! \param[in] level0 Time level to start output at (in case of new restart)
+  HDF5Restart(const std::string& name, const ProcessAdm& adm,
+              int stride = 1, int level0 = 0);
 
   //! \brief Returns whether or not restart data should be output.
   //! \param[in] tp Time stepping information
   bool dumpStep(const TimeStep& tp);
 
   //! \brief Writes restart data to file.
-  //! \param[in] tp Time stepping information
   //! \param[in] data Data to write
-  bool writeData(const TimeStep& tp, const SerializeData& data);
+  bool writeData(const SerializeData& data);
 
   //! \brief Reads restart data from file.
   //! \param[out] data The map to store data in
@@ -55,8 +56,13 @@ public:
   //! \returns Negative value on error, else restart level loaded
   int readData(SerializeData& data, int level = -1, bool basis = false);
 
+  //! \brief Returns current time level.
+  int getTimeLevel() const { return m_level; }
+
 private:
-  int m_stride; //!< Stride between outputs
+  int m_stride; //!< Time step stride between outputs
+  int m_level;  //!< Current time level for restart output
+  int m_last;   //!< Last time step that was written
 };
 
 #endif


### PR DESCRIPTION
This replaces #449 with some improvements/fixes:
* The signature of the `restart` method is unchanged to avoid too may downstream changes.
   Instead the `ProcessAdm` object is retrieved from the solver object.
* Methods for (de)serialization of bases is included in class `SIMinput`.
* Bases are stored as `<name>::basis` instead of `<name>-basis`
* `TimeStep::reset()` should not update `stopTime` if `istep > 0`.
* The reference norm of the Newton iterations are serialized.
* And some minor cosmetic changes.