### PR TITLE
changed: use BasisFunctionValues also in boundary integrals

### DIFF
--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -1423,7 +1423,8 @@ bool ASMs2D::getElementCoordinatesPrm (Matrix& X, double u, double v) const
   }
 
 #if SP_DEBUG > 2
-  std::cout <<"\nCoordinates for element "<< iel << X << std::endl;
+  std::cout <<"\nCoordinates for element containing parameters ("
+            << u <<"," << v << "):" << X << std::endl;
 #endif
   return true;
 }

--- a/src/ASM/BasisFunctionVals.h
+++ b/src/ASM/BasisFunctionVals.h
@@ -29,4 +29,63 @@ struct BasisFunctionVals
   Matrix4D d3Ndu3; //!< Third order derivatives of basis functions
 };
 
+
+//! \brief Convenience type alias
+using BasisValuesPtrs = std::vector<const BasisFunctionVals*>;
+
+
+//! \brief Utility class holding a vector of basis function values.
+//! \details This is a helper class that allows us to avoid pointer
+//!          semantics in code, while allowing to pass as
+//!          pointers into mapping functions. This is necessary
+//!          to avoid additional copying in code using the
+//!          basis function cache.
+//!          While it overrides most common vector operations,
+//!          be careful with advanced insertions.
+class BasisValues : public std::vector<BasisFunctionVals>
+{
+public:
+  //! \brief Constructor resizing to a given size.
+  BasisValues(size_t size) : std::vector<BasisFunctionVals>(size)
+  {
+    pointers.reserve(this->size());
+    for (const BasisFunctionVals& val : *this)
+      pointers.push_back(&val);
+  }
+
+   //! \brief Destructor.
+   //! \details Need to manually implement to call parent dtor.
+  ~BasisValues()
+  {
+    this->clear();
+  }
+
+  //! \brief Clears the container.
+  void clear() noexcept
+  {
+    this->std::vector<BasisFunctionVals>::clear();
+    pointers.clear();
+  }
+
+  //! \brief Push back for reference.
+  void push_back(const BasisFunctionVals& v)
+  {
+    this->std::vector<BasisFunctionVals>::push_back(v);
+    pointers.push_back(&this->back());
+  }
+
+  //! \brief Push back for r-reference.
+  void push_back(BasisFunctionVals&& v)
+  {
+    this->std::vector<BasisFunctionVals>::push_back(v);
+    pointers.push_back(&this->back());
+  }
+
+  //! \brief Cast to a vector with pointers to our values.
+  operator const BasisValuesPtrs& () const { return pointers; }
+
+private:
+  BasisValuesPtrs pointers; //!< Vector of pointers to our values
+};
+
 #endif

--- a/src/ASM/FiniteElement.h
+++ b/src/ASM/FiniteElement.h
@@ -14,12 +14,11 @@
 #ifndef _FINITE_ELEMENT_H
 #define _FINITE_ELEMENT_H
 
+#include "BasisFunctionVals.h"
 #include "ItgPoint.h"
 #include "MatVec.h"
 #include "Vec3.h"
 #include "Tensor.h"
-
-struct BasisFunctionVals;
 
 
 /*!
@@ -121,26 +120,24 @@ public:
   //! \param[out] Jac The inverse of the Jacobian matrix
   //! \param[in] Xnod Matrix of element nodal coordinates
   //! \param[in] gBasis 1-based index of basis representing the geometry
-  //! \param[in] bf Basis function values and derivatives
-  //! \param[in] dNxdu First order derivatives of basis functions
+  //! \param[in] bfs Basis function values and derivatives
   bool Jacobian(Matrix& Jac, const Matrix& Xnod,
                 unsigned short int gBasis,
-                const std::vector<const BasisFunctionVals*>* bf,
-                const std::vector<Matrix>* dNxdu = nullptr);
+                const BasisValuesPtrs& bfs);
 
   //! \brief Sets up the Jacobian matrix of the coordinate mapping on a boundary.
   //! \param[out] Jac The inverse of the Jacobian matrix
   //! \param[out] n Outward-directed unit normal vector on the boundary
   //! \param[in] Xnod Matrix of element nodal coordinates
   //! \param[in] gBasis 1-based index of basis representing the geometry
-  //! \param[in] dNxdu First order derivatives of basis functions
+  //! \param[in] bfs Derivatives of basis functions
   //! \param[in] t1 First parametric tangent direction of the boundary
   //! \param[in] t2 Second parametric tangent direction of the boundary
   //! \param[in] nBasis Number of basis functions
   //! \param[in] Xnod2 Matrix of element nodal coordinates for neighbor element
   bool Jacobian(Matrix& Jac, Vec3& n, const Matrix& Xnod,
                 unsigned short int gBasis,
-                const std::vector<Matrix>& dNxdu,
+                const BasisValuesPtrs& bfs,
                 size_t t1, size_t t2, size_t nBasis = 0,
                 const Matrix* Xnod2 = nullptr);
 
@@ -149,12 +146,10 @@ public:
   //! \param[in] Jac The inverse of the Jacobian matrix
   //! \param[in] Xnod Matrix of element nodal coordinates
   //! \param[in] gBasis 1-based index of basis representing the geometry
-  //! \param[in] bf Basis function values and derivatives
-  //! \param[in] d2Nxdu2 Second order derivatives of basis functions
+  //! \param[in] bfs Basis function derivatives
   bool Hessian(Matrix3D& Hess, const Matrix& Jac, const Matrix& Xnod,
                unsigned short int gBasis,
-               const std::vector<const BasisFunctionVals*>* bf,
-               const std::vector<Matrix3D>* d2Nxdu2 = nullptr);
+               const BasisValuesPtrs& bfs);
 
 protected:
   //! \brief Returns a reference to the basis function derivatives.


### PR DESCRIPTION
this allows simplifying the MxFiniteElement::(Hessian|Jacobian) methods.

add a type alias and a helper class to make it convenient.