### PR TITLE
Generalization of reaction- and interface force calculation

### DIFF
--- a/cmake/Modules/FindVTFWriter.cmake
+++ b/cmake/Modules/FindVTFWriter.cmake
@@ -9,6 +9,7 @@ IF (NOT VTFAPI OR VTFAPI GREATER 1)
   FIND_PATH(VTFWRITER_INCLUDES
     NAMES VTFXAPI.h
     PATHS $ENV{HOME}/include
+    /usr/local/include
     /sima/libs/VTFx/include
   )
   IF(VTFWRITER_INCLUDES)
@@ -20,6 +21,7 @@ IF (NOT VTFWRITER_INCLUDES)
   FIND_PATH(VTFWRITER_INCLUDES
     NAMES VTFAPI.h
     PATHS $ENV{HOME}/include
+    /usr/local/include
     /sima/libs/GLviewExpressWriter/include
   )
   IF(VTFWRITER_INCLUDES)
@@ -32,6 +34,7 @@ IF(VTFWRITER_INCLUDES)
     FIND_LIBRARY(VTFWRITER_LIBRARIES
       NAMES VTFExpressAPI
       PATHS $ENV{HOME}/lib
+      /usr/local/lib
       /sima/libs/GLviewExpressWriter/lib
     )
     MESSAGE(STATUS "Using VTF libraries")
@@ -39,11 +42,13 @@ IF(VTFWRITER_INCLUDES)
     FIND_LIBRARY(VTFWRITER_LIBRARIES
       NAMES GLviewExpressWriter2d
       PATHS $ENV{HOME}/lib
+      /usr/local/lib
       /sima/libs/VTFx/lib
     )
     FIND_LIBRARY(ZIP_LIBRARIES
       NAMES ziparch
       PATHS $ENV{HOME}/lib
+      /usr/local/lib
       /sima/libs/VTFx/lib
     )
     SET(VTFWRITER_LIBRARIES ${VTFWRITER_LIBRARIES} ${ZIP_LIBRARIES})

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -3501,14 +3501,16 @@ void ASMs3D::generateThreadGroups (char lIndex, bool silence, bool)
 
   fGrp.applyMap(map);
 
-  if (!silence && fGrp.size() > 1)
-    for (size_t i = 0; i < fGrp.size(); i++)
-    {
-      std::cout <<"\n Thread group "<< i+1 <<" for boundary face "<<(int)lIndex;
-      for (size_t j = 0; j < fGrp[i].size(); j++)
-	std::cout <<"\n\tthread "<< j+1
-		  << ": "<< fGrp[i][j].size() <<" elements";
-    }
+  if (silence || fGrp.size() < 2) return;
+
+  for (size_t i = 0; i < fGrp.size(); i++)
+  {
+    IFEM::cout <<"\n Thread group "<< i+1 <<" for boundary face "<< (int)lIndex;
+    for (size_t j = 0; j < fGrp[i].size(); j++)
+      IFEM::cout <<"\n\tthread "<< j+1
+                 << ": "<< fGrp[i][j].size() <<" elements";
+  }
+  IFEM::cout << std::endl;
 }
 
 

--- a/src/ASM/IntegrandBase.h
+++ b/src/ASM/IntegrandBase.h
@@ -84,6 +84,8 @@ public:
   virtual void initResultPoints(double, bool = false) {}
   //! \brief Initializes the global node number mapping for current patch.
   virtual void initNodeMap(const std::vector<int>&) {}
+  //! \brief Assigns a secondary integral to be computed (for reaction forces).
+  virtual void setSecondaryInt(GlobalIntegral* = nullptr) {}
   //! \brief Returns the system quantity to be integrated by \a *this.
   virtual GlobalIntegral& getGlobalInt(GlobalIntegral* gq) const;
 

--- a/src/ASM/ReactionsOnly.h
+++ b/src/ASM/ReactionsOnly.h
@@ -7,7 +7,7 @@
 //!
 //! \author Knut Morten Okstad / SINTEF
 //!
-//! \brief Global integral sub-class for reaction force integration.
+//! \brief Global integral class for reaction- and interface force calculation.
 //!
 //==============================================================================
 
