### PR TITLE
Changed: Remove "with grading" printout when explicit knots

### DIFF
--- a/src/SIM/SIM1D.C
+++ b/src/SIM/SIM1D.C
@@ -110,11 +110,11 @@ bool SIM1D::parseGeometryTag (const TiXmlElement* elem)
 
       for (int j : patches)
       {
-        IFEM::cout <<"\tRefining P"<< j <<" with ";
+        IFEM::cout <<"\tRefining P"<< j;
         if (refdata && isalpha(refdata[0]))
-          IFEM::cout <<"grading "<< refdata <<":";
+          IFEM::cout <<" with grading "<< refdata <<":";
         else
-          IFEM::cout <<"explicit knots:";
+          IFEM::cout <<" with explicit knots:";
         for (size_t i = 0; i < xi.size(); i++)
           IFEM::cout << (i%10 || xi.size() < 11 ? " " : "\n\t") << xi[i];
         IFEM::cout << std::endl;

--- a/src/SIM/SIM2D.C
+++ b/src/SIM/SIM2D.C
@@ -146,10 +146,12 @@ bool SIM2D::parseGeometryTag (const TiXmlElement* elem)
       double scale = 1.0;
       utl::getAttribute(elem,"dir",dir);
       utl::getAttribute(elem,"scale",scale);
+      const char* refdata = elem->FirstChild()->Value();
       for (int j : patches)
       {
-        IFEM::cout <<"\tRefining P"<< j <<" dir="<< dir
-                   <<" with grading "<< elem->FirstChild()->Value() <<":";
+        IFEM::cout <<"\tRefining P"<< j <<" dir="<< dir;
+        if (refdata && isalpha(refdata[0]))
+          IFEM::cout <<" with grading "<< refdata <<":";
         for (size_t i = 0; i < xi.size(); i++)
           IFEM::cout << (i%10 || xi.size() < 11 ? " " : "\n\t") << xi[i];
         IFEM::cout << std::endl;

--- a/src/SIM/SIM3D.C
+++ b/src/SIM/SIM3D.C
@@ -135,10 +135,12 @@ bool SIM3D::parseGeometryTag (const TiXmlElement* elem)
       // Non-uniform (graded) refinement
       int dir = 1;
       utl::getAttribute(elem,"dir",dir);
+      const char* refdata = elem->FirstChild()->Value();
       for (int j : patches)
       {
-        IFEM::cout <<"\tRefining P"<< j <<" dir="<< dir
-                   <<" with grading "<< elem->FirstChild()->Value() <<":";
+        IFEM::cout <<"\tRefining P"<< j <<" dir="<< dir;
+        if (refdata && isalpha(refdata[0]))
+          IFEM::cout <<" with grading "<< refdata <<":";
         for (size_t i = 0; i < xi.size(); i++)
           IFEM::cout << (i%10 || xi.size() < 11 ? " " : "\n\t") << xi[i];
         IFEM::cout << std::endl;


### PR DESCRIPTION
Cosmetic change, to avoid double print of the explicit knot definition. Hopefully without regression..