### PR TITLE
Quell warnings with newer PETsc and gtest versions

### DIFF
--- a/Apps/Common/Test/LR/TestMultiPatchLRRefine.C
+++ b/Apps/Common/Test/LR/TestMultiPatchLRRefine.C
@@ -123,9 +123,9 @@ TEST_P(TestMultiPatchLRRefine3D, Refine)
 
 
 const std::vector<int> refValues = {0,1,2};
-INSTANTIATE_TEST_CASE_P(TestMultiPatchLRRefine2D,
-                        TestMultiPatchLRRefine2D,
-                        testing::ValuesIn(refValues));
-INSTANTIATE_TEST_CASE_P(TestMultiPatchLRRefine3D,
-                        TestMultiPatchLRRefine3D,
-                        testing::ValuesIn(refValues));
+INSTANTIATE_TEST_SUITE_P(TestMultiPatchLRRefine2D,
+                         TestMultiPatchLRRefine2D,
+                         testing::ValuesIn(refValues));
+INSTANTIATE_TEST_SUITE_P(TestMultiPatchLRRefine3D,
+                         TestMultiPatchLRRefine3D,
+                         testing::ValuesIn(refValues));

--- a/src/ASM/LR/Test/TestASMu2D.C
+++ b/src/ASM/LR/Test/TestASMu2D.C
@@ -95,8 +95,8 @@ static const std::vector<EdgeTest> edgeTestData =
           {4,  2, {{-1,  1}}, {{ 1,  1}}}}};
 
 
-INSTANTIATE_TEST_CASE_P(TestASMu2D, TestASMu2D,
-                        testing::ValuesIn(edgeTestData));
+INSTANTIATE_TEST_SUITE_P(TestASMu2D, TestASMu2D,
+                         testing::ValuesIn(edgeTestData));
 
 
 TEST(TestASMu2D, InterfaceChecker)

--- a/src/ASM/LR/Test/TestASMu3D.C
+++ b/src/ASM/LR/Test/TestASMu3D.C
@@ -85,9 +85,9 @@ TEST_P(TestASMu3D, ConnectUneven)
 
 
 const std::vector<int> tests = {0,1,2,3,4,5,6,7,8,9,10,11,12};
-INSTANTIATE_TEST_CASE_P(TestASMu3D,
-                        TestASMu3D,
-                        testing::ValuesIn(tests));
+INSTANTIATE_TEST_SUITE_P(TestASMu3D,
+                         TestASMu3D,
+                         testing::ValuesIn(tests));
 
 
 TEST(TestASMu3D, TransferGaussPtVars)

--- a/src/LinAlg/LinAlgInit.C
+++ b/src/LinAlg/LinAlgInit.C
@@ -36,7 +36,7 @@ LinAlgInit::LinAlgInit (int argc, char** argv)
 #if defined(HAS_SLEPC)
   SlepcInitialize(&argc,&argv,(char*)0,PETSC_NULL);
 #elif defined(HAS_PETSC)
-  PetscInitialize(&argc,&argv,(char*)0,PETSC_NULL);
+  PetscInitialize(&argc,&argv,(char*)0,PETSC_NULLPTR);
 #endif
 #ifdef HAVE_MPI
 #ifndef HAS_PETSC

--- a/src/LinAlg/PETScSupport.h
+++ b/src/LinAlg/PETScSupport.h
@@ -41,6 +41,10 @@
 #include "slepceps.h"
 #endif
 
+#if PETSC_VERSION_MINOR < 19
+#define PETSC_NULLPTR PETSC_NULL
+#endif
+
 #else
 typedef int    PetscInt;  //!< To avoid compilation failures
 typedef double PetscReal; //!< To avoid compilation failures


### PR DESCRIPTION
Avoid some deprecation warnings with newer versions of gtest/petsc.