### PR TITLE
added: stopping criterion in time stepping

### DIFF
--- a/src/ASM/TimeDomain.h
+++ b/src/ASM/TimeDomain.h
@@ -25,15 +25,16 @@ struct TimeDomain
   double  dt; //!< Current timestep (or load parameter) increment
   double dtn; //!< Previous timestep (or load parameter) increment
   double CFL; //!< Current CFL number (used by CFD simulators)
+  double incNorm; //!< Norm of change between timesteps
   int     it; //!< Current iteration within current time/load step
   char first; //!< If \e true, this is the first load/time step
 
   //! \brief Default constructor.
   explicit TimeDomain(int i = 0, bool f = true) : it(i), first(f)
-  { t = dt = dtn = CFL = 0.0; }
+  { t = dt = dtn = CFL = incNorm = 0.0; }
   //! \brief Constructor for linear problems with fixed (non-zero) time.
   explicit TimeDomain(double t0) : t(t0), it(0), first(true)
-  { dt = dtn = CFL = 0.0; }
+  { dt = dtn = CFL = incNorm = 0.0; }
 };
 
 #endif

--- a/src/SIM/TimeStep.C
+++ b/src/SIM/TimeStep.C
@@ -32,6 +32,7 @@ TimeStep::TimeStep () : step(0), iter(time.it), lstep(0)
   f1 = 1.5;
   f2 = 0.25;
   maxStep = niter = 0;
+  stop_tol = 0.0;
   stepIt = mySteps.end();
 }
 
@@ -51,6 +52,7 @@ TimeStep& TimeStep::operator= (const TimeStep& ts)
   maxStep = ts.maxStep;
   niter = ts.niter;
   iter = ts.iter;
+  stop_tol = ts.stop_tol;
 
   time = ts.time;
   mySteps = ts.mySteps;
@@ -110,6 +112,7 @@ bool TimeStep::parse (const TiXmlElement* elem)
   utl::getAttribute(elem,"dtMax",dtMax);
   utl::getAttribute(elem,"maxCFL",maxCFL);
   utl::getAttribute(elem,"nInitStep",nInitStep);
+  utl::getAttribute(elem,"stop_tolerance",stop_tol);
   utl::getAttribute(elem,"maxStep",maxStep);
   utl::getAttribute(elem,"f1",f1);
   utl::getAttribute(elem,"f2",f2);
@@ -264,6 +267,12 @@ bool TimeStep::increment ()
   {
     IFEM::cout <<"\n  ** Terminating, maximum number of time steps reached."
                << std::endl;
+    return false;
+  }
+  else if (time.incNorm > 0.0 && time.incNorm < stop_tol)
+  {
+    IFEM::cout <<"\n  ** Terminating, solution increment norm "
+               << time.incNorm << " less than tolerance " << stop_tol << std::endl;
     return false;
   }
 

--- a/src/SIM/TimeStep.h
+++ b/src/SIM/TimeStep.h
@@ -62,6 +62,9 @@ public:
   //! \brief Returns \e true if the end of the simulation has been reached.
   bool finished() const;
 
+  //! \brief Returns configured stopping tolerance.
+  double stopTolerance() const { return stop_tol; }
+
   //! \brief Serialize internal state for restarting purposes.
   //! \param data Container for serialized data
   bool serialize(std::map<std::string,std::string>& data) const;
@@ -86,6 +89,8 @@ private:
   double dtMax;  //!< Maximun time increment size
   double f1;     //!< Scale factor for increased time step size
   double f2;     //!< Scale factor for reduced time step size
+
+  double stop_tol; //!< Stop time step loop if incNorm < stop_tol
 
   typedef std::pair<std::vector<double>,double> Step; //!< Time step definition
   typedef std::vector<Step> TimeSteps;                //!< Time step container


### PR DESCRIPTION
this allows to stop the time stepping based on
some kind of application-defined norm. e.g.
when the norm of increments between timesteps falls
below some threshold