### PR TITLE
ASMsxDmx::evalSolution: support separate geometry

### DIFF
--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -229,8 +229,9 @@ public:
   virtual Vec3 getCoord(size_t inod) const = 0;
   //! \brief Returns a matrix with all nodal coordinates within the patch.
   //! \param[out] X nsd\f$\times\f$n-matrix, where \a n is the number of nodes
+  //! \param[in] geo If true returns coordinates for geometry basis
   //! in the patch
-  virtual void getNodalCoordinates(Matrix& X) const = 0;
+  virtual void getNodalCoordinates(Matrix& X, bool geo = false) const = 0;
   //! \brief Returns a matrix with nodal coordinates for an element.
   //! \param[in] iel 1-based element index local to current patch
   //! \param[in] forceItg If true force returning integration basis coordinates

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -715,7 +715,7 @@ bool ASMs1D::getElementNodalRotations (TensorVec& T, size_t iel) const
 }
 
 
-void ASMs1D::getNodalCoordinates (Matrix& X) const
+void ASMs1D::getNodalCoordinates (Matrix& X, bool) const
 {
   const int n1 = curv->numCoefs();
 

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -101,7 +101,7 @@ public:
   //! \brief Returns a matrix with all nodal coordinates within the patch.
   //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes
   //! in the patch
-  virtual void getNodalCoordinates(Matrix& X) const;
+  virtual void getNodalCoordinates(Matrix& X, bool = false) const;
 
   //! \brief Updates the nodal coordinates for this patch.
   //! \param[in] displ Incremental displacements to update the coordinates with

--- a/src/ASM/ASMs1DLag.C
+++ b/src/ASM/ASMs1DLag.C
@@ -149,7 +149,7 @@ bool ASMs1DLag::getElementCoordinates (Matrix& X, int iel, bool) const
 }
 
 
-void ASMs1DLag::getNodalCoordinates (Matrix& X) const
+void ASMs1DLag::getNodalCoordinates (Matrix& X, bool) const
 {
   X.resize(nsd,coord.size());
 

--- a/src/ASM/ASMs1DLag.h
+++ b/src/ASM/ASMs1DLag.h
@@ -60,7 +60,7 @@ public:
   //! \brief Returns a matrix with all nodal coordinates within the patch.
   //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes
   //! in the patch
-  virtual void getNodalCoordinates(Matrix& X) const;
+  virtual void getNodalCoordinates(Matrix& X, bool = false) const;
 
   //! \brief Returns the global coordinates for the given node.
   //! \param[in] inod 1-based node index local to current patch

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -1430,20 +1430,21 @@ bool ASMs2D::getElementCoordinatesPrm (Matrix& X, double u, double v) const
 }
 
 
-void ASMs2D::getNodalCoordinates (Matrix& X) const
+void ASMs2D::getNodalCoordinates (Matrix& X, bool geo) const
 {
-  const int n1 = surf->numCoefs_u();
-  const int n2 = surf->numCoefs_v();
+  const Go::SplineSurface* spline = geo ? this->getBasis(ASM::GEOMETRY_BASIS) : surf;
+  const int n1 = spline->numCoefs_u();
+  const int n2 = spline->numCoefs_v();
   X.resize(nsd,n1*n2);
 
-  RealArray::const_iterator cit = surf->coefs_begin();
+  RealArray::const_iterator cit = spline->coefs_begin();
   size_t inod = 1;
   for (int i2 = 0; i2 < n2; i2++)
     for (int i1 = 0; i1 < n1; i1++, inod++)
     {
-      int ip = (i2*n1 + i1)*surf->dimension();
+      int ip = (i2*n1 + i1)*spline->dimension();
       for (size_t i = 0; i < nsd; i++)
-	X(i+1,inod) = *(cit+(ip+i));
+        X(i+1,inod) = *(cit+(ip+i));
     }
 }
 

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -246,8 +246,9 @@ public:
 
   //! \brief Returns a matrix with all nodal coordinates within the patch.
   //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes
+  //! \param[in] geo If true return coordinates of geometry basis
   //! in the patch
-  virtual void getNodalCoordinates(Matrix& X) const;
+  virtual void getNodalCoordinates(Matrix& X, bool geo = false) const;
 
   //! \brief Returns the global coordinates for the given node.
   //! \param[in] inod 1-based node index local to current patch

--- a/src/ASM/ASMs2DLag.C
+++ b/src/ASM/ASMs2DLag.C
@@ -242,7 +242,7 @@ bool ASMs2DLag::getElementCoordinates (Matrix& X, int iel, bool) const
 }
 
 
