### PR TITLE
Extended getBasis

### DIFF
--- a/Apps/Common/MultiPatchModelGenerator.C
+++ b/Apps/Common/MultiPatchModelGenerator.C
@@ -340,7 +340,7 @@ bool MultiPatchModelGenerator2D::createGeometry (SIMinput& sim) const
     }
 
   // Compute parameters
-  const Go::SplineSurface* srf = pch.getSurface();
+  const Go::SplineSurface* srf = pch.getBasis(ASM::GEOMETRY_BASIS);
   size_t px = srf->order_u()-1;
   size_t py = srf->order_v()-1;
   size_t nelemsx = srf->numCoefs_u() - px;
@@ -650,7 +650,7 @@ bool MultiPatchModelGenerator3D::createGeometry (SIMinput& sim) const
     }
 
   // Compute parameters
-  const Go::SplineVolume* vol = pch.getVolume();
+  const Go::SplineVolume* vol = pch.getBasis(ASM::GEOMETRY_BASIS);
   size_t px = vol->order(0)-1;
   size_t py = vol->order(1)-1;
   size_t pz = vol->order(2)-1;

--- a/src/ASM/ASMenums.h
+++ b/src/ASM/ASMenums.h
@@ -46,6 +46,15 @@ namespace ASM //! Assembly scope
     FULL_CACHE  //!< Cache basis function values up front
   };
 
+  //! \brief Enumeration of different basis types.
+  //! \details Entries should have non-positive values
+  enum BasisType {
+    GEOMETRY_BASIS     =  0, //!< Geometry basis
+    PROJECTION_BASIS   = -1, //!< Projection basis
+    PROJECTION_BASIS_2 = -2, //!< Second projection basis
+    REFINEMENT_BASIS   = -3, //!< Refinement basis
+    INTEGRATION_BASIS  = -4, //!< Integration basis
+  };
 }
 
 #endif

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -38,6 +38,7 @@
 #include "MPC.h"
 #include "IFEM.h"
 #include <array>
+#include <utility>
 
 
 ASMs2D::ASMs2D (unsigned char n_s, unsigned char n_f)
@@ -97,6 +98,29 @@ Go::SplineCurve* ASMs2D::getBoundary (int dir, int)
     bou[iedge] = surf->edgeCurve(iedge);
 
   return bou[iedge];
+}
+
+
+const Go::SplineSurface* ASMs2D::getBasis (int basis) const
+{
+  switch (basis) {
+    case ASM::GEOMETRY_BASIS:
+      return static_cast<const Go::SplineSurface*>(geomB);
+    case ASM::PROJECTION_BASIS:
+      return static_cast<const Go::SplineSurface*>(projB);
+    case ASM::PROJECTION_BASIS_2:
+      return static_cast<const Go::SplineSurface*>(projB2);
+    case ASM::REFINEMENT_BASIS:
+      return nullptr;
+    default:
+      return surf;
+  }
+}
+
+
+Go::SplineSurface* ASMs2D::getBasis (int basis)
+{
+  return const_cast<Go::SplineSurface*>(std::as_const(*this).getBasis(basis));
 }
 
 
