### PR TITLE
fixed: reading nodes from HDF5 file

### DIFF
--- a/src/SIM/SIMinput.C
+++ b/src/SIM/SIMinput.C
@@ -148,7 +148,8 @@ bool SIMinput::parseGeometryTag (const TiXmlElement* elem)
     else if (strstr(file,".hdf5"))
     {
       IFEM::cout <<"\tReading global node numbers from "<< file << std::endl;
-      HDF5Reader hdf5(file,ProcessAdm());
+      ProcessAdm adm;
+      HDF5Reader hdf5(file,adm);
       const char* field = elem->Attribute("field");
       for (int i = 1; i <= nGlPatches; i++)
       {


### PR DESCRIPTION
we need to instance the ProcessAdm and not pass a temporary. holding a reference to a temporary is not enough to keep it alive, which means it is killed and consequently the reader holds an invalid reference.