### PR TITLE
fixed: check number of components in function

### DIFF
--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -1167,7 +1167,8 @@ bool ASMs2D::updateDirichlet (const std::map<int,RealFunc*>& func,
     if ((fit = func.find(dirich[i].code)) != func.end())
       dcrv = SplineUtils::project(dirich[i].curve,*fit->second,1,time);
     else if ((vfit = vfunc.find(dirich[i].code)) != vfunc.end())
-      dcrv = SplineUtils::project(dirich[i].curve,*vfit->second,nf,time);
+      dcrv = SplineUtils::project(dirich[i].curve,*vfit->second,
+                                  vfit->second->dim(),time);
     else
     {
       std::cerr <<" *** ASMs2D::updateDirichlet: Code "<< dirich[i].code

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -1428,7 +1428,8 @@ bool ASMs3D::updateDirichlet (const std::map<int,RealFunc*>& func,
     if ((fit = func.find(dirich[i].code)) != func.end())
       dsurf = SplineUtils::project(dirich[i].surf,*fit->second,1,time);
     else if ((vfit = vfunc.find(dirich[i].code)) != vfunc.end())
-      dsurf = SplineUtils::project(dirich[i].surf,*vfit->second,nf,time);
+      dsurf = SplineUtils::project(dirich[i].surf,*vfit->second,
+                                   vfit->second->dim(),time);
     else
     {
       std::cerr <<" *** ASMs3D::updateDirichlet: Code "<< dirich[i].code


### PR DESCRIPTION
in particular for mixed integrands using anasol boundary conditions
nf can be greater than the number of components in the function. this is
because nf is set to the total number of fields and not the number
of fields on a single basis