### PR TITLE
fix initial conditions with partitioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,7 @@ else()
                          src/ASM/ImmersedBoundaries.h src/ASM/Interface.h
                          src/ASM/Integrand.h src/ASM/Lagrange.h
                          src/ASM/LocalIntegral.h src/ASM/SAMpatch.h
+                         src/ASM/SplineField?D.h src/ASM/SplineFields?D.h
                          src/ASM/TimeDomain.h src/ASM/ASMs?D.h src/ASM/ASM?D.h
                          src/ASM/ASMs?DLag.h
                          src/ASM/DomainDecomposition.h src/ASM/ItgPoint.h

--- a/src/LinAlg/ProcessAdm.C
+++ b/src/LinAlg/ProcessAdm.C
@@ -53,6 +53,14 @@ ProcessAdm::ProcessAdm(const ProcessAdm& adm) : cout(adm.cout)
 }
 
 
+void ProcessAdm::broadcast (std::vector<double>& vec, int root) const
+{
+#ifdef HAVE_MPI
+  MPI_Bcast(vec.data(), vec.size(), MPI_DOUBLE, root, comm);
+#endif
+}
+
+
 #ifdef HAVE_MPI
 ProcessAdm::ProcessAdm(bool) : cout(std::cout)
 {

--- a/src/LinAlg/ProcessAdm.h
+++ b/src/LinAlg/ProcessAdm.h
@@ -69,6 +69,11 @@ public:
   //! \brief Return if parallel
   int isParallel() const { return parallel; }
 
+  //! \brief Broadcast for a double vector.
+  //! \param vec Double array to broadcast
+  //! \param root Node to broadcast from
+  void broadcast(std::vector<double>& vec, int root) const;
+
 #if defined(HAS_PETSC) || defined(HAVE_MPI)
   //! \brief Return MPI communicator
   MPI_Comm* getCommunicator() { return &comm; }


### PR DESCRIPTION
calculate these on root node and broadcast instead of calculating
separately on each process. this can cause desync between processes,
for instance if the initial condition uses random numbers