### PR TITLE
Some matrix utilities

### DIFF
--- a/src/LinAlg/Test/TestMatrix.C
+++ b/src/LinAlg/Test/TestMatrix.C
@@ -38,6 +38,26 @@ TEST(TestMatrix, AddBlock)
 }
 
 
+TEST(TestMatrix, ExtractBlock)
+{
+  utl::matrix<int> a(3,3), b(2,2);
+
+  std::iota(a.begin(), a.end(), 1);
+
+  a.extractBlock(b,1,1);
+  EXPECT_EQ(b(1,1), 1);
+  EXPECT_EQ(b(2,1), 2);
+  EXPECT_EQ(b(1,2), 4);
+  EXPECT_EQ(b(2,2), 5);
+
+  a.extractBlock(b,2,2,true);
+  EXPECT_EQ(b(1,1), 1+5);
+  EXPECT_EQ(b(2,1), 2+6);
+  EXPECT_EQ(b(1,2), 4+8);
+  EXPECT_EQ(b(2,2), 5+9);
+}
+
+
 TEST(TestMatrix, AddRows)
 {
   utl::matrix<int> a(3,5);

--- a/src/LinAlg/matrix.h
+++ b/src/LinAlg/matrix.h
@@ -565,6 +565,24 @@ namespace utl //! General utility classes and functions.
       }
     }
 
+    //! \brief Extract a block of the matrix to another matrix.
+    void extractBlock(matrix<T>& block, size_t r, size_t c,
+                      bool addTo = false,
+                      bool transposed = false) const
+    {
+      size_t nr = transposed ? block.cols() : block.rows();
+      size_t nc = transposed ? block.rows() : block.cols();
+      for (size_t i = 1; i <= nr && i+r-1 <= nrow; i++)
+      {
+        size_t ip = i+r-2 + nrow*(c-1);
+        for (size_t j = 1; j <= nc && j+c-1 <= ncol; j++, ip += nrow)
+          if (addTo)
+            (transposed ? block(j,i) : block(i,j)) += this->elem[ip];
+          else
+            (transposed ? block(j,i) : block(i,j)) = this->elem[ip];
+      }
+    }
+
     //! \brief Create a diagonal matrix.
     matrix<T>& diag(T d, size_t dim = 0)
     {

--- a/src/LinAlg/matrix.h
+++ b/src/LinAlg/matrix.h
@@ -128,7 +128,8 @@ namespace utl //! General utility classes and functions.
     //! \brief Subtract the given vector \b X from \a *this.
     vector<T>& operator-=(const vector<T>& X) { return this->add(X,T(-1)); }
     //! \brief Add the given vector \b X scaled by \a alfa to \a *this.
-    vector<T>& add(const std::vector<T>& X, const T& alfa = T(1));
+    vector<T>& add(const std::vector<T>& X, const T& alfa = T(1),
+                   int ofsx = 0, int stridex = 1);
 
     //! \brief Perform \f${\bf Y} = \alpha{\bf Y} + (1-\alpha){\bf X} \f$
     //! where \b Y = \a *this.
@@ -963,19 +964,21 @@ namespace utl //! General utility classes and functions.
 
   template<> inline
   vector<float>& vector<float>::add(const std::vector<float>& X,
-                                    const float& alfa)
+                                    const float& alfa,
+                                    int ofsx, int stridex)
   {
     size_t n = this->size() < X.size() ? this->size() : X.size();
-    cblas_saxpy(n,alfa,&X.front(),1,this->ptr(),1);
+    cblas_saxpy(n,alfa,X.data()+ofsx,stridex,this->data(),1);
     return *this;
   }
 
   template<> inline
   vector<double>& vector<double>::add(const std::vector<double>& X,
-                                      const double& alfa)
+                                      const double& alfa,
+                                      int ofsx, int stridex)
   {
     size_t n = this->size() < X.size() ? this->size() : X.size();
-    cblas_daxpy(n,alfa,&X.front(),1,this->ptr(),1);
+    cblas_daxpy(n,alfa,X.data()+ofsx,stridex,this->data(),1);
     return *this;
   }
 
@@ -1345,11 +1348,12 @@ namespace utl //! General utility classes and functions.
   }
 
   template<class T> inline
-  vector<T>& vector<T>::add(const std::vector<T>& X, const T& alfa)
+  vector<T>& vector<T>::add(const std::vector<T>& X, const T& alfa,
+                            int ofsx, int stridex)
   {
     T* p = this->ptr();
-    const T* q = &X.front();
-    for (size_t i = 0; i < this->size() && i < X.size(); i++, p++, q++)
+    const T* q = X.data() + ofsx;
+    for (size_t i = 0; i < this->size() && i < X.size(); i++, p++, q += stridex)
       *p += alfa*(*q);
     return *this;
   }


### PR DESCRIPTION
This exposes stride and offset for x vector in utl::vector<T>::add and adds an extractBlock method to utl::matrix<T>.
Useful for making code more readable while doing some of the piola stuff.