### PR TITLE
ExprFunctions: some modernization

### DIFF
--- a/src/Utility/ExprFunctions.C
+++ b/src/Utility/ExprFunctions.C
@@ -91,7 +91,7 @@ int EvalFunc::numError = 0;
 
 
 EvalFunc::EvalFunc (const char* function, const char* x, Real eps)
-  : gradient(nullptr), dx(eps)
+  : dx(eps)
 {
   try {
 #ifdef USE_OPENMP
@@ -105,51 +105,31 @@ EvalFunc::EvalFunc (const char* function, const char* x, Real eps)
     expr.resize(nalloc);
     arg.resize(nalloc);
     for (size_t i = 0; i < nalloc; ++i) {
-      expr[i] = new Expression;
-      f[i] = new FunctionList;
-      v[i] = new ValueList;
+      expr[i] = std::make_unique<Expression>();
+      f[i] = std::make_unique<FunctionList>();
+      v[i] = std::make_unique<ValueList>();
       f[i]->AddDefaultFunctions();
       v[i]->AddDefaultValues();
       v[i]->Add(x,0.0,false);
-      expr[i]->SetFunctionList(f[i]);
-      expr[i]->SetValueList(v[i]);
+      expr[i]->SetFunctionList(f[i].get());
+      expr[i]->SetValueList(v[i].get());
       expr[i]->Parse(function);
       arg[i] = v[i]->GetAddress(x);
     }
   }
   catch (ExprEval::Exception& e) {
-    this->cleanup();
     ExprException(e,"parsing",function);
   }
 }
 
 
-EvalFunc::~EvalFunc ()
-{
-  this->cleanup();
-}
-
-
-void EvalFunc::cleanup ()
-{
-  for (Expression* it : expr)
-    delete it;
-  for (FunctionList* it : f)
-    delete it;
-  for (ValueList* it : v)
-    delete it;
-  delete gradient;
-  expr.clear();
-  f.clear();
-  v.clear();
-  arg.clear();
-}
+EvalFunc::~EvalFunc () = default;
 
 
 void EvalFunc::addDerivative (const std::string& function, const char* x)
 {
   if (!gradient)
-    gradient = new EvalFunc(function.c_str(),x);
+    gradient = std::make_unique<EvalFunc>(function.c_str(),x);
 }
 
 
@@ -185,7 +165,7 @@ Real EvalFunc::deriv (Real x) const
 
 
 EvalFunction::EvalFunction (const char* function, Real epsX, Real epsT)
-  : gradient{}, dgradient{}, dx(epsX), dt(epsT)
+  : dx(epsX), dt(epsT)
 {
   try {
 #ifdef USE_OPENMP
@@ -199,17 +179,17 @@ EvalFunction::EvalFunction (const char* function, Real epsX, Real epsT)
     expr.resize(nalloc);
     arg.resize(nalloc);
     for (size_t i = 0; i < nalloc; ++i) {
-      expr[i] = new Expression;
-      f[i] = new FunctionList;
-      v[i] = new ValueList;
+      expr[i] = std::make_unique<Expression>();
+      f[i] = std::make_unique<FunctionList>();
+      v[i] = std::make_unique<ValueList>();
       f[i]->AddDefaultFunctions();
       v[i]->AddDefaultValues();
       v[i]->Add("x",0.0,false);
       v[i]->Add("y",0.0,false);
       v[i]->Add("z",0.0,false);
       v[i]->Add("t",0.0,false);
-      expr[i]->SetFunctionList(f[i]);
-      expr[i]->SetValueList(v[i]);
+      expr[i]->SetFunctionList(f[i].get());
+      expr[i]->SetValueList(v[i].get());
       expr[i]->Parse(function);
       arg[i].x = v[i]->GetAddress("x");
       arg[i].y = v[i]->GetAddress("y");
@@ -218,7 +198,6 @@ EvalFunction::EvalFunction (const char* function, Real epsX, Real epsT)
     }
   }
   catch (ExprEval::Exception& e) {
-    this->cleanup();
     ExprException(e,"parsing",function);
   }
 
@@ -234,31 +213,7 @@ EvalFunction::EvalFunction (const char* function, Real epsX, Real epsT)
 }
 
 
