### PR TITLE
Override separateProjectionBasis()

### DIFF
--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -431,6 +431,12 @@ bool ASMs2D::raiseOrder (int ru, int rv)
 }
 
 
+bool ASMs2D::separateProjectionBasis () const
+{
+  return projB && projB != surf;
+}
+
+
 /*!
   This method is supposed to be invoked twice during the model generation.
   In the first call, with \a init = \e true, the spline surface object \a *surf

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -312,6 +312,8 @@ public:
   //! \brief Creates a separate projection basis for this patch.
   virtual bool createProjectionBasis(bool init);
 
+  //! \brief Checks if a separate projection basis is used for this patch.
+  virtual bool separateProjectionBasis() const;
 
   // Various methods for preprocessing of boundary conditions and patch topology
   // ===========================================================================

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -1128,3 +1128,11 @@ int ASMs2Dmx::getLastItgElmNode () const
 {
   return std::accumulate(elem_size.begin(), elem_size.begin() + geoBasis, -1);
 }
+
+
+bool ASMs2Dmx::separateProjectionBasis () const
+{
+  return std::none_of(m_basis.begin(), m_basis.end(),
+                      [this](const std::shared_ptr<Go::SplineSurface>& entry)
+                      { return entry.get() == projB; });
+}

--- a/src/ASM/ASMs2Dmx.h
+++ b/src/ASM/ASMs2Dmx.h
@@ -184,6 +184,9 @@ public:
   //! \brief Swap between main and alternative projection basis.
   virtual void swapProjectionBasis();
 
+  //! \brief Checks if a separate projection basis is used for this patch.
+  virtual bool separateProjectionBasis() const;
+
   //! \brief Extracts nodal results for this patch from the global vector.
   //! \param[in] globVec Global solution vector in DOF-order
   //! \param[out] nodeVec Nodal result vector for this patch

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -365,6 +365,12 @@ bool ASMs3D::raiseOrder (int ru, int rv, int rw, bool setOrder)
 }
 
 
+bool ASMs3D::separateProjectionBasis () const
+{
+  return projB && projB != svol;
+}
+
+
 /*!
   This method is supposed to be invoked twice during the model generation.
   In the first call, with \a init = \e true, the spline volume object \a *svol

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -337,6 +337,9 @@ public:
   //! \brief Creates a separate projection basis for this patch.
   virtual bool createProjectionBasis(bool init);
 
+  //! \brief Checks if a separate projection basis is used for this patch.
+  virtual bool separateProjectionBasis() const;
+
 
   // Various methods for preprocessing of boundary conditions and patch topology
   // ===========================================================================

--- a/src/ASM/ASMs3Dmx.C
+++ b/src/ASM/ASMs3Dmx.C
@@ -1280,3 +1280,11 @@ int ASMs3Dmx::getLastItgElmNode () const
 {
   return std::accumulate(elem_size.begin(), elem_size.begin() + geoBasis, -1);
 }
+
+
+bool ASMs3Dmx::separateProjectionBasis () const
+{
+  return std::none_of(m_basis.begin(), m_basis.end(),
+                      [this](const std::shared_ptr<Go::SplineVolume>& entry)
+                      { return entry.get() == projB; });
+}

--- a/src/ASM/ASMs3Dmx.h
+++ b/src/ASM/ASMs3Dmx.h
@@ -189,6 +189,9 @@ public:
   //! \brief Swap between main and alternative projection basis.
   virtual void swapProjectionBasis();
 
+  //! \brief Checks if a separate projection basis is used for this patch.
+  virtual bool separateProjectionBasis() const;
+
   //! \brief Extracts nodal results for this patch from the global vector.
   //! \param[in] globVec Global solution vector in DOF-order
   //! \param[out] nodeVec Nodal result vector for this patch

--- a/src/ASM/LR/ASMu2Dmx.C
+++ b/src/ASM/LR/ASMu2Dmx.C
@@ -1271,3 +1271,11 @@ BasisFunctionVals ASMu2Dmx::BasisFunctionCache::calculatePt (size_t el,
 
   return result;
 }
+
+
+bool ASMu2Dmx::separateProjectionBasis () const
+{
+  return std::none_of(m_basis.begin(), m_basis.end(),
+                      [this](const SplinePtr& entry)
+                      { return entry == projB; });
+}

--- a/src/ASM/LR/ASMu2Dmx.h
+++ b/src/ASM/LR/ASMu2Dmx.h
@@ -246,6 +246,9 @@ public:
   //! \brief Swaps between the main and alternative projection basis.
   virtual void swapProjectionBasis();
 
+  //! \brief Checks if a separate projection basis is used for this patch.
+  virtual bool separateProjectionBasis() const;
+
 private:
   //! \brief Finds the elements and associted sizes at given parametric point.
   //! \param[in] param Parametric point to find elements at

--- a/src/ASM/LR/ASMu3Dmx.C
+++ b/src/ASM/LR/ASMu3Dmx.C
@@ -1069,3 +1069,11 @@ BasisFunctionVals ASMu3Dmx::BasisFunctionCache::calculatePt (size_t el,
 
   return this->calculatePrm(fe,du,el,gp,reduced);
 }
+
+
+bool ASMu3Dmx::separateProjectionBasis () const
+{
+  return std::none_of(m_basis.begin(), m_basis.end(),
+                      [this](const SplinePtr& entry)
+                      { return entry == projB; });
+}

--- a/src/ASM/LR/ASMu3Dmx.h
+++ b/src/ASM/LR/ASMu3Dmx.h
@@ -211,6 +211,9 @@ public:
   //! \brief Swaps between the main and alternative projection basis.
   virtual void swapProjectionBasis();
 
+  //! \brief Checks if a separate projection basis is used for this patch.
+  virtual bool separateProjectionBasis() const;
+
 private:
   //! \brief Finds the elements and associted sizes at given parametric point.
   //! \param[in] param Parametric point to find elements at


### PR DESCRIPTION
This to fix a bug with two-field formulations where the second basis is the higher order basis, and to prepare for having a separate geometry basis.

Sits on top of https://github.com/OPM/IFEM/pull/608