### PR TITLE
bump minimum cmake version to 3.5

### DIFF
--- a/Apps/CMakeLists.txt
+++ b/Apps/CMakeLists.txt
@@ -1,6 +1,6 @@
-project(IFEM_Apps)
-
 cmake_minimum_required(VERSION 3.5)
+
+project(IFEM_Apps)
 
 # Add local modules
 set(IFEM_PATH ${PROJECT_SOURCE_DIR}/..)

--- a/Apps/Common/CMakeLists.txt
+++ b/Apps/Common/CMakeLists.txt
@@ -1,6 +1,6 @@
-project(IFEMAppCommon)
+cmake_minimum_required(VERSION 3.5)
 
-cmake_minimum_required(VERSION 3.0)
+project(IFEMAppCommon)
 
 include_directories(${PROJECT_SOURCE_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-project(IFEM)
+cmake_minimum_required(VERSION 3.5)
 
-cmake_minimum_required(VERSION 3.0)
+project(IFEM)
 
 set(IFEM_VERSION_MAJOR 0)
 set(IFEM_VERSION_MINOR 9)


### PR DESCRIPTION
and put the cmake_minimum_required before project. current cmake has removed support for < 3.5 and
tosses a warning if the project statement comes before the cmake_minimum_required statement.