### PR TITLE
Changed: Second (mostly dummy) argument in read method is removed.

### DIFF
--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -117,7 +117,9 @@ public:
   virtual bool empty() const = 0;
 
   //! \brief Creates an instance by reading the given input stream.
-  virtual bool read(std::istream& is, int basis = 0) = 0;
+  virtual bool read(std::istream& is) = 0;
+  //! \brief Reads a basis from the given input stream.
+  virtual bool readBasis(std::istream&, size_t) { return false; }
   //! \brief Writes the geometry/basis of the patch to the given stream.
   virtual bool write(std::ostream& os, int basis = 0) const = 0;
 

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -58,7 +58,7 @@ ASMs1D::ASMs1D (const ASMs1D& patch, unsigned char n_f)
 }
 
 
-bool ASMs1D::read (std::istream& is, int)
+bool ASMs1D::read (std::istream& is)
 {
   if (shareFE) return true;
   if (curv) delete curv;

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -49,7 +49,7 @@ public:
   // ============================
 
   //! \brief Creates an instance by reading the given input stream.
-  virtual bool read(std::istream&, int = 0);
+  virtual bool read(std::istream&);
   //! \brief Writes the geometry of the SplineCurve object to given stream.
   virtual bool write(std::ostream&, int = 0) const;
 

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -112,7 +112,7 @@ void ASMs2D::copyParameterDomain (const ASMbase* other)
 }
 
 
-bool ASMs2D::read (std::istream& is, int)
+bool ASMs2D::read (std::istream& is)
 {
   if (shareFE) return true;
   if (surf) delete surf;

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -201,7 +201,7 @@ public:
   // ============================
 
   //! \brief Creates an instance by reading the given input stream.
-  virtual bool read(std::istream&, int = 0);
+  virtual bool read(std::istream&);
   //! \brief Writes the geometry of the SplineSurface object to given stream.
   virtual bool write(std::ostream&, int) const;
 

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -79,23 +79,21 @@ Go::SplineCurve* ASMs2Dmx::getBoundary (int dir, int basis)
 }
 
 
-bool ASMs2Dmx::read (std::istream& is, int basis)
+bool ASMs2Dmx::readBasis (std::istream& is, size_t basis)
 {
-  if (basis == 0)
-    return this->ASMs2D::read(is);
-
-  if (basis < 0 || basis > static_cast<int>(nfx.size()))
+  if (basis < 1 || basis > nfx.size())
     return false;
 
-  if (m_basis.empty()) {
+  if (m_basis.empty())
+  {
     m_basis.resize(nfx.size());
     nb.resize(nfx.size(), 0);
   }
 
   Go::ObjectHeader head;
-  m_basis[basis-1] = std::make_shared<Go::SplineSurface>();
-  is >> head >> *m_basis[basis-1];
-  nb[basis-1] = m_basis[basis-1]->numCoefs_u()*m_basis[basis-1]->numCoefs_v();
+  m_basis[--basis] = std::make_shared<Go::SplineSurface>();
+  is >> head >> *m_basis[basis];
+  nb[basis] = m_basis[basis]->numCoefs_u() * m_basis[basis]->numCoefs_v();
 
   return true;
 }

--- a/src/ASM/ASMs2Dmx.h
+++ b/src/ASM/ASMs2Dmx.h
@@ -50,8 +50,8 @@ public:
   // Methods for model generation
   // ============================
 
-  //! \brief Creates an instance by reading the given input stream.
-  virtual bool read(std::istream&, int basis = 0);
+  //! \brief Reads a basis from the given input stream.
+  virtual bool readBasis(std::istream& is, size_t basis);
   //! \brief Writes the geometry/basis of the patch to given stream.
   virtual bool write(std::ostream& os, int basis) const;
 

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -90,7 +90,7 @@ void ASMs3D::copyParameterDomain (const ASMbase* other)
 }
 
 
-bool ASMs3D::read (std::istream& is, int)
+bool ASMs3D::read (std::istream& is)
 {
   if (shareFE) return true;
   if (svol) delete svol;

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -220,7 +220,7 @@ public:
   // ============================
 
   //! \brief Creates an instance by reading the given input stream.
-  virtual bool read(std::istream&, int = 0);
+  virtual bool read(std::istream&);
   //! \brief Writes the geometry of the SplineVolume object to given stream.
   virtual bool write(std::ostream&, int) const;
 

--- a/src/ASM/ASMs3Dmx.C
+++ b/src/ASM/ASMs3Dmx.C
@@ -78,25 +78,23 @@ Go::SplineSurface* ASMs3Dmx::getBoundary (int dir, int basis)
 }
 
 