-EvalFunction::~EvalFunction ()
-{
-  this->cleanup();
-}
-
-
-void EvalFunction::cleanup ()
-{
-  for (Expression* it : expr)
-    delete it;
-  for (FunctionList* it : f)
-    delete it;
-  for (ValueList* it : v)
-    delete it;
-  for (EvalFunction* it : gradient)
-    delete it;
-  for (EvalFunction* it : dgradient)
-    delete it;
-  expr.clear();
-  f.clear();
-  v.clear();
-  arg.clear();
-  gradient.fill(nullptr);
-  dgradient.fill(nullptr);
-}
+EvalFunction::~EvalFunction () = default;
 
 
 /*!
@@ -289,12 +244,12 @@ void EvalFunction::addDerivative (const std::string& function,
   if (d1 > 0 && d1 <= 4 && d2 < 1) // A first derivative is specified
   {
     if (!gradient[--d1])
-      gradient[d1] = new EvalFunction((variables+function).c_str());
+      gradient[d1] = std::make_unique<EvalFunction>((variables+function).c_str());
   }
   else if ((d1 = voigtIdx(d1,d2)) >= 0) // A second derivative is specified
   {
     if (!dgradient[d1])
-      dgradient[d1] = new EvalFunction((variables+function).c_str());
+      dgradient[d1] = std::make_unique<EvalFunction>((variables+function).c_str());
   }
 }
 
@@ -378,7 +333,7 @@ Real EvalFunction::dderiv (const Vec3& X, int d1, int d2) const
 
 void EvalFunction::setParam (const std::string& name, double value)
 {
-  for (ValueList* v1 : v) {
+  for (std::unique_ptr<ValueList>& v1 : v) {
     double* address = v1->GetAddress(name);
     if (!address)
       v1->Add(name,value,false);
@@ -421,15 +376,11 @@ EvalFunctions::EvalFunctions (const std::string& functions,
 {
   std::vector<std::string> components = splitComps(functions,variables);
   for (const std::string& comp : components)
-    p.push_back(new EvalFunction(comp.c_str()));
+    p.emplace_back(std::make_unique<EvalFunction>(comp.c_str()));
 }
 
 
-EvalFunctions::~EvalFunctions ()
-{
-  for (EvalFunction* it : p)
-    delete it;
-}
+EvalFunctions::~EvalFunctions () = default;
 
 
 void EvalFunctions::addDerivative (const std::string& functions,

--- a/src/Utility/ExprFunctions.C
+++ b/src/Utility/ExprFunctions.C
@@ -20,12 +20,17 @@
 #endif
 
 
+int EvalFunc::numError = 0;
+
+
+namespace {
+
 /*!
   Prints an error message with the exception occured to std::cerr.
 */
 
-static void ExprException (const ExprEval::Exception& exc, const char* task,
-                           const char* function = nullptr)
+void ExprException (const ExprEval::Exception& exc, const char* task,
+                    const char* function = nullptr)
 {
   std::cerr <<"\n *** Error "<< task <<" function";
   if (function)
@@ -87,7 +92,34 @@ static void ExprException (const ExprEval::Exception& exc, const char* task,
 }
 
 
-int EvalFunc::numError = 0;
+/*!
+  \brief Static helper that splits a function expression into components.
+*/
+
+std::vector<std::string> splitComps (const std::string& functions,
+                                     const std::string& variables)
+{
+  std::vector<std::string> comps;
+  size_t pos1 = functions.find("|");
+  size_t pos2 = 0;
+  while (pos2 < functions.size())
+  {
+    std::string func(variables);
+    if (!func.empty() && func[func.size()-1] != ';')
+      func += ';';
+    if (pos1 == std::string::npos)
+      func += functions.substr(pos2);
+    else
+      func += functions.substr(pos2,pos1-pos2);
+    comps.push_back(func);
+    pos2 = pos1 > 0 && pos1 < std::string::npos ? pos1+1 : pos1;
+    pos1 = functions.find("|",pos1+1);
+  }
+
+  return comps;
+}
+
+}
 
 
 EvalFunc::EvalFunc (const char* function, const char* x, Real eps)
