### PR TITLE
changed: add 'symmetric' as an alias for 'symmetrized' beta type

### DIFF
--- a/src/SIM/AdaptiveSetup.C
+++ b/src/SIM/AdaptiveSetup.C
@@ -143,7 +143,8 @@ bool AdaptiveSetup::parse (const TiXmlElement* elem)
         threshold = TRUE_BETA;
       else if (type.compare("dorfel") == 0)
         threshold = DORFEL;
-      else if (type.compare("symmetrized") == 0) {
+      else if (type.compare("symmetrized") == 0 ||
+               type.compare("symmetric") == 0) {
         threshold = SYMMETRIZED;
         utl::getAttribute(child,"eps",symmEps);
       }


### PR DESCRIPTION
Users keep getting this wrong. Having the alias is harmless..