### PR TITLE
Fixed: Don't recalculate tangent in pure linear analysis

### DIFF
--- a/src/SIM/NonLinSIM.C
+++ b/src/SIM/NonLinSIM.C
@@ -221,8 +221,8 @@ ConvStatus NonLinSIM::solveStep (TimeStep& param, SolutionMode mode,
     return FAILURE;
 
   bool poorConvg = false;
-  bool newTangent = true;
-  model.setMode(mode,false);
+  bool newTangent = param.time.first || iteNorm != NONE;
+  model.setMode(newTangent ? mode : RHS_ONLY, false);
   model.setQuadratureRule(opt.nGauss[0],true);
   if (!this->assembleSystem(param.time,solution,newTangent))
     return model.getProblem()->diverged() ? DIVERGED : FAILURE;
@@ -262,14 +262,8 @@ ConvStatus NonLinSIM::solveStep (TimeStep& param, SolutionMode mode,
 	if (subiter&FIRST && param.iter == 1 && !model.updateDirichlet())
 	  return FAILURE;
 
-	if (param.iter > nupdat)
-	{
-	  newTangent = false;
-	  model.setMode(RHS_ONLY,false);
-	}
-	else
-	  model.setMode(mode,false);
-
+	if (param.iter > nupdat) newTangent = false;
+	model.setMode(newTangent ? mode : RHS_ONLY, false);
 	if (!this->assembleSystem(param.time,solution,newTangent,poorConvg))
 	  return model.getProblem()->diverged() ? DIVERGED : FAILURE;
 

--- a/src/SIM/NonLinSIM.h
+++ b/src/SIM/NonLinSIM.h
@@ -28,7 +28,13 @@ class NonLinSIM : public MultiStepSIM
 {
 public:
   //! \brief Enum describing the norm used for convergence checks.
-  enum CNORM { NONE, L2, L2SOL, ENERGY };
+  //! \details The value \a NONE imples no checking at all and is used to
+  //! conduct a pure linear analysis without equilibrium iterations.
+  //! The value \a NONE_UPTAN value implies the same as \a NONE, but with
+  //! recalculation of the tangent matrix at each step. This is needed for
+  //! problems with inhomogeneous dirichlet conditions where the element
+  //! tangent matrix is used to calculate the equivalent load vector.
+  enum CNORM { NONE_UPTAN=-1, NONE=0, L2=1, L2SOL=2, ENERGY=3 };
 
   //! \brief The constructor initializes default solution parameters.
   //! \param sim Pointer to the spline FE model
@@ -38,7 +44,7 @@ public:
   virtual ~NonLinSIM();
 
   //! \brief Defines which type of iteration norm to use in convergence checks.
-  void setConvNorm(CNORM n) { if ((iteNorm = n) == NONE) fromIni = true; }
+  void setConvNorm(CNORM n) { if ((iteNorm = n) <= NONE) fromIni = true; }
 
   //! \brief Initializes the primary solution vectors.
   //! \param[in] nSol Number of consequtive solutions stored in core
@@ -77,7 +83,7 @@ public:
   int getMaxit() const { return maxit; }
 
   //! \brief Returns whether this solution driver is linear or not.
-  virtual bool isLinear() const { return iteNorm == NONE; }
+  virtual bool isLinear() const { return iteNorm <= NONE; }
 
 protected:
   //! \brief Prints out the worst DOFs when slow convergence is detected.


### PR DESCRIPTION
To speed up linear multi-loadcase simulations (e.g., with `NonLinEl -linear`).