### PR TITLE
Unify geometry pointer in ASMLRSpline with ASMstruct

### DIFF
--- a/src/ASM/LR/ASMLRSpline.C
+++ b/src/ASM/LR/ASMLRSpline.C
@@ -187,20 +187,20 @@ ASMLRSpline::ASMLRSpline (unsigned char n_p, unsigned char n_s,
                           unsigned char n_f)
   : ASMbase(n_p,n_s,n_f)
 {
-  geo = nullptr;
+  geomB = nullptr;
 }
 
 
 ASMLRSpline::ASMLRSpline (const ASMLRSpline& patch, unsigned char n_f)
   : ASMbase(patch,n_f)
 {
-  geo = patch.geo;
+  geomB = patch.geomB;
 }
 
 
 bool ASMLRSpline::refine (const LR::RefineData& prm, Vectors& sol)
 {
-  if (!geo)
+  if (!geomB)
     return false;
 
   if (shareFE && !prm.refShare)
@@ -208,8 +208,8 @@ bool ASMLRSpline::refine (const LR::RefineData& prm, Vectors& sol)
     // This patch shares spline object with another patch
     // (in another simulator on the same mesh),
     // and is assumed to have been refined already
-    nnod = geo->nBasisFunctions();
-    nel  = geo->nElements();
+    nnod = geomB->nBasisFunctions();
+    nel  = geomB->nElements();
     return true;
   }
 
@@ -220,32 +220,32 @@ bool ASMLRSpline::refine (const LR::RefineData& prm, Vectors& sol)
 
   IntVec nf(sol.size());
   for (size_t j = 0; j < sol.size(); j++)
-    if ((nf[j] = LR::extendControlPoints(geo,sol[j],this->getNoFields(1))) < 0)
+    if ((nf[j] = LR::extendControlPoints(geomB.get(),sol[j],this->getNoFields(1))) < 0)
       return false;
 
-  if (!this->doRefine(prm,geo))
+  if (!this->doRefine(prm,geomB.get()))
     return false;
 
-  nnod = geo->nBasisFunctions();
-  nel  = geo->nElements();
+  nnod = geomB->nBasisFunctions();
+  nel  = geomB->nElements();
   IFEM::cout <<"Refined mesh: "<< nel <<" elements "<< nnod <<" nodes."<< std::endl;
 
   for (int i = sol.size()-1; i >= 0; i--)
     if (nf[i] > 0) {
       sol[i].resize(nf[i]*nnod);
-      LR::contractControlPoints(geo,sol[i],nf[i]);
+      LR::contractControlPoints(geomB.get(),sol[i],nf[i]);
     }
 
   bool linIndepTest = prm.options.size() > 3 ? prm.options[3] != 0 : false;
   if (linIndepTest)
   {
     std::cout <<"Testing for linear independence by overloading"<< std::endl;
-    bool isLinIndep = geo->isLinearIndepByOverloading(false);
+    bool isLinIndep = geomB->isLinearIndepByOverloading(false);
     if (!isLinIndep) {
       std::cout <<"Inconclusive..."<< std::endl;
 #ifdef HAS_BOOST
       std::cout <<"Testing for linear independence by full tensor expansion"<< std::endl;
-      isLinIndep = geo->isLinearIndepByMappingMatrix(false);
+      isLinIndep = geomB->isLinearIndepByMappingMatrix(false);
 #endif
     }
     if (isLinIndep)
@@ -337,12 +337,12 @@ void ASMLRSpline::getFunctionsForElements (IntSet& functions,
                                            const IntVec& elements,
                                            bool globalId) const
 {
-  geo->generateIDs();
+  geomB->generateIDs();
   for (int elmId : elements)
   {
     int iel = globalId ? utl::findIndex(MLGE,1+elmId) : elmId;
-    if (iel >= 0 && iel < geo->nElements())
-      for (LR::Basisfunction* b : geo->getElement(iel)->support())
+    if (iel >= 0 && iel < geomB->nElements())
+      for (LR::Basisfunction* b : geomB->getElement(iel)->support())
         functions.insert(globalId ? this->getNodeID(b->getId()+1)-1:b->getId());
   }
 }
@@ -358,7 +358,7 @@ IntVec ASMLRSpline::getBoundaryCovered (const IntSet& nodes) const
     this->getBoundaryNodes(edge,oneBoundary,1,1,0,true);
     for (int i : nodes)
       for (int j : oneBoundary)
-        if (geo->getBasisfunction(i)->contains(*geo->getBasisfunction(j-1)))
+        if (geomB->getBasisfunction(i)->contains(*geomB->getBasisfunction(j-1)))
           result.insert(j-1);
   }
 
