### PR TITLE
Fix block matrix with single basis discretization

### DIFF
--- a/src/ASM/DomainDecomposition.C
+++ b/src/ASM/DomainDecomposition.C
@@ -1144,16 +1144,17 @@ bool DomainDecomposition::setup(const ProcessAdm& adm, const SIMbase& sim)
           dofType = cb == 1 ? 'D' : 'P'+cb-2;
           std::set<int> tmp = adm.dd.getSAM()->getEquations(dofType);
           blocks[i+1].localEqs.insert(tmp.begin(), tmp.end());
-          // HACK: multipliers always in second block
-          // Correct thing to do for average pressure constraint in Stokes.
-          if (i == 1) {
-            for (size_t n = 1; n <= sim.getPatch(1)->getNoNodes(); ++n) {
-              if (sim.getPatch(1)->isLMn(n) && sim.getPatch(1)->getLMType(n) == 'G') {
-                int lEq = sam->getEquation(sim.getPatch(1)->getNodeID(n), 1);
-                if (lEq > 0)
-                  blocks[i+1].localEqs.insert(lEq);
-              }
-            }
+        }
+      }
+
+      // HACK: multipliers always in second block
+      // Correct thing to do for average pressure constraint in Stokes.
+      if (i == 1) {
+        for (size_t n = 1; n <= sim.getPatch(1)->getNoNodes(); ++n) {
+          if (sim.getPatch(1)->isLMn(n) && sim.getPatch(1)->getLMType(n) == 'G') {
+            int lEq = sam->getEquation(sim.getPatch(1)->getNodeID(n), 1);
+            if (lEq > 0)
+              blocks[i+1].localEqs.insert(lEq);
           }
         }
       }

--- a/src/ASM/DomainDecomposition.C
+++ b/src/ASM/DomainDecomposition.C
@@ -1121,7 +1121,6 @@ bool DomainDecomposition::setup(const ProcessAdm& adm, const SIMbase& sim)
 
   // Establish local equation mappings for each block.
   if (sim.getSolParams() && sim.getSolParams()->getNoBlocks() > 1) {
-    IFEM::cout << "\tEstablishing local block equation numbers" << std::endl;
     const LinSolParams& solParams = *sim.getSolParams();
     blocks.clear();
     blocks.resize(solParams.getNoBlocks()+1);
@@ -1162,6 +1161,7 @@ bool DomainDecomposition::setup(const ProcessAdm& adm, const SIMbase& sim)
       size_t idx = 1;
       for (auto& it : blocks[i+1].localEqs)
         blocks[i+1].G2LEQ[it] = idx++;
+      IFEM::cout << "  Block " << i+1 << "             " << blocks[i+1].localEqs.size() << std::endl;
     }
   }
 


### PR DESCRIPTION
- Print block matrix sizes in serial
- Put global lagrange multipliers in second block also with single basis method