### PR TITLE
Add support for matrix/vector dumps in matrix-market format

### DIFF
--- a/src/LinAlg/DenseMatrix.C
+++ b/src/LinAlg/DenseMatrix.C
@@ -108,6 +108,16 @@ void DenseMatrix::dump (std::ostream& os, LinAlg::StorageFormat format, const ch
       utl::writeMatlab(label,myMat,os);
       break;
 
+    case LinAlg::MATRIX_MARKET:
+      os << "%%MatrixMarket matrix array real general\n";
+      if (label)
+        os << "% label = " << label << '\n';
+      os << myMat.rows() << ' ' << myMat.cols();
+      for (size_t j = 1; j <= myMat.rows(); ++j)
+        for (size_t i = 1; i <= myMat.cols(); ++i)
+          os << '\n' << myMat(i,j);
+      break;
+
     case LinAlg::FLAT:
       if (label) os << label <<" =";
       os << myMat;

--- a/src/LinAlg/DenseMatrix.C
+++ b/src/LinAlg/DenseMatrix.C
@@ -100,19 +100,18 @@ void DenseMatrix::init ()
 }
 
 
-void DenseMatrix::dump (std::ostream& os, char format, const char* label)
+void DenseMatrix::dump (std::ostream& os, LinAlg::StorageFormat format, const char* label)
 {
   switch (format)
-    {
-    case 'M':
-    case 'm':
+  {
+    case LinAlg::MATLAB:
       utl::writeMatlab(label,myMat,os);
       break;
 
-    default:
+    case LinAlg::FLAT:
       if (label) os << label <<" =";
       os << myMat;
-    }
+  }
 }
 
 

--- a/src/LinAlg/DenseMatrix.h
+++ b/src/LinAlg/DenseMatrix.h
@@ -63,7 +63,7 @@ public:
   const Real& operator()(size_t r, size_t c) const { return myMat(r,c); }
 
   //! \brief Dumps the system matrix on a specified format.
-  virtual void dump(std::ostream&, char, const char* = nullptr);
+  virtual void dump(std::ostream&, LinAlg::StorageFormat, const char* = nullptr);
 
   //! \brief Initializes the element assembly process.
   //! \details Must be called once before the element assembly loop.

--- a/src/LinAlg/DiagMatrix.C
+++ b/src/LinAlg/DiagMatrix.C
@@ -30,19 +30,18 @@ void DiagMatrix::initAssembly (const SAM& sam, bool)
 }
 
 
-void DiagMatrix::dump (std::ostream& os, char format, const char* label)
+void DiagMatrix::dump (std::ostream& os, LinAlg::StorageFormat format, const char* label)
 {
   switch (format)
-    {
-    case 'M':
-    case 'm':
+  {
+    case LinAlg::MATLAB:
       utl::writeMatlab(label,myMat,os);
       break;
 
-    default:
+    case LinAlg::FLAT:
       if (label) os << label <<" =";
       os << myMat;
-    }
+  }
 }
 
 

--- a/src/LinAlg/DiagMatrix.C
+++ b/src/LinAlg/DiagMatrix.C
@@ -38,6 +38,15 @@ void DiagMatrix::dump (std::ostream& os, LinAlg::StorageFormat format, const cha
       utl::writeMatlab(label,myMat,os);
       break;
 
+    case LinAlg::MATRIX_MARKET:
+      os << "%%MatrixMarket matrix coordinate real general\n";
+      if (label)
+        os << "% label = " << label << '\n';
+      os << myMat.size() << ' ' << myMat.size() << ' ' << myMat.size();
+      for (size_t row = 1; row <= myMat.size(); ++row)
+        os << '\n' << row << ' ' << row << ' ' << myMat(row);
+      break;
+
     case LinAlg::FLAT:
       if (label) os << label <<" =";
       os << myMat;

--- a/src/LinAlg/DiagMatrix.h
+++ b/src/LinAlg/DiagMatrix.h
@@ -54,7 +54,7 @@ public:
   const Real& operator()(size_t r) const { return myMat(r); }
 
   //! \brief Dumps the system matrix on a specified format.
-  virtual void dump(std::ostream&, char, const char*);
+  virtual void dump(std::ostream&, LinAlg::StorageFormat, const char*);
 
   //! \brief Initializes the element assembly process.
   //! \details Must be called once before the element assembly loop.

--- a/src/LinAlg/LinAlgenums.h
+++ b/src/LinAlg/LinAlgenums.h
@@ -37,6 +37,13 @@ namespace LinAlg //! Linear algebra scope
     SYMMETRIC      = 1, //!< Symmetric matrix (value and structure)
     SPD            = 2  //!< Symmetric, positive definite matrix
   };