@@ -216,31 +248,25 @@ EvalFunction::EvalFunction (const char* function, Real epsX, Real epsT)
 EvalFunction::~EvalFunction () = default;
 
 
-/*!
-  \brief Static helper converting an index pair into a single index.
-  \details Assuming Voigt notation ordering; 11, 22, 33, 12, 23, 13.
-*/
-
-static int voigtIdx (int d1, int d2)
-{
-  if (d1 > d2)
-    std::swap(d1,d2); // Assuming symmetry
-
-  if (d1 < 1 || d2 > 3)
-    return -1; // Out-of-range
-  else if (d2-d1 == 0) // diagonal term, 11, 22 and 33
-    return d1-1;
-  else if (d2-d1 == 1) // off-diagonal term, 12 and 23
-    return d2+1;
-  else // off-diagonal term, 13
-    return 5;
-}
-
-
 void EvalFunction::addDerivative (const std::string& function,
                                   const std::string& variables,
                                   int d1, int d2)
 {
+  auto&& voigtIdx = [](int d1, int d2)
+  {
+    if (d1 > d2)
+      std::swap(d1,d2); // Assuming symmetry
+
+    if (d1 < 1 || d2 > 3)
+      return -1; // Out-of-range
+    else if (d2-d1 == 0) // diagonal term, 11, 22 and 33
+      return d1-1;
+    else if (d2-d1 == 1) // off-diagonal term, 12 and 23
+      return d2+1;
+    else // off-diagonal term, 13
+      return 5;
+  };
+
   if (d1 > 0 && d1 <= 4 && d2 < 1) // A first derivative is specified
   {
     if (!gradient[--d1])
@@ -340,34 +366,6 @@ void EvalFunction::setParam (const std::string& name, double value)
     else
       *address = value;
   }
-}
-
-
-/*!
-  \brief Static helper that splits a function expression into components.
-*/
-
-static std::vector<std::string> splitComps (const std::string& functions,
-                                            const std::string& variables)
-{
-  std::vector<std::string> comps;
-  size_t pos1 = functions.find("|");
-  size_t pos2 = 0;
-  while (pos2 < functions.size())
-  {
-    std::string func(variables);
-    if (!func.empty() && func[func.size()-1] != ';')
-      func += ';';
-    if (pos1 == std::string::npos)
-      func += functions.substr(pos2);
-    else
-      func += functions.substr(pos2,pos1-pos2);
-    comps.push_back(func);
-    pos2 = pos1 > 0 && pos1 < std::string::npos ? pos1+1 : pos1;
-    pos1 = functions.find("|",pos1+1);
-  }
-
-  return comps;
 }
 
 

--- a/src/Utility/ExprFunctions.h
+++ b/src/Utility/ExprFunctions.h
@@ -63,10 +63,10 @@ public:
   void addDerivative(const std::string& function, const char* x = "x");
 
   //! \brief Returns whether the function is time-independent or not.
-  virtual bool isConstant() const { return false; }
+  bool isConstant() const override { return false; }
 
   //! \brief Returns the first-derivative of the function.
-  virtual Real deriv(Real x) const;
+  Real deriv(Real x) const override;
 
 protected:
   //! \brief Non-implemented copy constructor to disallow copying.
