### PR TITLE
Quell newer compiler warnings

### DIFF
--- a/src/ASM/ASMs2DInterpolate.C
+++ b/src/ASM/ASMs2DInterpolate.C
@@ -502,47 +502,32 @@ quasiInterpolation(const Go::BsplineBasis& basis_u,
 
 /*!
   \brief Local projection method (Variation Diminishing Spline Approximation).
-  \param[in] basis_u Basis values in the first parameter direction
-  \param[in] basis_v Basis values in the second parameter direction
-  \param[in] par_u Grevielle sites in the first parameter direction
-  \param[in] par_v Grevielle sites in the second parameter direction
+  \param[in] surf Spline surface to project onto
   \param[in] points Secondary solution field evaluated at Greville points
   \param[in] dimension Dimension of the secondary solution field
-  \param[in] rational Value marks NURBS geometry
-  \param[in] weights NURBS weights for the projective control points
   \return Spline surface object representing the projected field
 */
 
 static Go::SplineSurface*
-VariationDiminishingSplineApproximation(const Go::BsplineBasis& basis_u,
-                                        const Go::BsplineBasis& basis_v,
-                                        const RealArray& par_u,
-                                        const RealArray& par_v,
-                                        const RealArray& points,
-                                        int dimension, bool rational,
-                                        const RealArray& weights)
+VariationDiminishingSplineApproximation(const Go::SplineSurface* surf,
+                                        const RealArray& points, int dimension)
 {
-  // Check input
-  ASSERT(par_u.size()*par_v.size() == points.size()/dimension);
-  ASSERT(basis_u.numCoefs() == (int)par_u.size());
-  ASSERT(basis_v.numCoefs() == (int)par_v.size());
+  if (!surf->rational()) // Make spline surface
+    return new Go::SplineSurface(surf->basis(0), surf->basis(1),
+                                 points.begin(), dimension);
 
-  std::vector<double> local_coefs;
-  if (rational)
+  RealArray local_coefs, weights;
+  size_t k = 0, sizepoints = points.size()/dimension;
+  local_coefs.reserve((dimension+1)*sizepoints);
+  surf->getWeights(weights);
+  for (size_t i = 0; i < sizepoints; i++)
   {
-    size_t sizepoints = par_u.size()*par_v.size();
-    size_t countpoints = 0;
-    for (size_t i = 0; i < sizepoints; i++)
-    {
-      for (int j = 0; j < dimension; j++, countpoints++)
-        local_coefs.push_back(points[countpoints]*weights[i]);
-      local_coefs.push_back(weights[i]);
-    }
+    for (int j = 0; j < dimension; j++, k++)
+      local_coefs.push_back(points[k]*weights[i]);
+    local_coefs.push_back(weights[i]);
   }
-  else
-    local_coefs = points;
 
-  // Make surface
-  return new Go::SplineSurface(basis_u, basis_v, local_coefs.begin(),
-                               dimension, rational);
+  // Make rational spline surface
+  return new Go::SplineSurface(surf->basis(0), surf->basis(1),
+                               local_coefs.begin(), dimension, true);
 }

--- a/src/ASM/ASMs2Drecovery.C
+++ b/src/ASM/ASMs2Drecovery.C
@@ -491,8 +491,6 @@ bool ASMs2D::evaluate (const Field* field, RealArray& vec, int basisNum) const
     for (double u : gpar[0])
       sValues.push_back(field->valueFE(ItgPoint(u,v)));
 
-  Go::SplineSurface* surf = this->getBasis(basisNum);
-
   // Project the results onto the spline basis to find control point
   // values based on the result values evaluated at the Greville points.
   // Note that we here implicitly assume that the number of Greville points
@@ -500,16 +498,8 @@ bool ASMs2D::evaluate (const Field* field, RealArray& vec, int basisNum) const
   // the result array. Think that is always the case, but beware if trying
   // other projection schemes later.
 
-  RealArray weights;
-  if (surf->rational())
-    surf->getWeights(weights);
-
   Go::SplineSurface* surf_new =
-    VariationDiminishingSplineApproximation(surf->basis(0),
-                                            surf->basis(1),
-                                            gpar[0], gpar[1],
-                                            sValues, 1, surf->rational(),
-                                            weights);
+    VariationDiminishingSplineApproximation(this->getBasis(basisNum),sValues,1);
 
   vec.assign(surf_new->coefs_begin(),surf_new->coefs_end());
   delete surf_new;
@@ -616,15 +606,6 @@ Go::SplineSurface* ASMs2D::projectSolutionLocalApprox (const IntegrandBase& inte
   if (!this->evalSolution(sValues,integrand,gpar.data()))
     return nullptr;
 
-  RealArray weights;
-  if (surf->rational())
-    surf->getWeights(weights);
-
-  return VariationDiminishingSplineApproximation(surf->basis(0),
-						 surf->basis(1),
-						 gpar[0], gpar[1],
-						 sValues,
-						 sValues.rows(),
-						 surf->rational(),
-						 weights);
+  // Project onto the geometry basis
+  return VariationDiminishingSplineApproximation(surf,sValues,sValues.rows());
 }

--- a/src/ASM/ASMs3Drecovery.C
+++ b/src/ASM/ASMs3Drecovery.C
@@ -337,8 +337,6 @@ bool ASMs3D::evaluate (const Field* field, RealArray& vec, int basisNum) const
       for (double u : gpar[0])
         sValues.push_back(field->valueFE(ItgPoint(u,v,w)));
 
-  Go::SplineVolume* svol = this->getBasis(basisNum);
-
   // Project the results onto the spline basis to find control point
   // values based on the result values evaluated at the Greville points.
   // Note that we here implicitly assume that the number of Greville points
@@ -346,17 +344,8 @@ bool ASMs3D::evaluate (const Field* field, RealArray& vec, int basisNum) const
   // the result array. Think that is always the case, but beware if trying
   // other projection schemes later.
 
-  RealArray weights;
-  if (svol->rational())
-    svol->getWeights(weights);
-
   Go::SplineVolume* vol_new =
-    VariationDiminishingSplineApproximation(svol->basis(0),
-                                            svol->basis(1),
-                                            svol->basis(2),
-                                            gpar[0], gpar[1], gpar[2],
-                                            sValues, 1, svol->rational(),
-                                            weights);
+    VariationDiminishingSplineApproximation(this->getBasis(basisNum),sValues,1);
 
   vec.assign(vol_new->coefs_begin(),vol_new->coefs_end());
   delete vol_new;
@@ -464,16 +453,6 @@ Go::SplineVolume* ASMs3D::projectSolutionLocalApprox(const IntegrandBase& integr
   if (!this->evalSolution(sValues,integrand,gpar.data()))
     return nullptr;
 
-  RealArray weights;
-  if (svol->rational())
-    svol->getWeights(weights);
-
-  return VariationDiminishingSplineApproximation(svol->basis(0),
-						 svol->basis(1),
-						 svol->basis(2),
-						 gpar[0], gpar[1], gpar[2],
-						 sValues,
-						 sValues.rows(),
-						 svol->rational(),
-						 weights);
+  // Project onto the geometry basis
+  return VariationDiminishingSplineApproximation(svol,sValues,sValues.rows());
 }

--- a/src/SIM/AdaptiveSIM.C
+++ b/src/SIM/AdaptiveSIM.C
@@ -215,7 +215,7 @@ bool AdaptiveSIM::adaptMesh (int iStep, std::streamsize outPrec)
     return false;
 
   // Now refine the mesh and write out resulting grid
-  return model.refine(prm) & this->writeMesh(iStep);
+  return model.refine(prm) && this->writeMesh(iStep);
 }
 
 

