### PR TITLE
SysMatrix::solve argument cleanup

### DIFF
--- a/Apps/Common/SIMSolverAdap.h
+++ b/Apps/Common/SIMSolverAdap.h
@@ -44,12 +44,11 @@ protected:
     return true;
   }
 
-  //! \brief Saves point results to output file for a given time step.
-  //! \param[in] time Load/time step parameter
-  //! \param[in] iStep Load/time step counter
-  bool savePoints(double time, int iStep) const override
+  //! \brief Saves point results to output file for a given refinement step.
+  //! \param[in] iStep Refinement step counter
+  bool savePoints(int iStep) const override
   {
-    return model.savePoints(time, iStep);
+    return model.savePoints(0.0,iStep);
   }
 
   T1& model; //!< Reference to the actual sim

--- a/src/ASM/AlgEqSystem.C
+++ b/src/ASM/AlgEqSystem.C
@@ -340,7 +340,7 @@ bool AlgEqSystem::staticCondensation (Matrix& Ared, Vector& bred,
              <<"] --> ["<< neq2 <<"x"<< neq2 <<"]"<< std::endl;
 
   // Calculate [A11]^-1*{R1} => R1
-  if (!Asub[0].solve(R1,true))
+  if (!Asub[0].solve(R1))
     return false;
 
   FILE* fd = recmatFile ? fopen(recmatFile,"wb") : nullptr;
@@ -378,7 +378,7 @@ bool AlgEqSystem::staticCondensation (Matrix& Ared, Vector& bred,
     Asub[3].getColumn(ieq2,R2);
 
     // Calculate [A11]^-1*{R1} => R1, reusing the factorization of [A11]
-    if (!Asub[0].solve(R1,false))
+    if (!Asub[0].solve(R1))
       return false;
 
     // Calculate [A21]*([A11]^-1*{R1}) => Rtmp

--- a/src/LinAlg/DenseMatrix.C
+++ b/src/LinAlg/DenseMatrix.C
@@ -100,7 +100,8 @@ void DenseMatrix::init ()
 }
 
 
-void DenseMatrix::dump (std::ostream& os, LinAlg::StorageFormat format, const char* label)
+void DenseMatrix::dump (std::ostream& os, LinAlg::StorageFormat format,
+                        const char* label)
 {
   switch (format)
   {
@@ -386,7 +387,7 @@ bool DenseMatrix::multiply (const SystemVector& B, SystemVector& C) const
 }
 
 
-bool DenseMatrix::solve (SystemVector& B, bool, Real* rc)
+bool DenseMatrix::solve (SystemVector& B, Real* rc)
 {
   size_t nrhs = myMat.rows() > 0 ? B.dim()/myMat.rows() : 1;
   return this->solve(B.getPtr(),nrhs,rc);

--- a/src/LinAlg/DenseMatrix.h
+++ b/src/LinAlg/DenseMatrix.h
@@ -35,7 +35,7 @@ public:
   //! \brief Special constructor, type conversion from Matrix.
   DenseMatrix(const Matrix& A, bool s = false);
   //! \brief The destructor frees the dynamically allocated arrays.
-  virtual ~DenseMatrix() { if (ipiv) delete[] ipiv; }
+  virtual ~DenseMatrix() { delete[] ipiv; }
 
   //! \brief Returns the matrix type.
   virtual LinAlg::MatrixType getType() const { return LinAlg::DENSE; }
@@ -52,7 +52,7 @@ public:
   void setSymmetric(bool s = true) { symm = s && myMat.rows() == myMat.cols(); }
 
   //! \brief Returns the dimension of the system matrix.
-  //! \param[in] idim Which direction to return the dimension in.
+  //! \param[in] idim Which direction to return the dimension in
   virtual size_t dim(int idim = 1) const;
 
   //! \brief Access to the matrix itself.
@@ -63,7 +63,8 @@ public:
   const Real& operator()(size_t r, size_t c) const { return myMat(r,c); }
 
   //! \brief Dumps the system matrix on a specified format.
-  virtual void dump(std::ostream&, LinAlg::StorageFormat, const char* = nullptr);
+  virtual void dump(std::ostream& os, LinAlg::StorageFormat format,
+                    const char* label);
 
   //! \brief Initializes the element assembly process.
   //! \details Must be called once before the element assembly loop.
@@ -115,7 +116,7 @@ public:
   //! \brief Adds a matrix with similar dimension to the current matrix.
   //! \param[in] B     The matrix to be added
   //! \param[in] alpha Scale factor for matrix \b B
-  virtual bool add(const SystemMatrix& B, Real alpha = Real(1));
+  virtual bool add(const SystemMatrix& B, Real alpha);
 
   //! \brief Adds the diagonal matrix &sigma;\b I to the current matrix.
   virtual bool add(Real sigma);
@@ -127,7 +128,7 @@ public:
   //! \brief Solves the linear system of equations for a given right-hand-side.
   //! \param B Right-hand-side vector on input, solution vector on output
   //! \param[out] rc Reciprocal condition number of the LHS-matrix (optional)
-  virtual bool solve(SystemVector& B, bool, Real* rc = nullptr);
+  virtual bool solve(SystemVector& B, Real* rc = nullptr);
   //! \brief Solves the linear system of equations for a given right-hand-side.
   //! \param B Right-hand-side matrix on input, solution matrix on output
   bool solve(Matrix& B);

--- a/src/LinAlg/DiagMatrix.C
+++ b/src/LinAlg/DiagMatrix.C
@@ -30,7 +30,8 @@ void DiagMatrix::initAssembly (const SAM& sam, bool)
 }
 
 
-void DiagMatrix::dump (std::ostream& os, LinAlg::StorageFormat format, const char* label)
+void DiagMatrix::dump (std::ostream& os, LinAlg::StorageFormat format,
+                       const char* label)
 {
   switch (format)
   {
@@ -131,7 +132,7 @@ bool DiagMatrix::multiply (const SystemVector& B, SystemVector& C) const
 }
 
 
-bool DiagMatrix::solve (SystemVector& B, bool, Real*)
+bool DiagMatrix::solve (SystemVector& B, Real*)
 {
   if (myMat.empty()) return true; // Nothing to solve
 

--- a/src/LinAlg/DiagMatrix.h
+++ b/src/LinAlg/DiagMatrix.h
@@ -54,7 +54,8 @@ public:
   const Real& operator()(size_t r) const { return myMat(r); }
 
   //! \brief Dumps the system matrix on a specified format.
-  virtual void dump(std::ostream&, LinAlg::StorageFormat, const char*);
+  virtual void dump(std::ostream& os, LinAlg::StorageFormat format,
+                    const char* label);
 
   //! \brief Initializes the element assembly process.
   //! \details Must be called once before the element assembly loop.
@@ -100,7 +101,7 @@ public:
   using SystemMatrix::solve;
   //! \brief Solves the linear system of equations for a given right-hand-side.
   //! \param B Right-hand-side vector on input, solution vector on output
-  virtual bool solve(SystemVector& B, bool, Real*);
+  virtual bool solve(SystemVector& B, Real*);
 
   //! \brief Returns the L-infinity norm of the matrix.
   virtual Real Linfnorm() const { return myMat.normInf(); }

--- a/src/LinAlg/ISTLMatrix.C
+++ b/src/LinAlg/ISTLMatrix.C
@@ -52,34 +52,23 @@ ISTLVector::~ISTLVector()
 
 void ISTLVector::init(Real value)
 {
-  StdVector::init(value);
   x = value;
-}
-
-size_t ISTLVector::dim() const
-{
-  return x.size();
+  this->StdVector::init(value);
 }
 
 
 void ISTLVector::redim(size_t n)
 {
   x.resize(n);
-  StdVector::redim(n);
-}
-
-
-bool ISTLVector::beginAssembly()
-{
-  for (size_t i = 0; i < size(); ++i)
-    x[i] = (*this)[i];
-
-  return true;
+  this->StdVector::redim(n);
 }
 
 
 bool ISTLVector::endAssembly()
 {
+  for (size_t i = 0; i < x.size(); ++i)
+    x[i] = (*this)[i];
+
   return true;
 }
 
@@ -106,9 +95,6 @@ ISTLMatrix::ISTLMatrix (const ProcessAdm& padm, const LinSolParams& spar)
   : SparseMatrix(SUPERLU,1), adm(padm), solParams(spar,adm)
 {
   LinAlgInit::increfs();
-
-  setParams = true;
-  nLinSolves = 0;
 }
 
 
@@ -118,9 +104,6 @@ ISTLMatrix::ISTLMatrix (const ISTLMatrix& B)
   iA = B.iA;
 
   LinAlgInit::increfs();
-
-  setParams = true;
-  nLinSolves = 0;
 }
 
 
@@ -159,18 +142,13 @@ void ISTLMatrix::initAssembly (const SAM& sam, bool delayLocking)
   iA = 0;
 }
 
-bool ISTLMatrix::beginAssembly()
+
+bool ISTLMatrix::endAssembly()
 {
   for (size_t j = 0; j < cols(); ++j)
     for (int i = IA[j]; i < IA[j+1]; ++i)
       iA[JA[i]][j] = A[i];
 
-  return true;
-}
-
-
-bool ISTLMatrix::endAssembly()
-{
   return true;
 }
 
@@ -184,8 +162,7 @@ void ISTLMatrix::init ()
 }
 
 
-
-bool ISTLMatrix::solve (SystemVector& B, bool newLHS, Real*)
+bool ISTLMatrix::solve (SystemVector& B, Real*)
 {
   if (!pre)
     std::tie(solver, pre, op) = solParams.setupPC(iA);
@@ -211,7 +188,7 @@ bool ISTLMatrix::solve (SystemVector& B, bool newLHS, Real*)
 }
 
 
-bool ISTLMatrix::solve (const SystemVector& b, SystemVector& x, bool newLHS)
+bool ISTLMatrix::solve (const SystemVector& b, SystemVector& x)
 {
   if (!pre)
     std::tie(solver, pre, op) = solParams.setupPC(iA);

--- a/src/LinAlg/PETScMatrix.h
+++ b/src/LinAlg/PETScMatrix.h
@@ -51,7 +51,7 @@ public:
   virtual LinAlg::MatrixType getType() const { return LinAlg::PETSC; }
 
   //! \brief Initializes the vector to a given scalar value.
-  virtual void init(Real value = Real(0));
+  virtual void init(Real value);
 
   //! \brief Sets the dimension of the system vector.
   virtual void redim(size_t n);
@@ -80,8 +80,9 @@ public:
   //! \brief Returns the PETSc vector (for read access).
   virtual const Vec& getVector() const { return x; }
 
-  //! \brief Return associated process administrator
+  //! \brief Return associated process administrator.
   const ProcessAdm& getAdm() const { return adm; }
+
 protected:
   Vec x;                  //!< The actual PETSc vector
   const ProcessAdm& adm;  //!< Process administrator
@@ -130,18 +131,16 @@ public:
 
   //! \brief Solves the linear system of equations for a given right-hand-side.
   //! \param B Right-hand-side vector on input, solution vector on output
-  //! \param[in] newLHS \e true if the left-hand-side matrix has been updated
-  virtual bool solve(SystemVector& B, bool newLHS, Real*);
+  virtual bool solve(SystemVector& B, Real*);
 
   //! \brief Solves the linear system of equations for a given right-hand-side.
   //! \param[in] B Right-hand-side vector
   //! \param[out] x Solution vector
-  //! \param[in] newLHS \e true if the left-hand-side matrix has been updated
-  virtual bool solve(const SystemVector& B, SystemVector& x, bool newLHS);
+  virtual bool solve(const SystemVector& B, SystemVector& x);
 
   //! \brief Solves a generalized symmetric-definite eigenproblem.
   //! \details The eigenproblem is assumed to be on the form
-  //! \b A \b x = \f$\lambda\f$ \b B \b x where \b A ( = \a *this ) and \b B
+  //! \b A \b x = &lambda; \b B \b x where \b A ( = \a *this ) and \b B
   //! both are assumed to be symmetric and \b B also to be positive definite.
   //! The eigenproblem is solved by the SLEPc library subroutine \a EPSSolve.
   //! \sa SLEPc library documentation.
@@ -151,8 +150,8 @@ public:
   //! \param[in] nev The number of eigenvalues and eigenvectors to compute
   //! \param[in] shift Eigenvalue shift
   //! \param[in] iop Option telling whether to factorize matrix \a A or \b B.
-  virtual bool solveEig(PETScMatrix& B, RealArray& eigVal, Matrix& eigVec,
-			int nev, Real shift = Real(0), int iop = 1);
+  bool solveEig(PETScMatrix& B, RealArray& eigVal, Matrix& eigVec,
+                int nev, Real shift = Real(0), int iop = 1);
 
   //! \brief Returns the L-infinity norm of the matrix.
   virtual Real Linfnorm() const;
@@ -172,11 +171,11 @@ public:
   //! \param[in] P Preconditioner  matrix (ignored here)
   //! \param[in] Pb Preconditioner vector (ignored here)
   //! \return True on success
-  virtual bool setParameters(PETScMatrix* P = nullptr, PETScVector* Pb = nullptr);
+  bool setParameters(PETScMatrix* P = nullptr, PETScVector* Pb = nullptr);
 
 protected:
   //! \brief Solve a linear system
-  bool solve(const Vec& b, Vec& x, bool newLHS, bool knoll);
+  bool solve(const Vec& b, Vec& x, bool knoll);
 
   //! \brief Solve system stored in the elem map.
   //! \details Create matrix from elem table, and solve for (possibly) multiple

--- a/src/LinAlg/SPRMatrix.C
+++ b/src/LinAlg/SPRMatrix.C
@@ -144,11 +144,11 @@ SPRMatrix::SPRMatrix (const SPRMatrix& A)
 
 SPRMatrix::~SPRMatrix ()
 {
-  if (msica)  delete[] msica;
-  if (msifa)  delete[] msifa;
-  if (mtrees) delete[] mtrees;
-  if (mvarnc) delete[] mvarnc;
-  if (values) delete[] values;
+  delete[] msica;
+  delete[] msifa;
+  delete[] mtrees;
+  delete[] mvarnc;
+  delete[] values;
 }
 
 
@@ -367,7 +367,7 @@ bool SPRMatrix::multiply (const SystemVector& B, SystemVector& C) const
 //! \brief Convenience macro.
 #define MAX(a,b) (a) > (b) ? (a) : (b)
 
-bool SPRMatrix::solve (SystemVector& B, bool, Real*)
+bool SPRMatrix::solve (SystemVector& B, Real*)
 {
   if (mpar[7] < 1) return true; // No equations to solve
 

--- a/src/LinAlg/SPRMatrix.h
+++ b/src/LinAlg/SPRMatrix.h
@@ -79,7 +79,7 @@ public:
   //! \brief Adds a matrix with similar sparsity pattern to the current matrix.
   //! \param[in] B     The matrix to be added
   //! \param[in] alpha Scale factor for matrix \b B
-  virtual bool add(const SystemMatrix& B, Real alpha = 1.0);
+  virtual bool add(const SystemMatrix& B, Real alpha);
 
   //! \brief Adds the diagonal matrix &sigma;\b I to the current matrix.
   virtual bool add(Real sigma);
@@ -90,7 +90,7 @@ public:
   using SystemMatrix::solve;
   //! \brief Solves the linear system of equations for a given right-hand-side.
   //! \param B Right-hand-side vector on input, solution vector on output
-  virtual bool solve(SystemVector& B, bool, Real*);
+  virtual bool solve(SystemVector& B, Real*);
 
   //! \brief Solves a generalized symmetric-definite eigenproblem.
   //! \param B Symmetric and positive definite mass matrix.
@@ -106,12 +106,12 @@ public:
   virtual Real Linfnorm() const;
 
 private:
-  int mpar[NS] = {};      //!< Matrix of sparse PARameters
-  int* msica = nullptr;   //!< Matrix of Storage Information for CA
-  int* msifa = nullptr;   //!< Matrix of Storage Information for FA
-  int* mtrees = nullptr;  //!< Matrix of elimination assembly TREES
-  int* mvarnc = nullptr;  //!< Matrix of VARiable to Node Correspondence
-  Real* values = nullptr; //!< The actual matrix VALUES
+  int mpar[NS]; //!< Matrix of sparse PARameters
+  int* msica;   //!< Matrix of Storage Information for CA
+  int* msifa;   //!< Matrix of Storage Information for FA
+  int* mtrees;  //!< Matrix of elimination assembly TREES
+  int* mvarnc;  //!< Matrix of VARiable to Node Correspondence
+  Real* values; //!< The actual matrix VALUES
 
   std::vector<int>  iWork; //!< Integer work array
   std::vector<Real> rWork; //!< Real work array

--- a/src/LinAlg/SparseMatrix.C
+++ b/src/LinAlg/SparseMatrix.C
@@ -342,7 +342,8 @@ const Real& SparseMatrix::operator () (size_t r, size_t c) const
 }
 
 
-void SparseMatrix::dump (std::ostream& os, LinAlg::StorageFormat format, const char* label)
+void SparseMatrix::dump (std::ostream& os, LinAlg::StorageFormat format,
+                         const char* label)
 {
   if (label && format != LinAlg::MATRIX_MARKET) os << label <<" = [\n";
 
@@ -1011,7 +1012,7 @@ bool SparseMatrix::optimiseSLU (const std::vector<IntSet>& dofc)
 }
 
 
-bool SparseMatrix::solve (SystemVector& B, bool, Real* rc)
+bool SparseMatrix::solve (SystemVector& B, Real* rc)
 {
   if (this->size() < 1) return true; // No equations to solve
 

--- a/src/LinAlg/SparseMatrix.h
+++ b/src/LinAlg/SparseMatrix.h
@@ -100,7 +100,8 @@ public:
   void printFull(std::ostream& os) const;
 
   //! \brief Dumps the system matrix on a specified format.
-  virtual void dump(std::ostream&, LinAlg::StorageFormat, const char* = nullptr);
+  virtual void dump(std::ostream& os, LinAlg::StorageFormat format,
+                    const char* label);
 
   //! \brief Initializes the element assembly process.
   //! \details Must be called once before the element assembly loop.
@@ -194,7 +195,7 @@ public:
   //! \brief Adds a matrix with similar sparsity pattern to the current matrix.
   //! \param[in] B     The matrix to be added
   //! \param[in] alpha Scale factor for matrix \b B
-  virtual bool add(const SystemMatrix& B, Real alpha = Real(1));
+  virtual bool add(const SystemMatrix& B, Real alpha);
 
   //! \brief Adds the diagonal matrix &sigma;\b I to the current matrix.
   virtual bool add(Real sigma);
@@ -205,9 +206,8 @@ public:
   using SystemMatrix::solve;
   //! \brief Solves the linear system of equations for a given right-hand-side.
   //! \param B Right-hand-side vector on input, solution vector on output
-  //! \param[in] newLHS \e true if the left-hand-side matrix has been updated
   //! \param[out] rc Reciprocal condition number of the LHS-matrix (optional)
-  virtual bool solve(SystemVector& B, bool newLHS = true, Real* rc = nullptr);
+  virtual bool solve(SystemVector& B, Real* rc = nullptr);
 
   //! \brief Calculates compressed-sparse-row arrays from the element map.
   //! \param[out] iA Start index of each row in jA
@@ -275,9 +275,8 @@ private:
   //! '\0' : Values may be edited but the pattern is permanently locked
   char editable;
 
-  bool factored; //!< \e true when the matrix is factorized
-  size_t nrow;   //!< Number of matrix rows
-  size_t ncol;   //!< Number of matrix columns
+  size_t nrow; //!< Number of matrix rows
+  size_t ncol; //!< Number of matrix columns
 
   ValueMap       elem; //!< Stores nonzero matrix elements with index pairs
   SparseSolver solver; //!< Which equation solver to use
@@ -289,6 +288,8 @@ private:
 #endif
 
 protected:
+  bool factored; //!< Set to \e true when the matrix is factorized
+
   IntVec IA; //!< Identifies the beginning of each row or column
   IntVec JA; //!< Specifies column/row index of each nonzero element
   Vector  A; //!< Stores the nonzero matrix elements

--- a/src/LinAlg/SystemMatrix.h
+++ b/src/LinAlg/SystemMatrix.h
@@ -50,7 +50,7 @@ public:
   virtual size_t dim() const = 0;
 
   //! \brief Sets the dimension of the system vector.
-  virtual void redim(size_t) = 0;
+  virtual void redim(size_t n) = 0;
 
   //! \brief Resizes the vector to length \a n.
   virtual void resize(size_t n, bool = false) { this->redim(n); }
@@ -84,7 +84,7 @@ public:
   virtual bool endAssembly() { return true; }
 
   //! \brief Multiplication with a scalar.
-  virtual void mult(Real) = 0;
+  virtual void mult(Real alpha) = 0;
 
   //! \brief Addition of another system vector to this one.
   virtual void add(const SystemVector& vec, Real scale = Real(1)) = 0;
@@ -99,7 +99,8 @@ public:
   virtual Real Linfnorm() const = 0;
 
   //! \brief Dumps the system vector on a specified format.
-  virtual void dump(std::ostream&, LinAlg::StorageFormat, const char* = nullptr) {}
+  virtual void dump(std::ostream&, LinAlg::StorageFormat,
+                    const char* = nullptr) {}
 
 protected:
   //! \brief Writes the system vector to the given output stream.
@@ -179,7 +180,8 @@ public:
   virtual Real Linfnorm() const { size_t off = 0; return this->normInf(off); }
 
   //! \brief Dumps the system vector on a specified format.
-  virtual void dump(std::ostream& os, LinAlg::StorageFormat format, const char* label = nullptr);
+  virtual void dump(std::ostream& os, LinAlg::StorageFormat format,
+                    const char* label);
 
 protected:
   //! \brief Writes the system vector to the given output stream.
@@ -280,7 +282,7 @@ public:
   virtual bool truncate(Real = Real(1.0e-16)) { return false; }
 
   //! \brief Multiplication with a scalar.
-  virtual void mult(Real) = 0;
+  virtual void mult(Real alpha) = 0;
 
   //! \brief Adds a matrix with similar structure to the current matrix.
   virtual bool add(const SystemMatrix&, Real = Real(1)) { return false; }
@@ -293,25 +295,23 @@ public:
 
   //! \brief Solves the linear system of equations for a given right-hand-side.
   //! \param b Right-hand-side vector on input, solution vector on output
-  //! \param[in] newLHS \e true if the left-hand-side matrix has been updated
   //! \param[out] rc Reciprocal condition number of the LHS-matrix (optional)
-  virtual bool solve(SystemVector& b, bool newLHS = true,
-                     Real* rc = nullptr) = 0;
+  virtual bool solve(SystemVector& b, Real* rc = nullptr) = 0;
 
   //! \brief Solves the linear system of equations for a given right-hand-side.
   //! \param[in] b Right-hand-side vector
   //! \param[out] x Solution vector
-  //! \param[in] newLHS \e true if the left-hand-side matrix has been updated
-  virtual bool solve(const SystemVector& b, SystemVector& x, bool newLHS = true)
+  virtual bool solve(const SystemVector& b, SystemVector& x)
   {
-    return this->solve(x.copy(b),newLHS);
+    return this->solve(x.copy(b));
   }
 
   //! \brief Returns the L-infinity norm of the matrix.
   virtual Real Linfnorm() const = 0;
 
   //! \brief Dumps the system matrix on a specified format.
-  virtual void dump(std::ostream&, LinAlg::StorageFormat, const char* = nullptr) {}
+  virtual void dump(std::ostream&, LinAlg::StorageFormat,
+                    const char* = nullptr) {}
 
   //! \brief Calculates a matrix-vector product.
   StdVector operator*(const SystemVector& b) const;

--- a/src/SIM/AdaptiveSIM.C
+++ b/src/SIM/AdaptiveSIM.C
@@ -78,7 +78,7 @@ bool AdaptiveSIM::assembleAndSolveSystem ()
   int printSol = 1;
   solution.resize(model.getNoRHS());
   for (size_t i = 0; i < solution.size(); i++)
-    if (!model.solveSystem(solution[i],printSol,&rCond,"displacement",i==0,i))
+    if (!model.solveSystem(solution[i],printSol,&rCond,"displacement",i))
       return false;
     else if (i == 0)
     {

--- a/src/SIM/AdaptiveSIM.C
+++ b/src/SIM/AdaptiveSIM.C
@@ -180,7 +180,7 @@ bool AdaptiveSIM::solveStep (const char* inputfile, int iStep, bool withRF,
                          model.getProcessAdm().cout,true,precision))
     return failure();
 
-  if (!this->savePoints(0.0, iStep))
+  if (!this->savePoints(iStep))
     return failure();
 
   return true;
@@ -267,7 +267,7 @@ bool AdaptiveSIM::writeGlv (const char* infile, int iStep)
 }
 
 
-bool AdaptiveSIM::savePoints(double time, int iStep) const
+bool AdaptiveSIM::savePoints (int iStep) const
 {
-  return model.savePoints(solution.front(), time, iStep);
+  return model.savePoints(solution.front(),0.0,iStep);
 }

--- a/src/SIM/AdaptiveSIM.h
+++ b/src/SIM/AdaptiveSIM.h
@@ -53,7 +53,7 @@ public:
 
   //! \brief Writes current mesh and results to the VTF-file.
   //! \param[in] infile File name used to construct the VTF-file name from
-  //! \param[in] iStep  Refinement step identifier
+  //! \param[in] iStep  Refinement step counter
   bool writeGlv(const char* infile, int iStep);
 
   //! \brief Accesses the solution of the linear system.
@@ -78,15 +78,15 @@ public:
   //! \param[in] fixDup Merge duplicated FE nodes on patch interfaces?
   virtual bool preprocess(const std::vector<int>& ignored, bool fixDup);
 
-  //! \brief Saves point results to output file for a given time step.
-  //! \param[in] time Load/time step parameter
-  //! \param[in] iStep Load/time step counter
-  //! \details By default it just forwards to the underlying model
-  virtual bool savePoints(double time, int iStep) const;
-
 protected:
   //! \brief Assembles and solves the linear FE equation system.
   virtual bool assembleAndSolveSystem();
+
+  //! \brief Saves point results to output file for a given refinement step.
+  //! \param[in] iStep Refinement step counter
+  //!
+  //! \details By default, this method just forwards to the underlying model.
+  virtual bool savePoints(int iStep) const;
 
 private:
   Vectors gNorm; //!< Global norms

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -1091,7 +1091,7 @@ bool SIMbase::applyDirichlet (Vector& glbVec) const
 
 
 bool SIMbase::solveSystem (Vector& solution, int printSol, double* rCond,
-                           const char* compName, bool newLHS, size_t idxRHS)
+                           const char* compName, size_t idxRHS)
 {
   if (!myEqSys) return false;
 
@@ -1162,7 +1162,7 @@ bool SIMbase::solveSystem (Vectors& solution, int printSol, const char* cmpName)
 
   bool status = nSol > 0;
   for (size_t i = 0; i < nSol && status; i++)
-    status = this->solveSystem(solution[i],printSol,nullptr,cmpName,i==0,i);
+    status = this->solveSystem(solution[i],printSol,nullptr,cmpName,i);
 
   return status;
 }

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -1110,7 +1110,7 @@ bool SIMbase::solveSystem (Vector& solution, int printSol, double* rCond,
 
   double rcn = 1.0;
   utl::profiler->start("Equation solving");
-  bool status = A->solve(*b, newLHS, msgLevel > 1 ? &rcn : rCond);
+  bool status = A->solve(*b, msgLevel > 1 ? &rcn : rCond);
   utl::profiler->stop("Equation solving");
 
   if (msgLevel > 1)

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -297,11 +297,10 @@ public:
   //! \param[in] printSol Print solution if its size is less than \a printSol
   //! \param[out] rCond Reciprocal condition number
   //! \param[in] compName Solution name to be used in norm output
-  //! \param[in] newLHS If \e false, reuse the LHS-matrix from previous call.
   //! \param[in] idxRHS Index to the right-hand-side vector to solve for
   virtual bool solveSystem(Vector& solution, int printSol, double* rCond,
                            const char* compName = "displacement",
-                           bool newLHS = true, size_t idxRHS = 0);
+                           size_t idxRHS = 0);
 
   //! \brief Solves the assembled linear system of equations for a given load.
   //! \param[out] solution Global primary solution vector
@@ -352,7 +351,7 @@ public:
                        char type = 'D') const;
 
   //! \brief Integrates some solution norm quantities.