-void ASMs2DLag::getNodalCoordinates (Matrix& X) const
+void ASMs2DLag::getNodalCoordinates (Matrix& X, bool) const
 {
   X.resize(nsd,coord.size());
 

--- a/src/ASM/ASMs2DLag.h
+++ b/src/ASM/ASMs2DLag.h
@@ -116,7 +116,7 @@ public:
   //! \brief Returns a matrix with all nodal coordinates within the patch.
   //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes
   //! in the patch
-  virtual void getNodalCoordinates(Matrix& X) const;
+  virtual void getNodalCoordinates(Matrix& X, bool = false) const;
 
   //! \brief Returns the global coordinates for the given node.
   //! \param[in] inod 1-based node index local to current patch

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -1702,22 +1702,23 @@ bool ASMs3D::getElementCoordinatesPrm (Matrix& X, double u,
 }
 
 
-void ASMs3D::getNodalCoordinates (Matrix& X) const
+void ASMs3D::getNodalCoordinates (Matrix& X, bool geo) const
 {
-  const int n1 = svol->numCoefs(0);
-  const int n2 = svol->numCoefs(1);
-  const int n3 = svol->numCoefs(2);
+  const Go::SplineVolume* spline = geo ? this->getBasis(ASM::GEOMETRY_BASIS) : svol;
+  const int n1 = spline->numCoefs(0);
+  const int n2 = spline->numCoefs(1);
+  const int n3 = spline->numCoefs(2);
   X.resize(3,n1*n2*n3);
 
-  RealArray::const_iterator cit = svol->coefs_begin();
+  RealArray::const_iterator cit = spline->coefs_begin();
   size_t inod = 1;
   for (int i3 = 0; i3 < n3; i3++)
     for (int i2 = 0; i2 < n2; i2++)
       for (int i1 = 0; i1 < n1; i1++, inod++)
       {
-	int ip = ((i3*n2 + i2)*n1 + i1)*svol->dimension();
-	for (size_t i = 0; i < 3; i++)
-	  X(i+1,inod) = *(cit+(ip+i));
+        int ip = ((i3*n2 + i2)*n1 + i1)*spline->dimension();
+        for (size_t i = 0; i < 3; i++)
+          X(i+1,inod) = *(cit+(ip+i));
       }
 }
 

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -261,8 +261,9 @@ public:
 
   //! \brief Returns a matrix with all nodal coordinates within the patch.
   //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes
+  //! \param[in] geo If true returns coordinates for geometry basis
   //! in the patch
-  virtual void getNodalCoordinates(Matrix& X) const;
+  virtual void getNodalCoordinates(Matrix& X, bool geo = false) const;
 
   //! \brief Returns the global coordinates for the given node.
   //! \param[in] inod 1-based node index local to current patch

--- a/src/ASM/ASMs3DLag.C
+++ b/src/ASM/ASMs3DLag.C
@@ -267,7 +267,7 @@ bool ASMs3DLag::getElementCoordinates (Matrix& X, int iel, bool) const
 }
 
 
-void ASMs3DLag::getNodalCoordinates (Matrix& X) const
+void ASMs3DLag::getNodalCoordinates (Matrix& X, bool) const
 {
   X.resize(3,coord.size());
 

--- a/src/ASM/ASMs3DLag.h
+++ b/src/ASM/ASMs3DLag.h
@@ -116,7 +116,7 @@ public:
   //! \brief Returns a matrix with all nodal coordinates within the patch.
   //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes
   //! in the patch
-  virtual void getNodalCoordinates(Matrix& X) const;
+  virtual void getNodalCoordinates(Matrix& X, bool = false) const;
 
   //! \brief Returns the global coordinates for the given node.
   //! \param[in] inod 1-based node index local to current patch

--- a/src/ASM/ASMsupel.C
+++ b/src/ASM/ASMsupel.C
@@ -185,7 +185,7 @@ Vec3 ASMsupel::getCoord (size_t inod) const
 }
 
 
-void ASMsupel::getNodalCoordinates (Matrix& X) const
+void ASMsupel::getNodalCoordinates (Matrix& X, bool) const
 {
   X.resize(3,nnod);
   for (size_t inod = 1; inod <= nnod; inod++)

--- a/src/ASM/ASMsupel.h
+++ b/src/ASM/ASMsupel.h
@@ -61,7 +61,7 @@ public:
   //! \brief Returns a matrix with all nodal coordinates within the patch.
   //! \param[out] X nsd\f$\times\f$n-matrix, where \a n is the number of nodes
   //! in the patch
-  virtual void getNodalCoordinates(Matrix& X) const;
+  virtual void getNodalCoordinates(Matrix& X, bool = false) const;
   //! \brief Returns a matrix with nodal coordinates for an element.
   //! \param[in] iel 1-based element index local to current patch
   //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -170,7 +170,7 @@ public:
   //! \brief Returns a matrix with all nodal coordinates within the patch.
   //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes
   //! in the patch
-  virtual void getNodalCoordinates(Matrix& X) const
+  virtual void getNodalCoordinates(Matrix& X, bool = false) const
   { this->getCoordinates(X, nsd, *lrspline); }
 
   //! \brief Returns the global coordinates for the given node.

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -713,7 +713,7 @@ bool ASMu3D::getElementCoordinates (Matrix& X, int iel, bool forceItg) const
 }
 
 
-void ASMu3D::getNodalCoordinates (Matrix& X) const
+void ASMu3D::getNodalCoordinates (Matrix& X, bool) const
 {
   X.resize(3,lrspline->nBasisFunctions());
 

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -156,7 +156,7 @@ public:
   //! \brief Returns a matrix with all nodal coordinates within the patch.
   //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes
   //! in the patch
-  virtual void getNodalCoordinates(Matrix& X) const;
+  virtual void getNodalCoordinates(Matrix& X, bool = false) const;
 
   //! \brief Returns the global coordinates for the given node.
   //! \param[in] inod 1-based node index local to current patch


### PR DESCRIPTION
This adds support for separate geometry in evalSolution(2) for struct ASMs.