### PR TITLE
Allow for geometry definition separate from bases

### DIFF
--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -27,6 +27,7 @@
 
 
 bool ASMbase::fixHomogeneousDirichlet = true;
+bool ASMbase::refineGeometry = false;
 int  ASMbase::dbgElm = 0;
 ASM::CachePolicy ASMbase::cachePolicy = ASM::PRE_CACHE;
 

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -884,6 +884,7 @@ protected:
 
 public:
   static bool fixHomogeneousDirichlet; //!< If \e true, pre-eliminate fixed DOFs
+  static bool refineGeometry; //!< If \e true, apply refinements to the geometry
 
   static int dbgElm; //!< One-based element index to print debugging info for
 

--- a/src/ASM/ASMmxBase.C
+++ b/src/ASM/ASMmxBase.C
@@ -21,7 +21,7 @@
 #include <numeric>
 
 
-char ASMmxBase::geoBasis             = 2;
+char ASMmxBase::elmBasis             = 2;
 ASMmxBase::MixedType ASMmxBase::Type = ASMmxBase::FULL_CONT_RAISE_BASIS1;
 
 
@@ -180,7 +180,7 @@ ASMmxBase::SurfaceVec ASMmxBase::establishBases (Go::SplineSurface* surf,
     result[1].reset(Go::SurfaceInterpolator::regularInterpolation(a1,b2,
                                                                   u0,vg,XYZ1,ndim,
                                                                   false,XYZ1));
-    geoBasis = 3;
+    elmBasis = 3;
   } else if (type == SUBGRID) {
     // basis1 should be one degree higher than basis2 and C^p-1 continuous
     int ndim = surf->dimension();
@@ -240,11 +240,11 @@ ASMmxBase::SurfaceVec ASMmxBase::establishBases (Go::SplineSurface* surf,
                                                                     ug,vg,XYZ,ndim,
                                                                     false,XYZ));
     }
-    geoBasis = 1;
+    elmBasis = 1;
   }
 
   if (type == FULL_CONT_RAISE_BASIS2 || type == REDUCED_CONT_RAISE_BASIS2)
-    std::swap(result[0], result[1]), geoBasis = 1;
+    std::swap(result[0], result[1]), elmBasis = 1;
 
   return result;
 }
@@ -315,7 +315,7 @@ ASMmxBase::VolumeVec ASMmxBase::establishBases(Go::SplineVolume* svol,
                                                                  u0,v0,wg,XYZ2,ndim,
                                                                  false,XYZ2));
     result[3].reset(new Go::SplineVolume(*svol));
-    geoBasis = 4;
+    elmBasis = 4;
   } else if (type == SUBGRID) {
     // basis1 should be one degree higher than basis2 and C^p-1 continuous
     int ndim = svol->dimension();
@@ -376,7 +376,7 @@ ASMmxBase::VolumeVec ASMmxBase::establishBases(Go::SplineVolume* svol,
                                                                    XYZ,ndim,
                                                                    false,XYZ));
     }
-    geoBasis = 1;
+    elmBasis = 1;
   }
 
   if (type == FULL_CONT_RAISE_BASIS2 || type == REDUCED_CONT_RAISE_BASIS2)

--- a/src/ASM/ASMmxBase.h
+++ b/src/ASM/ASMmxBase.h
@@ -73,7 +73,7 @@ public:
   };
 
   static MixedType Type; //!< Type of mixed formulation used
-  static char  geoBasis; //!< 1-based index of basis representing the geometry
+  static char  elmBasis; //!< 1-based index of basis representing the integration elements
 
 protected:
   typedef std::vector<std::shared_ptr<Go::SplineSurface>> SurfaceVec; //!< Convenience type

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -188,6 +188,8 @@ public:
   virtual ~ASMs2D();
 
   //! \brief Returns the spline surface representing the geometry of this patch.
+  const Go::SplineSurface* getGeometry() const;
+  //! \brief Returns the spline surface representing the integration basis of this patch.
   Go::SplineSurface* getSurface() const { return surf; }
   //! \brief Returns the spline curve representing a boundary of this patch.
   //! \param[in] dir Parameter direction defining which boundary to return
@@ -242,6 +244,12 @@ public:
   //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes
   //! in one element
   virtual bool getElementCoordinates(Matrix& X, int iel) const;
+
+  //! \brief Returns a matrix with nodal coordinates for geometry element.
+  //! \param[in] node Node index on integration basis
+  //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes
+  //! in geometry element
+  bool getGeoElementCoordinates(Matrix& X, int node) const;
 
   //! \brief Returns a matrix with all nodal coordinates within the patch.
   //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes

--- a/src/ASM/ASMs2DmxLag.C
+++ b/src/ASM/ASMs2DmxLag.C
@@ -111,7 +111,7 @@ bool ASMs2DmxLag::generateFEMTopology ()
   // Generate/check FE data for the geometry/basis1
   bool haveFEdata = !MLGN.empty();
   bool basis1IsOK = this->ASMs2DLag::generateFEMTopology();