-  //! \param[in] time Parameters for nonlinear/time-dependent simulations.
+  //! \param[in] time Parameters for nonlinear/time-dependent simulations
   //! \param[in] psol Primary solution vectors
   //! \param[in] ssol Secondary solution vectors
   //! \param[out] gNorm Global norm quantities
@@ -369,7 +368,7 @@ public:
                      Vectors& gNorm, Matrix* eNorm = nullptr,
                      const char* name = nullptr);
   //! \brief Integrates some solution norm quantities.
-  //! \param[in] time Parameters for nonlinear/time-dependent simulations.
+  //! \param[in] time Parameters for nonlinear/time-dependent simulations
   //! \param[in] psol Primary solution vectors
   //! \param[out] gNorm Global norm quantities
   //! \param[out] eNorm Element-wise norm quantities


### PR DESCRIPTION
The argument `newLHS` is not (or shouldn't be) needed, and therefore removed to lessen confusion. It was referred only by the `PETScMatrix` subclass, but also there the `factored` member of the parent class (`SparseMatrix`) can now be used. This flag is reset whenever the matrix is reinitialized by the `initAssembly()` method.

Consequently, the `newLHS` argument in `SIMbase::solveSystem()` can also go away, which have some downstream effects.

The fourth commit is unreleated, but makes better sense.