+
+  //! \brief Enumeration of storage formats.
+  enum StorageFormat
+  {
+    FLAT,         //!< Flat format
+    MATLAB        //!< Matlab format
+  };
 }
 
 #endif

--- a/src/LinAlg/LinAlgenums.h
+++ b/src/LinAlg/LinAlgenums.h
@@ -42,7 +42,8 @@ namespace LinAlg //! Linear algebra scope
   enum StorageFormat
   {
     FLAT,         //!< Flat format
-    MATLAB        //!< Matlab format
+    MATLAB,       //!< Matlab format
+    MATRIX_MARKET //!< Matrix-market format
   };
 }
 

--- a/src/LinAlg/SparseMatrix.C
+++ b/src/LinAlg/SparseMatrix.C
@@ -342,13 +342,12 @@ const Real& SparseMatrix::operator () (size_t r, size_t c) const
 }
 
 
-void SparseMatrix::dump (std::ostream& os, char format, const char* label)
+void SparseMatrix::dump (std::ostream& os, LinAlg::StorageFormat format, const char* label)
 {
   if (label) os << label <<" = [\n";
   switch (format)
-    {
-    case 'M':
-    case 'm':
+  {
+    case LinAlg::MATLAB:
       if (editable)
         for (const ValueMap::value_type& val : elem)
           os << val.first.first <<' '<< val.first.second <<" "<< val.second
@@ -372,9 +371,9 @@ void SparseMatrix::dump (std::ostream& os, char format, const char* label)
       os <<"];\n";
       break;
 
-    default:
+    case LinAlg::FLAT:
       this->write(os);
-    }
+  }
 }
 
 

--- a/src/LinAlg/SparseMatrix.h
+++ b/src/LinAlg/SparseMatrix.h
@@ -100,7 +100,7 @@ public:
   void printFull(std::ostream& os) const;
 
   //! \brief Dumps the system matrix on a specified format.
-  virtual void dump(std::ostream&, char, const char* = nullptr);
+  virtual void dump(std::ostream&, LinAlg::StorageFormat, const char* = nullptr);
 
   //! \brief Initializes the element assembly process.
   //! \details Must be called once before the element assembly loop.

--- a/src/LinAlg/SystemMatrix.C
+++ b/src/LinAlg/SystemMatrix.C
@@ -71,6 +71,16 @@ void StdVector::dump (std::ostream& os, LinAlg::StorageFormat format, const char
       utl::writeMatlab(label,*this,os);
       break;
 
+    case LinAlg::MATRIX_MARKET:
+    {
+      os << "%%MatrixMarket matrix array real general\n" << this->size() << " 1";
+      int old = utl::nval_per_line;
+      utl::nval_per_line = 1;
+      os << *this;
+      utl::nval_per_line = old;
+      break;
+    }
+
     case LinAlg::FLAT:
       if (label) os << label <<" =";
       os << *this;

--- a/src/LinAlg/SystemMatrix.C
+++ b/src/LinAlg/SystemMatrix.C
@@ -63,19 +63,18 @@ SystemVector& SystemVector::copy (const SystemVector& x)
 }
 
 
-void StdVector::dump (std::ostream& os, char format, const char* label)
+void StdVector::dump (std::ostream& os, LinAlg::StorageFormat format, const char* label)
 {
   switch (format)
-    {
-    case 'M':
-    case 'm':
+  {
+    case LinAlg::MATLAB:
       utl::writeMatlab(label,*this,os);
       break;
 
-    default:
+    case LinAlg::FLAT:
       if (label) os << label <<" =";
       os << *this;
-    }
+  }
 }
 
 

