### PR TITLE
ASMsxD: move projection bases into ASMstruct

### DIFF
--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -784,7 +784,6 @@ private:
 
 protected:
   Go::SplineSurface* surf; //!< Pointer to the actual spline surface object
-  Go::SplineSurface* proj; //!< Pointer to spline surface for projection basis
   Go::SplineCurve* bou[4]; //!< Pointers to the four boundary curves
   bool              swapV; //!< Has the v-parameter direction been swapped?
 

--- a/src/ASM/ASMs2DLag.C
+++ b/src/ASM/ASMs2DLag.C
@@ -134,7 +134,7 @@ bool ASMs2DLag::addXElms (short int dim, short int item, size_t nXn,
 bool ASMs2DLag::generateFEMTopology ()
 {
   if (!surf) return false;
-  if (!proj) proj = surf;
+  if (!projB) projB = surf;
 
   // Order of basis in the two parametric directions (order = degree + 1)
   p1 = surf->order_u();

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -44,12 +44,6 @@ ASMs2Dmx::ASMs2Dmx (const ASMs2Dmx& patch, const CharVec& n_f)
 }
 
 
-ASMs2Dmx::~ASMs2Dmx ()
-{
-  delete altProjBasis;
-}
-
-
 Go::SplineSurface* ASMs2Dmx::getBasis (int basis) const
 {
   if (basis < 1 || basis > (int)m_basis.size())
@@ -212,7 +206,7 @@ bool ASMs2Dmx::generateFEMTopology ()
       projB = proj = ASMmxBase::raiseBasis(surf);
     else if (ASMmxBase::Type == ASMmxBase::SUBGRID) {
       projB = proj = m_basis.front()->clone();
-      altProjBasis = ASMmxBase::raiseBasis(surf);
+      projB2 = ASMmxBase::raiseBasis(surf);
     }
     else if (geoBasis < 3)
       projB = proj = m_basis[2-geoBasis]->clone();
@@ -1116,9 +1110,10 @@ void ASMs2Dmx::getBoundaryNodes (int lIndex, IntVec& nodes, int basis,
 
 void ASMs2Dmx::swapProjectionBasis ()
 {
-  if (altProjBasis) {
+  if (projB2) {
     ASMmxBase::geoBasis = ASMmxBase::geoBasis == 1 ? 2 : 1;
-    std::swap(proj, altProjBasis);
+    std::swap(projB, projB2);
+    proj = static_cast<Go::SplineSurface*>(projB);
     surf = this->getBasis(ASMmxBase::geoBasis);
   }
 }

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -96,7 +96,7 @@ bool ASMs2Dmx::readBasis (std::istream& is, size_t basis)
 bool ASMs2Dmx::write (std::ostream& os, int basis) const
 {
   if (basis == -1)
-    os <<"200 1 0 0\n" << *proj;
+    os <<"200 1 0 0\n" << *projB;
   else if (basis < 1 || basis > (int)m_basis.size())
     os <<"200 1 0 0\n" << *surf;
   else if (m_basis[basis-1])
@@ -203,13 +203,13 @@ bool ASMs2Dmx::generateFEMTopology ()
     if (ASMmxBase::Type == ASMmxBase::REDUCED_CONT_RAISE_BASIS1 ||
         ASMmxBase::Type == ASMmxBase::REDUCED_CONT_RAISE_BASIS2 ||
         ASMmxBase::Type == ASMmxBase::DIV_COMPATIBLE)
-      projB = proj = ASMmxBase::raiseBasis(surf);
+      projB = ASMmxBase::raiseBasis(surf);
     else if (ASMmxBase::Type == ASMmxBase::SUBGRID) {
-      projB = proj = m_basis.front()->clone();
+      projB = m_basis.front()->clone();
       projB2 = ASMmxBase::raiseBasis(surf);
     }
     else if (geoBasis < 3)
-      projB = proj = m_basis[2-geoBasis]->clone();
+      projB = m_basis[2-geoBasis]->clone();
     else
       return false; // Logic error
   }
@@ -1113,7 +1113,6 @@ void ASMs2Dmx::swapProjectionBasis ()
   if (projB2) {
     ASMmxBase::geoBasis = ASMmxBase::geoBasis == 1 ? 2 : 1;
     std::swap(projB, projB2);
-    proj = static_cast<Go::SplineSurface*>(projB);
     surf = this->getBasis(ASMmxBase::geoBasis);
   }
 }

--- a/src/ASM/ASMs2Dmx.h
+++ b/src/ASM/ASMs2Dmx.h
@@ -36,8 +36,8 @@ public:
   ASMs2Dmx(unsigned char n_s, const CharVec& n_f);
   //! \brief Copy constructor.
   ASMs2Dmx(const ASMs2Dmx& patch, const CharVec& n_f = CharVec(2,0));
-  //! \brief Destructor.
-  virtual ~ASMs2Dmx();
+  //! \brief Empty destructor.
+  virtual ~ASMs2Dmx() {}
 
   //! \brief Returns the spline surface representing the basis of this patch.
   virtual Go::SplineSurface* getBasis(int basis = 1) const;
@@ -229,7 +229,6 @@ protected:
   virtual int getLastItgElmNode() const;
 
   std::vector<std::shared_ptr<Go::SplineSurface>> m_basis; //!< Vector of bases
-  Go::SplineSurface* altProjBasis = nullptr; //!< Alternative projection basis
 };
 
 #endif

--- a/src/ASM/ASMs2Drecovery.C
+++ b/src/ASM/ASMs2Drecovery.C
@@ -166,6 +166,8 @@ bool ASMs2D::assembleL2matrices (SparseMatrix& A, StdVector& B,
 {
   const size_t nnod = this->getNoProjectionNodes();
 
+  const Go::SplineSurface* proj = static_cast<const Go::SplineSurface*>(projB);
+
   const int g1 = surf->order_u();
   const int g2 = surf->order_v();
   const int p1 = proj->order_u();

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -875,7 +875,6 @@ private:
 
 protected:
   Go::SplineVolume* svol;  //!< Pointer to the actual spline volume object
-  Go::SplineVolume* proj;  //!< Pointer to spline volume for projection basis
   bool              swapW; //!< Has the w-parameter direction been swapped?
 
   const IndexVec& nodeInd; //!< IJK-triplets for the control points (nodes)

--- a/src/ASM/ASMs3DLag.C
+++ b/src/ASM/ASMs3DLag.C
@@ -144,7 +144,7 @@ bool ASMs3DLag::addXElms (short int dim, short int item, size_t nXn,
 bool ASMs3DLag::generateFEMTopology ()
 {
   if (!svol) return false;
-  if (!proj) proj = svol;
+  if (!projB) projB = svol;
 
   // Order of basis in the three parametric directions (order = degree + 1)
   p1 = svol->order(0);

--- a/src/ASM/ASMs3Dmx.C
+++ b/src/ASM/ASMs3Dmx.C
@@ -97,7 +97,7 @@ bool ASMs3Dmx::readBasis (std::istream& is, size_t basis)
 bool ASMs3Dmx::write (std::ostream& os, int basis) const
 {
   if (basis == -1)
-    os <<"700 1 0 0\n" << *proj;
+    os <<"700 1 0 0\n" << *projB;
   else if (basis < 1 || basis > (int)m_basis.size())
     os <<"700 1 0 0\n" << *svol;
   else if (m_basis[basis-1])
@@ -204,13 +204,13 @@ bool ASMs3Dmx::generateFEMTopology ()
     if (ASMmxBase::Type == ASMmxBase::REDUCED_CONT_RAISE_BASIS1 ||
         ASMmxBase::Type == ASMmxBase::REDUCED_CONT_RAISE_BASIS2 ||
         ASMmxBase::Type == ASMmxBase::DIV_COMPATIBLE)
-      projB = proj = ASMmxBase::raiseBasis(svol);
+      projB = ASMmxBase::raiseBasis(svol);
     else if (ASMmxBase::Type == ASMmxBase::SUBGRID) {
-      projB = proj = m_basis.front()->clone();
+      projB = m_basis.front()->clone();
       projB2 = ASMmxBase::raiseBasis(svol);
     }
     else if (geoBasis < 3)
-      projB = proj = m_basis[2-geoBasis]->clone();
+      projB = m_basis[2-geoBasis]->clone();
     else
       return false; // Logic error
   }
@@ -1265,7 +1265,6 @@ void ASMs3Dmx::swapProjectionBasis ()
   if (projB2) {
     ASMmxBase::geoBasis = ASMmxBase::geoBasis == 1 ? 2 : 1;
     std::swap(projB, projB2);
-    proj = static_cast<Go::SplineVolume*>(projB);
     svol = this->getBasis(ASMmxBase::geoBasis);
   }
 }

--- a/src/ASM/ASMs3Dmx.C
+++ b/src/ASM/ASMs3Dmx.C
@@ -50,12 +50,6 @@ ASMs3Dmx::ASMs3Dmx (const ASMs3Dmx& patch, const CharVec& n_f)
 }
 
 
-ASMs3Dmx::~ASMs3Dmx ()
-{
-  delete altProjBasis;
-}
-
-
 Go::SplineVolume* ASMs3Dmx::getBasis (int basis) const
 {
   if (basis < 1 || basis > (int)m_basis.size())
@@ -213,7 +207,7 @@ bool ASMs3Dmx::generateFEMTopology ()
       projB = proj = ASMmxBase::raiseBasis(svol);
     else if (ASMmxBase::Type == ASMmxBase::SUBGRID) {
       projB = proj = m_basis.front()->clone();
-      altProjBasis = ASMmxBase::raiseBasis(svol);
+      projB2 = ASMmxBase::raiseBasis(svol);
     }
     else if (geoBasis < 3)
       projB = proj = m_basis[2-geoBasis]->clone();
@@ -1268,9 +1262,10 @@ void ASMs3Dmx::getBoundaryNodes (int lIndex, IntVec& nodes, int basis,
 
 void ASMs3Dmx::swapProjectionBasis ()
 {
-  if (altProjBasis) {
+  if (projB2) {
     ASMmxBase::geoBasis = ASMmxBase::geoBasis == 1 ? 2 : 1;
-    std::swap(proj, altProjBasis);
+    std::swap(projB, projB2);
+    proj = static_cast<Go::SplineVolume*>(projB);
     svol = this->getBasis(ASMmxBase::geoBasis);
   }
 }

--- a/src/ASM/ASMs3Dmx.h
+++ b/src/ASM/ASMs3Dmx.h
@@ -36,8 +36,8 @@ public:
   explicit ASMs3Dmx(const CharVec& n_f);
   //! \brief Copy constructor.
   ASMs3Dmx(const ASMs3Dmx& patch, const CharVec& n_f = CharVec(2,0));
-  //! \brief Destructor.
-  virtual ~ASMs3Dmx();
+  //! \brief Empty Destructor.
+  virtual ~ASMs3Dmx() {}
 
   //! \brief Returns the spline surface representing the basis of this patch.
   virtual Go::SplineVolume* getBasis(int basis = 1) const;
@@ -233,7 +233,6 @@ protected:
                                 int thick, int, bool local) const;
 
   std::vector<std::shared_ptr<Go::SplineVolume>> m_basis; //!< Vector of bases
-  Go::SplineVolume* altProjBasis = nullptr; //!< Alternative projection basis
 };
 
 #endif

--- a/src/ASM/ASMs3Drecovery.C
+++ b/src/ASM/ASMs3Drecovery.C
@@ -166,6 +166,8 @@ bool ASMs3D::assembleL2matrices (SparseMatrix& A, StdVector& B,
 {
   const size_t nnod = this->getNoProjectionNodes();
 
+  const Go::SplineVolume* proj = static_cast<const Go::SplineVolume*>(projB);
+
   const int g1 = svol->order(0);
   const int g2 = svol->order(1);
   const int g3 = svol->order(2);

--- a/src/ASM/ASMstruct.C
+++ b/src/ASM/ASMstruct.C
@@ -24,7 +24,7 @@
 ASMstruct::ASMstruct (unsigned char n_p, unsigned char n_s, unsigned char n_f)
   : ASMbase(n_p,n_s,n_f)
 {
-  geomB = projB = nullptr;
+  geomB = projB = projB2 = nullptr;
 }
 
 
@@ -33,6 +33,7 @@ ASMstruct::ASMstruct (const ASMstruct& patch, unsigned char n_f)
 {
   geomB = patch.geomB;
   projB = patch.projB;
+  projB2 = patch.projB2;
 }
 
 
@@ -40,6 +41,8 @@ ASMstruct::~ASMstruct ()
 {
   if (projB && projB != geomB)
     delete projB;
+
+  delete projB2;
 
   if (geomB && !shareFE)
     delete geomB;

--- a/src/ASM/ASMstruct.h
+++ b/src/ASM/ASMstruct.h
@@ -109,6 +109,7 @@ protected:
 protected:
   Go::GeomObject* geomB; //!< Pointer to spline object of the geometry basis
   Go::GeomObject* projB; //!< Pointer to spline object of the projection basis
+  Go::GeomObject* projB2; //!< Pointer to spline object of the secondary projection basis
 };
 
 #endif


### PR DESCRIPTION
Make this consistent with other bases. This introduces some more casts than comfortable but they will go away later.