@@ -3061,7 +3085,7 @@ short int ASMs2D::InterfaceChecker::hasContribution (int,
 bool ASMs2D::evaluate (const FunctionBase* func, RealArray& vec,
                        int basisNum, double time) const
 {
-  Go::SplineSurface* oldSurf = this->getBasis(basisNum);
+  const Go::SplineSurface* oldSurf = this->getBasis(basisNum);
   Go::SplineSurface* newSurf = SplineUtils::project(oldSurf,*func,
                                                     func->dim(),time);
   if (!newSurf)

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -187,8 +187,6 @@ public:
   //! \brief The destructor frees the dynamically allocated boundary curves.
   virtual ~ASMs2D();
 
-  //! \brief Returns the spline surface representing the geometry of this patch.
-  Go::SplineSurface* getSurface() const { return surf; }
   //! \brief Returns the spline curve representing a boundary of this patch.
   //! \param[in] dir Parameter direction defining which boundary to return
   virtual Go::SplineCurve* getBoundary(int dir, int = 1);

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -192,8 +192,10 @@ public:
   //! \brief Returns the spline curve representing a boundary of this patch.
   //! \param[in] dir Parameter direction defining which boundary to return
   virtual Go::SplineCurve* getBoundary(int dir, int = 1);
-  //! \brief Returns the spline surface representing the basis of this patch.
-  virtual Go::SplineSurface* getBasis(int = 1) const { return surf; }
+  //! \brief Returns the spline surface representing a basis of this patch.
+  virtual Go::SplineSurface* getBasis(int basis = 1);
+  //! \brief Returns the spline surface representing a basis of this patch.
+  virtual const Go::SplineSurface* getBasis(int basis = 1) const;
   //! \brief Copies the parameter domain from the \a other patch.
   virtual void copyParameterDomain(const ASMbase* other);
 

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -28,6 +28,7 @@
 #include "Profiler.h"
 #include <array>
 #include <numeric>
+#include <utility>
 
 
 ASMs2Dmx::ASMs2Dmx (unsigned char n_s, const CharVec& n_f)
@@ -44,12 +45,21 @@ ASMs2Dmx::ASMs2Dmx (const ASMs2Dmx& patch, const CharVec& n_f)
 }
 
 
-Go::SplineSurface* ASMs2Dmx::getBasis (int basis) const
+const Go::SplineSurface* ASMs2Dmx::getBasis (int basis) const
 {
-  if (basis < 1 || basis > (int)m_basis.size())
-    return surf;
+  if (basis < 1)
+    return this->ASMs2D::getBasis(basis);
+
+  if (basis > static_cast<int>(m_basis.size()))
+    return nullptr;
 
   return m_basis[basis-1].get();
+}
+
+
+Go::SplineSurface* ASMs2Dmx::getBasis (int basis)
+{
+  return const_cast<Go::SplineSurface*>(std::as_const(*this).getBasis(basis));
 }
 
 

--- a/src/ASM/ASMs2Dmx.h
+++ b/src/ASM/ASMs2Dmx.h
@@ -39,8 +39,11 @@ public:
   //! \brief Empty destructor.
   virtual ~ASMs2Dmx() {}
 
-  //! \brief Returns the spline surface representing the basis of this patch.
-  virtual Go::SplineSurface* getBasis(int basis = 1) const;
+  //! \brief Returns the spline surface representing a basis of this patch.
+  virtual const Go::SplineSurface* getBasis(int basis = 1) const;
+  //! \brief Returns the spline surface representing a basis of this patch.
+  virtual Go::SplineSurface* getBasis(int basis = 1);
+
   //! \brief Returns the spline curve representing a boundary of this patch.
   //! \param[in] dir Parameter direction defining which boundary to return
   //! \param[in] basis Basis of boundary to return

--- a/src/ASM/ASMs2Drecovery.C
+++ b/src/ASM/ASMs2Drecovery.C
@@ -83,7 +83,7 @@ bool ASMs2D::evaluate (const ASMbase* basis, const Vector& locVec,
   if (!pch->evalSolution(sValues,locVec,gpar.data()))
     return false;
 
-  Go::SplineSurface* surf = this->getBasis(basisNum);
+  const Go::SplineSurface* surf = this->getBasis(basisNum);
 
   // Project the results onto the spline basis to find control point
   // values based on the result values evaluated at the Greville points.

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -206,8 +206,6 @@ public:
   //! \brief Empty destructor.
   virtual ~ASMs3D() {}
 
-  //! \brief Returns the spline volume representing the geometry of this patch.
-  Go::SplineVolume* getVolume() const { return svol; }
   //! \brief Returns the spline surface representing a boundary of this patch.
   //! \param[in] dir Parameter direction defining which boundary to return
   virtual Go::SplineSurface* getBoundary(int dir, int = 1);

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -211,8 +211,10 @@ public:
   //! \brief Returns the spline surface representing a boundary of this patch.
   //! \param[in] dir Parameter direction defining which boundary to return
   virtual Go::SplineSurface* getBoundary(int dir, int = 1);
-  //! \brief Returns the spline volume representing the basis of this patch.
-  virtual Go::SplineVolume* getBasis(int = 1) const { return svol; }
+  //! \brief Returns the spline volume representing a basis of this patch.
+  virtual const Go::SplineVolume* getBasis(int basis = 1) const;
+  //! \brief Returns the spline volume representing a basis of this patch.
+  virtual Go::SplineVolume* getBasis(int basis = 1);
   //! \brief Copies the parameter domain from the \a other patch.
   virtual void copyParameterDomain(const ASMbase* other);
 

--- a/src/ASM/ASMs3Dmx.C
+++ b/src/ASM/ASMs3Dmx.C
@@ -31,6 +31,7 @@
 #include "Vec3Oper.h"
 #include <array>
 #include <numeric>
+#include <utility>
 #ifdef USE_OPENMP
 #include <omp.h>
 #endif
@@ -50,12 +51,21 @@ ASMs3Dmx::ASMs3Dmx (const ASMs3Dmx& patch, const CharVec& n_f)
 }
 
 
-Go::SplineVolume* ASMs3Dmx::getBasis (int basis) const
+const Go::SplineVolume* ASMs3Dmx::getBasis (int basis) const
 {
-  if (basis < 1 || basis > (int)m_basis.size())
-    return svol;
+  if (basis < 1)
+    return this->ASMs3D::getBasis(basis);
+
+  if (basis > static_cast<int>(m_basis.size()))
+    return nullptr;
 
   return m_basis[basis-1].get();
+}
+
+
+Go::SplineVolume* ASMs3Dmx::getBasis (int basis)
+{
+  return const_cast<Go::SplineVolume*>(std::as_const(*this).getBasis(basis));
 }
 
 

--- a/src/ASM/ASMs3Dmx.h
+++ b/src/ASM/ASMs3Dmx.h
@@ -39,8 +39,10 @@ public:
   //! \brief Empty Destructor.
   virtual ~ASMs3Dmx() {}
 
-  //! \brief Returns the spline surface representing the basis of this patch.
-  virtual Go::SplineVolume* getBasis(int basis = 1) const;
+  //! \brief Returns the spline surface representing a basis of this patch.
+  virtual const Go::SplineVolume* getBasis(int basis = 1) const;
+  //! \brief Returns the spline surface representing a basis of this patch.
+  virtual Go::SplineVolume* getBasis(int basis = 1);
   //! \brief Returns the spline curve representing a boundary of this patch.
   //! \param[in] dir Parameter direction defining which boundary to return
   //! \param[in] basis The basis to get the boundary for

--- a/src/ASM/ASMs3Drecovery.C
+++ b/src/ASM/ASMs3Drecovery.C
@@ -81,7 +81,7 @@ bool ASMs3D::evaluate (const ASMbase* basis, const Vector& locVec,
   if (!pch->evalSolution(sValues,locVec,gpar.data()))
     return false;
 
-  Go::SplineVolume* svol = this->getBasis(basisNum);
+  const Go::SplineVolume* svol = this->getBasis(basisNum);
 
   // Project the results onto the spline basis to find control point
   // values based on the result values evaluated at the Greville points.

--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -39,6 +39,7 @@
 #include "IFEM.h"
 #include <array>
 #include <fstream>
+#include <utility>
 
 
 ASMu2D::ASMu2D (unsigned char n_s, unsigned char n_f)
@@ -62,6 +63,32 @@ ASMu2D::ASMu2D (const ASMu2D& patch, unsigned char n_f)
   // as hasXNodes might be invoked before the FE data is generated
   if (nnod == 0 && lrspline)
     nnod = lrspline->nBasisFunctions();
+}
+
+
+const LR::LRSplineSurface* ASMu2D::getBasis (int basis) const
+{
+  switch (basis) {
+    case ASM::GEOMETRY_BASIS:
+      return static_cast<const LR::LRSplineSurface*>(geomB.get());
+    case ASM::PROJECTION_BASIS:
+      return static_cast<const LR::LRSplineSurface*>(projB.get());
+    case ASM::PROJECTION_BASIS_2:
+      return static_cast<const LR::LRSplineSurface*>(projB2.get());
+    case ASM::REFINEMENT_BASIS:
+      return static_cast<const LR::LRSplineSurface*>(refB.get());
+    default:
+      return lrspline.get();
+  }
+}
+
+
+LR::LRSplineSurface* ASMu2D::getBasis (int basis)
+{
+  if (tensorspline)
+    this->createLRfromTensor();
+
+  return const_cast<LR::LRSplineSurface*>(std::as_const(*this).getBasis(basis));
 }
 
 

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -138,10 +138,10 @@ public:
   //! \brief Returns the spline surface representing the geometry of this patch.
   const LR::LRSplineSurface* getSurface() const { return lrspline.get(); }
 
-  //! \brief Returns the spline surface representing the basis of this patch.
-  virtual const LR::LRSplineSurface* getBasis(int = 1) const { return lrspline.get(); }
-  //! \brief Returns the spline surface representing the basis of this patch.
-  virtual LR::LRSplineSurface* getBasis(int = 1) { return lrspline.get(); }
+  //! \brief Returns the spline surface representing a basis of this patch.
+  virtual const LR::LRSplineSurface* getBasis(int basis = 1) const;
+  //! \brief Returns the spline surface representing a basis of this patch.
+  virtual LR::LRSplineSurface* getBasis(int basis = 1);
 
 
   // Methods for model generation and refinement

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -133,11 +133,6 @@ public:
   //! \brief Empty destructor.
   virtual ~ASMu2D() { geomB = nullptr; }
 
-  //! \brief Returns the spline surface representing the geometry of this patch.
-  LR::LRSplineSurface* getSurface() { return this->createLRfromTensor().get(); }
-  //! \brief Returns the spline surface representing the geometry of this patch.
-  const LR::LRSplineSurface* getSurface() const { return lrspline.get(); }
-
   //! \brief Returns the spline surface representing a basis of this patch.
   virtual const LR::LRSplineSurface* getBasis(int basis = 1) const;
   //! \brief Returns the spline surface representing a basis of this patch.

--- a/src/ASM/LR/ASMu2Dmx.C
+++ b/src/ASM/LR/ASMu2Dmx.C
@@ -35,6 +35,7 @@
 #include <array>
 #include <fstream>
 #include <numeric>
+#include <utility>
 
 
 ASMu2Dmx::ASMu2Dmx (unsigned char n_s, const CharVec& n_f)
@@ -56,7 +57,10 @@ ASMu2Dmx::ASMu2Dmx (const ASMu2Dmx& patch, const CharVec& n_f)
 
 const LR::LRSplineSurface* ASMu2Dmx::getBasis (int basis) const
 {
-  if (basis < 1 || basis > (int)m_basis.size())
+  if (basis < 1)
+    return this->ASMu2D::getBasis(basis);
+
+  if (basis > static_cast<int>(m_basis.size()))
     return nullptr;
 
   return m_basis[basis-1].get();
@@ -65,10 +69,7 @@ const LR::LRSplineSurface* ASMu2Dmx::getBasis (int basis) const
 
 LR::LRSplineSurface* ASMu2Dmx::getBasis (int basis)
 {
-  if (basis < 1 || basis > (int)m_basis.size())
-    return nullptr;
-
-  return m_basis[basis-1].get();
+  return const_cast<LR::LRSplineSurface*>(std::as_const(*this).getBasis(basis));
 }
 
 

--- a/src/ASM/LR/ASMu2Dmx.h
+++ b/src/ASM/LR/ASMu2Dmx.h
@@ -65,11 +65,10 @@ public:
   //! \brief Empty destructor.
   virtual ~ASMu2Dmx() {}
 
-  //! \brief Returns the spline surface representing the basis of this patch.
-  virtual LR::LRSplineSurface* getBasis(int basis = 1);
-
-  //! \brief Returns the spline surface representing the basis of this patch.
+  //! \brief Returns the spline surface representing a basis of this patch.
   virtual const LR::LRSplineSurface* getBasis(int basis = 1) const;
+  //! \brief Returns the spline surface representing a basis of this patch.
+  virtual LR::LRSplineSurface* getBasis(int basis = 1);
 
   // Methods for model generation
   // ============================

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -38,6 +38,7 @@
 #include "Point.h"
 #include "IFEM.h"
 #include <array>
+#include <utility>
 
 
 ASMu3D::ASMu3D (unsigned char n_f)
@@ -60,6 +61,32 @@ ASMu3D::ASMu3D (const ASMu3D& patch, unsigned char n_f)
   // as hasXNodes might be invoked before the FE data is generated
   if (nnod == 0 && lrspline)
     nnod = lrspline->nBasisFunctions();
+}
+
+
+const LR::LRSplineVolume* ASMu3D::getBasis (int basis) const
+{
+  switch (basis) {
+    case ASM::GEOMETRY_BASIS:
+      return static_cast<const LR::LRSplineVolume*>(geomB.get());
+    case ASM::PROJECTION_BASIS:
+      return static_cast<const LR::LRSplineVolume*>(projB.get());
+    case ASM::PROJECTION_BASIS_2:
+      return static_cast<const LR::LRSplineVolume*>(projB2.get());
+    case ASM::REFINEMENT_BASIS:
+      return static_cast<const LR::LRSplineVolume*>(refB.get());
+    default:
+      return lrspline.get();
+  }
+}
+
+
+LR::LRSplineVolume* ASMu3D::getBasis (int basis)
+{
+  if (tensorspline)
+    this->createLRfromTensor();
+
+  return const_cast<LR::LRSplineVolume*>(std::as_const(*this).getBasis(basis));
 }
 
 

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -121,10 +121,10 @@ public:
   //! \brief Returns the spline volume representing the geometry of this patch.
   const LR::LRSplineVolume* getVolume() const { return lrspline.get(); }
 
-  //! \brief Returns the spline volume representing the basis of this patch.
-  virtual const LR::LRSplineVolume* getBasis(int = 1) const { return lrspline.get(); }
-  //! \brief Returns the spline volume representing the basis of this patch.
-  virtual LR::LRSplineVolume* getBasis(int = 1) { return lrspline.get(); }
+  //! \brief Returns the spline volume representing a basis of this patch.
+  virtual const LR::LRSplineVolume* getBasis(int basis = 1) const;
+  //! \brief Returns the spline volume representing a basis of this patch.
+  virtual LR::LRSplineVolume* getBasis(int basis = 1);
 
 
   // Methods for model generation and refinement

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -116,11 +116,6 @@ public:
   //! \brief Empty destructor.
   virtual ~ASMu3D() {}
 
-  //! \brief Returns the spline volume representing the geometry of this patch.
-  LR::LRSplineVolume* getVolume() { return this->createLRfromTensor().get(); }
-  //! \brief Returns the spline volume representing the geometry of this patch.
-  const LR::LRSplineVolume* getVolume() const { return lrspline.get(); }
-
   //! \brief Returns the spline volume representing a basis of this patch.
   virtual const LR::LRSplineVolume* getBasis(int basis = 1) const;
   //! \brief Returns the spline volume representing a basis of this patch.

--- a/src/ASM/LR/ASMu3Dmx.C
+++ b/src/ASM/LR/ASMu3Dmx.C
@@ -34,6 +34,7 @@
 
 #include <array>
 #include <numeric>
+#include <utility>
 
 
 ASMu3Dmx::ASMu3Dmx (const CharVec& n_f)
@@ -59,7 +60,10 @@ ASMu3Dmx::ASMu3Dmx (const ASMu3Dmx& patch, const CharVec& n_f)
 
 const LR::LRSplineVolume* ASMu3Dmx::getBasis (int basis) const
 {
-  if (basis < 1 || basis > (int)m_basis.size())
+  if (basis < 1)
+    return this->ASMu3D::getBasis(basis);
+
+  if (basis > static_cast<int>(m_basis.size()))
     return nullptr;
 
   return m_basis[basis-1].get();
@@ -68,10 +72,7 @@ const LR::LRSplineVolume* ASMu3Dmx::getBasis (int basis) const
 
 LR::LRSplineVolume* ASMu3Dmx::getBasis (int basis)
 {
-  if (basis < 1 || basis > (int)m_basis.size())
-    return nullptr;
-
-  return m_basis[basis-1].get();
+  return const_cast<LR::LRSplineVolume*>(std::as_const(*this).getBasis(basis));
 }
 
 

--- a/src/ASM/LR/ASMu3Dmx.h
+++ b/src/ASM/LR/ASMu3Dmx.h
@@ -65,11 +65,10 @@ public:
   //! \brief Empty destructor.
   virtual ~ASMu3Dmx() {}
 
-  //! \brief Returns the spline surface representing the basis of this patch.
-  virtual LR::LRSplineVolume* getBasis(int basis = 1);
-
-  //! \brief Returns the spline surface representing the basis of this patch.
+  //! \brief Returns the spline volume representing a basis of this patch.
   virtual const LR::LRSplineVolume* getBasis(int basis = 1) const;
+  //! \brief Returns the spline volume representing a basis of this patch.
+  virtual LR::LRSplineVolume* getBasis(int basis = 1);
 
   // Methods for model generation
   // ============================

--- a/src/ASM/LR/LRSplineField2D.C
+++ b/src/ASM/LR/LRSplineField2D.C
@@ -26,7 +26,7 @@ LRSplineField2D::LRSplineField2D (const ASMu2D* patch,
                                   char cmp, const char* name)
   : FieldBase(name),
     basis(patch->getBasis(nbasis)),
-    surf(patch->getSurface()),
+    surf(patch->getBasis(ASM::GEOMETRY_BASIS)),
     is_rational(patch->rational())
 {
   nno = basis->nBasisFunctions();

--- a/src/ASM/LR/LRSplineField3D.C
+++ b/src/ASM/LR/LRSplineField3D.C
@@ -18,14 +18,15 @@
 
 #include "ASMu3D.h"
 #include "ItgPoint.h"
-#include "SplineUtils.h"
 #include "Vec3.h"
 
 
 LRSplineField3D::LRSplineField3D (const ASMu3D* patch,
                                   const RealArray& v, char nbasis,
                                   char cmp, const char* name)
-  : FieldBase(name), basis(patch->getBasis(nbasis)), vol(patch->getVolume())
+  : FieldBase(name),
+    basis(patch->getBasis(nbasis)),
+    vol(patch->getBasis(ASM::GEOMETRY_BASIS))
 {
   nno = basis->nBasisFunctions();
   nelm = basis->nElements();

--- a/src/ASM/LR/LRSplineFields2D.C
+++ b/src/ASM/LR/LRSplineFields2D.C
@@ -26,7 +26,7 @@ LRSplineFields2D::LRSplineFields2D (const ASMu2D* patch,
                                     int nnf, const char* name)
   : Fields(name),
     basis(patch->getBasis(nbasis)),
-    surf(patch->getSurface()),
+    surf(patch->getBasis(ASM::GEOMETRY_BASIS)),
     is_rational(patch->rational())
 {
   nno = basis->nBasisFunctions();

--- a/src/ASM/LR/LRSplineFields3D.C
+++ b/src/ASM/LR/LRSplineFields3D.C
@@ -18,14 +18,15 @@
 
 #include "ASMu3D.h"
 #include "ItgPoint.h"
-#include "SplineUtils.h"
 #include "Vec3.h"
 
 
 LRSplineFields3D::LRSplineFields3D (const ASMu3D* patch,
                                     const RealArray& v, char nbasis,
                                     int nnf, const char* name)
-  : Fields(name), basis(patch->getBasis(nbasis)), vol(patch->getVolume())
+  : Fields(name),
+    basis(patch->getBasis(nbasis)),
+    vol(patch->getBasis(ASM::GEOMETRY_BASIS))
 {
   nno = basis->nBasisFunctions();
   nelm = basis->nElements();

--- a/src/ASM/LR/Test/TestASMu2D.C
+++ b/src/ASM/LR/Test/TestASMu2D.C
@@ -107,7 +107,7 @@ TEST(TestASMu2D, InterfaceChecker)
   pch->raiseOrder(1,1);
   pch->uniformRefine(0, 3);
   pch->uniformRefine(1, 3);
-  LR::LRSplineSurface* lr = pch->getSurface();
+  LR::LRSplineSurface* lr = pch->getBasis();
   lr->insert_const_u_edge(0.5,   0, 1, 2);
   lr->insert_const_v_edge(0.125, 0.5, 1, 2);
   lr->insert_const_v_edge(0.25,  0.5, 1, 2);
@@ -190,7 +190,7 @@ TEST(TestASMu2D, TransferGaussPtVars)
   sim.opt.discretization = ASM::LRSpline;
 
   ASMu2D* pch = static_cast<ASMu2D*>(sim.createDefaultModel());
-  LR::LRSplineSurface* lr = pch->getSurface();
+  LR::LRSplineSurface* lr = pch->getBasis(1);
   lr->generateIDs();
 
   RealArray oldAr(9), newAr;
@@ -201,7 +201,7 @@ TEST(TestASMu2D, TransferGaussPtVars)
     simNew.opt.discretization = ASM::LRSpline;
     ASMu2D* pchNew = static_cast<ASMu2D*>(simNew.createDefaultModel());
     pchNew->uniformRefine(idx, 1);
-    LR::LRSplineSurface* lrNew = pchNew->getSurface();
+    LR::LRSplineSurface* lrNew = pchNew->getBasis(1);
     ASSERT_TRUE(lrNew != nullptr);
     lrNew->generateIDs();
     for (id[1] = 0; id[1] < 3; ++id[1])
@@ -223,12 +223,12 @@ TEST(TestASMu2D, TransferGaussPtVarsN)
   sim.opt.discretization = sim2.opt.discretization = ASM::LRSpline;
 
   ASMu2D* pch = static_cast<ASMu2D*>(sim.createDefaultModel());
-  LR::LRSplineSurface* lr = pch->getSurface();
+  LR::LRSplineSurface* lr = pch->getBasis(1);
   lr->generateIDs();
 
   ASMu2D* pchNew = static_cast<ASMu2D*>(sim2.createDefaultModel());
   pchNew->uniformRefine(0, 1);
-  LR::LRSplineSurface* lrNew = pchNew->getSurface();
+  LR::LRSplineSurface* lrNew = pchNew->getBasis(1);
   ASSERT_TRUE(lrNew != nullptr);
   lrNew->generateIDs();
 
@@ -281,7 +281,7 @@ TEST(TestASMu2D, ElementConnectivities)
   ASSERT_TRUE(pch1.uniformRefine(0,1));
   ASSERT_TRUE(pch1.uniformRefine(1,1));
   ASSERT_TRUE(pch1.generateFEMTopology());
-  pch1.getSurface()->generateIDs();
+  pch1.getBasis(1)->generateIDs();
   IntMat neigh(4);
   pch1.getElmConnectivities(neigh);
   const std::array<std::vector<int>,4> ref = {{{1, 2},

--- a/src/ASM/LR/Test/TestASMu3D.C
+++ b/src/ASM/LR/Test/TestASMu3D.C
@@ -110,7 +110,7 @@ public:
 TEST(TestASMu3D, TransferGaussPtVars)
 {
   ASMuCube pch;
-  LR::LRSplineVolume* lr = pch.getVolume();
+  LR::LRSplineVolume* lr = pch.getBasis(1);
   ASSERT_TRUE(lr != nullptr);
   lr->generateIDs();
 
@@ -120,7 +120,7 @@ TEST(TestASMu3D, TransferGaussPtVars)
   for (size_t idx = 0; idx < 3; ++idx) {
     ASMuCube pchNew;
     pchNew.uniformRefine(idx,1);
-    pchNew.getVolume()->generateIDs();
+    pchNew.getBasis(1)->generateIDs();
     for (id[2] = 0; id[2] < 3; ++id[2])
       for (id[1] = 0; id[1] < 3; ++id[1])
         for (id[0] = 0; id[0] < 3; ++id[0])
@@ -139,12 +139,12 @@ TEST(TestASMu3D, TransferGaussPtVars)
 TEST(TestASMu3D, TransferGaussPtVarsN)
 {
   ASMuCube pch, pchNew;
-  LR::LRSplineVolume* lr = pch.getVolume();
+  LR::LRSplineVolume* lr = pch.getBasis(1);
   ASSERT_TRUE(lr != nullptr);
   lr->generateIDs();
 
   pchNew.uniformRefine(0,1);
-  pchNew.getVolume()->generateIDs();
+  pchNew.getBasis(1)->generateIDs();
 
   RealArray oldAr(3*3*3), newAr;
   std::iota(oldAr.begin(), oldAr.end(), 1);

--- a/src/ASM/SplineField2D.C
+++ b/src/ASM/SplineField2D.C
@@ -28,7 +28,9 @@
 SplineField2D::SplineField2D (const ASMs2D* patch,
                               const RealArray& v, char nbasis,
                               char cmp, const char* name)
-  : FieldBase(name), basis(patch->getBasis(nbasis)), surf(patch->getSurface())
+  : FieldBase(name),
+    basis(patch->getBasis(nbasis)),
+    surf(patch->getBasis(ASM::GEOMETRY_BASIS))
 {
   const int n1 = basis->numCoefs_u();
   const int n2 = basis->numCoefs_v();

--- a/src/ASM/SplineField3D.C
+++ b/src/ASM/SplineField3D.C
@@ -28,7 +28,9 @@
 SplineField3D::SplineField3D (const ASMs3D* patch,
                               const RealArray& v, char nbasis,
                               char cmp, const char* name)
-  : FieldBase(name), basis(patch->getBasis(nbasis)), vol(patch->getVolume())
+  : FieldBase(name),
+    basis(patch->getBasis(nbasis)),
+    vol(patch->getBasis(ASM::GEOMETRY_BASIS))
 {
   const int n1 = basis->numCoefs(0);
   const int n2 = basis->numCoefs(1);

--- a/src/ASM/SplineFields2D.C
+++ b/src/ASM/SplineFields2D.C
@@ -18,7 +18,6 @@
 
 #include "ASMs2D.h"
 #include "ItgPoint.h"
-#include "SplineUtils.h"
 #include "Utilities.h"
 #include "Vec3.h"
 
@@ -26,7 +25,9 @@
 SplineFields2D::SplineFields2D (const ASMs2D* patch,
                                 const RealArray& v, char nbasis,
                                 int nnf, const char* name)
-  : Fields(name), basis(patch->getBasis(nbasis)), surf(patch->getSurface())
+  : Fields(name),
+    basis(patch->getBasis(nbasis)),
+    surf(patch->getBasis(ASM::GEOMETRY_BASIS))
 {
   const int n1 = basis->numCoefs_u();
   const int n2 = basis->numCoefs_v();

--- a/src/ASM/SplineFields2Dmx.C
+++ b/src/ASM/SplineFields2Dmx.C
@@ -79,7 +79,7 @@ bool SplineFields2Dmx::valueFE (const ItgPoint& x, Vector& vals) const
   auto vit = values.begin();
   auto rit = vals.begin();
   for (int b : bases) {
-    Go::SplineSurface* basis = surf->getBasis(b);
+    const Go::SplineSurface* basis = surf->getBasis(b);
     Go::BasisPtsSf spline;
 #pragma omp critical
     basis->computeBasis(x.u,x.v,spline);

--- a/src/ASM/SplineFields3D.C
+++ b/src/ASM/SplineFields3D.C
@@ -26,7 +26,9 @@
 SplineFields3D::SplineFields3D (const ASMs3D* patch,
                                 const RealArray& v, char nbasis,
                                 int nnf, const char* name)
-  : Fields(name), basis(patch->getBasis(nbasis)), vol(patch->getVolume())
+  : Fields(name),
+    basis(patch->getBasis(nbasis)),
+    vol(patch->getBasis(ASM::GEOMETRY_BASIS))
 {
   const int n1 = basis->numCoefs(0);
   const int n2 = basis->numCoefs(1);

--- a/src/ASM/SplineFields3Dmx.C
+++ b/src/ASM/SplineFields3Dmx.C
@@ -79,7 +79,7 @@ bool SplineFields3Dmx::valueFE (const ItgPoint& x, Vector& vals) const
   auto vit = values.begin();
   auto rit = vals.begin();
   for (int b : bases) {
-    Go::SplineVolume* basis = svol->getBasis(b);
+    const Go::SplineVolume* basis = svol->getBasis(b);
     Go::BasisPts spline;
 #pragma omp critical
     basis->computeBasis(x.u,x.v,x.w,spline);


### PR DESCRIPTION
This extends the getBasis method in ASMs to be able to return more than just the finite element bases.