### PR TITLE
ASMu3Dmx: disable bezier extraction with subgrid

### DIFF
--- a/src/ASM/LR/ASMu3Dmx.C
+++ b/src/ASM/LR/ASMu3Dmx.C
@@ -305,7 +305,8 @@ bool ASMu3Dmx::integrate (Integrand& integrand,
   bool use2ndDer = integrand.getIntegrandType() & Integrand::SECOND_DERIVATIVES;
 
   if (myCache.empty()) {
-    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this, cachePolicy, 1));
+    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this, cachePolicy, 1,
+                                                              ASMmxBase::Type != SUBGRID));
     for (size_t b = 2; b <= this->getNoBasis(); ++b) {
       const BasisFunctionCache& c = static_cast<const BasisFunctionCache&>(*myCache.front());
       myCache.emplace_back(std::make_unique<BasisFunctionCache>(c,b));
@@ -992,6 +993,7 @@ void ASMu3Dmx::swapProjectionBasis ()
     ASMmxBase::itgBasis = ASMmxBase::itgBasis == 1 ? 2 : 1;
     std::swap(projB, projB2);
     std::swap(projThreadGroups, proj2ThreadGroups);
+    geomB = lrspline = m_basis[ASMmxBase::itgBasis-1];
   }
 }
 


### PR DESCRIPTION
we cannot uniformly use bezier extraction from gauss points
with subgrid, since we are not evaluating in gauss points
distributed across the element for all bases. this because
our integration elements have an additional subdivision,
which means the pressure basis is evaluated in non-uniform points
(ie we evaluate in 4 distinct sets of gauss-points over its elements).

Sits on top of https://github.com/OPM/IFEM/pull/619