### PR TITLE
Some deduplication in ASMsxDmx

### DIFF
--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -1336,10 +1336,11 @@ bool ASMs2D::getElementCoordinates (Matrix& X, int iel) const
 
   X.resize(nsd,surf->order_u()*surf->order_v());
 
+  int lnod0 = this->getFirstItgElmNode();
   RealArray::const_iterator cit = surf->coefs_begin();
   for (size_t n = 0; n < X.cols(); n++)
   {
-    int ip = this->coeffInd(MNPC[iel-1][n])*surf->dimension();
+    int ip = this->coeffInd(MNPC[iel-1][n + lnod0])*surf->dimension();
     if (ip < 0) return false;
 
     for (size_t i = 0; i < nsd; i++)

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -1233,7 +1233,7 @@ double ASMs2D::getParametricArea (int iel) const
   if (MNPC[iel-1].empty())
     return 0.0;
 
-  int inod1 = MNPC[iel-1][surf->order_u()*surf->order_v()-1];
+  int inod1 = MNPC[iel-1][this->getLastItgElmNode()];
 #ifdef INDEX_CHECK
   if (inod1 < 0 || (size_t)inod1 >= nnod)
   {
@@ -1263,7 +1263,7 @@ double ASMs2D::getParametricLength (int iel, int dir) const
   if (MNPC[iel-1].empty())
     return 0.0;
 
-  int inod1 = MNPC[iel-1][surf->order_u()*surf->order_v()-1];
+  int inod1 = MNPC[iel-1][this->getLastItgElmNode()];
 #ifdef INDEX_CHECK
   if (inod1 < 0 || (size_t)inod1 >= nnod)
   {
@@ -1274,13 +1274,13 @@ double ASMs2D::getParametricLength (int iel, int dir) const
 #endif
 
   switch (dir)
-    {
+  {
     case 1: return surf->knotSpan(0,nodeInd[inod1].I);
     case 2: return surf->knotSpan(1,nodeInd[inod1].J);
-    }
+  }
 
   std::cerr <<" *** ASMs2D::getParametricLength: Invalid edge direction "
-	    << dir << std::endl;
+            << dir << std::endl;
   return DERR;
 }
 
@@ -3219,6 +3219,12 @@ bool ASMs2D::addRigidCpl (int lindx, int ldim, int basis,
   }
 
   return this->ASMstruct::addRigidCpl(lindx,ldim,basis,gMaster,Xmaster,extraPt);
+}
+
+
+int ASMs2D::getLastItgElmNode () const
+{
+  return surf->order_u()*surf->order_v()-1;
 }
 
 

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -680,6 +680,8 @@ protected:
   //! \brief Generates element groups from a partition.
   virtual void generateThreadGroupsFromElms(const IntVec& elms);
 
+  //! \brief Returns 0-based index of first node on integration basis.
+  virtual int getFirstItgElmNode() const { return 0; }
   //! \brief Returns 0-based index of last node on integration basis.
   virtual int getLastItgElmNode() const;
 

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -630,7 +630,7 @@ protected:
 
   //! \brief Returns the area in the parameter space for an element.
   //! \param[in] iel Element index
-  virtual double getParametricArea(int iel) const;
+  double getParametricArea(int iel) const;
   //! \brief Returns boundary edge length in the parameter space for an element.
   //! \param[in] iel Element index
   //! \param[in] dir Local index of the boundary edge
@@ -679,6 +679,9 @@ protected:
 
   //! \brief Generates element groups from a partition.
   virtual void generateThreadGroupsFromElms(const IntVec& elms);
+
+  //! \brief Returns 0-based index of last node on integration basis.
+  virtual int getLastItgElmNode() const;
 
 public:
   //! \brief Auxilliary function for computation of basis function indices.

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -371,42 +371,6 @@ void ASMs2Dmx::closeBoundaries (int dir, int, int)
 }
 
 
