### PR TITLE
changed: unify computeBasis signatures

### DIFF
--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -2848,59 +2848,64 @@ void ASMu2D::generateBezierExtraction ()
 void ASMu2D::computeBasis (double u, double v, Go::BasisPtsSf& bas,
                            int iel, const LR::LRSplineSurface* spline) const
 {
+  if (!spline)
+    spline = lrspline.get();
+
   if (is_rational) {
-    this->computeBasisNurbs(u, v, bas, iel, spline);
+    this->computeBasisNurbs(u, v, bas, iel, *spline);
     return;
   }
 
   PROFILE3("ASMu2D::compBasis(0)");
-
-  if (spline)
-    spline->computeBasis(u,v,bas,iel);
-  else
-    lrspline->computeBasis(u,v,bas,iel);
+  spline->computeBasis(u,v,bas,iel);
 }
 
 
 void ASMu2D::computeBasis (double u, double v, Go::BasisDerivsSf& bas,
                            int iel, const LR::LRSplineSurface* spline) const
 {
+  if (!spline)
+    spline = lrspline.get();
+
   if (is_rational) {
-    this->computeBasisNurbs(u, v, bas, iel, spline);
+    this->computeBasisNurbs(u, v, bas, iel, *spline);
     return;
   }
-  PROFILE3("ASMu2D::compBasis(1)");
 
-  if (spline)
-    spline->computeBasis(u,v,bas,iel);
-  else
-    lrspline->computeBasis(u,v,bas,iel);
+  PROFILE3("ASMu2D::compBasis(1)");
+  spline->computeBasis(u,v,bas,iel);
 }
 
 
 void ASMu2D::computeBasis (double u, double v, Go::BasisDerivsSf2& bas,
-                           int iel) const
+                           int iel, const LR::LRSplineSurface* spline) const
 {
+  if (!spline)
+    spline = lrspline.get();
+
   if (is_rational) {
-    this->computeBasisNurbs(u, v, bas, iel);
+    this->computeBasisNurbs(u, v, bas, iel, *spline);
     return;
   }
-  PROFILE3("ASMu2D::compBasis(2)");
 
-  lrspline->computeBasis(u,v,bas,iel);
+  PROFILE3("ASMu2D::compBasis(2)");
+  spline->computeBasis(u,v,bas,iel);
 }
 
 
 void ASMu2D::computeBasis (double u, double v, Go::BasisDerivsSf3& bas,
-                           int iel) const
+                           int iel, const LR::LRSplineSurface* spline) const
 {
+  if (!spline)
+    spline = lrspline.get();
+
   if (is_rational) {
-    this->computeBasisNurbs(u, v, bas, iel);
+    this->computeBasisNurbs(u, v, bas, iel, *spline);
     return;
   }
-  PROFILE3("ASMu2D::compBasis(3)");
 
-  lrspline->computeBasis(u,v,bas,iel);
+  PROFILE3("ASMu2D::compBasis(3)");
+  spline->computeBasis(u,v,bas,iel);
 }
 
 

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -601,10 +601,12 @@ protected:
                     const LR::LRSplineSurface* spline = nullptr) const;
   //! \brief Evaluate basis functions and two derivatives in a point.
   void computeBasis(double u, double v,
-                     Go::BasisDerivsSf2& bas, int iel) const;
+                    Go::BasisDerivsSf2& bas, int iel,
+                    const LR::LRSplineSurface* spline = nullptr) const;
   //! \brief Evaluate basis functions and three derivatives in a point.
   void computeBasis(double u, double v,
-                    Go::BasisDerivsSf3& bas, int iel) const;
+                    Go::BasisDerivsSf3& bas, int iel,
+                    const LR::LRSplineSurface* spline = nullptr) const;
 
   //! \brief Evaluates the geometry at a specified point.
   //! \param[in] iel 0-based local element index
@@ -694,17 +696,19 @@ private:
   //! \brief Evaluate NURBS basis functions in a point.
   void computeBasisNurbs(double u, double v,
                          Go::BasisPtsSf& bas, int iel,
-                         const LR::LRSplineSurface* spline = nullptr) const;
+                         const LR::LRSplineSurface& spline) const;
   //! \brief Evaluate NURBS basis functions and first derivatives in a point.
   void computeBasisNurbs(double u, double v,
                          Go::BasisDerivsSf& bas, int iel,
-                         const LR::LRSplineSurface* spline) const;
+                         const LR::LRSplineSurface& spline) const;
   //! \brief Evaluate NURBS basis functions and two derivatives in a point.
   void computeBasisNurbs(double u, double v,
-                         Go::BasisDerivsSf2& bas, int iel) const;
+                         Go::BasisDerivsSf2& bas, int iel,
+                         const LR::LRSplineSurface& spline) const;
   //! \brief Evaluate NURBS basis functions and three derivatives in a point.
   void computeBasisNurbs(double u, double v,
-                         Go::BasisDerivsSf3& bas, int iel) const;
+                         Go::BasisDerivsSf3& bas, int iel,
+                         const LR::LRSplineSurface& spline) const;
 };
 
 #endif