--- a/src/SIM/SIMmultiCpl.C
+++ b/src/SIM/SIMmultiCpl.C
@@ -53,7 +53,7 @@ bool SIMmultiCpl::parse (const TiXmlElement* elem)
     if (!sim->parse(elem))
       return false;
 
-  return true;
+  return results;
 }
 
 

--- a/src/SIM/SIMoptions.C
+++ b/src/SIM/SIMoptions.C
@@ -24,6 +24,7 @@
 #include <cstring>
 #include <cstdlib>
 #include <fstream>
+#include <functional>
 
 
 SIMoptions::SIMoptions ()
@@ -404,7 +405,7 @@ utl::LogStream& SIMoptions::print (utl::LogStream& os, bool addBlankLine) const
        <<"\nShift value: "<< shift;
 
   // Lambda function to print proper interpretation of nGauss
-  auto printG = [&os](int n)
+  std::function<int(int)> printG = [&os](int n) -> int
   {
     if (n > 0 && n <= 10)
     {
@@ -443,7 +444,7 @@ utl::LogStream& SIMoptions::print (utl::LogStream& os, bool addBlankLine) const
   }
 
   std::vector<std::string> projections;
-  for (const auto& prj : project)
+  for (const ProjectionMap::value_type& prj : project)
     if (prj.first == NONE)
       os <<"\nPure residual error estimates enabled";
     else

--- a/src/Utility/Utilities.C
+++ b/src/Utility/Utilities.C
@@ -167,7 +167,7 @@ bool utl::ignoreComments (std::istream& is)
 }
 
 
