### PR TITLE
Added: Optional element shrinkage factor for LR meshes to VTF

### DIFF
--- a/src/Utility/ElementBlock.C
+++ b/src/Utility/ElementBlock.C
@@ -18,6 +18,9 @@
 #include <numeric>
 
 
+double ElementBlock::eps = 0.0;
+
+
 ElementBlock::ElementBlock (size_t nenod)
 {
   if (nenod != 2 && nenod != 3 && nenod != 4 && nenod != 6 && nenod != 9 &&

--- a/src/Utility/ElementBlock.h
+++ b/src/Utility/ElementBlock.h
@@ -109,6 +109,9 @@ private:
   std::vector<int>  MMNPC; //!< Matrix of Matrices of Nodal Point Correspondance
   std::vector<int>  MINEX; //!< Matrix of Internal to External element numbers
   size_t            nen;   //!< Number of Element Nodes
+
+public:
+  static double eps; //!< Element shrinkage factor
 };
 
 


### PR DESCRIPTION
This is needed for models with internal C^{-1} lines, to properly visualize the discontinuity with deformed geometry.
Without it, one often picks the wrong nodal results along the discontinuity.