### PR TITLE
Unify ASMsxDmx and ASMsxD write methods

### DIFF
--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -181,12 +181,14 @@ bool ASMs2D::read (std::istream& is)
 }
 
 
-bool ASMs2D::write (std::ostream& os, int) const
+bool ASMs2D::write (std::ostream& os, int basis) const
 {
   if (!surf) return false;
+  if (basis > static_cast<int>(this->getNoBasis())) return false;
+  const Go::SplineSurface* spline = this->getBasis(basis);
+  if (!spline) return false;
 
-  os <<"200 1 0 0\n";
-  os << *surf;
+  os <<"200 1 0 0\n" << *spline;
 
   return os.good();
 }

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -103,21 +103,6 @@ bool ASMs2Dmx::readBasis (std::istream& is, size_t basis)
 }
 
 
-bool ASMs2Dmx::write (std::ostream& os, int basis) const
-{
-  if (basis == -1)
-    os <<"200 1 0 0\n" << *projB;
-  else if (basis < 1 || basis > (int)m_basis.size())
-    os <<"200 1 0 0\n" << *surf;
-  else if (m_basis[basis-1])
-    os <<"200 1 0 0\n" << *m_basis[basis-1];
-  else
-    return false;
-
-  return os.good();
-}
-
-
 void ASMs2Dmx::clear (bool retainGeometry)
 {
   // Erase the solution field bases

--- a/src/ASM/ASMs2Dmx.h
+++ b/src/ASM/ASMs2Dmx.h
@@ -55,8 +55,6 @@ public:
 
   //! \brief Reads a basis from the given input stream.
   virtual bool readBasis(std::istream& is, size_t basis);
-  //! \brief Writes the geometry/basis of the patch to given stream.
-  virtual bool write(std::ostream& os, int basis) const;
 
   //! \brief Generates the finite element topology data for the patch.
   //! \details The data generated are the element-to-node connectivity array,

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -152,12 +152,14 @@ bool ASMs3D::read (std::istream& is)
 }
 
 
-bool ASMs3D::write (std::ostream& os, int) const
+bool ASMs3D::write (std::ostream& os, int basis) const
 {
   if (!svol) return false;
+  if (basis > static_cast<int>(this->getNoBasis())) return false;
+  const Go::SplineVolume* spline = this->getBasis(basis);
+  if (!spline) return false;
 
-  os <<"700 1 0 0\n";
-  os << *svol;
+  os <<"700 1 0 0\n" << *spline;
 
   return os.good();
 }

--- a/src/ASM/ASMs3Dmx.C
+++ b/src/ASM/ASMs3Dmx.C
@@ -104,21 +104,6 @@ bool ASMs3Dmx::readBasis (std::istream& is, size_t basis)
 }
 
 
