### PR TITLE
Changed: Enable MathJax for equation rendering

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1050,6 +1050,9 @@ LATEX_BATCHMODE        = NO
 
 LATEX_HIDE_INDICES     = NO
 
+# To render equations in the browser instead of generating png-files
+USE_MATHJAX = TRUE
+
 #---------------------------------------------------------------------------
 # configuration options related to the RTF output
 #---------------------------------------------------------------------------

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -120,7 +120,7 @@ public:
   //! \param[in] orient Local orientation of indices, see ASMLRSpline::Sort()
   //! \param[in] local If \e true, return patch-local numbers
   //! \param[in] open If \e true, exclude edge end points
-  virtual void getBoundary1Nodes(int lIndex, IntVec& nodes, int basis,
+  virtual void getBoundary1Nodes(int lEdge, IntVec& nodes, int basis,
                                  int orient, bool local,
                                  bool open = false) const;
 


### PR DESCRIPTION
For circumventing a bug in doxygen for Ubuntu 20.04