### PR TITLE
changed: facilitate reuse of ForceBase derived integrands

### DIFF
--- a/src/ASM/IntegrandBase.C
+++ b/src/ASM/IntegrandBase.C
@@ -571,26 +571,36 @@ bool NormBase::reducedInt (LocalIntegral& elmInt,
 
 ForceBase::~ForceBase ()
 {
-  for (LocalIntegral* lint : eForce)
-    delete lint;
-  delete[] eBuffer;
+  this->clearBuffer();
 }
 
 
-bool ForceBase::initBuffer (size_t nel)
+void ForceBase::clearBuffer ()
 {
-  if (eBuffer) return false;
+  for (LocalIntegral* lint : eForce)
+    delete lint;
+  eForce.clear();
+  delete[] eBuffer;
+  eBuffer = nullptr;
+}
 
+
+void ForceBase::initBuffer (size_t nel)
+{
   size_t ncmp = this->getNoComps();
-  eBuffer = new double[ncmp*nel];
+
+  if (eForce.size() != nel) {
+    this->clearBuffer();
+
+    eBuffer = new double[ncmp*nel];
+
+    eForce.reserve(nel);
+    double* q = eBuffer;
+    for (size_t i = 0; i < nel; i++, q += ncmp)
+      eForce.push_back(new ElmNorm(q,ncmp));
+  }
+
   memset(eBuffer,0,ncmp*nel*sizeof(double));
-
-  eForce.reserve(nel);
-  double* q = eBuffer;
-  for (size_t i = 0; i < nel; i++, q += ncmp)
-    eForce.push_back(new ElmNorm(q,ncmp));
-
-  return true;
 }
 
 

--- a/src/ASM/IntegrandBase.h
+++ b/src/ASM/IntegrandBase.h
@@ -481,7 +481,7 @@ public:
   virtual ~ForceBase();
 
   //! \brief Allocates internal element force buffers.
-  bool initBuffer(size_t nel);
+  void initBuffer(size_t nel);
 
   //! \brief Assembles the global forces.
   void assemble(RealArray& force) const;
@@ -536,6 +536,9 @@ public:
   virtual bool hasBoundaryTerms() const { return true; }
 
 protected:
+  //! \brief Clears out internal buffers.
+  void clearBuffer();
+
   IntegrandBase& myProblem; //!< The problem-specific data
   LintegralVec      eForce; //!< Local integrals used during force integration
   double*          eBuffer; //!< Element force buffer used during integration


### PR DESCRIPTION
previously there was no way to clear the buffers used during
integration. now initBuffer resizes only if necessary, but
always zeros the underlying buffer.

closes https://github.com/OPM/IFEM-Darcy/issues/51