-bool ASMs3Dmx::write (std::ostream& os, int basis) const
-{
-  if (basis == -1)
-    os <<"700 1 0 0\n" << *projB;
-  else if (basis < 1 || basis > (int)m_basis.size())
-    os <<"700 1 0 0\n" << *svol;
-  else if (m_basis[basis-1])
-    os <<"700 1 0 0\n" << *m_basis[basis-1];
-  else
-    return false;
-
-  return os.good();
-}
-
-
 void ASMs3Dmx::clear (bool retainGeometry)
 {
   // Erase the solution field bases

--- a/src/ASM/ASMs3Dmx.h
+++ b/src/ASM/ASMs3Dmx.h
@@ -74,8 +74,6 @@ public:
 
   //! \brief Reads a basis from the given input stream.
   virtual bool readBasis(std::istream& is, size_t basis);
-  //! \brief Writes the geometry/basis of the patch to given stream.
-  virtual bool write(std::ostream& os, int basis) const;
 
   //! \brief Returns the number of bases.
   virtual size_t getNoBasis() const { return m_basis.size(); }

--- a/src/ASM/Test/ASMCube.h
+++ b/src/ASM/Test/ASMCube.h
@@ -16,17 +16,27 @@
 #include "ASMs3Dmx.h"
 #include <sstream>
 
-static const char* cube = "700 1 0 0 3 0\n"
-                          "2 2 0 0 1 1\n"
-                          "2 2 0 0 1 1\n"
-                          "2 2 0 0 1 1\n"
-                          "0 0 0  1 0 0  0 1 0  1 1 0\n"
-                          "0 0 1  1 0 1  0 1 1  1 1 1\n";
-
-
 class ASMCube : public ASMs3D
 {
 public:
+  // formatting matches write routine, do not change
+  static constexpr const char* cube = "700 1 0 0\n"
+                                      "3 0\n"
+                                      "2 2\n"
+                                      "0 0 1 1\n"
+                                      "2 2\n"
+                                      "0 0 1 1\n"
+                                      "2 2\n"
+                                      "0 0 1 1\n"
+                                      "0 0 0\n"
+                                      "1 0 0\n"
+                                      "0 1 0\n"
+                                      "1 1 0\n"
+                                      "0 0 1\n"
+                                      "1 0 1\n"
+                                      "0 1 1\n"
+                                      "1 1 1\n\n";
+
   explicit ASMCube(unsigned char n_f = 3) : ASMs3D(n_f)
   {
     std::stringstream geo(cube);
@@ -41,7 +51,7 @@ class ASMmxCube : public ASMs3Dmx
 public:
   explicit ASMmxCube(const CharVec& n_f) : ASMs3Dmx(n_f)
   {
-    std::stringstream geo(cube);
+    std::stringstream geo(ASMCube::cube);
     this->read(geo);
   }
   virtual ~ASMmxCube() {}

--- a/src/ASM/Test/ASMCube.h
+++ b/src/ASM/Test/ASMCube.h
@@ -43,7 +43,6 @@ public:
   {
     std::stringstream geo(cube);
     this->read(geo);
-    this->generateFEMTopology();
   }
   virtual ~ASMmxCube() {}
 };

--- a/src/ASM/Test/ASMSquare.h
+++ b/src/ASM/Test/ASMSquare.h
@@ -40,7 +40,6 @@ public:
   {
     std::stringstream geo(square);
     this->read(geo);
-    this->generateFEMTopology();
   }
   virtual ~ASMmxSquare() {}
 };

--- a/src/ASM/Test/ASMSquare.h
+++ b/src/ASM/Test/ASMSquare.h
@@ -16,14 +16,21 @@
 #include "ASMs2Dmx.h"
 #include <sstream>
 
-static const char* square = "200 1 0 0 2 0\n"
-                            "2 2 0 0 1 1\n"
-                            "2 2 0 0 1 1\n"
-                            "0 0 1 0 0 1 1 1\n";
-
 class ASMSquare : public ASMs2D
 {
 public:
+  // formatting matches write routine, do not change
+  static constexpr const char* square = "200 1 0 0\n"
+                                        "2 0\n"
+                                        "2 2\n"
+                                        "0 0 1 1\n"
+                                        "2 2\n"
+                                        "0 0 1 1\n"
+                                        "0 0\n"
+                                        "1 0\n"
+                                        "0 1\n"
+                                        "1 1\n\n";
+
   explicit ASMSquare(unsigned char n_f = 2) : ASMs2D(2,n_f)
   {
     std::stringstream geo(square);
@@ -38,7 +45,7 @@ class ASMmxSquare : public ASMs2Dmx
 public:
   explicit ASMmxSquare(const CharVec& n_f) : ASMs2Dmx(2,n_f)
   {
-    std::stringstream geo(square);
+    std::stringstream geo(ASMSquare::square);
     this->read(geo);
   }
   virtual ~ASMmxSquare() {}

--- a/src/ASM/Test/TestASMs2D.C
+++ b/src/ASM/Test/TestASMs2D.C
@@ -58,6 +58,35 @@ TEST(TestASMs2D, BoundaryElements)
 }
 
 
+TEST(TestASMs2D, Write)
+{
+  ASMbase::resetNumbering();
+  ASMSquare pch1;
+  EXPECT_TRUE(pch1.generateFEMTopology());
+
+  std::stringstream str;
+  EXPECT_TRUE(pch1.write(str, 1));
+  EXPECT_EQ(str.str(), ASMSquare::square);
+
+  EXPECT_FALSE(pch1.write(str, 2));
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::GEOMETRY_BASIS));
+  EXPECT_EQ(str.str(), ASMSquare::square);
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::PROJECTION_BASIS));
+  EXPECT_EQ(str.str(), ASMSquare::square);
+
+  EXPECT_FALSE(pch1.write(str, ASM::PROJECTION_BASIS_2));
+  EXPECT_FALSE(pch1.write(str, ASM::REFINEMENT_BASIS));
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::INTEGRATION_BASIS));
+  EXPECT_EQ(str.str(), ASMSquare::square);
+}
+
+
 class TestASMs2D : public testing::Test,
                    public testing::WithParamInterface<int>
 {

--- a/src/ASM/Test/TestASMs2Dmx.C
+++ b/src/ASM/Test/TestASMs2Dmx.C
@@ -1,0 +1,297 @@
+//==============================================================================
+//!
+//! \file TestASMs2Dmx.C
+//!
+//! \date Aug 25 2023
+//!
+//! \author Arne Morten Kvarving / SINTEF
+//!
+//! \brief Tests for structured 2D mixed spline FE models.
+//!
+//==============================================================================
+
+#include "ASMmxBase.h"
+#include "ASMSquare.h"
+
+#include "gtest/gtest.h"
+
+
+namespace {
+
+// formatting matches write routine, do not change
+const char* squareTH_1 =
+  "200 1 0 0\n"
+  "2 0\n"
+  "5 3\n"
+  "0 0 0 0.5 0.5 1 1 1\n"
+  "5 3\n"
+  "0 0 0 0.5 0.5 1 1 1\n"
+  "0 0\n"
+  "0.25 0\n"
+  "0.5 0\n"
+  "0.75 0\n"
+  "1 0\n"
+  "0 0.25\n"
+  "0.25 0.25\n"
+  "0.5 0.25\n"
+  "0.75 0.25\n"
+  "1 0.25\n"
+  "0 0.5\n"
+  "0.25 0.5\n"
+  "0.5 0.5\n"
+  "0.75 0.5\n"
+  "1 0.5\n"
+  "0 0.75\n"
+  "0.25 0.75\n"
+  "0.5 0.75\n"
+  "0.75 0.75\n"
+  "1 0.75\n"
+  "0 1\n"
+  "0.25 1\n"
+  "0.5 1\n"
+  "0.75 1\n"
+  "1 1\n\n";
+
+// formatting matches write routine, do not change
+const char* squareTH_2 =
+  "200 1 0 0\n"
+  "2 0\n"
+  "3 2\n"
+  "0 0 0.5 1 1\n"
+  "3 2\n"
+  "0 0 0.5 1 1\n"
+  "0 0\n"
+  "0.5 0\n"
+  "1 0\n"
+  "0 0.5\n"
+  "0.5 0.5\n"
+  "1 0.5\n"
+  "0 1\n"
+  "0.5 1\n"
+  "1 1\n\n";
+
+const char* squareTH_p =
+  "200 1 0 0\n"
+  "2 0\n"
+  "4 3\n"
+  "0 0 0 0.5 1 1 1\n"
+  "4 3\n"
+  "0 0 0 0.5 1 1 1\n"
+  "0 0\n"
+  "0.25 0\n"
+  "0.75 0\n"
+  "1 0\n"
+  "0 0.25\n"
+  "0.25 0.25\n"
+  "0.75 0.25\n"
+  "1 0.25\n"
+  "0 0.75\n"
+  "0.25 0.75\n"
+  "0.75 0.75\n"
+  "1 0.75\n"
+  "0 1\n"
+  "0.25 1\n"
+  "0.75 1\n"
+  "1 1\n\n";
+
+const char* squareFRTH_1 =
+  "200 1 0 0\n"
+  "2 0\n"
+  "3 3\n"
+  "0 0 0 1 1 1\n"
+  "3 3\n"
+  "0 0 0 1 1 1\n"
+  "0 0\n"
+  "0.5 0\n"
+  "1 0\n"
+  "0 0.5\n"
+  "0.5 0.5\n"
+  "1 0.5\n"
+  "0 1\n"
+  "0.5 1\n"
+  "1 1\n\n";
+
+const char* squareRT_1 =
+  "200 1 0 0\n"
+  "2 0\n"
+  "3 3\n"
+  "0 0 0 1 1 1\n"
+  "2 2\n"
+  "0 0 1 1\n"
+  "0 0\n"
+  "0.5 0\n"
+  "1 0\n"
+  "0 1\n"
+  "0.5 1\n"
+  "1 1\n\n";
+
+const char* squareRT_2 =
+  "200 1 0 0\n"
+  "2 0\n"
+  "2 2\n"
+  "0 0 1 1\n"
+  "3 3\n"
+  "0 0 0 1 1 1\n"
+  "0 0\n"
+  "1 0\n"
+  "0 0.5\n"
+  "1 0.5\n"
+  "0 1\n"
+  "1 1\n\n";
+
+}
+
+
+class TestASMs2Dmx : public testing::Test,
+                     public testing::WithParamInterface<int>
+{
+};
+
+
+TEST_P(TestASMs2Dmx, WriteFRTH)
+{
+  ASMmxBase::Type = GetParam() == 0 ? ASMmxBase::FULL_CONT_RAISE_BASIS1
+                                    : ASMmxBase::FULL_CONT_RAISE_BASIS2;
+  ASMbase::resetNumbering();
+  ASMmxSquare pch1({1,1});
+  EXPECT_TRUE(pch1.generateFEMTopology());
+
+  std::stringstream str;
+  EXPECT_TRUE(pch1.write(str, 1));
+  EXPECT_EQ(str.str(), GetParam() == 0 ? squareFRTH_1 : ASMSquare::square);
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, 2));
+  EXPECT_EQ(str.str(), GetParam() == 1 ? squareFRTH_1 : ASMSquare::square);
+
+  EXPECT_FALSE(pch1.write(str, 3));
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::GEOMETRY_BASIS));
+  EXPECT_EQ(str.str(), ASMSquare::square);
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::PROJECTION_BASIS));
+  EXPECT_EQ(str.str(), squareFRTH_1);
+
+  EXPECT_FALSE(pch1.write(str, ASM::PROJECTION_BASIS_2));
+  EXPECT_FALSE(pch1.write(str, ASM::REFINEMENT_BASIS));
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::INTEGRATION_BASIS));
+  EXPECT_EQ(str.str(), ASMSquare::square);
+}
+
+
+TEST(TestASMs2Dmx, WriteRT)
+{
+  ASMmxBase::Type = ASMmxBase::DIV_COMPATIBLE;
+  ASMbase::resetNumbering();
+  ASMmxSquare pch1({1,1,1});
+  EXPECT_TRUE(pch1.generateFEMTopology());
+
+  std::stringstream str;
+  EXPECT_TRUE(pch1.write(str, 1));
+  EXPECT_EQ(str.str(), squareRT_1);
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, 2));
+  EXPECT_EQ(str.str(), squareRT_2);
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, 3));
+  EXPECT_EQ(str.str(), ASMSquare::square);
+
+  EXPECT_FALSE(pch1.write(str, 4));
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::GEOMETRY_BASIS));
+  EXPECT_EQ(str.str(), ASMSquare::square);
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::PROJECTION_BASIS));
+  EXPECT_EQ(str.str(), squareFRTH_1);
+
+  EXPECT_FALSE(pch1.write(str, ASM::PROJECTION_BASIS_2));
+  EXPECT_FALSE(pch1.write(str, ASM::REFINEMENT_BASIS));
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::INTEGRATION_BASIS));
+  EXPECT_EQ(str.str(), ASMSquare::square);
+}
+
+
+TEST(TestASMs2Dmx, WriteSG)
+{
+  ASMmxBase::Type = ASMmxBase::SUBGRID;
+  ASMbase::resetNumbering();
+  ASMmxSquare pch1({1,1});
+  EXPECT_TRUE(pch1.generateFEMTopology());
+
+  std::stringstream str;
+  EXPECT_TRUE(pch1.write(str, 1));
+  EXPECT_EQ(str.str(), squareTH_p);
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, 2));
+  EXPECT_EQ(str.str(), ASMSquare::square);
+
+  EXPECT_FALSE(pch1.write(str, 3));
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::GEOMETRY_BASIS));
+  EXPECT_EQ(str.str(), squareTH_p);
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::PROJECTION_BASIS));
+  EXPECT_EQ(str.str(), squareTH_p);
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::PROJECTION_BASIS_2));
+  EXPECT_EQ(str.str(), squareFRTH_1);
+
+  EXPECT_FALSE(pch1.write(str, ASM::REFINEMENT_BASIS));
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::INTEGRATION_BASIS));
+  EXPECT_EQ(str.str(), squareTH_p);
+}
+
+
+TEST_P(TestASMs2Dmx, WriteTH)
+{
+  ASMmxBase::Type = GetParam() == 0 ? ASMmxBase::REDUCED_CONT_RAISE_BASIS1
+                                    : ASMmxBase::REDUCED_CONT_RAISE_BASIS2;
+  ASMbase::resetNumbering();
+  ASMmxSquare pch1({1,1});
+  EXPECT_TRUE(pch1.uniformRefine(0, 1));
+  EXPECT_TRUE(pch1.uniformRefine(1, 1));
+  EXPECT_TRUE(pch1.generateFEMTopology());
+
+  std::stringstream str;
+  EXPECT_TRUE(pch1.write(str, 1));
+  EXPECT_EQ(str.str(), GetParam() == 0 ? squareTH_1 : squareTH_2);
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, 2));
+  EXPECT_EQ(str.str(), GetParam() == 1 ? squareTH_1 : squareTH_2);
+
+  EXPECT_FALSE(pch1.write(str, 3));
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::GEOMETRY_BASIS));
+  EXPECT_EQ(str.str(), squareTH_2);
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::PROJECTION_BASIS));
+  EXPECT_EQ(str.str(), squareTH_p);
+
+  EXPECT_FALSE(pch1.write(str, ASM::PROJECTION_BASIS_2));
+  EXPECT_FALSE(pch1.write(str, ASM::REFINEMENT_BASIS));
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::INTEGRATION_BASIS));
+  EXPECT_EQ(str.str(), squareTH_2);
+}
+
+INSTANTIATE_TEST_SUITE_P(TestASMs2Dmx, TestASMs2Dmx, testing::Values(0,1));

