### PR TITLE
Traction output (to VTF) corrections

### DIFF
--- a/src/SIM/MultiStepSIM.C
+++ b/src/SIM/MultiStepSIM.C
@@ -115,7 +115,7 @@ bool MultiStepSIM::saveStep (int iStep, double time, const char* vecName)
   lastSt = iStep;
 
   // Write boundary tractions, if any
-  if (!opt.pSolOnly)
+  if (!opt.pSolOnly || opt.saveTrac)
     if (!model.writeGlvT(iStep,geoBlk,nBlock))
       return false;
 

--- a/src/SIM/SIMoptions.C
+++ b/src/SIM/SIMoptions.C
@@ -44,7 +44,7 @@ SIMoptions::SIMoptions ()
   format  = -1;
   saveInc =  1;
   dtSave  =  0.0;
-  pSolOnly = saveNorms = saveLog = false;
+  pSolOnly = saveTrac = saveNorms = saveLog = false;
   restartInc = 0;
   restartStep = -1;
 
@@ -178,6 +178,9 @@ bool SIMoptions::parseOutputTag (const TiXmlElement* elem)
 
   else if (!strcasecmp(elem->Value(),"primarySolOnly"))
     pSolOnly = true;
+
+  else if (!strncasecmp(elem->Value(),"saveTrac",8))
+    saveTrac = true;
 
   else if (!strcasecmp(elem->Value(),"saveNorms"))
     saveNorms = true;

--- a/src/SIM/SIMoptions.h
+++ b/src/SIM/SIMoptions.h
@@ -89,6 +89,7 @@ public:
   int saveInc;   //!< Number of load/time increments between each result output
   double dtSave; //!< Time interval between each result output
   bool pSolOnly; //!< If \e true, don't save secondary solution variables
+  bool saveTrac; //!< If \e true, save gauss point traction values
   bool saveNorms;//!< If \e true, save element norms
   bool saveLog;  //!< If \e true, export the log
 

--- a/src/SIM/SIMoutput.h
+++ b/src/SIM/SIMoutput.h
@@ -210,7 +210,6 @@ public:
   //! \param[in] f The function to output
   //! \param[in] fname Name of the function
   //! \param[in] iStep Load/time step identifier
-  //! \param[in] idBlock Starting value of result block numbering
   //! \param nBlock Running result block counter
   //! \param[in] idBlock Starting value of result block numbering
   //! \param[in] time Load/time step parameter


### PR DESCRIPTION
Adding `<saveTrac/>` within `<postprocessing>` which can be used by multi-step solvers to save tractions to VTF without having to save other secondary solution variables. And avoid writing traction points for the zero-knot-span elements. They didn't do any harm though, only contribute to unnecessary increased VTF-file size.