### PR TITLE
Avoid cloning in ASMsxDmx

### DIFF
--- a/src/ASM/ASMs2Dmx.h
+++ b/src/ASM/ASMs2Dmx.h
@@ -36,8 +36,8 @@ public:
   ASMs2Dmx(unsigned char n_s, const CharVec& n_f);
   //! \brief Copy constructor.
   ASMs2Dmx(const ASMs2Dmx& patch, const CharVec& n_f = CharVec(2,0));
-  //! \brief Empty destructor.
-  virtual ~ASMs2Dmx() {}
+  //! \brief Destructor.
+  virtual ~ASMs2Dmx();
 
   //! \brief Returns the spline surface representing a basis of this patch.
   virtual const Go::SplineSurface* getBasis(int basis = 1) const;

--- a/src/ASM/ASMs3Dmx.h
+++ b/src/ASM/ASMs3Dmx.h
@@ -37,7 +37,7 @@ public:
   //! \brief Copy constructor.
   ASMs3Dmx(const ASMs3Dmx& patch, const CharVec& n_f = CharVec(2,0));
   //! \brief Empty Destructor.
-  virtual ~ASMs3Dmx() {}
+  virtual ~ASMs3Dmx();
 
   //! \brief Returns the spline surface representing a basis of this patch.
   virtual const Go::SplineVolume* getBasis(int basis = 1) const;


### PR DESCRIPTION
Unnecessary copies has been used earlier due to lazyness, in particular to avoid bare pointer juggling.
Also unify structure of basis establishment between structured and unstructured ASMs, and fixes handling for ASMmxBase::REDUCED_CONT_RAISE_BASIS2  in the 3D LR ASM.