@@ -19,7 +19,7 @@
 
 
 /*!
-  \brief Class for assembly of reaction forces only.
+  \brief Class for assembly of reaction- and interface forces.
 
   \details This class can be used for linear problems which normally consists
   of a single assembly loop. For non-linear problems, the reaction forces for
@@ -27,18 +27,21 @@
   the solution vector of the previous iteration is used. In linear problems we
   therefore need a separate assembly loop where only the reaction forces are
   calculated. This class is provided to facilitate such calculations.
+
+  The class can also be used to calculate interface force resultants,
+  for boundaries not associated with dirichlet conditions.
 */
 
 class ReactionsOnly : public GlobalIntegral
 {
 public:
   //! \brief The constructor initializes the data members.
-  //! \param[in] rf The reaction force vector to be assembled
   //! \param[in] sam Data for FE assembly management
   //! \param[in] adm Parallell processing administrator
+  //! \param[in] rf Reaction force vector to be assembled
   //! \param[in] sf Internal force vector to be assembled
-  ReactionsOnly(Vector& rf, const SAM* sam, const ProcessAdm& adm,
-                Vector* sf = nullptr);
+  ReactionsOnly(const SAM* sam, const ProcessAdm& adm,
+                Vector* rf = nullptr, Vector* sf = nullptr);
   //! \brief Empty destructor.
   virtual ~ReactionsOnly() {}
 
@@ -49,10 +52,10 @@ public:
 
   //! \brief Adds a LocalIntegral object into a corresponding global object.
   //! \param[in] elmObj The local integral object to add into \a *this.
-  //! \param[in] elmId Global number of the element associated with elmObj
+  //! \param[in] elmId Global number of the element associated with \a elmObj
   virtual bool assemble(const LocalIntegral* elmObj, int elmId);
 
-  //! \brief Returns \e false if no contributions from the specified patch.
+  //! \brief Returns \e true if the patch \a pidx have any force contributions.
   //! \param[in] pidx 1-based patch index
   //! \param[in] pvec Physical property mapping
   virtual bool haveContributions(size_t pidx,
@@ -62,9 +65,9 @@ private:
   const SAM*        mySam; //!< Data for FE assembly management
   const ProcessAdm& myAdm; //!< Parallel processing administrator
 
-  Vector&   R; //!< Nodal reaction forces
-  StdVector b; //!< Dummy right-hand-side vector
-  Vector*   S; //!< Internal force vector
+  StdVector b; //!< Internal right-hand-side vector used in the assembly process
+  Vector*   R; //!< Nodal reaction forces
+  Vector*   S; //!< Nodal internal forces
 };
 
 #endif

--- a/src/ASM/TimeDomain.h
+++ b/src/ASM/TimeDomain.h
@@ -31,6 +31,9 @@ struct TimeDomain
   //! \brief Default constructor.
   explicit TimeDomain(int i = 0, bool f = true) : it(i), first(f)
   { t = dt = dtn = CFL = 0.0; }
+  //! \brief Constructor for linear problems with fixed (non-zero) time.
+  explicit TimeDomain(double t0) : t(t0), it(0), first(true)
+  { dt = dtn = CFL = 0.0; }
 };
 
 #endif

--- a/src/LinAlg/SAM.C
+++ b/src/LinAlg/SAM.C
@@ -976,9 +976,13 @@ Real SAM::getReaction (int dir, const RealArray& rf, const IntVec* nodes) const
       if (!nodes || std::find(nodes->begin(),nodes->end(),i+1) != nodes->end())
       {
         int idof = madof[i]+dir-2;
-        if (idof < madof[i+1]-1)
-          if (msc[idof] < 0 && -msc[idof] <= (int)rf.size())
-            retVal += rf[-msc[idof]-1];
+        int ipr = -msc[idof]-1;
+        if (idof < madof[i+1]-1 && ipr >= 0 && ipr < (int)rf.size())
+        {
+          retVal += rf[ipr];
+          if (nodes) // clear this force component to avoid it being added twice
+            const_cast<RealArray&>(rf)[ipr] = 0.0;
+        }
       }
 
   return retVal;

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -1149,7 +1149,7 @@ bool SIMbase::extractLoadVec (Vector& loadVec, size_t idx, const char* hd) const
     return false;
 
 #if SP_DEBUG > 1
-  std::cout <<"\nLoad vector:"<< loadVec;
+  mySam->printVector(std::cout,loadVec,"\nLoad vector");
 #endif
   if (hd)
   {

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -278,11 +278,12 @@ public:
                               bool newLHSmatrix = true, bool poorConvg = false);
 
   //! \brief Administers assembly of the linear equation system.
+  //! \param[in] t0 Time for evaluation of time-dependent property functions
   //! \param[in] pSol Primary solution vectors in DOF-order
   //!
   //! \details Use this version for linear/stationary problems only.
-  bool assembleSystem(const Vectors& pSol = Vectors())
-  { return this->assembleSystem(TimeDomain(),pSol); }
+  bool assembleSystem(double t0 = 0.0, const Vectors& pSol = Vectors())
+  { return this->assembleSystem(TimeDomain(t0),pSol); }
 
   //! \brief Extracts the assembled load vector for inspection/visualization.
   //! \param[out] loadVec Global load vector in DOF-order