-bool ASMs2Dmx::getElementCoordinates (Matrix& X, int iel) const
-{
-#ifdef INDEX_CHECK
-  if (iel < 1 || (size_t)iel > MNPC.size())
-  {
-    std::cerr <<" *** ASMs2Dmx::getElementCoordinates: Element index "<< iel
-	      <<" out of range [1,"<< MNPC.size() <<"]."<< std::endl;
-    return false;
-  }
-#endif
-
-  size_t nenod = surf->order_u()*surf->order_v();
-  size_t lnod0 = 0;
-  for (int i = 1; i < geoBasis; ++i)
-    lnod0 += m_basis[i-1]->order_u()*m_basis[i-1]->order_v();
-
-  X.resize(nsd,nenod);
-  const IntVec& mnpc = MNPC[iel-1];
-
-  RealArray::const_iterator cit = surf->coefs_begin();
-  for (size_t n = 0; n < nenod; n++)
-  {
-    int iI = nodeInd[mnpc[lnod0+n]].I;
-    int iJ = nodeInd[mnpc[lnod0+n]].J;
-    int ip = (iJ*surf->numCoefs_u() + iI)*surf->dimension();
-    for (size_t i = 0; i < nsd; i++)
-      X(i+1,n+1) = *(cit+(ip+i));
-  }
-
-#if SP_DEBUG > 2
-  std::cout <<"\nCoordinates for element "<< iel << X << std::endl;
-#endif
-  return true;
-}
-
-
 Vec3 ASMs2Dmx::getCoord (size_t inod) const
 {
   if (inod > nodeInd.size() && inod <= MLGN.size())
@@ -1159,6 +1123,12 @@ void ASMs2Dmx::swapProjectionBasis ()
     std::swap(proj, altProjBasis);
     surf = this->getBasis(ASMmxBase::geoBasis);
   }
+}
+
+
+int ASMs2Dmx::getFirstItgElmNode () const
+{
+  return std::accumulate(elem_size.begin(), elem_size.begin() + geoBasis-1, 0);
 }
 
 

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -456,75 +456,6 @@ bool ASMs2Dmx::getSize (int& n1, int& n2, int basis) const
 }
 
 
-#define DERR -999.99
-
-double ASMs2Dmx::getParametricArea (int iel) const
-{
-#ifdef INDEX_CHECK
-  if (iel < 1 || (size_t)iel > MNPC.size())
-  {
-    std::cerr <<" *** ASMs2Dmx::getParametricArea: Element index "<< iel
-	      <<" out of range [1,"<< MNPC.size() <<"]."<< std::endl;
-    return DERR;
-  }
-#endif
-  if (MNPC[iel-1].empty())
-    return 0.0;
-
-  int inod1 = MNPC[iel-1][std::accumulate(elem_size.begin(),
-                                          elem_size.begin()+geoBasis, -1)];
-#ifdef INDEX_CHECK
-  if (inod1 < 0 || (size_t)inod1 >= nnod)
-  {
-    std::cerr <<" *** ASMs2Dmx::getParametricArea: Node index "<< inod1
-	      <<" out of range [0,"<< nnod <<">."<< std::endl;
-    return DERR;
-  }
-#endif
-
-  double du = m_basis[geoBasis-1]->knotSpan(0,nodeInd[inod1].I);
-  double dv = m_basis[geoBasis-1]->knotSpan(1,nodeInd[inod1].J);
-
-  return du*dv;
-}
-
-
-double ASMs2Dmx::getParametricLength (int iel, int dir) const
-{
-#ifdef INDEX_CHECK
-  if (iel < 1 || (size_t)iel > MNPC.size())
-  {
-    std::cerr <<" *** ASMs2Dmx::getParametricLength: Element index "<< iel
-	      <<" out of range [1,"<< MNPC.size() <<"]."<< std::endl;
-    return DERR;
-  }
-#endif
-  if (MNPC[iel-1].empty())
-    return 0.0;
-
-  int inod1 = MNPC[iel-1][std::accumulate(elem_size.begin(),
-                                          elem_size.begin()+geoBasis, -1)];
-#ifdef INDEX_CHECK
-  if (inod1 < 0 || (size_t)inod1 >= nnod)
-  {
-    std::cerr <<" *** ASMs2Dmx::getParametricLength: Node index "<< inod1
-	      <<" out of range [0,"<< nnod <<">."<< std::endl;
-    return DERR;
-  }
-#endif
-
-  switch (dir)
-    {
-    case 1: return m_basis[geoBasis-1]->knotSpan(0,nodeInd[inod1].I);
-    case 2: return m_basis[geoBasis-1]->knotSpan(1,nodeInd[inod1].J);
-    }
-
-  std::cerr <<" *** ASMs2Dmx::getParametricLength: Invalid edge direction "
-	    << dir << std::endl;
-  return DERR;
-}
-
-
 bool ASMs2Dmx::integrate (Integrand& integrand,
 			  GlobalIntegral& glInt,
 			  const TimeDomain& time)
