### PR TITLE
Fix external load tratment for HHTSIM

### DIFF
--- a/src/ASM/AlgEqSystem.C
+++ b/src/ASM/AlgEqSystem.C
@@ -152,6 +152,11 @@ bool AlgEqSystem::assemble (const LocalIntegral* elmObj, int elmId)
   else if (elMat->empty())
     return true; // Silently ignore if no element matrices
 
+#if SP_DEBUG > 2
+  std::cout <<"\n>>> Assembling equation system contributions from element "
+            << elmId <<" <<<\n";
+#endif
+
   size_t i;
   bool status = true;
   if (A.size() == 1 && !b.empty())
@@ -162,8 +167,8 @@ bool AlgEqSystem::assemble (const LocalIntegral* elmObj, int elmId)
     std::vector<double>* reac = R.empty() ? nullptr : &R;
     status = sam.assembleSystem(*b.front(), elMat->getRHSVector(), elmId, reac);
 #if SP_DEBUG > 2
-    for (i = 1; i < b.size() && i < elMat->b.size(); i++)
-      std::cout <<"\nElement right-hand-side vector "<< i+1 << elMat->b[i];
+    for (i = 1; i < b.size(); i++)
+      elMat->printVec(std::cout,i);
 #endif
 
     if (status && elMat->withLHS) // we have LHS element matrices
@@ -184,12 +189,10 @@ bool AlgEqSystem::assemble (const LocalIntegral* elmObj, int elmId)
   {
 #if SP_DEBUG > 2
     if (elMat->withLHS && !elMat->rhsOnly)
-      for (i = 0; i < elMat->A.size() && i < A.size(); i++)
-	std::cout <<"Coefficient matrix A"<< i <<" for element "
-		  << elmId << elMat->A[i] << std::endl;
-    for (i = 0; i < elMat->b.size() && i < b.size(); i++)
-      std::cout <<"Right-hand-side vector b"<< i <<" for element "
-		<< elmId << elMat->b[i] << std::endl;
+      for (i = 0; i < A.size(); i++)
+        elMat->printMat(std::cout,i);
+    for (i = 0; i < b.size(); i++)
+      elMat->printVec(std::cout,i);
 #endif
 
     // Assembly of system right-hand-side vectors
@@ -212,9 +215,8 @@ bool AlgEqSystem::assemble (const LocalIntegral* elmObj, int elmId)
   }
 
 #if SP_DEBUG > 2
-  for (i = 0; i < elMat->c.size() && i < c.size(); i++)
-    std::cout <<"Scalar "<< i <<" for element "
-              << elmId <<": "<< elMat->c[i] << std::endl;
+  for (i = 0; i < c.size(); i++)
+    elMat->printScl(std::cout,i);
 #endif
 
   // Assembly of scalar quantities

--- a/src/ASM/ElmMats.C
+++ b/src/ASM/ElmMats.C
@@ -41,7 +41,7 @@ const Matrix& ElmMats::getNewtonMatrix () const
   }
 
 #if SP_DEBUG > 2
-  std::cout <<"\nElement coefficient matrix"<< A.front();
+  this->printMat(std::cout);
 #endif
   return A.front();
 }
@@ -59,7 +59,49 @@ const Vector& ElmMats::getRHSVector () const
   }
 
 #if SP_DEBUG > 2
-  std::cout <<"\nElement right-hand-side vector"<< b.front();
+  this->printVec(std::cout);
 #endif
   return b.front();
+}
+
+
+void ElmMats::printMat (std::ostream& os, size_t idx) const
+{
+  if (idx > A.size()) return;
+
+  os <<"\nElement coefficient matrix";
+  if (idx > 0) os <<" "<< idx;
+
+  if (idx < Aname.size() && Aname[idx])
+    os <<" ("<< Aname[idx] <<")";
+
+  os << A[idx];
+}
+
+
+void ElmMats::printVec (std::ostream& os, size_t idx) const
+{
+  if (idx > b.size()) return;
+
+  os <<"\nElement right-hand-side vector";
+  if (idx > 0) os <<" "<< idx;
+
+  if (idx < Bname.size() && Bname[idx])
+    os <<" ("<< Bname[idx] <<")";
+
+  os << b[idx];
+}
+
+
+void ElmMats::printScl (std::ostream& os, size_t idx) const
+{
+  if (idx > c.size()) return;
+
+  os <<"Element scalar";
+  if (idx > 0) os <<" "<< idx;
+
+  if (idx < Cname.size() && Cname[idx])
+    os <<" ("<< Cname[idx] <<"): ";
+
+  os << c[idx] << std::endl;
 }