@@ -464,19 +465,30 @@ public:
   //! \param[in] ncv Number of Arnoldi vectors (see ARPack documentation)
   //! \param[in] shift Eigenvalue shift
   //! \param[out] solution Computed eigenvalues and associated eigenvectors
-  //! \param[in] iA Index of system matrix \b A in \a myEqSys->A
-  //! \param[in] iB Index of system matrix \b B in \a myEqSys->A
+  //! \param[in] iA Index of system matrix \b A in \ref myEqSys
+  //! \param[in] iB Index of system matrix \b B in \ref myEqSys
   bool systemModes(std::vector<Mode>& solution,
                    int nev, int ncv, int iop, double shift,
                    size_t iA = 0, size_t iB = 1);
   //! \brief Performs a generalized eigenvalue analysis of the assembled system.
   //! \param[out] solution Computed eigenvalues and associated eigenvectors
-  //! \param[in] iA Index of system matrix \b A in \a myEqSys->A
-  //! \param[in] iB Index of system matrix \b B in \a myEqSys->A
+  //! \param[in] iA Index of system matrix \b A in \ref myEqSys
+  //! \param[in] iB Index of system matrix \b B in \ref myEqSys
   bool systemModes(std::vector<Mode>& solution, size_t iA = 0, size_t iB = 1)
   {
     return this->systemModes(solution,opt.nev,opt.ncv,opt.eig,opt.shift,iA,iB);
   }
+
+  //! \brief Returns whether reaction forces are to be computed or not.
+  virtual bool haveBoundaryReactions(bool = false) const { return false; }
+
+  //! \brief Assembles reaction and interface forces for specified boundaries.
+  //! \param[in] solution Current primary solution vector
+  //! \param[in] t0 Current time (for time-dependent loads)
+  //! \param[out] R Nodal reaction force container
+  //! \param[out] S Nodal interface force container
+  bool assembleForces(const Vector& solution, double t0,
+                      Vector* R, Vector* S = nullptr);
 
 
   // Post-processing methods

--- a/src/SIM/SIMgeneric.C
+++ b/src/SIM/SIMgeneric.C
@@ -69,11 +69,21 @@ Vector SIMgeneric::getInterfaceForces (const Vector& sf,
 
   IntVec glbNodes;
   this->getBoundaryNodes(code,glbNodes);
+#if SP_DEBUG > 1
+  std::cout <<"\nInternal nodal forces at interface "<< code
+            <<" with "<< glbNodes.size() <<" nodes"<< std::endl;
+#endif
 
   for (int inod : glbNodes)
   {
     double w = inod <= (int)weights.size() ? weights[inod-1] : 1.0;
     std::pair<int,int> dof = mySam->getNodeDOFs(inod);
+#if SP_DEBUG > 1
+    std::cout <<"Node "<< inod <<":";
+    for (int j = dof.first; j <= dof.second; j++)
+      std::cout <<" "<< sf(j);
+    std::cout << std::endl;
+#endif
     for (unsigned char i = 0; i < nsd; i++, dof.first++)
       if (dof.first <= dof.second && dof.first < (int)sf.size())
         force[i] += w*sf(dof.first);

--- a/src/SIM/SIMoutput.h
+++ b/src/SIM/SIMoutput.h
@@ -80,7 +80,7 @@ public:
   //! \brief Writes additional, problem-specific, results to the VTF-file.
   //! \param nBlock Running result block counter
   //! \param[in] iStep Load/time step identifier
-  virtual bool writeGlvA(int& nBlock, int iStep = 1) const { return true; }
+  virtual bool writeGlvA(int& nBlock, int iStep, int = 1) const { return true; }
 
   //! \brief Writes boundary conditions as scalar fields to the VTF-file.
   //! \param nBlock Running result block counter

--- a/src/SIM/SIMoutput.h
+++ b/src/SIM/SIMoutput.h
@@ -297,6 +297,8 @@ public:
   virtual double getEffectivityIndex(const Vectors&, size_t, size_t) const = 0;
   //! \brief Prints integrated solution norms to the log stream.
   virtual void printNorms(const Vectors&, size_t = 36) const = 0;
+  //! \brief Prints out interface force resultants to log stream.
+  virtual void printIFforces(const Vector&, RealArray&) {}
 
   //! \brief Writes out the additional functions to VTF-file.
   virtual bool writeAddFuncs(int iStep, int& nBlock, int idBlock, double time);


### PR DESCRIPTION
A general method SIMbase::assembleForces() is provided for the integration of reaction and/or interface forces, for the identified boundaries. The virtual method haveBoundaryReactions() need to be overridden by the application to decide which patches to be considered.