### PR TITLE
changed: print iteration history in NonLinSIM even at msgLevel -1

### DIFF
--- a/src/SIM/NonLinSIM.C
+++ b/src/SIM/NonLinSIM.C
@@ -434,7 +434,7 @@ ConvStatus NonLinSIM::checkConvergence (TimeStep& param)
   if (param.iter > 1 && prevNorm > 0.0 && fabs(norm) > prevNorm*0.1)
     status = SLOW;
 
-  if (msgLevel > 0)
+  if (msgLevel > 0 || msgLevel == -1)
   {
     // Print convergence history
     utl::LogStream& cout = model.getProcessAdm().cout;


### PR DESCRIPTION
allows suppressing norm and solution summary output, while still
keeping the iteration history. useful in split simulators
such as Chorin