@@ -74,7 +74,7 @@ protected:
   //! \brief Non-implemented assignment operator to disallow copying.
   EvalFunc& operator=(const EvalFunc&) = delete;
   //! \brief Evaluates the function expression.
-  virtual Real evaluate(const Real& x) const;
+  Real evaluate(const Real& x) const override;
 };
 
 
@@ -124,12 +124,12 @@ public:
                      int d1, int d2 = 0);
 
   //! \brief Returns whether the function is time-independent or not.
-  virtual bool isConstant() const { return IAmConstant; }
+  bool isConstant() const override { return IAmConstant; }
 
   //! \brief Returns first-derivative of the function.
-  virtual Real deriv(const Vec3& X, int dir) const;
+  Real deriv(const Vec3& X, int dir) const override;
   //! \brief Returns second-derivative of the function.
-  virtual Real dderiv(const Vec3& X, int dir1, int dir2) const;
+  Real dderiv(const Vec3& X, int dir1, int dir2) const override;
 
   //! \brief Set an additional parameter in the function.
   void setParam(const std::string& name, double value);
@@ -140,7 +140,7 @@ protected:
   //! \brief Non-implemented assignment operator to disallow copying.
   EvalFunction& operator=(const EvalFunction&) = delete;
   //! \brief Evaluates the function expression.
-  virtual Real evaluate(const Vec3& X) const;
+  Real evaluate(const Vec3& X) const override;
 };
 
 
@@ -188,7 +188,7 @@ public:
   virtual ~EvalMultiFunction() {}
 
   //! \brief Returns whether the function is time-independent or not.
-  virtual bool isConstant() const
+  bool isConstant() const override
   {
     for (const std::unique_ptr<EvalFunction>& func : p)
       if (!func->isConstant())
@@ -197,12 +197,12 @@ public:
   }
 
   //! \brief Returns the function type flag.
-  virtual unsigned char getType() const { return 2; }
+  unsigned char getType() const override { return 2; }
 
   //! \brief Returns first-derivative of the function.
-  virtual Ret deriv(const Vec3& X, int dir) const;
+  Ret deriv(const Vec3& X, int dir) const override;
   //! \brief Returns second-derivative of the function.
-  virtual Ret dderiv(const Vec3& X, int dir1, int dir2) const;
+  Ret dderiv(const Vec3& X, int dir1, int dir2) const override;
 
   //! \brief Set an additional parameter in the function.
   void setParam(const std::string& name, double value)
@@ -216,7 +216,7 @@ protected:
   void setNoDims() { ParentFunc::ncmp = nsd = p.size(); }
 
   //! \brief Evaluates the function expressions.
-  virtual Ret evaluate(const Vec3& X) const;
+  Ret evaluate(const Vec3& X) const override;
 };
 
 //! Vector-valued function expression

--- a/src/Utility/ExprFunctions.h
+++ b/src/Utility/ExprFunctions.h
@@ -220,11 +220,11 @@ protected:
 };
 
 //! Vector-valued function expression
-typedef EvalMultiFunction<VecFunc,Vec3>           VecFuncExpr;
+using VecFuncExpr = EvalMultiFunction<VecFunc,Vec3>;
 //! Tensor-valued function expression
-typedef EvalMultiFunction<TensorFunc,Tensor>      TensorFuncExpr;
+using TensorFuncExpr = EvalMultiFunction<TensorFunc,Tensor>;
 //! Symmetric tensor-valued function expression
-typedef EvalMultiFunction<STensorFunc,SymmTensor> STensorFuncExpr;
+using STensorFuncExpr = EvalMultiFunction<STensorFunc,SymmTensor>;
 
 //! \brief Specialization for vector functions.
 template<> Vec3 VecFuncExpr::evaluate(const Vec3& X) const;


### PR DESCRIPTION
- use language construct to manage pointers
- use anon namespace
- use override
- use type aliases, not typedefs

Sits on top of https://github.com/OPM/IFEM/pull/635