@@ -1228,4 +1159,10 @@ void ASMs2Dmx::swapProjectionBasis ()
     std::swap(proj, altProjBasis);
     surf = this->getBasis(ASMmxBase::geoBasis);
   }
+}
+
+
+int ASMs2Dmx::getLastItgElmNode () const
+{
+  return std::accumulate(elem_size.begin(), elem_size.begin() + geoBasis, -1);
 }

--- a/src/ASM/ASMs2Dmx.h
+++ b/src/ASM/ASMs2Dmx.h
@@ -65,12 +65,6 @@ public:
   //! This is used to reinitialize the patch after it has been refined.
   virtual void clear(bool retainGeometry);
 
-  //! \brief Returns a matrix with nodal coordinates for an element.
-  //! \param[in] iel Element index
-  //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes
-  //! in one element
-  virtual bool getElementCoordinates(Matrix& X, int iel) const;
-
   //! \brief Returns the global coordinates for the given node.
   //! \param[in] inod 1-based node index local to current patch
   virtual Vec3 getCoord(size_t inod) const;
@@ -229,6 +223,8 @@ public:
                                 int thick, int, bool local) const;
 
 protected:
+  //! \brief Returns 0-based index of first node on integration basis.
+  virtual int getFirstItgElmNode() const;
   //! \brief Returns 0-based index of last node on integration basis.
   virtual int getLastItgElmNode() const;
 

--- a/src/ASM/ASMs2Dmx.h
+++ b/src/ASM/ASMs2Dmx.h
@@ -87,13 +87,6 @@ public:
   //! \brief Returns the classification of a node.
   //! \param[in] inod 1-based node index local to current patch
   virtual char getNodeType(size_t inod) const;
-  //! \brief Returns the area in the parameter space for an element.
-  //! \param[in] iel Element index
-  virtual double getParametricArea(int iel) const;
-  //! \brief Returns boundary edge length in the parameter space for an element.
-  //! \param[in] iel Element index
-  //! \param[in] dir Local index of the boundary edge
-  double getParametricLength(int iel, int dir) const;
 
   //! \brief Initializes the patch level MADOF array for mixed problems.
   virtual void initMADOF(const int* sysMadof);
@@ -236,6 +229,9 @@ public:
                                 int thick, int, bool local) const;
 
 protected:
+  //! \brief Returns 0-based index of last node on integration basis.
+  virtual int getLastItgElmNode() const;
+
   std::vector<std::shared_ptr<Go::SplineSurface>> m_basis; //!< Vector of bases
   Go::SplineSurface* altProjBasis = nullptr; //!< Alternative projection basis
 };

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -1603,11 +1603,12 @@ bool ASMs3D::getElementCoordinates (Matrix& X, int iel) const
 #endif
 
   X.resize(3,svol->order(0)*svol->order(1)*svol->order(2));
