### PR TITLE
Fixes for warnings emitted by new clang/gcc versions

### DIFF
--- a/src/ASM/LR/ASMLRSpline.h
+++ b/src/ASM/LR/ASMLRSpline.h
@@ -187,6 +187,7 @@ protected:
   //! \param lrspline The spline to perform adaptation for
   bool doRefine(const LR::RefineData& prm, LR::LRSpline* lrspline);
 
+  using ASMbase::evalPoint;
   //! \brief Evaluates the geometry at a specified point.
   virtual int evalPoint(int iel, const double* param, Vec3& X) const = 0;
 

--- a/src/ASM/SAMpatch.C
+++ b/src/ASM/SAMpatch.C
@@ -59,7 +59,7 @@ bool SAMpatch::init (const std::vector<ASMbase*>& patches, int numNod,
     ndofs[nodeType[n]] += madof[n+1] - madof[n];
   for (size_t d = 0; d < dof_type.size(); d++)
     ndofs[dof_type[d]] ++;
-  for (const std::pair<char,size_t>& dof : ndofs)
+  for (const std::pair<const char,size_t>& dof : ndofs)
     if (dof.second > 0)
       IFEM::cout <<"Number of "<< dof.first <<"-dofs      "
                  << dof.second << std::endl;
@@ -226,7 +226,7 @@ bool SAMpatch::initElementConn ()
   int* new_mpmnpc = new int[nel+1];
   int* new_mmnpc  = new int[nmmnpc];
   ip = new_mpmnpc[0] = 1;
-  for (const std::pair<int,Ipair>& elm : sortedElms)
+  for (const std::pair<const int,Ipair>& elm : sortedElms)
   {
     int nen = elm.second.second;
     new_mpmnpc[ip] = new_mpmnpc[ip-1] + nen;
@@ -465,7 +465,7 @@ bool SAMpatch::merge (const SAM* other, const std::map<int,int>* old2new)
     ndofs[nodeType[n]] += madof[n+1] - madof[n];
   for (size_t d = 0; d < dof_type.size(); d++)
     ndofs[dof_type[d]] ++;
-  for (const std::pair<char,size_t>& dof : ndofs)
+  for (const std::pair<const char,size_t>& dof : ndofs)
     if (dof.second > 0)
       IFEM::cout <<"Number of "<< dof.first <<"-dofs      "
                  << dof.second << std::endl;

--- a/src/SIM/FunctionSum.C
+++ b/src/SIM/FunctionSum.C
@@ -84,7 +84,7 @@ std::vector<double> FunctionSum::getValue (const Vec3& X) const
         if (val[j] > sum[j]) sum[j] = val[j];
     }
 
-  return sum;
+  return std::move(sum);
 }
 
 

--- a/src/SIM/NonLinSIM.C
+++ b/src/SIM/NonLinSIM.C
@@ -52,7 +52,7 @@ NonLinSIM::~NonLinSIM ()
   cout <<"\n *** Here are the nodal points flagged with slow convergence"
        <<"\n     ======================================================="
        <<"\n     Node  Count  Patch  Coordinates\n";
-  for (const std::pair<int,int>& node : slowNodes)
+  for (const std::pair<const int,int>& node : slowNodes)
   {
     Vec4 X = model.getNodeCoord(node.first);
     cout << std::setw(9) << node.first
@@ -491,7 +491,7 @@ void NonLinSIM::printWorst (utl::LogStream& os, double eps)
   else
     os <<".";
 
-  for (const std::pair<std::pair<int,int>,RealArray>& wd : worstDOFs)
+  for (const std::pair<const std::pair<int,int>,RealArray>& wd : worstDOFs)
   {
     os <<"\n     Node "<< wd.first.first <<" local DOF "<< wd.first.second;
     char nodeType = model.getNodeType(wd.first.first);

--- a/src/SIM/SIM2D.C
+++ b/src/SIM/SIM2D.C
@@ -879,7 +879,7 @@ Vector SIM2D::getSolution (const Vector& psol, double u, double v,
 
 bool SIM2D::writeAddFuncs (int iStep, int& nBlock, int idBlock, double time)
 {
-  for (const std::pair<std::string,RealFunc*>& func : myAddScalars)
+  for (const std::pair<const std::string,RealFunc*>& func : myAddScalars)
     if (!this->writeGlvF(*func.second, func.first.c_str(), iStep,
                          nBlock, idBlock++, time))
       return false;

--- a/src/SIM/SIMmultiCpl.C
+++ b/src/SIM/SIMmultiCpl.C
@@ -142,7 +142,7 @@ bool SIMmultiCpl::preprocess (const std::vector<int>& ignored, bool fixDup)
     return false;
 
   IFEM::cout <<"\nCoupling node mapping:";
-  for (const std::pair<int,int>& cp : cplNodes)
+  for (const std::pair<const int,int>& cp : cplNodes)
     IFEM::cout <<"\n\t"<< cp.first <<" -> "<< cp.second;
   IFEM::cout << std::endl;
 

--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -1952,7 +1952,7 @@ bool SIMoutput::serialize (std::map<std::string,std::string>&) const
 
 bool SIMoutput::writeAddFuncs (int iStep, int& nBlock, int idBlock, double time)
 {
-  for (const std::pair<std::string,RealFunc*>& func : myAddScalars)
+  for (const std::pair<const std::string,RealFunc*>& func : myAddScalars)
     if (!this->writeGlvF(*func.second, func.first.c_str(), iStep,
                          nBlock, idBlock++, time))
       return false;

--- a/src/Utility/DataExporter.C
+++ b/src/Utility/DataExporter.C
@@ -122,7 +122,7 @@ bool DataExporter::dumpTimeLevel (const TimeStep* tp, bool geoUpd, bool doLog)
 
   for (DataWriter* writer : m_writers) {
     writer->openFile(m_level);
-    for (const DataEntry& it : m_entry) {
+    for (const std::pair<const std::string,DataExporter::FileEntry>& it : m_entry) {
       if (!it.second.data)
         return false;
       switch (it.second.field) {

--- a/src/Utility/FieldFunctions.C
+++ b/src/Utility/FieldFunctions.C
@@ -314,7 +314,7 @@ RealArray FieldsFuncBase::getValues (const Vec3& X)
   else
   {
     int level = this->findClosestLevel(x4->t);
-    if (level < 0) return vals;
+    if (level < 0) return std::move(vals);
     if (level != currentLevel)
       if (this->load(fName,bName,level))
         currentLevel = level;
@@ -325,7 +325,7 @@ RealArray FieldsFuncBase::getValues (const Vec3& X)
       field[pidx]->valueCoor(*x4,vals);
   }
 
-  return vals;
+  return std::move(vals);
 }
 
 

--- a/src/Utility/HDF5Restart.C
+++ b/src/Utility/HDF5Restart.C
@@ -100,7 +100,7 @@ bool HDF5Restart::writeData (const SerializeData& data)
   };
 
   for (int p = 0; p < ptot; p++)
-    for (const std::pair<std::string,std::string>& it : data) {
+    for (const std::pair<const std::string,std::string>& it : data) {
       std::stringstream str;
       str << m_level << '/' << p;
       hid_t group;


### PR DESCRIPTION
- const for keys
- std::move to avoid some copies
- a missing using statement