### PR TITLE
Changed: Set initial time level for restart runs from previous

### DIFF
--- a/Apps/Common/SIMSolverTS.h
+++ b/Apps/Common/SIMSolverTS.h
@@ -64,6 +64,9 @@ public:
       else if (!this->saveState(geoBlk,nBlock))
         return 2;
 
+    // Activate printing of time level for result dumps
+    SIMSolver<T1>::dumpLog = true;
+
     // Adaptive loop
     while (!this->tp.finished())
     {

--- a/src/Utility/DataExporter.h
+++ b/src/Utility/DataExporter.h
@@ -16,7 +16,6 @@
 
 #include "ControlFIFO.h"
 #include <map>
-#include <memory>
 #include <string>
 #include <vector>
 
@@ -80,11 +79,13 @@ public:
   //! \param[in] dynWriters If \e true, delete the writers on destruction
   //! \param[in] ndump Interval between dumps
   DataExporter(bool dynWriters = false, int ndump=1) :
-    m_delete(dynWriters), m_level(-1), m_ndump(ndump),
-    m_last_step(-1), m_infoReader(0), m_dataReader(0) {}
+    m_delete(dynWriters), m_level(-1), m_ndump(ndump), m_last_step(-1) {}
 
   //! \brief The destructor deletes the writers if \a dynWriters was \e true.
   virtual ~DataExporter();
+
+  //! \brief Adds the data \a writer to the list of registered writers.
+  void registerWriter(DataWriter* writer) { m_writers.push_back(writer); }
 
   //! \brief Registers an entry for storage.
   //! \param[in] name Name of entry
@@ -97,12 +98,6 @@ public:
                      const std::string& description,
                      FieldType field, int results = PRIMARY,
                      const std::string& prefix = "", int ncmps = 0);
-
-  //! \brief Registers a data writer.
-  //! \param[in] writer A pointer to the data writer we want registered
-  //! \param info If \e true, set as default info reader
-  //! \param reader If \e true, set as default data reader
-  bool registerWriter(DataWriter* writer, bool info=false, bool reader=false);
 
   //! \brief Sets the data values for a registered field.
   //! \param[in] name Name the field is registered with
@@ -135,10 +130,10 @@ public:
   //! \brief Returns context name for callback for external controller.
   virtual std::string GetContext() const { return "datawriter"; }
 
-  //! \brief Return name from data writer
+  //! \brief Returns name from (first) data writer.
   std::string getName() const;
 
-  //! \brief Returns visualization data stride
+  //! \brief Returns the data dump stride.
   int getStride() const { return m_ndump; }
 
 protected:
@@ -154,9 +149,6 @@ protected:
   int  m_level;     //!< Current time level
   int  m_ndump;     //!< Time level stride for dumping
   int  m_last_step; //!< Last time step we dumped for
-
-  DataWriter* m_infoReader; //!< DataWriter to read data information from
-  DataWriter* m_dataReader; //!< DataWriter to read numerical data from
 };
 
 //! \brief Convenience type

--- a/src/Utility/DataExporter.h
+++ b/src/Utility/DataExporter.h
@@ -78,8 +78,9 @@ public:
   //! \brief Default constructor.
   //! \param[in] dynWriters If \e true, delete the writers on destruction
   //! \param[in] ndump Interval between dumps
-  DataExporter(bool dynWriters = false, int ndump=1) :
-    m_delete(dynWriters), m_level(-1), m_ndump(ndump), m_last_step(-1) {}
+  //! \param[in] level0 Time level to start dumping from (in case of restart)
+  DataExporter(bool dynWriters = false, int ndump = 1, int level0 = 0) :
+    m_delete(dynWriters), m_ndump(ndump), m_level(level0-1), m_last_step(-1) {}
 
   //! \brief The destructor deletes the writers if \a dynWriters was \e true.
   virtual ~DataExporter();
@@ -113,14 +114,10 @@ public:
 
   //! \brief Dumps all registered fields using the registered writers.
   //! \param[in] tp Current time stepping info
-  //! \param[in] geometryUpdated Whether or not geometries are updated
-  bool dumpTimeLevel(const TimeStep* tp=nullptr, bool geometryUpdated=false);
-
-  //! \brief Returns the current time level of the exporter.
-  int getTimeLevel();
-
-  //! \brief Calculates the real time level taking ndump into account.
-  int realTimeLevel(int filelevel) const;
+  //! \param[in] geoUpd If \e true, write updated geometry as well
+  //! \param[in] doLog If \e true, write a log message when dumping data
+  bool dumpTimeLevel(const TimeStep* tp = nullptr,
+                     bool geoUpd = false, bool doLog = false);
 
   //! \brief Sets the prefices used for norm output.
   void setNormPrefixes(const std::vector<std::string>& prefixes);
@@ -137,17 +134,14 @@ public:
   int getStride() const { return m_ndump; }
 
 protected:
-  //! \brief Internal helper function.
-  int getWritersTimeLevel() const;
-
   //! A map of field names -> field info structures
   std::map<std::string,FileEntry> m_entry;
   //! A vector of registered data writers
   std::vector<DataWriter*>        m_writers;
 
   bool m_delete;    //!< If true, we are in charge of freeing up datawriters
-  int  m_level;     //!< Current time level
   int  m_ndump;     //!< Time level stride for dumping
+  int  m_level;     //!< Current time level
   int  m_last_step; //!< Last time step we dumped for
 };
 


### PR DESCRIPTION
The first commit here is a polished version of #469.

Then a proposed solution to the mismatching time level flags on hdf5-files for restart and visualization in restart runs.
Now we use the time level specified for the restart as the initial time level for the DataExporter, instead of always starting from 0.
Perhaps a similar approach should be used from HDF5Restart as well (there istep and stride are used to compute the time level, which will yield incorrect results if the stride is changed in a restart, not an unusual scenario).