-bool ASMs3Dmx::read (std::istream& is, int basis)
+bool ASMs3Dmx::readBasis (std::istream& is, size_t basis)
 {
-  if (basis == 0)
-    return this->ASMs3D::read(is);
-
-  if (basis < 0 || basis > static_cast<int>(nfx.size()))
+  if (basis < 1 || basis > nfx.size())
     return false;
 
-  if (m_basis.empty()) {
+  if (m_basis.empty())
+  {
     m_basis.resize(nfx.size());
     nb.resize(nfx.size(), 0);
   }
 
   Go::ObjectHeader head;
-  m_basis[basis-1] = std::make_shared<Go::SplineVolume>();
-  is >> head >> *m_basis[basis-1];
-  nb[basis-1] = m_basis[basis-1]->numCoefs(0)*
-                m_basis[basis-1]->numCoefs(1)*
-                m_basis[basis-1]->numCoefs(2);
+  m_basis[--basis] = std::make_shared<Go::SplineVolume>();
+  is >> head >> *m_basis[basis];
+  nb[basis] = m_basis[basis]->numCoefs(0) *
+              m_basis[basis]->numCoefs(1) *
+              m_basis[basis]->numCoefs(2);
 
   return true;
 }

--- a/src/ASM/ASMs3Dmx.h
+++ b/src/ASM/ASMs3Dmx.h
@@ -70,8 +70,8 @@ public:
   //! \param[in] inod 1-based node index local to current patch
   virtual Vec3 getCoord(size_t inod) const;
 
-  //! \brief Creates an instance by reading the given input stream.
-  virtual bool read(std::istream&, int basis = 0);
+  //! \brief Reads a basis from the given input stream.
+  virtual bool readBasis(std::istream& is, size_t basis);
   //! \brief Writes the geometry/basis of the patch to given stream.
   virtual bool write(std::ostream& os, int basis) const;
 

--- a/src/ASM/ASMsupel.C
+++ b/src/ASM/ASMsupel.C
@@ -18,7 +18,7 @@
 #include <numeric>
 
 
-bool ASMsupel::read (std::istream& is, int)
+bool ASMsupel::read (std::istream& is)
 {
   // Lambda function for reading the supernode coordinates.
   auto&& readCoord = [&is](Vec3Vec& Xsup)

--- a/src/ASM/ASMsupel.h
+++ b/src/ASM/ASMsupel.h
@@ -39,7 +39,7 @@ public:
   virtual ~ASMsupel() {}
 
   //! \brief Creates an instance by reading the given input stream.
-  virtual bool read(std::istream& is, int = 0);
+  virtual bool read(std::istream& is);
   //! \brief Writes the geometry of the patch to the given stream.
   virtual bool write(std::ostream&, int) const;
   //! \brief Generates the finite element topology data for this patch.

--- a/src/ASM/ASMu1DLag.C
+++ b/src/ASM/ASMu1DLag.C
@@ -37,7 +37,7 @@ ASMu1DLag::ASMu1DLag (const ASMu1DLag& p) :
 }
 
 
-bool ASMu1DLag::read (std::istream& is, int)
+bool ASMu1DLag::read (std::istream& is)
 {
   switch (fileType) {
   case 'm':

--- a/src/ASM/ASMu1DLag.h
+++ b/src/ASM/ASMu1DLag.h
@@ -41,7 +41,7 @@ public:
   // ============================
 
   //! \brief Creates an instance by reading the given input stream.
-  virtual bool read(std::istream& is, int = 0);
+  virtual bool read(std::istream& is);
   //! \brief Generates a beam finite element model for the patch.
   //! \param[in] Zaxis Vector defining a point in the local XZ-plane
   virtual bool generateOrientedFEModel(const Vec3& Zaxis);

--- a/src/ASM/ASMu2DLag.C
+++ b/src/ASM/ASMu2DLag.C
@@ -37,7 +37,7 @@ ASMu2DLag::ASMu2DLag (const ASMu2DLag& p) :
 }
 
 
-bool ASMu2DLag::read (std::istream& is, int)
+bool ASMu2DLag::read (std::istream& is)
 {
   switch (fileType) {
   case 'm':

--- a/src/ASM/ASMu2DLag.h
+++ b/src/ASM/ASMu2DLag.h
@@ -41,7 +41,7 @@ public:
   // ============================
 
   //! \brief Creates an instance by reading the given input stream.
-  virtual bool read(std::istream& is, int = 0);
+  virtual bool read(std::istream& is);
   //! \brief Generates the finite element topology data for the patch.
   virtual bool generateFEMTopology();
   //! \brief Checks if this patch is empty.

--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -66,7 +66,7 @@ ASMu2D::ASMu2D (const ASMu2D& patch, unsigned char n_f)
 }
 
 
-bool ASMu2D::read (std::istream& is, int)
+bool ASMu2D::read (std::istream& is)
 {
   if (shareFE) return true;
 

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -148,7 +148,7 @@ public:
   // ===========================================
 
   //! \brief Creates an instance by reading the given input stream.
-  virtual bool read(std::istream&, int = 0);
+  virtual bool read(std::istream&);
   //! \brief Writes the geometry of the SplineSurface object to given stream.
   virtual bool write(std::ostream&, int) const;
 

--- a/src/ASM/LR/ASMu2Dmx.C
+++ b/src/ASM/LR/ASMu2Dmx.C
@@ -72,23 +72,21 @@ LR::LRSplineSurface* ASMu2Dmx::getBasis (int basis)
 }
 
 
-bool ASMu2Dmx::read (std::istream& is, int basis)
+bool ASMu2Dmx::readBasis (std::istream& is, size_t basis)
 {
-  if (basis == 0)
-    return this->ASMu2D::read(is);
-
-  if (basis < 0 || basis > static_cast<int>(nfx.size()))
+  if (basis < 1 || basis > nfx.size())
     return false;
 
-  if (m_basis.empty()) {
+  if (m_basis.empty())
+  {
     m_basis.resize(nfx.size());
     nb.resize(nfx.size(), 0);
   }
 
-  m_basis[basis-1] = std::make_shared<LR::LRSplineSurface>();
-  is >> *m_basis[basis-1];
-  nb[basis-1] = m_basis[basis-1]->nBasisFunctions();
-  m_basis[basis-1]->generateIDs();
+  m_basis[--basis] = std::make_shared<LR::LRSplineSurface>();
+  is >> *m_basis[basis];
+  nb[basis] = m_basis[basis]->nBasisFunctions();
+  m_basis[basis]->generateIDs();
 
   return true;
 }

--- a/src/ASM/LR/ASMu2Dmx.h
+++ b/src/ASM/LR/ASMu2Dmx.h
@@ -74,8 +74,8 @@ public:
   // Methods for model generation
   // ============================
 
-  //! \brief Creates an instance by reading the given input stream.
-  virtual bool read(std::istream&, int basis);
+  //! \brief Reads a basis from the given input stream.
+  virtual bool readBasis(std::istream& is, size_t basis);
   //! \brief Writes the geometry/basis of the patch to given stream.
   virtual bool write(std::ostream& os, int basis) const;
 

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -64,7 +64,7 @@ ASMu3D::ASMu3D (const ASMu3D& patch, unsigned char n_f)
 }
 
 
-bool ASMu3D::read (std::istream& is, int)
+bool ASMu3D::read (std::istream& is)
 {
   if (shareFE) return true;
 

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -131,7 +131,7 @@ public:
   // ===========================================
 
   //! \brief Creates an instance by reading the given input stream.
-  virtual bool read(std::istream&, int = 0);
+  virtual bool read(std::istream&);
   //! \brief Writes the geometry of the SplineVolume object to given stream.
   virtual bool write(std::ostream&, int) const;
 

--- a/src/ASM/LR/ASMu3Dmx.C
+++ b/src/ASM/LR/ASMu3Dmx.C
@@ -75,23 +75,21 @@ LR::LRSplineVolume* ASMu3Dmx::getBasis (int basis)
 }
 
 
-bool ASMu3Dmx::read (std::istream& is, int basis)
+bool ASMu3Dmx::readBasis (std::istream& is, size_t basis)
 {
-  if (basis == 0)
-    return this->ASMu3D::read(is,0);
-
-  if (basis < 0 || basis > static_cast<int>(nfx.size()))
+  if (basis < 1 || basis > nfx.size())
     return false;
 
-  if (m_basis.empty()) {
+  if (m_basis.empty())
+  {
     m_basis.resize(nfx.size());
     nb.resize(nfx.size(), 0);
   }
 
-  m_basis[basis-1] = std::make_shared<LR::LRSplineVolume>();
-  is >> *m_basis[basis-1];
-  nb[basis-1] = m_basis[basis-1]->nBasisFunctions();
-  m_basis[basis-1]->generateIDs();
+  m_basis[--basis] = std::make_shared<LR::LRSplineVolume>();
+  is >> *m_basis[basis];
+  nb[basis] = m_basis[basis]->nBasisFunctions();
+  m_basis[basis]->generateIDs();
 
   return true;
 }

--- a/src/ASM/LR/ASMu3Dmx.h
+++ b/src/ASM/LR/ASMu3Dmx.h
@@ -74,8 +74,8 @@ public:
   // Methods for model generation
   // ============================
 
-  //! \brief Creates an instance by reading the given input stream.
-  virtual bool read(std::istream&, int basis);
+  //! \brief Reads a basis from the given input stream.
+  virtual bool readBasis(std::istream& is, size_t basis);
   //! \brief Writes the geometry/basis of the patch to given stream.
   virtual bool write(std::ostream& os, int basis) const;
 

--- a/src/Utility/FieldFunctions.C
+++ b/src/Utility/FieldFunctions.C
@@ -156,7 +156,7 @@ bool FieldFuncHDF5::load (const std::vector<std::string>& fieldNames,
               patch[ip] = ASM3D::create(ASM::LRSpline,nFld);
           }
           std::stringstream strg2(g2);
-          patch[ip]->read(strg2, i);
+          patch[ip]->readBasis(strg2, i);
         }
       } else {
         if (patch[ip])


### PR DESCRIPTION
Instead, introducing a separate `readBasis()` method.
Consider if this simplifies the logic, and does not break any future intentions.