### PR TITLE
ASMuxDmx: simplify remapErrors by using elm->midpoint()

### DIFF
--- a/src/ASM/LR/ASMu2Dmx.C
+++ b/src/ASM/LR/ASMu2Dmx.C
@@ -1134,8 +1134,7 @@ void ASMu2Dmx::remapErrors (RealArray& errors,
 {
   const LR::LRSplineSurface* geo = this->getBasis(ASMmxBase::geoBasis);
   for (const LR::Element* elm : geo->getAllElements()) {
-    int rEl = refBasis->getElementContaining((elm->umin()+elm->umax())/2.0,
-                                             (elm->vmin()+elm->vmax())/2.0);
+    int rEl = refBasis->getElementContaining(elm->midpoint());
     if (elemErrors)
       errors[rEl] += origErr[elm->getId()];
     else

--- a/src/ASM/LR/ASMu3Dmx.C
+++ b/src/ASM/LR/ASMu3Dmx.C
@@ -985,9 +985,7 @@ void ASMu3Dmx::remapErrors (RealArray& errors,
 {
   const LR::LRSplineVolume* geo = this->getBasis(ASMmxBase::geoBasis);
   for (const LR::Element* elm : geo->getAllElements()) {
-    int rEl = refBasis->getElementContaining((elm->umin()+elm->umax())/2.0,
-                                             (elm->vmin()+elm->vmax())/2.0,
-                                             (elm->wmin()+elm->wmax())/2.0);
+    int rEl = refBasis->getElementContaining(elm->midpoint());
     if (elemErrors)
       errors[rEl] += origErr[elm->getId()];
     else


### PR DESCRIPTION
Just a small cleanup.