--- a/src/ASM/Test/TestASMs3D.C
+++ b/src/ASM/Test/TestASMs3D.C
@@ -72,6 +72,35 @@ TEST(TestASMs3D, BoundaryElements)
 }
 
 
+TEST(TestASMs3D, Write)
+{
+  ASMbase::resetNumbering();
+  ASMCube pch1;
+  EXPECT_TRUE(pch1.generateFEMTopology());
+
+  std::stringstream str;
+  EXPECT_TRUE(pch1.write(str, 1));
+  EXPECT_EQ(str.str(), ASMCube::cube);
+
+  EXPECT_FALSE(pch1.write(str, 2));
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::GEOMETRY_BASIS));
+  EXPECT_EQ(str.str(), ASMCube::cube);
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::PROJECTION_BASIS));
+  EXPECT_EQ(str.str(), ASMCube::cube);
+
+  EXPECT_FALSE(pch1.write(str, ASM::PROJECTION_BASIS_2));
+  EXPECT_FALSE(pch1.write(str, ASM::REFINEMENT_BASIS));
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::INTEGRATION_BASIS));
+  EXPECT_EQ(str.str(), ASMCube::cube);
+}
+
+
 class TestASMs3D : public testing::Test,
                    public testing::WithParamInterface<int>
 {

--- a/src/ASM/Test/TestASMs3Dmx.C
+++ b/src/ASM/Test/TestASMs3Dmx.C
@@ -1,0 +1,529 @@
+//==============================================================================
+//!
+//! \file TestASMs3Dmx.C
+//!
+//! \date Aug 25 2023
+//!
+//! \author Arne Morten Kvarving / SINTEF
+//!
+//! \brief Tests for structured 3D mixed spline FE models.
+//!
+//==============================================================================
+
+#include "ASMCube.h"
+
+#include "gtest/gtest.h"
+
+
+namespace {
+
+const char* cubeTH_1 =
+  "700 1 0 0\n"
+  "3 0\n"
+  "5 3\n"
+  "0 0 0 0.5 0.5 1 1 1\n"
+  "5 3\n"
+  "0 0 0 0.5 0.5 1 1 1\n"
+  "5 3\n"
+  "0 0 0 0.5 0.5 1 1 1\n"
+  "0 0 0\n"
+  "0.25 0 0\n"
+  "0.5 0 0\n"
+  "0.75 0 0\n"
+  "1 0 0\n"
+  "0 0.25 0\n"
+  "0.25 0.25 0\n"
+  "0.5 0.25 0\n"
+  "0.75 0.25 0\n"
+  "1 0.25 0\n"
+  "0 0.5 0\n"
+  "0.25 0.5 0\n"
+  "0.5 0.5 0\n"
+  "0.75 0.5 0\n"
+  "1 0.5 0\n"
+  "0 0.75 0\n"
+  "0.25 0.75 0\n"
+  "0.5 0.75 0\n"
+  "0.75 0.75 0\n"
+  "1 0.75 0\n"
+  "0 1 0\n"
+  "0.25 1 0\n"
+  "0.5 1 0\n"
+  "0.75 1 0\n"
+  "1 1 0\n"
+  "0 0 0.25\n"
+  "0.25 0 0.25\n"
+  "0.5 0 0.25\n"
+  "0.75 0 0.25\n"
+  "1 0 0.25\n"
+  "0 0.25 0.25\n"
+  "0.25 0.25 0.25\n"
+  "0.5 0.25 0.25\n"
+  "0.75 0.25 0.25\n"
+  "1 0.25 0.25\n"
+  "0 0.5 0.25\n"
+  "0.25 0.5 0.25\n"
+  "0.5 0.5 0.25\n"
+  "0.75 0.5 0.25\n"
+  "1 0.5 0.25\n"
+  "0 0.75 0.25\n"
+  "0.25 0.75 0.25\n"
+  "0.5 0.75 0.25\n"
+  "0.75 0.75 0.25\n"
+  "1 0.75 0.25\n"
+  "0 1 0.25\n"
+  "0.25 1 0.25\n"
+  "0.5 1 0.25\n"
+  "0.75 1 0.25\n"
+  "1 1 0.25\n"
+  "0 0 0.5\n"
+  "0.25 0 0.5\n"
+  "0.5 0 0.5\n"
+  "0.75 0 0.5\n"
+  "1 0 0.5\n"
+  "0 0.25 0.5\n"
+  "0.25 0.25 0.5\n"
+  "0.5 0.25 0.5\n"
+  "0.75 0.25 0.5\n"
+  "1 0.25 0.5\n"
+  "0 0.5 0.5\n"
+  "0.25 0.5 0.5\n"
+  "0.5 0.5 0.5\n"
+  "0.75 0.5 0.5\n"
+  "1 0.5 0.5\n"
+  "0 0.75 0.5\n"
+  "0.25 0.75 0.5\n"
+  "0.5 0.75 0.5\n"
+  "0.75 0.75 0.5\n"
+  "1 0.75 0.5\n"
+  "0 1 0.5\n"
+  "0.25 1 0.5\n"
+  "0.5 1 0.5\n"
+  "0.75 1 0.5\n"
+  "1 1 0.5\n"
+  "0 0 0.75\n"
+  "0.25 0 0.75\n"
+  "0.5 0 0.75\n"
+  "0.75 0 0.75\n"
+  "1 0 0.75\n"
+  "0 0.25 0.75\n"
+  "0.25 0.25 0.75\n"
+  "0.5 0.25 0.75\n"
+  "0.75 0.25 0.75\n"
+  "1 0.25 0.75\n"
+  "0 0.5 0.75\n"
+  "0.25 0.5 0.75\n"
+  "0.5 0.5 0.75\n"
+  "0.75 0.5 0.75\n"
+  "1 0.5 0.75\n"
+  "0 0.75 0.75\n"
+  "0.25 0.75 0.75\n"
+  "0.5 0.75 0.75\n"
+  "0.75 0.75 0.75\n"
+  "1 0.75 0.75\n"
+  "0 1 0.75\n"
+  "0.25 1 0.75\n"
+  "0.5 1 0.75\n"
+  "0.75 1 0.75\n"
+  "1 1 0.75\n"
+  "0 0 1\n"
+  "0.25 0 1\n"
+  "0.5 0 1\n"
+  "0.75 0 1\n"
+  "1 0 1\n"
+  "0 0.25 1\n"
+  "0.25 0.25 1\n"
+  "0.5 0.25 1\n"
+  "0.75 0.25 1\n"
+  "1 0.25 1\n"
+  "0 0.5 1\n"
+  "0.25 0.5 1\n"
+  "0.5 0.5 1\n"
+  "0.75 0.5 1\n"
+  "1 0.5 1\n"
+  "0 0.75 1\n"
+  "0.25 0.75 1\n"
+  "0.5 0.75 1\n"
+  "0.75 0.75 1\n"
+  "1 0.75 1\n"
+  "0 1 1\n"
+  "0.25 1 1\n"
+  "0.5 1 1\n"
+  "0.75 1 1\n"
+  "1 1 1\n\n";
+
+const char* cubeTH_p =
+  "700 1 0 0\n"
+  "3 0\n"
+  "4 3\n"
+  "0 0 0 0.5 1 1 1\n"
+  "4 3\n"
+  "0 0 0 0.5 1 1 1\n"
+  "4 3\n"
+  "0 0 0 0.5 1 1 1\n"
+  "0 0 0\n"
+  "0.25 0 0\n"
+  "0.75 0 0\n"
+  "1 0 0\n"
+  "0 0.25 0\n"
+  "0.25 0.25 0\n"
+  "0.75 0.25 0\n"
+  "1 0.25 0\n"
+  "0 0.75 0\n"
+  "0.25 0.75 0\n"
+  "0.75 0.75 0\n"
+  "1 0.75 0\n"
+  "0 1 0\n"
+  "0.25 1 0\n"
+  "0.75 1 0\n"
+  "1 1 0\n"
+  "0 0 0.25\n"
+  "0.25 0 0.25\n"
+  "0.75 0 0.25\n"
+  "1 0 0.25\n"
+  "0 0.25 0.25\n"
+  "0.25 0.25 0.25\n"
+  "0.75 0.25 0.25\n"
+  "1 0.25 0.25\n"
+  "0 0.75 0.25\n"
+  "0.25 0.75 0.25\n"
+  "0.75 0.75 0.25\n"
+  "1 0.75 0.25\n"
+  "0 1 0.25\n"
+  "0.25 1 0.25\n"
+  "0.75 1 0.25\n"
+  "1 1 0.25\n"
+  "0 0 0.75\n"
+  "0.25 0 0.75\n"
+  "0.75 0 0.75\n"
+  "1 0 0.75\n"
+  "0 0.25 0.75\n"
+  "0.25 0.25 0.75\n"
+  "0.75 0.25 0.75\n"
+  "1 0.25 0.75\n"
+  "0 0.75 0.75\n"
+  "0.25 0.75 0.75\n"
+  "0.75 0.75 0.75\n"
+  "1 0.75 0.75\n"
+  "0 1 0.75\n"
+  "0.25 1 0.75\n"
+  "0.75 1 0.75\n"
+  "1 1 0.75\n"
+  "0 0 1\n"
+  "0.25 0 1\n"
+  "0.75 0 1\n"
+  "1 0 1\n"
+  "0 0.25 1\n"
+  "0.25 0.25 1\n"
+  "0.75 0.25 1\n"
+  "1 0.25 1\n"
+  "0 0.75 1\n"
+  "0.25 0.75 1\n"
+  "0.75 0.75 1\n"
+  "1 0.75 1\n"
+  "0 1 1\n"
+  "0.25 1 1\n"
+  "0.75 1 1\n"
+  "1 1 1\n\n";
+
+const char* cubeTH_2 =
+  "700 1 0 0\n"
+  "3 0\n"
+  "3 2\n"
+  "0 0 0.5 1 1\n"
+  "3 2\n"
+  "0 0 0.5 1 1\n"
+  "3 2\n"
+  "0 0 0.5 1 1\n"
+  "0 0 0\n"
+  "0.5 0 0\n"
+  "1 0 0\n"
+  "0 0.5 0\n"
+  "0.5 0.5 0\n"
+  "1 0.5 0\n"
+  "0 1 0\n"
+  "0.5 1 0\n"
+  "1 1 0\n"
+  "0 0 0.5\n"
+  "0.5 0 0.5\n"
+  "1 0 0.5\n"
+  "0 0.5 0.5\n"
+  "0.5 0.5 0.5\n"
+  "1 0.5 0.5\n"
+  "0 1 0.5\n"
+  "0.5 1 0.5\n"
+  "1 1 0.5\n"
+  "0 0 1\n"
+  "0.5 0 1\n"
+  "1 0 1\n"
+  "0 0.5 1\n"
+  "0.5 0.5 1\n"
+  "1 0.5 1\n"
+  "0 1 1\n"
+  "0.5 1 1\n"
+  "1 1 1\n\n";
+
+const char* cubeFRTH_1 =
+  "700 1 0 0\n"
+  "3 0\n"
+  "3 3\n"
+  "0 0 0 1 1 1\n"
+  "3 3\n"
+  "0 0 0 1 1 1\n"
+  "3 3\n"
+  "0 0 0 1 1 1\n"
+  "0 0 0\n"
+  "0.5 0 0\n"
+  "1 0 0\n"
+  "0 0.5 0\n"
+  "0.5 0.5 0\n"
+  "1 0.5 0\n"
+  "0 1 0\n"
+  "0.5 1 0\n"
+  "1 1 0\n"
+  "0 0 0.5\n"
+  "0.5 0 0.5\n"
+  "1 0 0.5\n"
+  "0 0.5 0.5\n"
+  "0.5 0.5 0.5\n"
+  "1 0.5 0.5\n"
+  "0 1 0.5\n"
+  "0.5 1 0.5\n"
+  "1 1 0.5\n"
+  "0 0 1\n"
+  "0.5 0 1\n"
+  "1 0 1\n"
+  "0 0.5 1\n"
+  "0.5 0.5 1\n"
+  "1 0.5 1\n"
+  "0 1 1\n"
+  "0.5 1 1\n"
+  "1 1 1\n\n";
+
+const char* cubeRT_1 =
+  "700 1 0 0\n"
+  "3 0\n"
+  "3 3\n"
+  "0 0 0 1 1 1\n"
+  "2 2\n"
+  "0 0 1 1\n"
+  "2 2\n"
+  "0 0 1 1\n"
+  "0 0 0\n"
+  "0.5 0 0\n"
+  "1 0 0\n"
+  "0 1 0\n"
+  "0.5 1 0\n"
+  "1 1 0\n"
+  "0 0 1\n"
+  "0.5 0 1\n"
+  "1 0 1\n"
+  "0 1 1\n"
+  "0.5 1 1\n"
+  "1 1 1\n\n";
+
+const char* cubeRT_2 =
+  "700 1 0 0\n"
+  "3 0\n"
+  "2 2\n"
+  "0 0 1 1\n"
+  "3 3\n"
+  "0 0 0 1 1 1\n"
+  "2 2\n"
+  "0 0 1 1\n"
+  "0 0 0\n"
+  "1 0 0\n"
+  "0 0.5 0\n"
+  "1 0.5 0\n"
+  "0 1 0\n"
+  "1 1 0\n"
+  "0 0 1\n"
+  "1 0 1\n"
+  "0 0.5 1\n"
+  "1 0.5 1\n"
+  "0 1 1\n"
+  "1 1 1\n\n";
+
+const char* cubeRT_3 =
+  "700 1 0 0\n"
+  "3 0\n"
+  "2 2\n"
+  "0 0 1 1\n"
+  "2 2\n"
+  "0 0 1 1\n"
+  "3 3\n"
+  "0 0 0 1 1 1\n"
+  "0 0 0\n"
+  "1 0 0\n"
+  "0 1 0\n"
+  "1 1 0\n"
+  "0 0 0.5\n"
+  "1 0 0.5\n"
+  "0 1 0.5\n"
+  "1 1 0.5\n"
+  "0 0 1\n"
+  "1 0 1\n"
+  "0 1 1\n"
+  "1 1 1\n\n";
+
+}
+
+
+class TestASMs3Dmx : public testing::Test,
+                     public testing::WithParamInterface<int>
+{
+};
+
+
+TEST_P(TestASMs3Dmx, WriteFRTH)
+{
+  ASMmxBase::Type = GetParam() == 0 ? ASMmxBase::FULL_CONT_RAISE_BASIS1
+                                    : ASMmxBase::FULL_CONT_RAISE_BASIS2;
+  ASMbase::resetNumbering();
+  ASMmxCube pch1({1,1});
+  EXPECT_TRUE(pch1.generateFEMTopology());
+
+  std::stringstream str;
+  EXPECT_TRUE(pch1.write(str, 1));
+  EXPECT_EQ(str.str(), GetParam() == 0 ? cubeFRTH_1 : ASMCube::cube);
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, 2));
+  EXPECT_EQ(str.str(), GetParam() == 1 ? cubeFRTH_1 : ASMCube::cube);
+
+  EXPECT_FALSE(pch1.write(str, 3));
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::GEOMETRY_BASIS));
+  EXPECT_EQ(str.str(), ASMCube::cube);
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::PROJECTION_BASIS));
+  EXPECT_EQ(str.str(), cubeFRTH_1);
+
+  EXPECT_FALSE(pch1.write(str, ASM::PROJECTION_BASIS_2));
+  EXPECT_FALSE(pch1.write(str, ASM::REFINEMENT_BASIS));
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::INTEGRATION_BASIS));
+  EXPECT_EQ(str.str(), ASMCube::cube);
+}
+
+
+TEST(TestASMs3Dmx, WriteRT)
+{
+  ASMmxBase::Type = ASMmxBase::DIV_COMPATIBLE;
+  ASMbase::resetNumbering();
+  ASMmxCube pch1({1,1,1});
+  EXPECT_TRUE(pch1.generateFEMTopology());
+
+  std::stringstream str;
+  EXPECT_TRUE(pch1.write(str, 1));
+  EXPECT_EQ(str.str(), cubeRT_1);
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, 2));
+  EXPECT_EQ(str.str(), cubeRT_2);
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, 3));
+  EXPECT_EQ(str.str(), cubeRT_3);
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, 4));
+  EXPECT_EQ(str.str(), ASMCube::cube);
+
+  EXPECT_FALSE(pch1.write(str, 5));
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::GEOMETRY_BASIS));
+  EXPECT_EQ(str.str(), ASMCube::cube);
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::PROJECTION_BASIS));
+  EXPECT_EQ(str.str(), cubeFRTH_1);
+
+  EXPECT_FALSE(pch1.write(str, ASM::PROJECTION_BASIS_2));
+  EXPECT_FALSE(pch1.write(str, ASM::REFINEMENT_BASIS));
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::INTEGRATION_BASIS));
+  EXPECT_EQ(str.str(), ASMCube::cube);
+}
+
+
+TEST(TestASMs3Dmx, WriteSG)
+{
+  ASMmxBase::Type = ASMmxBase::SUBGRID;
+  ASMbase::resetNumbering();
+  ASMmxCube pch1({1,1});
+  EXPECT_TRUE(pch1.generateFEMTopology());
+
+  std::stringstream str;
+  EXPECT_TRUE(pch1.write(str, 1));
+  EXPECT_EQ(str.str(), cubeTH_p);
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, 2));
+  EXPECT_EQ(str.str(), ASMCube::cube);
+
+  EXPECT_FALSE(pch1.write(str, 3));
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::GEOMETRY_BASIS));
+  EXPECT_EQ(str.str(), cubeTH_p);
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::PROJECTION_BASIS));
+  EXPECT_EQ(str.str(), cubeTH_p);
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::PROJECTION_BASIS_2));
+  EXPECT_EQ(str.str(), cubeFRTH_1);
+
+  EXPECT_FALSE(pch1.write(str, ASM::REFINEMENT_BASIS));
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::INTEGRATION_BASIS));
+  EXPECT_EQ(str.str(), cubeTH_p);
+}
+
+
+TEST_P(TestASMs3Dmx, WriteTH)
+{
+  ASMmxBase::Type = GetParam() == 0 ? ASMmxBase::REDUCED_CONT_RAISE_BASIS1
+                                    : ASMmxBase::REDUCED_CONT_RAISE_BASIS2;
+  ASMbase::resetNumbering();
+  ASMmxCube pch1({1,1});
+  EXPECT_TRUE(pch1.uniformRefine(0, 1));
+  EXPECT_TRUE(pch1.uniformRefine(1, 1));
+  EXPECT_TRUE(pch1.uniformRefine(2, 1));
+  EXPECT_TRUE(pch1.generateFEMTopology());
+
+  std::stringstream str;
+  EXPECT_TRUE(pch1.write(str, 1));
+  EXPECT_EQ(str.str(), GetParam() == 0 ? cubeTH_1 : cubeTH_2);
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, 2));
+  EXPECT_EQ(str.str(), GetParam() == 1 ? cubeTH_1 : cubeTH_2);
+
+  EXPECT_FALSE(pch1.write(str, 3));
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::GEOMETRY_BASIS));
+  EXPECT_EQ(str.str(), cubeTH_2);
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::PROJECTION_BASIS));
+  EXPECT_EQ(str.str(), cubeTH_p);
+
+  EXPECT_FALSE(pch1.write(str, ASM::PROJECTION_BASIS_2));
+  EXPECT_FALSE(pch1.write(str, ASM::REFINEMENT_BASIS));
+
+  str.str("");
+  EXPECT_TRUE(pch1.write(str, ASM::INTEGRATION_BASIS));
+  EXPECT_EQ(str.str(), cubeTH_2);
+}
+
+INSTANTIATE_TEST_SUITE_P(TestASMs3Dmx, TestASMs3Dmx, testing::Values(0,1));

--- a/src/ASM/Test/TestSplineFields.C
+++ b/src/ASM/Test/TestSplineFields.C
@@ -51,6 +51,7 @@ TEST(TestSplineFields, Value2Dmx)
 {
   ASMmxBase::Type = ASMmxBase::DIV_COMPATIBLE;
   ASMmxSquare patch({1,1,1});
+  EXPECT_TRUE(patch.generateFEMTopology());
 
   // {x+y+x*y, x-y+x*y}
   std::vector<double> vc = {0.0,
@@ -203,6 +204,7 @@ TEST(TestSplineFields, Value3Dmx)
 {
   ASMmxBase::Type = ASMmxBase::DIV_COMPATIBLE;
   ASMmxCube patch({1,1,1,1});
+  EXPECT_TRUE(patch.generateFEMTopology());
 
   // {x+y+z+x*y*z, x+y-z+x*y*z, x-y+z+x*y*z}
   std::vector<double> vc = {0.0, 0.5, 1.0,


### PR DESCRIPTION
This removes some unnecessary overrides and adds tests for write/getBasis implementations in structured ASMs.