--- a/src/ASM/LR/ASMu2Dnurbs.C
+++ b/src/ASM/LR/ASMu2Dnurbs.C
@@ -128,17 +128,14 @@ bool ASMu2D::evaluateBasisNurbs (int iel, FiniteElement& fe,
 
 void ASMu2D::computeBasisNurbs (double u, double v,
                                 Go::BasisPtsSf& bas, int iel,
-                                const LR::LRSplineSurface* spline) const
+                                const LR::LRSplineSurface& spline) const
 {
   PROFILE3("ASMu2D::compBasisN(0)");
 
-  if (!spline)
-    spline = lrspline.get();
-
-  const LR::Element* el = spline->getElement(iel);
+  const LR::Element* el = spline.getElement(iel);
 
   Go::BasisPtsSf tmp;
-  spline->computeBasis(u,v,tmp,iel);
+  spline.computeBasis(u,v,tmp,iel);
   Vector w; w.reserve(tmp.basisValues.size());
   for (const LR::Basisfunction* func : el->support())
     w.push_back(func->cp(func->dim()-1));
@@ -153,17 +150,14 @@ void ASMu2D::computeBasisNurbs (double u, double v,
 
 void ASMu2D::computeBasisNurbs (double u, double v,
                                 Go::BasisDerivsSf& bas, int iel,
-                                const LR::LRSplineSurface* spline) const
+                                const LR::LRSplineSurface& spline) const
 {
   PROFILE3("ASMu2D::compBasisN(1)");
 
-  if (!spline)
-    spline = lrspline.get();
-
-  const LR::Element* el = spline->getElement(iel);
+  const LR::Element* el = spline.getElement(iel);
 
   Go::BasisDerivsSf tmp;
-  spline->computeBasis(u,v,tmp,iel);
+  spline.computeBasis(u,v,tmp,iel);
   Vector w; w.reserve(tmp.basisValues.size());
   for (const LR::Basisfunction* func : el->support())
     w.push_back(func->cp(func->dim()-1));
@@ -183,14 +177,15 @@ void ASMu2D::computeBasisNurbs (double u, double v,
 
 
 void ASMu2D::computeBasisNurbs (double u, double v,
-                                Go::BasisDerivsSf2& bas, int iel) const
+                                Go::BasisDerivsSf2& bas, int iel,
+                                const LR::LRSplineSurface& spline) const
 {
   PROFILE3("ASMu2D::compBasisN(2)");
 
-  const LR::Element* el = lrspline->getElement(iel);
+  const LR::Element* el = spline.getElement(iel);
 
   Go::BasisDerivsSf2 tmp;
-  lrspline->computeBasis(u,v,tmp,iel);
+  spline.computeBasis(u,v,tmp,iel);
   Vector w; w.reserve(tmp.basisValues.size());
   for (const LR::Basisfunction* func : el->support())
     w.push_back(func->cp(func->dim()-1));
@@ -224,14 +219,15 @@ void ASMu2D::computeBasisNurbs (double u, double v,
 
 
 void ASMu2D::computeBasisNurbs (double u, double v,
-                                Go::BasisDerivsSf3& bas, int iel) const
+                                Go::BasisDerivsSf3& bas, int iel,
+                                const LR::LRSplineSurface& spline) const
 {
   PROFILE3("ASMu2D::compBasisN(3)");
 
-  const LR::Element* el = lrspline->getElement(iel);
+  const LR::Element* el = spline.getElement(iel);
 
   Go::BasisDerivsSf3 tmp;
-  lrspline->computeBasis(u,v,tmp,iel);
+  spline.computeBasis(u,v,tmp,iel);
   Vector w; w.reserve(tmp.basisValues.size());
   for (const LR::Basisfunction* func : el->support())
     w.push_back(func->cp(func->dim()-1));


### PR DESCRIPTION
always take a spline pointer parameter. use reference in the NURBS interfaces.