-  geoBasis = 1;
+  elmBasis = 1;
   if ((haveFEdata && !shareFE) || !basis1IsOK) return basis1IsOK;
 
   // Order of 2nd basis in the two parametric directions (order = degree + 1)
@@ -319,11 +319,11 @@ bool ASMs2DmxLag::integrate (Integrand& integrand,
             }
 
             // Compute Jacobian inverse of coordinate mapping and derivatives
-            if (!fe.Jacobian(Jac,Xnod,geoBasis,&bfs))
+            if (!fe.Jacobian(Jac,Xnod,elmBasis,&bfs))
               continue; // skip singular points
 
             // Cartesian coordinates of current integration point
-            X.assign(Xnod * fe.basis(geoBasis));
+            X.assign(Xnod * fe.basis(elmBasis));
 
             // Evaluate the integrand and accumulate element contributions
             fe.detJxW *= wg[0][i]*wg[1][j];
@@ -370,8 +370,8 @@ bool ASMs2DmxLag::integrate (Integrand& integrand, int lIndex,
 
 
   // Number of elements in each direction
-  const int nelx = (nxx[geoBasis-1]-1)/(elem_sizes[geoBasis-1][0]-1);
-  const int nely = (nyx[geoBasis-1]-1)/(elem_sizes[geoBasis-1][1]-1);
+  const int nelx = (nxx[elmBasis-1]-1)/(elem_sizes[elmBasis-1][0]-1);
+  const int nely = (nyx[elmBasis-1]-1)/(elem_sizes[elmBasis-1][1]-1);
 
   std::map<char,size_t>::const_iterator iit = firstBp.find(lIndex%10);
   size_t firstp = iit == firstBp.end() ? 0 : iit->second;
@@ -428,18 +428,18 @@ bool ASMs2DmxLag::integrate (Integrand& integrand, int lIndex,
             ok = false;
 
         // Compute basis function derivatives and the edge normal
-        fe.detJxW = utl::Jacobian(Jac,normal,fe.grad(geoBasis),Xnod,
-                                  dNxdu[geoBasis-1],t1,t2);
+        fe.detJxW = utl::Jacobian(Jac,normal,fe.grad(elmBasis),Xnod,
+                                  dNxdu[elmBasis-1],t1,t2);
         if (fe.detJxW == 0.0) continue; // skip singular points
 
         for (size_t b = 0; b < nxx.size(); ++b)
-          if (b != (size_t)geoBasis-1)
+          if (b != (size_t)elmBasis-1)
             fe.grad(b+1).multiply(dNxdu[b],Jac);
 
 	if (edgeDir < 0) normal *= -1.0;
 
 	// Cartesian coordinates of current integration point
-	X.assign(Xnod * fe.basis(geoBasis));
+    X.assign(Xnod * fe.basis(elmBasis));
 
 	// Evaluate the integrand and accumulate element contributions
 	fe.detJxW *= wg[i];
@@ -510,11 +510,11 @@ bool ASMs2DmxLag::evalSolution (Matrix& sField, const IntegrandBase& integrand,
   // Evaluate the secondary solution field at each point
   for (size_t iel = 1; iel <= nel; iel++)
   {
-    IntVec::const_iterator f2start = geoBasis == 1? MNPC[iel-1].begin() :
+    IntVec::const_iterator f2start = elmBasis == 1? MNPC[iel-1].begin() :
                                      MNPC[iel-1].begin() +
-                                     std::accumulate(elem_size.begin()+geoBasis-2,
-                                                     elem_size.begin()+geoBasis-1, 0);
-    IntVec::const_iterator f2end = f2start + elem_size[geoBasis-1];
+                                     std::accumulate(elem_size.begin()+elmBasis-2,
+                                                     elem_size.begin()+elmBasis-1, 0);
+    IntVec::const_iterator f2end = f2start + elem_size[elmBasis-1];
     IntVec mnpc1(f2start,f2end);
 
     this->getElementCoordinates(Xnod,iel);
@@ -533,11 +533,11 @@ bool ASMs2DmxLag::evalSolution (Matrix& sField, const IntegrandBase& integrand,
 
         // Compute Jacobian inverse of the coordinate mapping and
         // basis function derivatives w.r.t. Cartesian coordinates
-        if (!fe.Jacobian(Jac,Xnod,geoBasis,nullptr,&dNxdu))
+        if (!fe.Jacobian(Jac,Xnod,elmBasis,nullptr,&dNxdu))
           continue; // skip singular points
 
 	// Now evaluate the solution field
-	if (!integrand.evalSol(solPt,fe,Xnod*fe.basis(geoBasis),
+    if (!integrand.evalSol(solPt,fe,Xnod*fe.basis(elmBasis),
                                MNPC[iel-1],elem_size,nb))
 	  return false;
 	else if (sField.empty())

--- a/src/ASM/ASMs3Dmx.C
+++ b/src/ASM/ASMs3Dmx.C
@@ -217,13 +217,13 @@ bool ASMs3Dmx::generateFEMTopology ()
       projB = proj = m_basis.front()->clone();
       altProjBasis = ASMmxBase::raiseBasis(svol);
     }
-    else if (geoBasis < 3)
-      projB = proj = m_basis[2-geoBasis]->clone();
+    else if (elmBasis < 3)
+      projB = proj = m_basis[2-elmBasis]->clone();
     else
       return false; // Logic error
   }
   delete svol;
-  geomB = svol = m_basis[geoBasis-1]->clone();
+  geomB = svol = m_basis[elmBasis-1]->clone();
 
   nb.clear();
   nb.reserve(m_basis.size());
@@ -269,9 +269,9 @@ bool ASMs3Dmx::generateFEMTopology ()
   }
 #endif
 
-  nel = (m_basis[geoBasis-1]->numCoefs(0)-m_basis[geoBasis-1]->order(0)+1)*
-        (m_basis[geoBasis-1]->numCoefs(1)-m_basis[geoBasis-1]->order(1)+1)*
-        (m_basis[geoBasis-1]->numCoefs(2)-m_basis[geoBasis-1]->order(2)+1);
+  nel = (m_basis[elmBasis-1]->numCoefs(0)-m_basis[elmBasis-1]->order(0)+1)*
+        (m_basis[elmBasis-1]->numCoefs(1)-m_basis[elmBasis-1]->order(1)+1)*
+        (m_basis[elmBasis-1]->numCoefs(2)-m_basis[elmBasis-1]->order(2)+1);
 
   myMLGE.resize(nel,0);
   myMLGN.resize(nnod);
@@ -293,14 +293,14 @@ bool ASMs3Dmx::generateFEMTopology ()
 
   int lnod2 = 0;
   int lnod3 = 0;
-  for (i2 = 0; i2 < geoBasis-1; ++i2)
+  for (i2 = 0; i2 < elmBasis-1; ++i2)
     lnod2 += m_basis[i2]->order(0)*m_basis[i2]->order(1)*m_basis[i2]->order(2);
   for (i2 = 0; i2 < (int)m_basis.size(); ++i2)
     lnod3 += m_basis[i2]->order(0)*m_basis[i2]->order(1)*m_basis[i2]->order(2);
 
   // Create nodal connectivities for bases
-  inod = std::accumulate(nb.begin(),nb.begin()+geoBasis-1,0u);
-  Go::SplineVolume* b = m_basis[geoBasis-1].get();
+  inod = std::accumulate(nb.begin(),nb.begin()+elmBasis-1,0u);
+  Go::SplineVolume* b = m_basis[elmBasis-1].get();
   auto knotw = b->basis(2).begin();
   for (i3 = 1; i3 <= b->numCoefs(2); i3++, ++knotw) {
     auto knotv = b->basis(1).begin();
@@ -325,7 +325,7 @@ bool ASMs3Dmx::generateFEMTopology ()
                 lnod = 0;
                 size_t lnod4 = 0;
                 for (size_t bas = 0; bas < m_basis.size(); ++bas) {
-                  if (bas != (size_t)geoBasis-1) {
+                  if (bas != (size_t)elmBasis-1) {
                     double ku = *knotu;
                     double kv = *knotv;
                     double kw = *knotw;
@@ -404,7 +404,7 @@ bool ASMs3Dmx::getElementCoordinates (Matrix& X, int iel) const
 
   size_t nenod = svol->order(0)*svol->order(1)*svol->order(2);
   size_t lnod0 = 0;
-  for (int i = 1; i < geoBasis; ++i)
+  for (int i = 1; i < elmBasis; ++i)
     lnod0 += m_basis[i-1]->order(0)*m_basis[i-1]->order(1)*m_basis[i-1]->order(2);
 
   X.resize(3,nenod);
@@ -608,11 +608,11 @@ bool ASMs3Dmx::integrate (Integrand& integrand,
 
               // Compute Jacobian inverse of the coordinate mapping and
               // basis function derivatives w.r.t. Cartesian coordinates
-              if (!fe.Jacobian(Jac,Xnod,geoBasis,&bfs))
+              if (!fe.Jacobian(Jac,Xnod,elmBasis,&bfs))
                 continue; // skip singular points
 
               // Compute Hessian of coordinate mapping and 2nd order derivatives
-              if (use2ndDer && !fe.Hessian(Hess,Jac,Xnod,geoBasis,&bfs))
+              if (use2ndDer && !fe.Hessian(Hess,Jac,Xnod,elmBasis,&bfs))
                 ok = false;
 
               // Compute G-matrix
@@ -620,7 +620,7 @@ bool ASMs3Dmx::integrate (Integrand& integrand,
                 utl::getGmat(Jac,dXidu,fe.G);
 
               // Cartesian coordinates of current integration point
-              X.assign(Xnod * fe.basis(geoBasis));
+              X.assign(Xnod * fe.basis(elmBasis));
 
               // Evaluate the integrand and accumulate element contributions
               fe.detJxW *= dV*wg[0][i]*wg[1][j]*wg[2][k];
@@ -822,18 +822,18 @@ bool ASMs3Dmx::integrate (Integrand& integrand, int lIndex,
 
             // Compute Jacobian inverse of the coordinate mapping and
             // basis function derivatives w.r.t. Cartesian coordinates
-            fe.detJxW = utl::Jacobian(Jac,normal,fe.grad(geoBasis),Xnod,
-                                      dNxdu[geoBasis-1],t1,t2);
+            fe.detJxW = utl::Jacobian(Jac,normal,fe.grad(elmBasis),Xnod,
+                                      dNxdu[elmBasis-1],t1,t2);
             if (fe.detJxW == 0.0) continue; // skip singular points
 
             for (size_t b = 0; b < m_basis.size(); ++b)
-              if (b != (size_t)geoBasis-1)
+              if (b != (size_t)elmBasis-1)
                 fe.grad(b+1).multiply(dNxdu[b],Jac);
 
             if (faceDir < 0) normal *= -1.0;
 
             // Cartesian coordinates of current integration point
-            X.assign(Xnod * fe.basis(geoBasis));
+            X.assign(Xnod * fe.basis(elmBasis));
 
             // Evaluate the integrand and accumulate element contributions
             fe.detJxW *= dA*wg[i]*wg[j];
@@ -1039,13 +1039,13 @@ bool ASMs3Dmx::integrate (Integrand& integrand,
                 }
 
               // Compute basis function derivatives and the edge normal
-              fe.detJxW = utl::Jacobian(Jac,normal,fe.grad(geoBasis+m_basis.size()),
-                                        Xnod,dNxdu[geoBasis-1+m_basis.size()],t1,t2);
-              fe.detJxW = utl::Jacobian(Jac,normal,fe.grad(geoBasis),Xnod,
-                                        dNxdu[geoBasis-1],t1,t2);
+              fe.detJxW = utl::Jacobian(Jac,normal,fe.grad(elmBasis+m_basis.size()),
+                                        Xnod,dNxdu[elmBasis-1+m_basis.size()],t1,t2);
+              fe.detJxW = utl::Jacobian(Jac,normal,fe.grad(elmBasis),Xnod,
+                                        dNxdu[elmBasis-1],t1,t2);
               if (fe.detJxW == 0.0) continue; // skip singular points
               for (size_t b = 0; b < m_basis.size(); ++b)
-                if (b != (size_t)geoBasis-1) {
+                if (b != (size_t)elmBasis-1) {
                   fe.grad(b+1).multiply(dNxdu[b],Jac);
                   fe.grad(b+1+m_basis.size()).multiply(dNxdu[b+m_basis.size()],Jac);
                 }
@@ -1053,7 +1053,7 @@ bool ASMs3Dmx::integrate (Integrand& integrand,
               if (faceDir < 0) normal *= -1.0;
 
               // Cartesian coordinates of current integration point
-              X.assign(Xnod * fe.basis(geoBasis));
+              X.assign(Xnod * fe.basis(elmBasis));
 
               // Evaluate the integrand and accumulate element contributions
               fe.detJxW *= 0.25*dA*wg[i]*wg[j];
@@ -1206,8 +1206,8 @@ bool ASMs3Dmx::evalSolution (Matrix& sField, const IntegrandBase& integrand,
                  splinex[b][i].left_idx,ip[b]);
 
       // Fetch associated control point coordinates
-      if (b == (size_t)geoBasis-1)
-        utl::gather(ip[geoBasis-1], 3, Xnod, Xtmp);
+      if (b == (size_t)elmBasis-1)
+        utl::gather(ip[elmBasis-1], 3, Xnod, Xtmp);
 
       for (int& c : ip[b]) c += ofs;
       ipa.insert(ipa.end(), ip[b].begin(), ip[b].end());
@@ -1224,11 +1224,11 @@ bool ASMs3Dmx::evalSolution (Matrix& sField, const IntegrandBase& integrand,
 
     // Compute Jacobian inverse of the coordinate mapping and
     // basis function derivatives w.r.t. Cartesian coordinate
-    if (!fe.Jacobian(Jac,Xtmp,geoBasis,nullptr,&dNxdu))
+    if (!fe.Jacobian(Jac,Xtmp,elmBasis,nullptr,&dNxdu))
       continue; // skip singular points
 
     // Cartesian coordinates of current integration point
-    utl::Point X4(Xtmp * fe.basis(geoBasis),{fe.u,fe.v,fe.w});
+    utl::Point X4(Xtmp * fe.basis(elmBasis),{fe.u,fe.v,fe.w});
 
     // Now evaluate the solution field
     if (!integrand.evalSol(solPt,fe,X4,ipa,elem_size,nb))
@@ -1273,7 +1273,7 @@ double ASMs3Dmx::getParametricVolume (int iel) const
     return 0.0;
 
   int inod1 = MNPC[iel-1][std::accumulate(elem_size.begin(),
-                                          elem_size.begin()+geoBasis, -1)];
+                                          elem_size.begin()+elmBasis, -1)];
 #ifdef INDEX_CHECK
   if (inod1 < 0 || (size_t)inod1 >= nnod)
   {
@@ -1304,7 +1304,7 @@ double ASMs3Dmx::getParametricArea (int iel, int dir) const
     return 0.0;
 
   int inod1 = MNPC[iel-1][std::accumulate(elem_size.begin(),
-                                          elem_size.begin()+geoBasis, -1)];
+                                          elem_size.begin()+elmBasis, -1)];
 #ifdef INDEX_CHECK
   if (inod1 < 0 || (size_t)inod1 >= nnod)
   {
@@ -1344,8 +1344,8 @@ void ASMs3Dmx::getBoundaryNodes (int lIndex, IntVec& nodes, int basis,
 void ASMs3Dmx::swapProjectionBasis ()
 {
   if (altProjBasis) {
-    ASMmxBase::geoBasis = ASMmxBase::geoBasis == 1 ? 2 : 1;
+    ASMmxBase::elmBasis = ASMmxBase::elmBasis == 1 ? 2 : 1;
     std::swap(proj, altProjBasis);
-    svol = this->getBasis(ASMmxBase::geoBasis);
+    svol = this->getBasis(ASMmxBase::elmBasis);
   }
 }

--- a/src/ASM/ASMs3DmxLag.C
+++ b/src/ASM/ASMs3DmxLag.C
@@ -112,7 +112,7 @@ bool ASMs3DmxLag::generateFEMTopology ()
   // Generate/check FE data for the geometry/basis1
   bool haveFEdata = !MLGN.empty();
   bool basis1IsOK = this->ASMs3DLag::generateFEMTopology();
-  geoBasis = 1;
+  elmBasis = 1;
   if ((haveFEdata && !shareFE) || !basis1IsOK) return basis1IsOK;
 
   // Order of 2nd basis in the three parametric directions (order = degree + 1)
@@ -355,11 +355,11 @@ bool ASMs3DmxLag::integrate (Integrand& integrand,
               }
 
               // Compute Jacobian inverse of coordinate mapping and derivatives
-              if (!fe.Jacobian(Jac,Xnod,geoBasis,&bfs))
+              if (!fe.Jacobian(Jac,Xnod,elmBasis,&bfs))
                 continue; // skip singular points
 
               // Cartesian coordinates of current integration point
-              X.assign(Xnod * fe.basis(geoBasis));
+              X.assign(Xnod * fe.basis(elmBasis));
 
               // Evaluate the integrand and accumulate element contributions
               fe.detJxW *= wg[0][i]*wg[1][j]*wg[2][k];
@@ -415,8 +415,8 @@ bool ASMs3DmxLag::integrate (Integrand& integrand, int lIndex,
   integrand.setNeumannOrder(1 + lIndex/10);
 
   // Number of elements in each direction
-  const int nel1 = (nxx[geoBasis-1]-1)/(elem_sizes[geoBasis-1][0]-1);
-  const int nel2 = (nyx[geoBasis-1]-1)/(elem_sizes[geoBasis-1][1]-1);
+  const int nel1 = (nxx[elmBasis-1]-1)/(elem_sizes[elmBasis-1][0]-1);
+  const int nel2 = (nyx[elmBasis-1]-1)/(elem_sizes[elmBasis-1][1]-1);
 
   std::map<char,size_t>::const_iterator iit = firstBp.find(lIndex%10);
   size_t firstp = iit == firstBp.end() ? 0 : iit->second;
@@ -494,18 +494,18 @@ bool ASMs3DmxLag::integrate (Integrand& integrand, int lIndex,
                 ok = false;
 
 	    // Compute basis function derivatives and the edge normal
-	    fe.detJxW = utl::Jacobian(Jac,normal,fe.grad(geoBasis),Xnod,
-                                      dNxdu[geoBasis-1],t1,t2);
+        fe.detJxW = utl::Jacobian(Jac,normal,fe.grad(elmBasis),Xnod,
+                                      dNxdu[elmBasis-1],t1,t2);
 	    if (fe.detJxW == 0.0) continue; // skip singular points
 
             for (size_t b = 0; b < nxx.size(); ++b)
-              if (b != (size_t)geoBasis-1)
+              if (b != (size_t)elmBasis-1)
                 fe.grad(b+1).multiply(dNxdu[b],Jac);
 
 	    if (faceDir < 0) normal *= -1.0;
 
 	    // Cartesian coordinates of current integration point
-	    X.assign(Xnod * fe.basis(geoBasis));
+        X.assign(Xnod * fe.basis(elmBasis));
 
 	    // Evaluate the integrand and accumulate element contributions
 	    fe.detJxW *= wg[i]*wg[j];
@@ -577,11 +577,11 @@ bool ASMs3DmxLag::evalSolution (Matrix& sField, const IntegrandBase& integrand,
   // Evaluate the secondary solution field at each point
   for (size_t iel = 1; iel <= nel; iel++)
   {
-    IntVec::const_iterator f2start = geoBasis == 1? MNPC[iel-1].begin() :
+    IntVec::const_iterator f2start = elmBasis == 1? MNPC[iel-1].begin() :
                                      MNPC[iel-1].begin() +
-                                     std::accumulate(elem_size.begin()+geoBasis-2,
-                                                     elem_size.begin()+geoBasis-1, 0);
-    IntVec::const_iterator f2end = f2start + elem_size[geoBasis-1];
+                                     std::accumulate(elem_size.begin()+elmBasis-2,
+                                                     elem_size.begin()+elmBasis-1, 0);
+    IntVec::const_iterator f2end = f2start + elem_size[elmBasis-1];
     IntVec mnpc1(f2start,f2end);
 
     this->getElementCoordinates(Xnod,iel);
@@ -603,11 +603,11 @@ bool ASMs3DmxLag::evalSolution (Matrix& sField, const IntegrandBase& integrand,
 
           // Compute Jacobian inverse of the coordinate mapping and
           // basis function derivatives w.r.t. Cartesian coordinates
-          if (!fe.Jacobian(Jac,Xnod,geoBasis,nullptr,&dNxdu))
+          if (!fe.Jacobian(Jac,Xnod,elmBasis,nullptr,&dNxdu))
             continue; // skip singular points
 
 	  // Now evaluate the solution field
-	  if (!integrand.evalSol(solPt,fe,Xnod*fe.basis(geoBasis),
+      if (!integrand.evalSol(solPt,fe,Xnod*fe.basis(elmBasis),
                                  MNPC[iel-1],elem_size,nb))
 	    return false;
 	  else if (sField.empty())

--- a/src/ASM/BasisFunctionCache.h
+++ b/src/ASM/BasisFunctionCache.h
@@ -104,7 +104,7 @@ protected:
 
   //! \brief Calculates basis function info in a single integration point.
   //! \param el Element of integration point (0-indexed)
-  //! \param gp Integratin point on element (0-indexed)
+  //! \param gp Integration point on element (0-indexed)
   //! \param reduced If true, returns values for reduced integration scheme
   virtual BasisFunctionVals calculatePt(size_t el, size_t gp,
                                         bool reduced = false) const = 0;

--- a/src/ASM/FiniteElement.C
+++ b/src/ASM/FiniteElement.C
@@ -80,15 +80,17 @@ bool MxFiniteElement::Jacobian (Matrix& Jac, const Matrix& Xnod,
                                 const std::vector<const BasisFunctionVals*>* bf,
                                 const std::vector<Matrix>* dNxdu)
 {
-  detJxW = utl::Jacobian(Jac,
-                         gBasis > 1 ? dMdX[gBasis-2] : dNdX, Xnod,
-                         bf ? (*bf)[gBasis-1]->dNdu : (*dNxdu)[gBasis-1]);
-  if (detJxW == 0.0) return false; // singular point
+  size_t nBasis = bf ? bf->size() : dNxdu->size();
+  if (gBasis <= nBasis) {
+    detJxW = utl::Jacobian(Jac,
+                           gBasis > 1 ? dMdX[gBasis-2] : dNdX, Xnod,
+                           bf ? (*bf)[gBasis-1]->dNdu : (*dNxdu)[gBasis-1]);
+    if (detJxW == 0.0) return false; // singular point
+  }
 
   if (gBasis > 1)
     dNdX.multiply(bf ? bf->front()->dNdu : dNxdu->front(),Jac);
 
-  size_t nBasis = bf ? bf->size() : dNxdu->size();
   for (size_t b = 2; b <= nBasis; b++)
     if (b != gBasis)
       dMdX[b-2].multiply(bf ? (*bf)[b-1]->dNdu : (*dNxdu)[b-1], Jac);

--- a/src/ASM/LR/LRSplineFields2Dmx.C
+++ b/src/ASM/LR/LRSplineFields2Dmx.C
@@ -103,7 +103,7 @@ bool LRSplineFields2Dmx::gradFE (const ItgPoint& x, Matrix& grad) const
   // Evaluate the basis functions at the given point
   Matrix Xnod, Jac, dNdX;
   const LR::Element* elm;
-  const LR::LRSplineSurface* geo = surf->getBasis(ASMmxBase::geoBasis);
+  const LR::LRSplineSurface* geo = surf->getBasis(ASMmxBase::elmBasis);
   if (!geo)
     geo = surf->getBasis(1);
   if (!LRSplineField::evalMapping(*geo,x,elm,Xnod,Jac,dNdX,surf->rational()))
@@ -142,7 +142,7 @@ bool LRSplineFields2Dmx::hessianFE (const ItgPoint& x, Matrix3D& H) const
   Matrix Xnod, Jac, dNdX;
   Matrix3D d2NdX2, Hess;
   const LR::Element* elm;
-  const LR::LRSplineSurface* geo = surf->getBasis(ASMmxBase::geoBasis);
+  const LR::LRSplineSurface* geo = surf->getBasis(ASMmxBase::elmBasis);
   if (!geo)
     geo = surf->getBasis(1);
   if (!LRSplineField::evalMapping(*geo,x,elm,Xnod,Jac,

--- a/src/ASM/LR/LRSplineFields3Dmx.C
+++ b/src/ASM/LR/LRSplineFields3Dmx.C
@@ -101,7 +101,7 @@ bool LRSplineFields3Dmx::gradFE (const ItgPoint& x, Matrix& grad) const
 
   // Evaluate the basis functions at the given point
   Matrix Xnod, Jac, dNdX;
-  const LR::LRSplineVolume* geo = vol->getBasis(ASMmxBase::geoBasis);
+  const LR::LRSplineVolume* geo = vol->getBasis(ASMmxBase::elmBasis);
   if (!geo)
     geo = vol->getBasis(1);
   const LR::Element* elm;
@@ -141,7 +141,7 @@ bool LRSplineFields3Dmx::hessianFE (const ItgPoint& x, Matrix3D& H) const
   // Evaluate the basis functions at the given point
   Matrix Xnod, Jac, dNdX;
   Matrix3D d2NdX2, Hess;
-  const LR::LRSplineVolume* geo = vol->getBasis(ASMmxBase::geoBasis);
+  const LR::LRSplineVolume* geo = vol->getBasis(ASMmxBase::elmBasis);
   if (!geo)
     geo = vol->getBasis(1);
   const LR::Element* elm;

--- a/src/ASM/SplineFields2Dmx.C
+++ b/src/ASM/SplineFields2Dmx.C
@@ -59,7 +59,7 @@ bool SplineFields2Dmx::valueCoor (const Vec4& x, Vector& vals) const
   // Use with caution, very slow!
   Go::Point pt(x.x,x.y,x.z), clopt(3);
   double clo_u, clo_v, dist;
-  const Go::SplineSurface* geo = surf->getBasis(ASMmxBase::geoBasis);
+  const Go::SplineSurface* geo = surf->getBasis(ASMmxBase::elmBasis);
   if (!geo)
     geo = surf->getBasis(1);
 #pragma omp critical
@@ -109,7 +109,7 @@ bool SplineFields2Dmx::gradFE (const ItgPoint& x, Matrix& grad) const
   // Evaluate the basis functions at the given point
   Matrix Xnod, Jac, dNdX;
   std::vector<int> ip;
-  const Go::SplineSurface* geo = surf->getBasis(ASMmxBase::geoBasis);
+  const Go::SplineSurface* geo = surf->getBasis(ASMmxBase::elmBasis);
   if (!geo)
     geo = surf->getBasis(1);
   if (!SplineField::evalMapping(*geo,surf->getNoSpaceDim(),x,ip,Xnod,Jac,dNdX))
@@ -146,7 +146,7 @@ bool SplineFields2Dmx::hessianFE (const ItgPoint& x, Matrix3D& H) const
   Matrix Xnod, Jac, dNdX;
   Matrix3D d2NdX2, Hess;
   std::vector<int> ip;
-  const Go::SplineSurface* geo = surf->getBasis(ASMmxBase::geoBasis);
+  const Go::SplineSurface* geo = surf->getBasis(ASMmxBase::elmBasis);
   if (!geo)
     geo = surf->getBasis(1);
   if (!SplineField::evalMapping(*geo,surf->getNoSpaceDim(),x,ip,Xnod,Jac,dNdX,&d2NdX2,&Hess))

--- a/src/ASM/SplineFields3Dmx.C
+++ b/src/ASM/SplineFields3Dmx.C
@@ -59,7 +59,7 @@ bool SplineFields3Dmx::valueCoor (const Vec4& x, Vector& vals) const
   // Use with caution, very slow!
   Go::Point pt(x.x,x.y,x.z), clopt(3);
   double clo_u, clo_v, clo_w, dist;
-  const Go::SplineVolume* geo = svol->getBasis(ASMmxBase::geoBasis);
+  const Go::SplineVolume* geo = svol->getBasis(ASMmxBase::elmBasis);
   if (!geo)
     geo = svol->getBasis(1);
 #pragma omp critical
@@ -110,7 +110,7 @@ bool SplineFields3Dmx::gradFE (const ItgPoint& x, Matrix& grad) const
   // Evaluate the basis functions at the given point
   Matrix Xnod, Jac, dNdX;
   std::vector<int> ip;
-  const Go::SplineVolume* geo = svol->getBasis(ASMmxBase::geoBasis);
+  const Go::SplineVolume* geo = svol->getBasis(ASMmxBase::elmBasis);
   if (!geo)
     geo = svol->getBasis(1);
   if (!SplineField::evalMapping(*geo,x,ip,Xnod,Jac,dNdX))
@@ -146,7 +146,7 @@ bool SplineFields3Dmx::hessianFE (const ItgPoint& x, Matrix3D& H) const
   Matrix Xnod, Jac, dNdX;
   Matrix3D d2NdX2, Hess;
   std::vector<int> ip;
-  const Go::SplineVolume* geo = svol->getBasis(ASMmxBase::geoBasis);
+  const Go::SplineVolume* geo = svol->getBasis(ASMmxBase::elmBasis);
   if (!geo)
     geo = svol->getBasis(1);
   if (!SplineField::evalMapping(*geo,x,ip,Xnod,Jac,dNdX,&d2NdX2,&Hess))

--- a/src/LinAlg/Test/TestISTLMatrix.C
+++ b/src/LinAlg/Test/TestISTLMatrix.C
@@ -69,7 +69,7 @@ TEST(TestISTLMatrix, Assemble)
 TEST(TestISTLMatrix, AssembleBasisBlocks)
 {
   ASMmxBase::Type = ASMmxBase::FULL_CONT_RAISE_BASIS1;
-  ASMmxBase::geoBasis = 2;
+  ASMmxBase::elmBasis = 2;
   SIM2D sim({1,1});
   sim.read("src/LinAlg/Test/refdata/petsc_test_blocks_basis.xinp");
   sim.opt.solver = LinAlg::ISTL;

--- a/src/LinAlg/Test/TestPETScMatrix.C
+++ b/src/LinAlg/Test/TestPETScMatrix.C
@@ -81,7 +81,7 @@ TEST(TestPETScMatrix, Assemble)
 TEST(TestPETScMatrix, AssembleBasisBlocks)
 {
   ASMmxBase::Type = ASMmxBase::FULL_CONT_RAISE_BASIS1;
-  ASMmxBase::geoBasis = 2;
+  ASMmxBase::elmBasis = 2;
   SIM2D sim({1,1});
   sim.read("src/LinAlg/Test/refdata/petsc_test_blocks_basis.xinp");
   sim.opt.solver = LinAlg::PETSC;

--- a/src/LinAlg/Test/TestSAM.C
+++ b/src/LinAlg/Test/TestSAM.C
@@ -94,7 +94,7 @@ TEST(TestSAM, SingleBasisDirichlet1P)
 TEST(TestSAM, MixedBasis1P)
 {
   ASMmxBase::Type = ASMmxBase::FULL_CONT_RAISE_BASIS1;
-  ASMmxBase::geoBasis = 2;
+  ASMmxBase::elmBasis = 2;
 
   SIM2D sim({1,1});
   sim.read("src/LinAlg/Test/refdata/sam_2D_1P.xinp");

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -845,7 +845,7 @@ bool SIMbase::updateGrid (const RealArray& displ)
     Vector locdisp;
     if (this->mixedProblem())
       this->extractPatchSolution(displ,locdisp,pch,
-                                 pch->getNoSpaceDim(),ASMmxBase::geoBasis);
+                                 pch->getNoSpaceDim(),ASMmxBase::elmBasis);
     else
       pch->extractNodeVec(displ,locdisp,pch->getNoSpaceDim(),-1);
 

--- a/src/SIM/Test/TestSIM.C
+++ b/src/SIM/Test/TestSIM.C
@@ -159,7 +159,7 @@ TEST(TestSIM3D, ProjectSolutionMixed)
 TEST(TestSIM2D, InjectPatchSolution)
 {
   ASMmxBase::Type = ASMmxBase::REDUCED_CONT_RAISE_BASIS1;
-  ASMmxBase::geoBasis = 2;
+  ASMmxBase::elmBasis = 2;
   TestProjectSIM<SIM2D> sim({1,1});
   ASMbase* pch = sim.getPatch(1);
 

--- a/src/Utility/Test/TestCoordinateMapping.C
+++ b/src/Utility/Test/TestCoordinateMapping.C
@@ -305,14 +305,14 @@ TEST(TestCoordinateMapping, Hessian2D_mixed)
   Matrix Jac;
   std::array<Matrix, 2> grad;
 
-  int geoBasis = ASMmxBase::geoBasis - 1;
+  int elmBasis = ASMmxBase::elmBasis - 1;
 
   Matrix Xnod;
   p.getElementCoordinates(Xnod,1);
 
-  utl::Jacobian(Jac, grad[geoBasis], Xnod, dNxdu[geoBasis]);
+  utl::Jacobian(Jac, grad[elmBasis], Xnod, dNxdu[elmBasis]);
 
-  grad[1-geoBasis].multiply(dNxdu[1-geoBasis],Jac);
+  grad[1-elmBasis].multiply(dNxdu[1-elmBasis],Jac);
 
   const double Hess_basis1[] = {
     0.5,-1.0, 0.5, 1.0,-2.0, 1.0, 0.5,-1.0, 0.5,


### PR DESCRIPTION
This allows for a geometry that is separate from solution bases.
In particular this will be needed for proper RT support where we need the geometry to quadratic for the lowest-order RT basis (ie where the solution bases are (2,1) x (1,2) x (1,1) we need geometry to be (2,2)).

Very drafty still, only done structured 2D ASMs and only handling first order derivatives, ie there is no hessian handling yet. I'm opening early to get feedback on how I have approached it.