+  int lnod0 = this->getFirstItgElmNode();
 
   RealArray::const_iterator cit = svol->coefs_begin();
   for (size_t n = 0; n < X.cols(); n++)
   {
-    int ip = this->coeffInd(MNPC[iel-1][n])*svol->dimension();
+    int ip = this->coeffInd(MNPC[iel-1][n + lnod0])*svol->dimension();
     if (ip < 0) return false;
 
     for (size_t i = 0; i < 3; i++)

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -1495,7 +1495,7 @@ double ASMs3D::getParametricVolume (int iel) const
   if (MNPC[iel-1].empty())
     return 0.0;
 
-  int inod1 = MNPC[iel-1][svol->order(0)*svol->order(1)*svol->order(2)-1];
+  int inod1 = MNPC[iel-1][this->getLastItgElmNode()];
 #ifdef INDEX_CHECK
   if (inod1 < 0 || (size_t)inod1 >= nnod)
   {
@@ -1525,7 +1525,7 @@ double ASMs3D::getParametricArea (int iel, int dir) const
   if (MNPC[iel-1].empty())
     return 0.0;
 
-  int inod1 = MNPC[iel-1][svol->order(0)*svol->order(1)*svol->order(2)-1];
+  int inod1 = MNPC[iel-1][this->getLastItgElmNode()];
 #ifdef INDEX_CHECK
   if (inod1 < 0 || (size_t)inod1 >= nnod)
   {
@@ -3485,6 +3485,12 @@ void ASMs3D::generateThreadGroups (char lIndex, bool silence, bool)
                  << ": "<< fGrp[i][j].size() <<" elements";
   }
   IFEM::cout << std::endl;
+}
+
+
+int ASMs3D::getLastItgElmNode () const
+{
+  return svol->order(0)*svol->order(1)*svol->order(2)-1;
 }
 
 

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -700,7 +700,7 @@ protected:
 
   //! \brief Returns the volume in the parameter space for an element.
   //! \param[in] iel Element index
-  virtual double getParametricVolume(int iel) const;
+  double getParametricVolume(int iel) const;
   //! \brief Returns boundary face area in the parameter space for an element.
   //! \param[in] iel Element index
   //! \param[in] dir Local face index of the boundary face
@@ -746,6 +746,9 @@ protected:
   //! \param[in] ignoreGlobalLM Sanity check option
   void generateThreadGroups(size_t strip1, size_t strip2, size_t strip3,
                             bool silence, bool ignoreGlobalLM);
+
+  //! \brief Returns 0-based index of last node on integration basis.
+  virtual int getLastItgElmNode() const;
 
 public:
   //! \brief Generates element groups for multi-threading of interior integrals.

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -747,6 +747,8 @@ protected:
   void generateThreadGroups(size_t strip1, size_t strip2, size_t strip3,
                             bool silence, bool ignoreGlobalLM);
 
+  //! \brief Returns 0-based index of first node on integration basis.
+  virtual int getFirstItgElmNode() const { return 0; }
   //! \brief Returns 0-based index of last node on integration basis.
   virtual int getLastItgElmNode() const;
 

--- a/src/ASM/ASMs3Dmx.C
+++ b/src/ASM/ASMs3Dmx.C
@@ -1278,6 +1278,12 @@ void ASMs3Dmx::swapProjectionBasis ()
 }
 
 