--- a/src/LinAlg/SystemMatrix.h
+++ b/src/LinAlg/SystemMatrix.h
@@ -99,7 +99,7 @@ public:
   virtual Real Linfnorm() const = 0;
 
   //! \brief Dumps the system vector on a specified format.
-  virtual void dump(std::ostream&, char, const char* = nullptr) {}
+  virtual void dump(std::ostream&, LinAlg::StorageFormat, const char* = nullptr) {}
 
 protected:
   //! \brief Writes the system vector to the given output stream.
@@ -179,7 +179,7 @@ public:
   virtual Real Linfnorm() const { size_t off = 0; return this->normInf(off); }
 
   //! \brief Dumps the system vector on a specified format.
-  virtual void dump(std::ostream& os, char format, const char* label = nullptr);
+  virtual void dump(std::ostream& os, LinAlg::StorageFormat format, const char* label = nullptr);
 
 protected:
   //! \brief Writes the system vector to the given output stream.
@@ -311,7 +311,7 @@ public:
   virtual Real Linfnorm() const = 0;
 
   //! \brief Dumps the system matrix on a specified format.
-  virtual void dump(std::ostream&, char, const char* = nullptr) {}
+  virtual void dump(std::ostream&, LinAlg::StorageFormat, const char* = nullptr) {}
 
   //! \brief Calculates a matrix-vector product.
   StdVector operator*(const SystemVector& b) const;

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -775,13 +775,13 @@ protected:
   struct DumpData
   {
     std::string   fname;  //!< File name
-    char          format; //!< File format flag
+    LinAlg::StorageFormat format; //!< File format flag
     std::set<int> step;   //!< Dump step identifiers
     int           count;  //!< Internal step counter, dump only when step==count
     double        eps;    //!< Zero tolerance for printing small values
 
     //! \brief Default constructor.
-    DumpData() : format('P'), count(0), eps(1.0e-6) { step.insert(1); }
+    DumpData() : format(LinAlg::FLAT), count(0), eps(1.0e-6) { step.insert(1); }
     //! \brief Checks if the matrix or vector should be dumped now.
     bool doDump() { return !fname.empty() && step.find(++count) != step.end(); }
   };

--- a/src/SIM/SIMinput.C
+++ b/src/SIM/SIMinput.C
@@ -680,8 +680,12 @@ bool SIMinput::parseOutputTag (const TiXmlElement* elem)
     dmp.step.insert(steps.begin(),steps.end());
     if (format == "matlab")
       dmp.format = LinAlg::MATLAB;
-    else if (std::toupper(format[0]) == 'M')
-      dmp.format = LinAlg::MATLAB;
+    else if (format == "matrix_market")
+      dmp.format = LinAlg::MATRIX_MARKET;
+    else {
+      std::cerr << "  ** SIMinput::parseOutputTag: Unknown matrix dump format \"" << format << "\", ignored" << std::endl;
+      return true;
+    }
     dmp.fname = elem->FirstChild()->Value();
     if (toupper(elem->Value()[5]) == 'R')
       rhsDump.push_back(dmp);

--- a/src/SIM/SIMinput.C
+++ b/src/SIM/SIMinput.C
@@ -678,7 +678,10 @@ bool SIMinput::parseOutputTag (const TiXmlElement* elem)
     utl::getAttribute(elem,"step",steps);
     utl::getAttribute(elem,"eps",dmp.eps);
     dmp.step.insert(steps.begin(),steps.end());
-    dmp.format = format[0];
+    if (format == "matlab")
+      dmp.format = LinAlg::MATLAB;
+    else if (std::toupper(format[0]) == 'M')
+      dmp.format = LinAlg::MATLAB;
     dmp.fname = elem->FirstChild()->Value();
     if (toupper(elem->Value()[5]) == 'R')
       rhsDump.push_back(dmp);


### PR DESCRIPTION
Matrix-market format is useful for testing as it is supported by various linalg packages (in my case amgcl).