### PR TITLE
ASMu3D(mx): simplify basis function cache

### DIFF
--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -3112,6 +3112,11 @@ BasisFunctionVals ASMu2D::BasisFunctionCache::calculatePt (size_t el,
   double u = this->getParam(0,el,gpIdx[0],reduced);
   double v = this->getParam(1,el,gpIdx[1],reduced);
 
+  if (patch.lrspline.get() != patch.getBasis(basis)) {
+    const LR::Element* el1 = patch.lrspline->getElement(el);
+    el = patch.getBasis(basis)->getElementContaining(el1->midpoint());
+  }
+
   BasisFunctionVals result;
   if (nderiv == 1 || reduced) {
     Go::BasisDerivsSf spline;

--- a/src/ASM/LR/ASMu2Dmx.C
+++ b/src/ASM/LR/ASMu2Dmx.C
@@ -1226,34 +1226,6 @@ void ASMu2Dmx::getElementsAt (const RealArray& param,
 }
 
 
-BasisFunctionVals ASMu2Dmx::BasisFunctionCache::calculatePt (size_t el,
-                                                             size_t gp,
-                                                             bool reduced) const
-{
-  const std::array<size_t,2> gpIdx = this->gpIndex(gp,reduced);
-  double u = this->getParam(0,el,gpIdx[0],reduced);
-  double v = this->getParam(1,el,gpIdx[1],reduced);
-
-  const ASMu2Dmx& pch = static_cast<const ASMu2Dmx&>(patch);
-
-  const LR::Element* el1 = pch.getBasis(ASMmxBase::itgBasis)->getElement(el);
-  size_t el_b = patch.getBasis(basis)->getElementContaining(el1->midpoint());
-
-  BasisFunctionVals result;
-  if (nderiv == 1 || reduced) {
-    Go::BasisDerivsSf spline;
-    pch.computeBasis(u,v,spline,el_b,patch.getBasis(basis));
-    SplineUtils::extractBasis(spline,result.N,result.dNdu);
-  } else if (nderiv == 2) {
-    Go::BasisDerivsSf2 spline;
-    pch.computeBasis(u,v,spline,el_b,patch.getBasis(basis));
-    SplineUtils::extractBasis(spline,result.N,result.dNdu,result.d2Ndu2);
-  }
-
-  return result;
-}
-
-
 bool ASMu2Dmx::separateProjectionBasis () const
 {
   return std::none_of(m_basis.begin(), m_basis.end(),

--- a/src/ASM/LR/ASMu2Dmx.h
+++ b/src/ASM/LR/ASMu2Dmx.h
@@ -30,33 +30,6 @@
 
 class ASMu2Dmx : public ASMu2D, private ASMmxBase
 {
-protected:
-  //! \brief Implementation of basis function cache.
-  class BasisFunctionCache : public ASMu2D::BasisFunctionCache
-  {
-  public:
-    //! \brief The constructor initializes the class.
-    //! \param pch Patch the cache is for
-    //! \param plcy Cache policy to use
-    //! \param b Basis to use
-    BasisFunctionCache(const ASMu2D& pch,
-                       ASM::CachePolicy plcy, int b)
-      : ASMu2D::BasisFunctionCache(pch,plcy,b) {}
-
-    //! \brief Constructor reusing quadrature info from another instance.
-    //! \param cache Instance holding quadrature information
-    //! \param b Basis to use
-    BasisFunctionCache(const BasisFunctionCache& cache, int b)
-      : ASMu2D::BasisFunctionCache(cache,b) {}
-
-  protected:
-    //! \brief Calculates basis function info in a single integration point.
-    //! \param el Element of integration point (0-indexed)
-    //! \param gp Integration point on element (0-indexed)
-    //! \param reduced If true, returns values for reduced integration scheme
-    BasisFunctionVals calculatePt(size_t el, size_t gp, bool reduced) const override;
-  };
-
 public:
   //! \brief The constructor initializes the dimension of each basis.
   ASMu2Dmx(unsigned char n_s, const CharVec& n_f);

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -2615,7 +2615,7 @@ void ASMu3D::BasisFunctionCache::calculateAll ()
   size_t iel, jp, rp;
   for (iel = jp = rp = 0; iel < patch.nel; iel++)
   {
-    for (int k = 0; k < reducedQ->ng[2]; k++)
+    for (int k = 0; k < mainQ->ng[2]; k++)
       for (int j = 0; j < mainQ->ng[1]; j++)
         for (int i = 0; i < mainQ->ng[0]; i++, jp++)
           values[jp] = this->calculatePt(iel,(k*mainQ->ng[1]+j)*mainQ->ng[0]+i,false);

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -880,16 +880,15 @@ void ASMu3D::evaluateBasis (Vector& N, Matrix& dNdu,
   dNdu.fillColumn(3,CB.getColumn(4));
 }
 
-void ASMu3D::evaluateBasis (int iel, FiniteElement& fe,
-                            Matrix& dNdu, Matrix3D& d2Ndu2,
+void ASMu3D::evaluateBasis (int iel, double u, double v, double w,
+                            Vector& N, Matrix& dNdu, Matrix3D& d2Ndu2,
                             int basis) const
 {
   PROFILE3("ASMu3D::evalBasis(2)");
 
   std::vector<RealArray> result;
-  this->getBasis(basis)->computeBasis(fe.u, fe.v, fe.w, result, 2, iel);
+  this->getBasis(basis)->computeBasis(u, v, w, result, 2, iel);
   size_t n = 0, nBasis = result.size();
-  Vector& N = fe.basis(basis);
 
   N.resize(nBasis);
   dNdu.resize(nBasis,3);
@@ -1764,7 +1763,7 @@ bool ASMu3D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
     }
 
     if (use2ndDer)
-      this->evaluateBasis(iel, fe, dNdu, d2Ndu2);
+      this->evaluateBasis(iel, fe.u, fe.v, fe.w, fe.basis(1), dNdu, d2Ndu2);
     else
       this->evaluateBasis(fe.basis(1), dNdu, bezierExtract[iel], B);
 
@@ -2599,10 +2598,9 @@ calculatePrm (FiniteElement& fe,
     B.fillColumn(4, b.dNdw.getColumn(gp+1)*2.0/du[2]);
 
     patch.evaluateBasis(result.N, result.dNdu, C, B);
-  } else if (nderiv == 2) {
-    patch.evaluateBasis(el, fe, result.dNdu, result.d2Ndu2, basis);
-    result.N = fe.N;
-  }
+  } else if (nderiv == 2)
+    patch.evaluateBasis(el, fe.u, fe.v, fe.w,
+                        result.N, result.dNdu, result.d2Ndu2, basis);
 
   return result;
 }

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -531,14 +531,9 @@ void ASMu3D::constrainFace (int dir, bool open, int dof, int code, char basis)
   de.MNPC.reserve(faceElements.size());
   for (LR::Element* el : faceElements)
   {
-    // for mixed FEM models, let MLGE point to the *geometry* index
+    // for mixed FEM models, let MLGE point to the integration basis
     if (de.lr != this->lrspline.get())
-    {
-      double umid = (el->umax() + el->umin())/2.0;
-      double vmid = (el->vmax() + el->vmin())/2.0;
-      double wmid = (el->wmax() + el->wmin())/2.0;
-      de.MLGE.push_back(lrspline->getElementContaining(umid,vmid,wmid));
-    }
+      de.MLGE.push_back(lrspline->getElementContaining(el->midpoint()));
     else
       de.MLGE.push_back(el->getId());
 

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -632,12 +632,12 @@ protected:
   void getCornerPoints(int iel, std::vector<utl::Point>& XC) const;
 
   //! \brief Evaluate all basis functions and first derivatives on one element
-  void evaluateBasis(int iel, int basis, double u, double v, double w,
-                     Vector& N, Matrix& dNdu) const;
+  void evaluateBasis(int iel, double u, double v, double w,
+                     Vector& N, Matrix& dNdu, int basis = 1) const;
 
   //! \brief Evaluate all basis functions and first derivatives on one element
-  void evaluateBasis(FiniteElement& fe, Matrix& dNdu,
-                     const Matrix& C, const Matrix& B, int basis = 1) const;
+  void evaluateBasis(Vector& N, Matrix& dNdu,
+                     const Matrix& C, const Matrix& B) const;
 
   //! \brief Evaluate all basis functions and first derivatives on one element
   void evaluateBasis(int iel, FiniteElement& fe, Matrix& dNdu,

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -644,8 +644,8 @@ protected:
                      int basis = 1) const;
 
   //! \brief Evaluate all basis functions and second order derivatives on one element
-  void evaluateBasis(int iel, FiniteElement& fe, Matrix& dNdu, Matrix3D& d2Ndu2,
-                     int basis = 1) const;
+  void evaluateBasis(int iel, double u, double v, double w,
+                     Vector& N, Matrix& dNdu, Matrix3D& d2Ndu2, int basis = 1) const;
 
   //! \brief Evaluates the geometry at a specified point.
   //! \param[in] iel 0-based local element index

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -52,7 +52,9 @@ protected:
     //! \param pch Patch the cache is for
     //! \param plcy Cache policy to use
     //! \param b Basis to use
-    BasisFunctionCache(const ASMu3D& pch, ASM::CachePolicy plcy, int b);
+    //! \param useBezier True to use bezier extraction
+    BasisFunctionCache(const ASMu3D& pch, ASM::CachePolicy plcy,
+                       int b, bool useBezier = true);
 
     //! \brief Constructor reusing quadrature info from another instance.
     //! \param cache Instance holding quadrature information
@@ -96,6 +98,7 @@ protected:
       Matrix dNdw; //!< Basis function w-derivatives
     };
 
+    bool bezierEnabled; //!< True to enable Bezier extraction
     BezierExtract mainB; //!< Bezier extraction for main basis
     BezierExtract reducedB; //!< Bezier extraction for reduced basis
 

--- a/src/ASM/LR/ASMu3Dmx.C
+++ b/src/ASM/LR/ASMu3Dmx.C
@@ -1037,31 +1037,6 @@ void ASMu3Dmx::getElementsAt (const RealArray& param,
 }
 
 
-BasisFunctionVals ASMu3Dmx::BasisFunctionCache::calculatePt (size_t el,
-                                                             size_t gp,
-                                                             bool reduced) const
-{
-  PROFILE2("Spline evaluation");
-  const std::array<size_t,3> gpIdx = this->gpIndex(gp,reduced);
-  FiniteElement fe;
-  fe.u = this->getParam(0,el,gpIdx[0],reduced);
-  fe.v = this->getParam(1,el,gpIdx[1],reduced);
-  fe.w = this->getParam(2,el,gpIdx[2],reduced);
-
-  const ASMu3Dmx& pch = static_cast<const ASMu3Dmx&>(patch);
-
-  const LR::Element* elm = pch.lrspline->getElement(el);
-  std::array<double,3> du;
-  du[0] = elm->umax() - elm->umin();
-  du[1] = elm->vmax() - elm->vmin();
-  du[2] = elm->wmax() - elm->wmin();
-
-  el = pch.getBasis(basis)->getElementContaining(elm->midpoint());
-
-  return this->calculatePrm(fe,du,el,gp,reduced);
-}
-
-
 bool ASMu3Dmx::separateProjectionBasis () const
 {
   return std::none_of(m_basis.begin(), m_basis.end(),

--- a/src/ASM/LR/ASMu3Dmx.C
+++ b/src/ASM/LR/ASMu3Dmx.C
@@ -38,8 +38,7 @@
 
 
 ASMu3Dmx::ASMu3Dmx (const CharVec& n_f)
-  : ASMu3D(std::accumulate(n_f.begin(), n_f.end(), 0)), ASMmxBase(n_f),
-    bezierExtractmx(myBezierExtractmx)
+  : ASMu3D(std::accumulate(n_f.begin(), n_f.end(), 0)), ASMmxBase(n_f)
 {
   threadBasis = nullptr;
   myGeoBasis = ASMmxBase::itgBasis;
@@ -48,8 +47,7 @@ ASMu3Dmx::ASMu3Dmx (const CharVec& n_f)
 
 ASMu3Dmx::ASMu3Dmx (const ASMu3Dmx& patch, const CharVec& n_f)
   : ASMu3D(patch), ASMmxBase(n_f[0]==0?patch.nfx:n_f),
-    m_basis(patch.m_basis),
-    bezierExtractmx(patch.myBezierExtractmx)
+    m_basis(patch.m_basis)
 {
   threadBasis = patch.threadBasis;
   nfx = patch.nfx;
@@ -273,23 +271,6 @@ bool ASMu3Dmx::generateFEMTopology ()
     }
 
     myMLGE[iel++] = ++gEl; // global element number over all patches
-  }
-
-  size_t b = 0;
-  myBezierExtractmx.resize(m_basis.size());
-  for (const SplinePtr& it : m_basis) {
-    myBezierExtractmx[b].resize(it->nElements());
-    for (int iel = 0; iel < it->nElements(); iel++)
-    {
-      PROFILE("Bezier extraction");
-      // Get bezier extraction matrix
-      RealArray extrMat;
-      it->getBezierExtraction(iel,extrMat);
-      myBezierExtractmx[b][iel].resize(it->getElement(iel)->nBasisFunctions(),
-                                       it->order(0)*it->order(1)*it->order(2));
-      myBezierExtractmx[b][iel].fill(extrMat.data(),extrMat.size());
-    }
-    ++b;
   }
 
   for (size_t inod = 0; inod < nnod; ++inod)

--- a/src/ASM/LR/ASMu3Dmx.h
+++ b/src/ASM/LR/ASMu3Dmx.h
@@ -207,9 +207,6 @@ private:
   std::vector<SplinePtr> m_basis;      //!< All bases
   LR::LRSplineVolume*    threadBasis;  //!< Basis for thread groups
 
-  const std::vector<Matrices>& bezierExtractmx;  //!< Bezier extraction matrices
-  std::vector<Matrices>        myBezierExtractmx; //!< Bezier extraction matrices
-
   ThreadGroups proj2ThreadGroups; //!< Element groups for multi-threaded assembly - second projection basis
 };
 

--- a/src/ASM/LR/ASMu3Dmx.h
+++ b/src/ASM/LR/ASMu3Dmx.h
@@ -30,33 +30,6 @@
 
 class ASMu3Dmx : public ASMu3D, private ASMmxBase
 {
-protected:
-  //! \brief Implementation of basis function cache.
-  class BasisFunctionCache : public ASMu3D::BasisFunctionCache
-  {
-  public:
-    //! \brief The constructor initializes the class.
-    //! \param pch Patch the cache is for
-    //! \param plcy Cache policy to use
-    //! \param b Basis to use
-    BasisFunctionCache(const ASMu3D& pch,
-                       ASM::CachePolicy plcy, int b)
-      : ASMu3D::BasisFunctionCache(pch,plcy,b) {}
-
-    //! \brief Constructor reusing quadrature info from another instance.
-    //! \param cache Instance holding quadrature information
-    //! \param b Basis to use
-    BasisFunctionCache(const BasisFunctionCache& cache, int b)
-      : ASMu3D::BasisFunctionCache(cache,b) {}
-
-protected:
-    //! \brief Calculates basis function info in a single integration point.
-    //! \param el Element of integration point (0-indexed)
-    //! \param gp Integratin point on element (0-indexed)
-    //! \param reduced If true, returns values for reduced integration scheme
-    BasisFunctionVals calculatePt(size_t el, size_t gp, bool reduced) const override;
-  };
-
 public:
   //! \brief The constructor initializes the dimension of each basis.
   explicit ASMu3Dmx(const CharVec& n_f);

--- a/src/ASM/LR/ASMu3Drecovery.C
+++ b/src/ASM/LR/ASMu3Drecovery.C
@@ -577,7 +577,7 @@ bool ASMu3D::faceL2projection (const DirichletFace& face,
         if (gpar[2].size() > 1) w = param[2] = gpar[2](k3+1);
 
         // Evaluate basis function derivatives at integration points
-        this->evaluateBasis(iel-1, myGeoBasis, u, v, w, N, dNdu);
+        this->evaluateBasis(iel-1, u, v, w, N, dNdu, myGeoBasis);
 
         // Compute basis function derivatives
         double dJxW = dA*wg[i]*wg[j]*utl::Jacobian(Jac,X,dNdX,Xnod,dNdu,t1,t2);


### PR DESCRIPTION
In particular avoid duplication by putting conditionals in base implementation.

Also add an option to disable use of bezier extraction in the 3DLR implementation. Bezier extraction from gauss points do not work with subgrid, so subgrid in 3D has always been broken. I will use that to fix subgrid but I want to do that afterwards as it requires downstream updates and I prefer to keep those in a separate PR - less branch jumping required.