+int ASMs3Dmx::getFirstItgElmNode () const
+{
+  return std::accumulate(elem_size.begin(), elem_size.begin() + geoBasis-1, 0);
+}
+
+
 int ASMs3Dmx::getLastItgElmNode () const
 {
   return std::accumulate(elem_size.begin(), elem_size.begin() + geoBasis, -1);

--- a/src/ASM/ASMs3Dmx.C
+++ b/src/ASM/ASMs3Dmx.C
@@ -1257,79 +1257,6 @@ void ASMs3Dmx::generateThreadGroups (const Integrand& integrand, bool silence,
 }
 
 
-#define DERR -999.99
-
-double ASMs3Dmx::getParametricVolume (int iel) const
-{
-#ifdef INDEX_CHECK
-  if (iel < 1 || (size_t)iel > MNPC.size())
-  {
-    std::cerr <<" *** ASMs3Dmx::getParametricVolume: Element index "<< iel
-	      <<" out of range [1,"<< MNPC.size() <<"]."<< std::endl;
-    return DERR;
-  }
-#endif
-  if (MNPC[iel-1].empty())
-    return 0.0;
-
-  int inod1 = MNPC[iel-1][std::accumulate(elem_size.begin(),
-                                          elem_size.begin()+geoBasis, -1)];
-#ifdef INDEX_CHECK
-  if (inod1 < 0 || (size_t)inod1 >= nnod)
-  {
-    std::cerr <<" *** ASMs3Dmx::getParametricVolume: Node index "<< inod1
-	      <<" out of range [0,"<< nnod <<">."<< std::endl;
-    return DERR;
-  }
-#endif
-
-  double du = svol->knotSpan(0,nodeInd[inod1].I);
-  double dv = svol->knotSpan(1,nodeInd[inod1].J);
-  double dw = svol->knotSpan(2,nodeInd[inod1].K);
-  return du*dv*dw;
-}
-
-
-double ASMs3Dmx::getParametricArea (int iel, int dir) const
-{
-#ifdef INDEX_CHECK
-  if (iel < 1 || (size_t)iel > MNPC.size())
-  {
-    std::cerr <<" *** ASMs3Dmx::getParametricArea: Element index "<< iel
-	      <<" out of range [1,"<< MNPC.size() <<"]."<< std::endl;
-    return DERR;
-  }
-#endif
-  if (MNPC[iel-1].empty())
-    return 0.0;
-
-  int inod1 = MNPC[iel-1][std::accumulate(elem_size.begin(),
-                                          elem_size.begin()+geoBasis, -1)];
-#ifdef INDEX_CHECK
-  if (inod1 < 0 || (size_t)inod1 >= nnod)
-  {
-    std::cerr <<" *** ASMs3Dmx::getParametricArea: Node index "<< inod1
-	      <<" out of range [0,"<< nnod <<">."<< std::endl;
-    return DERR;
-  }
-#endif
-
-  const int ni = nodeInd[inod1].I;
-  const int nj = nodeInd[inod1].J;
-  const int nk = nodeInd[inod1].K;
-  switch (dir)
-    {
-    case 1: return svol->knotSpan(1,nj)*svol->knotSpan(2,nk);
-    case 2: return svol->knotSpan(0,ni)*svol->knotSpan(2,nk);
-    case 3: return svol->knotSpan(0,ni)*svol->knotSpan(1,nj);
-    }
-
-  std::cerr <<" *** ASMs3Dmx::getParametricArea: Invalid face direction "
-	    << dir << std::endl;
-  return DERR;
-}
-
-
 void ASMs3Dmx::getBoundaryNodes (int lIndex, IntVec& nodes, int basis,
                                  int thick, int, bool local) const
 {
@@ -1348,4 +1275,10 @@ void ASMs3Dmx::swapProjectionBasis ()
     std::swap(proj, altProjBasis);
     svol = this->getBasis(ASMmxBase::geoBasis);
   }
+}
+
+
+int ASMs3Dmx::getLastItgElmNode () const
+{
+  return std::accumulate(elem_size.begin(), elem_size.begin() + geoBasis, -1);
 }

--- a/src/ASM/ASMs3Dmx.h
+++ b/src/ASM/ASMs3Dmx.h
@@ -218,13 +218,8 @@ public:
   virtual bool getSize(int& n1, int& n2, int& n3, int basis) const;
 
 protected:
-  //! \brief Returns the volume in the parameter space for an element.
-  //! \param[in] iel Element index
-  virtual double getParametricVolume(int iel) const;
-  //! \brief Returns boundary face area in the parameter space for an element.
-  //! \param[in] iel Element index
-  //! \param[in] dir Local face index of the boundary face
-  double getParametricArea(int iel, int dir) const;
+  //! \brief Returns 0-based index of last node on integration basis.
+  virtual int getLastItgElmNode() const;
 
   //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
   //! \param[in] lIndex Local index of the boundary edge

--- a/src/ASM/ASMs3Dmx.h
+++ b/src/ASM/ASMs3Dmx.h
@@ -218,6 +218,8 @@ public:
   virtual bool getSize(int& n1, int& n2, int& n3, int basis) const;
 
 protected:
+  //! \brief Returns 0-based index of first node on integration basis.
+  virtual int getFirstItgElmNode() const;
   //! \brief Returns 0-based index of last node on integration basis.
   virtual int getLastItgElmNode() const;
 


### PR DESCRIPTION
Introduce a method to obtain last node on integration basis and use this to deduplicate the methods that obtains parametric area/volume/length. Likewise introduce a method to obtain first node on integration basis and use this to deduplicate getElementCoordinates().