-bool utl::getAttribute (const TiXmlElement* xml, const char* att, bool& val)
+int utl::getAttribute (const TiXmlElement* xml, const char* att, bool& val)
 {
   if (!xml || !xml->Attribute(att))
     return false;
@@ -188,7 +188,7 @@ bool utl::getAttribute (const TiXmlElement* xml, const char* att, bool& val)
 }
 
 
-bool utl::getAttribute (const TiXmlElement* xml, const char* att, int& val)
+int utl::getAttribute (const TiXmlElement* xml, const char* att, int& val)
 {
   if (xml && xml->Attribute(att))
     val = atoi(xml->Attribute(att));
@@ -199,8 +199,8 @@ bool utl::getAttribute (const TiXmlElement* xml, const char* att, int& val)
 }
 
 
-bool utl::getAttribute (const TiXmlElement* xml, const char* att, char& val,
-                        bool useIntValue)
+int utl::getAttribute (const TiXmlElement* xml, const char* att, char& val,
+                       bool useIntValue)
 {
   if (xml && xml->Attribute(att))
     val = useIntValue ? atoi(xml->Attribute(att)) : xml->Attribute(att)[0];
@@ -211,7 +211,7 @@ bool utl::getAttribute (const TiXmlElement* xml, const char* att, char& val,
 }
 
 
-bool utl::getAttribute (const TiXmlElement* xml, const char* att, size_t& val)
+int utl::getAttribute (const TiXmlElement* xml, const char* att, size_t& val)
 {
   if (xml && xml->Attribute(att))
     val = atoi(xml->Attribute(att));
@@ -222,7 +222,7 @@ bool utl::getAttribute (const TiXmlElement* xml, const char* att, size_t& val)
 }
 
 
-bool utl::getAttribute (const TiXmlElement* xml, const char* att, Real& val)
+int utl::getAttribute (const TiXmlElement* xml, const char* att, Real& val)
 {
   if (xml && xml->Attribute(att))
     val = atof(xml->Attribute(att));
@@ -238,8 +238,8 @@ bool utl::getAttribute (const TiXmlElement* xml, const char* att, Real& val)
   If \a ncomp is zero, use the value zero for the missing components, if any.
 */
 
-bool utl::getAttribute (const TiXmlElement* xml, const char* att,
-                        Vec3& val, int ncomp)
+int utl::getAttribute (const TiXmlElement* xml, const char* att,
+                       Vec3& val, int ncomp)
 {
   if (!xml || !xml->Attribute(att))
     return false;
@@ -260,8 +260,8 @@ bool utl::getAttribute (const TiXmlElement* xml, const char* att,
 }
 
 
-bool utl::getAttribute (const TiXmlElement* xml, const char* att,
-                        std::vector<int>& val)
+int utl::getAttribute (const TiXmlElement* xml, const char* att,
+                       std::vector<int>& val)
 {
   if (xml && xml->Attribute(att))
     parseIntegers(val,xml->Attribute(att));
@@ -272,8 +272,8 @@ bool utl::getAttribute (const TiXmlElement* xml, const char* att,
 }
 
 
-bool utl::getAttribute (const TiXmlElement* xml, const char* att,
-                        std::string& val, bool toLower)
+int utl::getAttribute (const TiXmlElement* xml, const char* att,
+                       std::string& val, bool toLower)
 {
   if (!xml || !xml->Attribute(att))
     return false;

--- a/src/Utility/Utilities.h
+++ b/src/Utility/Utilities.h
@@ -61,14 +61,14 @@ namespace utl
   //! \param[out] val The attribute value
   //! \return \e true if the attribute \a att is found in \a xml,
   //! otherwise \e false
-  bool getAttribute(const TiXmlElement* xml, const char* att, bool& val);
+  int getAttribute(const TiXmlElement* xml, const char* att, bool& val);
   //! \brief Extracts an integer attribute value from the specified XML-element.
   //! \param[in] xml Pointer to XML-element to extract from
   //! \param[in] att The attribute tag
   //! \param[out] val The attribute value
   //! \return \e true if the attribute \a att is found in \a xml,
   //! otherwise \e false
-  bool getAttribute(const TiXmlElement* xml, const char* att, int& val);
+  int getAttribute(const TiXmlElement* xml, const char* att, int& val);
   //! \brief Extracts a char attribute value from the specified XML-element.
   //! \param[in] xml Pointer to XML-element to extract from
   //! \param[in] att The attribute tag
@@ -76,22 +76,22 @@ namespace utl
   //! \param[in] useIntValue If \e true, convert the value to an integer
   //! \return \e true if the attribute \a att is found in \a xml,
   //! otherwise \e false
-  bool getAttribute(const TiXmlElement* xml, const char* att, char& val,
-                    bool useIntValue = true);
+  int getAttribute(const TiXmlElement* xml, const char* att, char& val,
+                   bool useIntValue = true);
   //! \brief Extracts a size_t attribute value from the specified XML-element.
   //! \param[in] xml Pointer to XML-element to extract from
   //! \param[in] att The attribute tag
   //! \param[out] val The attribute value
   //! \return \e true if the attribute \a att is found in \a xml,
   //! otherwise \e false
-  bool getAttribute(const TiXmlElement* xml, const char* att, size_t& val);
+  int getAttribute(const TiXmlElement* xml, const char* att, size_t& val);
   //! \brief Extracts a real attribute value from the specified XML-element.
   //! \param[in] xml Pointer to XML-element to extract from
   //! \param[in] att The attribute tag
   //! \param[out] val The attribute value
   //! \return \e true if the attribute \a att is found in \a xml,
   //! otherwise \e false
-  bool getAttribute(const TiXmlElement* xml, const char* att, Real& val);
+  int getAttribute(const TiXmlElement* xml, const char* att, Real& val);
   //! \brief Extracts a vector attribute value from the specified XML-element.
   //! \param[in] xml Pointer to XML-element to extract from
   //! \param[in] att The attribute tag
@@ -99,16 +99,16 @@ namespace utl
   //! \param[in] ncomp Maximum number of components to read
   //! \return \e true if the attribute \a att is found in \a xml,
   //! otherwise \e false
-  bool getAttribute(const TiXmlElement* xml, const char* att, Vec3& val,
-                    int ncomp = 0);
+  int getAttribute(const TiXmlElement* xml, const char* att, Vec3& val,
+                   int ncomp = 0);
   //! \brief Extracts an integer vector attribute from specified XML-element.
   //! \param[in] xml Pointer to XML-element to extract from
   //! \param[in] att The attribute tag
   //! \param[out] val The attribute value
   //! \return \e true if the attribute \a att is found in \a xml,
   //! otherwise \e false
-  bool getAttribute(const TiXmlElement* xml, const char* att,
-                    std::vector<int>& val);
+  int getAttribute(const TiXmlElement* xml, const char* att,
+                   std::vector<int>& val);
 
   //! \brief Extracts a string attribute value from the specified XML-element.
   //! \param[in] xml Pointer to XML-element to extract from
@@ -117,8 +117,8 @@ namespace utl
   //! \param[in] toLower If \e true, convert return string to lower case
   //! \return \e true if the attribute \a att is found in \a xml,
   //! otherwise \e false
-  bool getAttribute(const TiXmlElement* xml, const char* att, std::string& val,
-                    bool toLower = false);
+  int getAttribute(const TiXmlElement* xml, const char* att, std::string& val,
+                   bool toLower = false);
   //! \brief Returns the value (if any) of the specified XML-node.
   //! \param[in] xml Pointer to XML-node to extract the value from
   //! \param[in] tag The name of the XML-element to extract the value from


### PR DESCRIPTION
This (hopefully) silence the compler warnings detected by newer compilers in Build [#353](http://afem.sintef.no:8080/job/IFEM/353/). In addition, the signature of the static VariationDiminishingSplineApproximation() methods are simplified passing (pointer to) the spline object to project only instead of its components.