@@ -371,7 +371,7 @@ IntVec ASMLRSpline::getOverlappingNodes (const IntSet& nodes, int dir) const
   IntSet result;
   for (int i : nodes)
   {
-    LR::Basisfunction* b = geo->getBasisfunction(i);
+    LR::Basisfunction* b = geomB->getBasisfunction(i);
     for (LR::Element* el : b->support())
       for (LR::Basisfunction* basis : el->support())
       {
@@ -432,7 +432,7 @@ std::pair<size_t,double> ASMLRSpline::findClosestNode (const Vec3& X) const
 {
   double distance = 0.0;
   size_t inod = 0, iclose = 0;
-  for (LR::Basisfunction* b : geo->getAllBasisfunctions())
+  for (LR::Basisfunction* b : geomB->getAllBasisfunctions())
   {
     double d = (X-Vec3(&(*b->cp()),nsd)).length();
     if (++inod == 1 || d < distance)
@@ -449,16 +449,16 @@ std::pair<size_t,double> ASMLRSpline::findClosestNode (const Vec3& X) const
 Vec3 ASMLRSpline::getElementCenter (int iel) const
 {
 #ifdef INDEX_CHECK
-  if (iel < 1 || iel > geo->nElements())
+  if (iel < 1 || iel > geomB->nElements())
   {
     std::cerr <<" *** ASMLRSpline::getElementCenter: Element index "<< iel
-              <<" out of range [1,"<< geo->nElements() <<"]."<< std::endl;
+              <<" out of range [1,"<< geomB->nElements() <<"]."<< std::endl;
     return Vec3();
   }
 #endif
 
   double u0[3] = { 0.0, 0.0, 0.0 };
-  LR::Element* elm = geo->getElement(iel-1);
+  LR::Element* elm = geomB->getElement(iel-1);
   for (unsigned char d = 0; d < ndim; d++)
     u0[d] = 0.5*(elm->getParmin(d) + elm->getParmax(d));
 
@@ -524,23 +524,23 @@ void ASMLRSpline::analyzeThreadGroups (const IntMat& groups)
 
 bool ASMLRSpline::getParameterDomain (Real2DMat& u, IntVec* corners) const
 {
-  u.resize(geo->nVariate(),RealArray(2));
-  for (int i = 0; i < geo->nVariate(); ++i) {
-    u[i][0] = geo->startparam(i);
-    u[i][1] = geo->endparam(i);
+  u.resize(geomB->nVariate(),RealArray(2));
+  for (int i = 0; i < geomB->nVariate(); ++i) {
+    u[i][0] = geomB->startparam(i);
+    u[i][1] = geomB->endparam(i);
   }
 
   if (corners) {
-    if (geo->nVariate() == 2) {
+    if (geomB->nVariate() == 2) {
       for (int J = 0; J < 2; ++J)
         for (int I = 0; I < 2; ++I) {
           std::vector<LR::Basisfunction*> funcs;
           int dir = (I > 0 ? LR::EAST : LR::WEST) |
                     (J > 0 ? LR::NORTH : LR::SOUTH);
-          geo->getEdgeFunctions(funcs, static_cast<LR::parameterEdge>(dir));
+          geomB->getEdgeFunctions(funcs, static_cast<LR::parameterEdge>(dir));
           corners->push_back(funcs.front()->getId()+1);
         }
-    } else if (geo->nVariate() == 3) {
+    } else if (geomB->nVariate() == 3) {
       for (int K = 0; K < 2; ++K)
         for (int J = 0; J < 2; ++J)
           for (int I = 0; I < 2; ++I) {
@@ -548,7 +548,7 @@ bool ASMLRSpline::getParameterDomain (Real2DMat& u, IntVec* corners) const
             int dir = (I > 0 ? LR::EAST  : LR::WEST)  |
                       (J > 0 ? LR::NORTH : LR::SOUTH) |
                       (K > 0 ? LR::TOP   : LR::BOTTOM);
-            geo->getEdgeFunctions(funcs, static_cast<LR::parameterEdge>(dir));
+            geomB->getEdgeFunctions(funcs, static_cast<LR::parameterEdge>(dir));
             corners->push_back(funcs.front()->getId()+1);
           }
     }

--- a/src/ASM/LR/ASMLRSpline.h
+++ b/src/ASM/LR/ASMLRSpline.h
@@ -85,7 +85,7 @@ public:
   virtual ~ASMLRSpline() {}
 
   //! \brief Checks if the patch is empty.
-  virtual bool empty() const { return geo == nullptr; }
+  virtual bool empty() const { return geomB == nullptr; }
 
   //! \brief Returns parameter values and node numbers of the domain corners.
   virtual bool getParameterDomain(Real2DMat&, IntVec*) const;
@@ -203,7 +203,7 @@ protected:
   //! \param[in] groups The generated thread groups
   static void analyzeThreadGroups(const IntMat& groups);
 
-  LR::LRSpline* geo; //!< Pointer to the actual spline geometry object
+  std::shared_ptr<LR::LRSpline> geomB; //!< Pointer to the actual spline geometry object
 };
 
 #endif

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -131,10 +131,10 @@ public:
   //! \brief Copy constructor.
   ASMu2D(const ASMu2D& patch, unsigned char n_f = 0);
   //! \brief Empty destructor.
-  virtual ~ASMu2D() { geo = nullptr; }
+  virtual ~ASMu2D() { geomB = nullptr; }
 
   //! \brief Returns the spline surface representing the geometry of this patch.
-  LR::LRSplineSurface* getSurface() { return this->createLRfromTensor(); }
+  LR::LRSplineSurface* getSurface() { return this->createLRfromTensor().get(); }
   //! \brief Returns the spline surface representing the geometry of this patch.
   const LR::LRSplineSurface* getSurface() const { return lrspline.get(); }
 
@@ -687,7 +687,7 @@ protected:
                                       const IntSet& neighborIndices) const;
 
   //! \brief Converts current tensor spline object to LR-spline.
-  LR::LRSplineSurface* createLRfromTensor();
+  std::shared_ptr<LR::LRSplineSurface> createLRfromTensor();
 
   //! \brief Converts a rational spline surface to a LR NURBS surface.
   static LR::LRSplineSurface* createLRNurbs(const Go::SplineSurface& srf);

--- a/src/ASM/LR/ASMu2DC1.C
+++ b/src/ASM/LR/ASMu2DC1.C
@@ -18,13 +18,14 @@
 
 bool ASMu2DC1::generateFEMTopology ()
 {
-  if (!(geo = this->createLRfromTensor()))
+  geomB = this->createLRfromTensor();
+  if (!geomB)
     return false;
-  else if (geo->order(0) > 2 || geo->order(1) > 2)
+  else if (geomB->order(0) > 2 || geomB->order(1) > 2)
     return this->ASMu2D::generateFEMTopology();
 
   std::cerr <<" *** ASMu2DC1::generateFEMTopology:"
-            <<" The polynomial order "<< geo->order(0) <<"x"<< geo->order(1)
+            <<" The polynomial order "<< geomB->order(0) <<"x"<< geomB->order(1)
             <<" is too low.\n     C1-continuity requires"
             <<" at least quadratic order."<< std::endl;
   return false;

--- a/src/ASM/LR/ASMu2Dmx.C
+++ b/src/ASM/LR/ASMu2Dmx.C
@@ -302,7 +302,7 @@ bool ASMu2Dmx::generateFEMTopology ()
   std::cout <<"NEL = "<< nel <<" NNOD = "<< nnod << std::endl;
 #endif
 
-  geo = m_basis[geoBasis-1].get();
+  geomB = m_basis[geoBasis-1];
   this->generateBezierBasis();
   this->generateBezierExtraction();
 
@@ -397,8 +397,8 @@ bool ASMu2Dmx::integrate (Integrand& integrand,
       if (integrand.getIntegrandType() & Integrand::G_MATRIX)
       {
         // Element size in parametric space
-        dXidu[0] = geo->getElement(geoEl-1)->umax()-geo->getElement(geoEl-1)->umin();
-        dXidu[1] = geo->getElement(geoEl-1)->vmax()-geo->getElement(geoEl-1)->vmin();
+        dXidu[0] = geomB->getElement(geoEl-1)->umax() - geomB->getElement(geoEl-1)->umin();
+        dXidu[1] = geomB->getElement(geoEl-1)->vmax() - geomB->getElement(geoEl-1)->vmin();
       }
 
       // Initialize element quantities
@@ -1220,7 +1220,7 @@ void ASMu2Dmx::swapProjectionBasis ()
     std::swap(projBasis, altProjBasis);
     std::swap(projThreadGroups, altProjThreadGroups);
     lrspline = m_basis[ASMmxBase::geoBasis-1];
-    geo = lrspline.get();
+    geomB = lrspline;
     this->generateBezierBasis();
     this->generateBezierExtraction();
   }

--- a/src/ASM/LR/ASMu2Dmx.h
+++ b/src/ASM/LR/ASMu2Dmx.h
@@ -63,7 +63,7 @@ public:
   //! \brief Copy constructor.
   ASMu2Dmx(const ASMu2Dmx& patch, const CharVec& n_f = CharVec(2,0));
   //! \brief Empty destructor.
-  virtual ~ASMu2Dmx() { lrspline = nullptr; geo = nullptr; }
+  virtual ~ASMu2Dmx() {}
 
   //! \brief Returns the spline surface representing the basis of this patch.
   virtual LR::LRSplineSurface* getBasis(int basis = 1);

--- a/src/ASM/LR/ASMu2Dnurbs.C
+++ b/src/ASM/LR/ASMu2Dnurbs.C
@@ -298,7 +298,7 @@ void ASMu2D::writePostscriptElementsNurbs (std::shared_ptr<LR::LRSplineSurface> 
 
   if (mesh != lrspline) {
     mesh.swap(lrspline);
-    geo = lrspline.get();
+    geomB = lrspline;
   }
 
   // This is done unconditionally as it will not have been performed
@@ -383,7 +383,7 @@ void ASMu2D::writePostscriptElementsNurbs (std::shared_ptr<LR::LRSplineSurface> 
 
   if (mesh != lrspline) {
     mesh.swap(lrspline);
-    geo = lrspline.get();
+    geomB = lrspline;
     this->generateBezierBasis();
     this->generateBezierExtraction();
   }

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -105,7 +105,7 @@ bool ASMu3D::read (std::istream& is)
     return false;
   }
 
-  geo = lrspline.get();
+  geomB = lrspline;
   return true;
 }
 
@@ -129,7 +129,7 @@ void ASMu3D::clear (bool retainGeometry)
       delete tensorspline;
       delete tensorPrjBas;
     }
-    geo = nullptr;
+    geomB = nullptr;
     tensorspline = tensorPrjBas = nullptr;
   }
 
@@ -231,12 +231,12 @@ bool ASMu3D::createProjectionBasis (bool init)
 
   std::swap(tensorspline,tensorPrjBas);
   std::swap(lrspline,projBasis);
-  geo = lrspline.get();
+  geomB = lrspline;
   return true;
 }
 
 
-LR::LRSplineVolume* ASMu3D::createLRfromTensor ()
+std::shared_ptr<LR::LRSplineVolume> ASMu3D::createLRfromTensor ()
 {
   if (tensorspline)
   {
@@ -245,13 +245,13 @@ LR::LRSplineVolume* ASMu3D::createLRfromTensor ()
     tensorspline = nullptr;
   }
 
-  return lrspline.get();
+  return lrspline;
 }
 
 
 bool ASMu3D::generateFEMTopology ()
 {
-  geo = this->createLRfromTensor();
+  geomB = this->createLRfromTensor();
 
   if (tensorPrjBas)
   {
@@ -1836,9 +1836,9 @@ void ASMu3D::getBoundaryNodes (int lIndex, IntVec& nodes, int basis,
 
 bool ASMu3D::getOrder (int& p1, int& p2, int& p3) const
 {
-  p1 = geo->order(0);
-  p2 = geo->order(1);
-  p3 = geo->order(2);
+  p1 = geomB->order(0);
+  p2 = geomB->order(1);
+  p3 = geomB->order(2);
 
   return true;
 }

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -117,7 +117,7 @@ public:
   virtual ~ASMu3D() {}
 
   //! \brief Returns the spline volume representing the geometry of this patch.
-  LR::LRSplineVolume* getVolume() { return this->createLRfromTensor(); }
+  LR::LRSplineVolume* getVolume() { return this->createLRfromTensor().get(); }
   //! \brief Returns the spline volume representing the geometry of this patch.
   const LR::LRSplineVolume* getVolume() const { return lrspline.get(); }
 
@@ -685,7 +685,7 @@ protected:
                                       const IntSet& neighborIndices) const;
 
   //! \brief Converts current tensor spline object to LR-spline.
-  LR::LRSplineVolume* createLRfromTensor();
+  std::shared_ptr<LR::LRSplineVolume> createLRfromTensor();
 
 public:
   //! \brief Returns the number of elements on a boundary.

--- a/src/ASM/LR/ASMu3Dmx.C
+++ b/src/ASM/LR/ASMu3Dmx.C
@@ -311,7 +311,7 @@ bool ASMu3Dmx::generateFEMTopology ()
   std::cout <<"NEL = "<< nel <<" NNOD = "<< nnod << std::endl;
 #endif
 
-  geo = m_basis[geoBasis-1].get();
+  geomB = m_basis[geoBasis-1];
 
   return true;
 }

--- a/src/ASM/LR/ASMu3Dmx.h
+++ b/src/ASM/LR/ASMu3Dmx.h
@@ -63,7 +63,7 @@ public:
   //! \brief Copy constructor.
   ASMu3Dmx(const ASMu3Dmx& patch, const CharVec& n_f = CharVec(3,0));
   //! \brief Empty destructor.
-  virtual ~ASMu3Dmx() { lrspline = nullptr; geo = nullptr; }
+  virtual ~ASMu3Dmx() {}
 
   //! \brief Returns the spline surface representing the basis of this patch.
   virtual LR::LRSplineVolume* getBasis(int basis = 1);


### PR DESCRIPTION
This is stored as geomB in ASMstruct. Do the same in ASMLRSpline for consistency (and to facilitate further upcoming changes).