--- a/src/ASM/ElmMats.h
+++ b/src/ASM/ElmMats.h
@@ -59,9 +59,20 @@ public:
   //! \brief Returns the element-level right-hand-side vector.
   virtual const Vector& getRHSVector() const;
 
+  //! \brief Prints element matrix \a idx to output stream \a os.
+  void printMat(std::ostream& os, size_t idx = 0) const;
+  //! \brief Prints element vector \a idx to output stream \a os.
+  void printVec(std::ostream& os, size_t idx = 0) const;
+  //! \brief Prints element scalar \a idx to output stream \a os.
+  void printScl(std::ostream& os, size_t idx = 0) const;
+
   std::vector<Matrix> A; //!< The element coefficient matrices
   std::vector<Vector> b; //!< The element right-hand-side vectors
   std::vector<double> c; //!< The scalar quantities
+
+  std::vector<const char*> Aname; //!< Matrix names (for debug print)
+  std::vector<const char*> Bname; //!< Vector names (for debug print)
+  std::vector<const char*> Cname; //!< Scalar names (for debug print)
 
   bool rhsOnly; //!< If \e true, only the right-hand-sides are assembled
   bool withLHS; //!< If \e true, left-hand-side element matrices are present

--- a/src/ASM/HHTMats.C
+++ b/src/ASM/HHTMats.C
@@ -136,7 +136,7 @@ const Vector& HHTMats::getRHSVector () const
     RHS.add(A[1]*vec[ia],-1.0); // RHS -= M*a
   }
 
-  if (b.size() > 2)
+  if (oldHHT && b.size() > 2)
     RHS.add(b[2],alphaPlus1); // RHS += (1+alphaH)*S_ext
 
   if (!isPredictor) alphaPlus1 = -alphaPlus1;

--- a/src/ASM/HHTMats.C
+++ b/src/ASM/HHTMats.C
@@ -89,7 +89,7 @@ const Vector& HHTMats::getRHSVector () const
     if (iv > 0 && A.size() > 4)
       Fia.add(A[4]*vec[iv],-1.0); // Fia -= C*v
 #if SP_DEBUG > 2
-    std::cout <<"Element inertia vector"<< Fia;
+    std::cout <<"Element inertia force vector"<< Fia;
 #endif
   }
 
@@ -151,7 +151,7 @@ const Vector& HHTMats::getRHSVector () const
     RHS.add(A[4]*vec[iv],alphaPlus1);        // RHS -= (1+alphaH)*C*v
 
 #if SP_DEBUG > 2
-  std::cout <<"\nElement right-hand-side vector"<< b.front();
+  this->printVec(std::cout);
 #endif
 
   return b.front();

--- a/src/ASM/NewmarkMats.C
+++ b/src/ASM/NewmarkMats.C
@@ -110,7 +110,7 @@ const Vector& NewmarkMats::getRHSVector () const
     dF.add(A[2]*vec[iv],-alpha2); // dF -= alpha2*K*v
 
 #if SP_DEBUG > 2
-  std::cout <<"\nElement right-hand-side vector"<< b.front();
+  this->printVec(std::cout);
 #endif
 
   return b.front();


### PR DESCRIPTION
The important thing here is the third commit. Without it, the external forces (when resulting from internal and neumann integrals - not for direct point loads) are added twice to the residual force vector, since it is also done in `HHTSIM::finalizeRHSvector()`. The other two commits are for debug print handling and added unit test for `NewmarkNLSIM`.