### PR TITLE
fixed: clear additional functions in clearProperties

### DIFF
--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -52,6 +52,9 @@ SIMoutput::~SIMoutput ()
 void SIMoutput::clearProperties ()
 {
   myPoints.clear();
+  for (std::pair<const std::string,RealFunc*>& func : myAddScalars)
+    delete func.second;
+  myAddScalars.clear();
   this->SIMinput::clearProperties();
 }
 


### PR DESCRIPTION
this is necessary to not register multiple functions if
used in adaptive simulations