### PR TITLE
Deactivate multi-threading for patches with rigid coupling

### DIFF
--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -1630,3 +1630,14 @@ bool ASMbase::writeLagBasis (std::ostream& os, const char* type) const
 
   return true;
 }
+
+
+void ASMbase::getBoundaryElms (int lIndex, IntVec& elms,
+                               int orient, bool local) const
+{
+  this->findBoundaryElms(elms,lIndex,orient);
+  if (local) return;
+
+  for (int& elm : elms)
+    elm = MLGE[elm]-1;
+}

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -229,14 +229,15 @@ public:
   virtual Vec3 getCoord(size_t inod) const = 0;
   //! \brief Returns a matrix with all nodal coordinates within the patch.
   //! \param[out] X nsd\f$\times\f$n-matrix, where \a n is the number of nodes
-  //! \param[in] geo If true returns coordinates for geometry basis
-  //! in the patch
+  //! \param[in] geo If \e true, coordinates for the geometry basis are returned
+  //! otherwise the integration basis coordinates are returned
   virtual void getNodalCoordinates(Matrix& X, bool geo = false) const = 0;
   //! \brief Returns a matrix with nodal coordinates for an element.
-  //! \param[in] iel 1-based element index local to current patch
-  //! \param[in] forceItg If true force returning integration basis coordinates
   //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes
   //! in one element
+  //! \param[in] iel 1-based element index local to current patch
+  //! \param[in] forceItg If \e true, return the integration basis coordinates
+  //! otherwise the geometry basis coordinates are returned
   virtual bool getElementCoordinates(Matrix& X, int iel,
                                      bool forceItg = false) const = 0;
 
@@ -245,7 +246,7 @@ public:
   //! \param nodes Array of node numbers
   //! \param[in] basis Which basis to grab nodes for (for mixed methods)
   //! \param[in] thick Thickness of connection
-  //! \param[in] orient Local orientation of the boundary face/edge
+  //! \param[in] orient Local orientation flag (for LR splines only)
   //! \param[in] local If \e true, return patch-local numbers
   virtual void getBoundaryNodes(int lIndex, IntVec& nodes,
                                 int basis = 0, int thick = 1,
@@ -262,11 +263,13 @@ public:
                                  int basis = 0, int orient = -1,
                                  bool local = false, bool open = false) const {}
 
-  //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
-  //! \param[in] lIndex Local index of the boundary face/edge
-  //! \param[in] orient Local orientation of the boundary face/edge
+  //! \brief Finds the global (or patch-local) element numbers on a boundary.
+  //! \param[in] lIndex Local index of the boundary face/edge/vertex
   //! \param[out] elms Array of element numbers
-  virtual void getBoundaryElms(int lIndex, int orient, IntVec& elms) const = 0;
+  //! \param[in] orient Local orientation flag (for LR splines only)
+  //! \param[in] local If \e true, return patch-local element numbers
+  void getBoundaryElms(int lIndex, IntVec& elms,
+                       int orient = -1, bool local = false) const;
 
   //! \brief Returns (1-based) index of a predefined node set in the patch.
   virtual int getNodeSetIdx(const std::string&) const { return 0; }
@@ -820,6 +823,12 @@ protected:
   //! \param[in] tol Zero tolerance
   int searchCtrlPt(RealArray::const_iterator cit, RealArray::const_iterator end,
                    const Vec3& X, int dimension, double tol = 0.001) const;
+
+  //! \brief Finds the patch-local element numbers on a patch boundary.
+  //! \param[out] elms Array of element numbers
+  //! \param[in] lIndex Local index of the boundary face/edge/vertex
+  //! \param[in] orient Local orientation flag (for LR splines only)
+  virtual void findBoundaryElms(IntVec& elms, int lIndex, int orient) const = 0;
 
   //! \brief Assembles L2-projection matrices for the secondary solution.
   //! \param[out] A Left-hand-side matrix

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -1893,10 +1893,7 @@ void ASMs1D::getElmConnectivities (IntMat& neigh) const
 }
 
 
-void ASMs1D::getBoundaryElms (int lIndex, int, IntVec& elms) const
+void ASMs1D::findBoundaryElms (IntVec& elms, int lIndex, int) const
 {
-  if (lIndex == 1)
-    elms = {0};
-  else
-    elms = {MLGE[nel-1]-1};
+  elms = { lIndex == 1 ? 0 : static_cast<int>(nel)-1 };
 }

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -125,11 +125,6 @@ public:
   virtual void getBoundaryNodes(int lIndex, IntVec& nodes,
                                 int, int thick, int, bool local) const;
 
-  //! \brief Finds the global (or patch-local) node number on a patch end.
-  //! \param[in] lIndex Local index of the end point
-  //! \param[out] elms Array of global element numbers
-  virtual void getBoundaryElms(int lIndex, int, IntVec& elms) const;
-
   //! \brief Finds the node that is closest to the given point.
   //! \param[in] X Global coordinates of point to search for
   //! \return 1-based nodal index and distance to to the found node
@@ -343,6 +338,11 @@ protected:
 
   // Internal utility methods
   // ========================
+
+  //! \brief Finds the path-local element numbers on a patch boundary.
+  //! \param[out] elms Array of element numbers
+  //! \param[in] lIndex Local index of the end point
+  virtual void findBoundaryElms(IntVec& elms, int lIndex, int = 0) const;
 
   //! \brief Assembles L2-projection matrices for the secondary solution.
   //! \param[out] A Left-hand-side matrix

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -3239,7 +3239,7 @@ void ASMs2D::getElmConnectivities (IntMat& neigh) const
 }
 
 
-void ASMs2D::getBoundaryElms (int lIndex, int, IntVec& elms) const
+void ASMs2D::findBoundaryElms (IntVec& elms, int lIndex, int) const
 {
   int N1m = surf->numCoefs_u() - surf->order_u() + 1;
   int N2m = surf->numCoefs_v() - surf->order_v() + 1;
@@ -3250,13 +3250,13 @@ void ASMs2D::getBoundaryElms (int lIndex, int, IntVec& elms) const
   case 2:
     elms.reserve(N2m);
     for (int i = 0; i < N2m; ++i)
-      elms.push_back(MLGE[i*N1m + (lIndex-1)*(N1m-1)] - 1);
+      elms.push_back(i*N1m + (lIndex-1)*(N1m-1));
     break;
   case 3:
   case 4:
     elms.reserve(N1m);
     for (int i = 0; i < N1m; ++i)
-      elms.push_back(MLGE[i + (lIndex-3)*N1m*(N2m-1)] - 1);
+      elms.push_back(i + (lIndex-3)*N1m*(N2m-1));
   }
 }
 

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -3279,29 +3279,10 @@ void ASMs2D::generateThreadGroupsFromElms (const IntVec& elms)
 bool ASMs2D::addRigidCpl (int lindx, int ldim, int basis,
                           int& gMaster, const Vec3& Xmaster, bool extraPt)
 {
-  if (ldim == 1)
-  {
-    ThreadGroups::StripDirection useDir = ThreadGroups::ANY;
-    switch (lindx) {
-    case 1:
-    case 2:
-      useDir = ThreadGroups::U;
-      break;
-    case 3:
-    case 4:
-      useDir = ThreadGroups::V;
-      break;
-    }
-
-    if (threadGroups.stripDir == ThreadGroups::ANY)
-      threadGroups.stripDir = useDir;
-    else if (threadGroups.stripDir != useDir)
-    {
-      threadGroups.stripDir = ThreadGroups::NONE;
-      IFEM::cout <<"  ** ASMs2D::addRigidCpl: Conflicting strip directions."
-                 << std::endl;
-    }
-  }
+  if (threadGroups.stripDir != ThreadGroups::NONE)
+    IFEM::cout <<"  ** ASMs2D::addRigidCpl: Multi-threading deactivated"
+               <<" for Patch "<< idx+1 << std::endl;
+  threadGroups.stripDir = ThreadGroups::NONE;
 
   return this->ASMstruct::addRigidCpl(lindx,ldim,basis,gMaster,Xmaster,extraPt);
 }

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -80,8 +80,7 @@ protected:
     virtual ~BasisFunctionCache() = default;
 
     //! \brief Returns number of elements in each direction.
-    const std::array<size_t,2>& noElms() const
-    { return nel; }
+    const std::array<size_t,2>& noElms() const { return nel; }
 
   protected:
     //! \brief Implementation specific initialization.
@@ -105,22 +104,21 @@ protected:
     //! \param reduced True to return index for reduced quadrature
     size_t index(size_t el, size_t gp, bool reduced) const override;
 
-  protected:
-    //! \brief Configure quadratures.
-    bool setupQuadrature();
-
     //! \brief Setup integration point parameters.
     virtual void setupParameters();
 
     const ASMs2D& patch; //!< Reference to patch cache is for
 
     int basis; //!< Basis to use
-    std::array<size_t,2> nel{0,0}; //!< Number of elements in each direction
+    std::array<size_t,2> nel; //!< Number of elements in each direction
 
   private:
     //! \brief Obtain structured element indices.
     //! \param el Global element index
     std::array<size_t,2> elmIndex(size_t el) const;
+
+    //! \brief Configure quadratures.
+    bool setupQuadrature();
   };
 
 public:
@@ -238,16 +236,17 @@ public:
   virtual int getNodeID(size_t inod, bool noAddedNodes = false) const;
 
   //! \brief Returns a matrix with nodal coordinates for an element.
-  //! \param[in] iel Element index
   //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes
   //! in one element
-  //! \param[in] forceItg If true return integration basis element coordinates
+  //! \param[in] iel 1-based element index local to current patch
+  //! \param[in] forceItg If \e true, return the integration basis coordinates
+  //! otherwise the geometry basis coordinates are returned
   virtual bool getElementCoordinates(Matrix& X, int iel, bool forceItg = false) const;
 
   //! \brief Returns a matrix with all nodal coordinates within the patch.
   //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes
-  //! \param[in] geo If true return coordinates of geometry basis
-  //! in the patch
+  //! \param[in] geo If \e true, coordinates for the geometry basis are returned
+  //! otherwise the integration basis coordinates are returned
   virtual void getNodalCoordinates(Matrix& X, bool geo = false) const;
 
   //! \brief Returns the global coordinates for the given node.
@@ -267,11 +266,6 @@ public:
   virtual void getBoundaryNodes(int lIndex, IntVec& nodes,
                                 int basis, int thick = 1,
                                 int = 0, bool local = false) const;
-
-  //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
-  //! \param[in] lIndex Local index of the boundary face/edge
-  //! \param[out] elms Array of element numbers
-  virtual void getBoundaryElms(int lIndex, int, IntVec& elms) const;
 
   //! \brief Returns the node index for a given corner.
   //! \param[in] I -1 or +1 for either umin or umax corner
@@ -316,6 +310,7 @@ public:
 
   //! \brief Checks if a separate projection basis is used for this patch.
   virtual bool separateProjectionBasis() const;
+
 
   // Various methods for preprocessing of boundary conditions and patch topology
   // ===========================================================================
@@ -588,6 +583,11 @@ protected:
 
   // Internal utility methods
   // ========================
+
+  //! \brief Finds the patch-local element numbers on a patch boundary.
+  //! \param[out] elms Array of element numbers
+  //! \param[in] lIndex Local index of the boundary edge
+  virtual void findBoundaryElms(IntVec& elms, int lIndex, int = 0) const;
 
   //! \brief Assembles L2-projection matrices for the secondary solution.
   //! \param[out] A Left-hand-side matrix

--- a/src/ASM/ASMs2DC1.C
+++ b/src/ASM/ASMs2DC1.C
@@ -20,6 +20,7 @@
 #include "Vec3Oper.h"
 #include "Vec3.h"
 #include "MPC.h"
+#include "IFEM.h"
 
 //! \brief Solves A1j*xi*eta + A2j*ci + A3j*eta = A4j, j=1,2 for xi,eta.
 extern "C" void dslbln_(const int& ipsw, const int& iwr, const double& eps,
@@ -317,6 +318,11 @@ bool ASMs2DC1::addRigidCpl (int lindx, int ldim, int basis,
       return false;
     }
   }
+
+  if (threadGroups.stripDir != ThreadGroups::NONE)
+    IFEM::cout <<"  ** ASMs2DC1::addRigidCpl: Multi-threading deactivated"
+               <<" for Patch "<< idx+1 << std::endl;
+  threadGroups.stripDir = ThreadGroups::NONE;
 
   return extraPt;
 }

--- a/src/ASM/ASMs2DLag.C
+++ b/src/ASM/ASMs2DLag.C
@@ -789,6 +789,28 @@ void ASMs2DLag::generateThreadGroups (const Integrand&, bool, bool)
 }
 
 
+void ASMs2DLag::findBoundaryElms (IntVec& elms, int lIndex, int) const
+{
+  const int N1m = (nx-1)/(p1-1);
+  const int N2m = (ny-1)/(p2-1);
+
+  elms.clear();
+  switch (lIndex) {
+  case 1:
+  case 2:
+    elms.reserve(N2m);
+    for (int i = 0; i < N2m; ++i)
+      elms.push_back(i*N1m + (lIndex-1)*(N1m-1));
+    break;
+  case 3:
+  case 4:
+    elms.reserve(N1m);
+    for (int i = 0; i < N1m; ++i)
+      elms.push_back(i + (lIndex-3)*N1m*(N2m-1));
+  }
+}
+
+
 bool ASMs2DLag::write(std::ostream& os, int) const
 {
   return this->writeLagBasis(os, "quad");

--- a/src/ASM/ASMs2DLag.h
+++ b/src/ASM/ASMs2DLag.h
@@ -128,6 +128,11 @@ protected:
   //! \param[in] Xnod Coordinates of the node
   void setCoord(size_t inod, const Vec3& Xnod);
 
+  //! \brief Finds the patch-local element numbers on a patch boundary.
+  //! \param[out] elms Array of element numbers
+  //! \param[in] lIndex Local index of the boundary edge
+  virtual void findBoundaryElms(IntVec& elms, int lIndex, int = 0) const;
+
   //! \brief Find element for parameter, and optionally calculate local coordinates.
   int findElement(double u, double v,
                   double* xi = nullptr, double* eta = nullptr) const;

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -3776,7 +3776,7 @@ void ASMs3D::getElmConnectivities (IntMat& neigh) const
 }
 
 
-void ASMs3D::getBoundaryElms (int lIndex, int, IntVec& elms) const
+void ASMs3D::findBoundaryElms (IntVec& elms, int lIndex, int) const
 {
   int N1m = svol->numCoefs(0) - svol->order(0) + 1;
   int N2m = svol->numCoefs(1) - svol->order(1) + 1;
@@ -3789,21 +3789,21 @@ void ASMs3D::getBoundaryElms (int lIndex, int, IntVec& elms) const
     elms.reserve(N2m*N3m);
     for (int k = 0; k < N3m; ++k)
       for (int j = 0; j < N2m; ++j)
-        elms.push_back(MLGE[j*N1m + k*N1m*N2m + (lIndex-1)*(N1m-1)] - 1);
+        elms.push_back(j*N1m + k*N1m*N2m + (lIndex-1)*(N1m-1));
     break;
   case 3:
   case 4:
     elms.reserve(N1m*N3m);
     for (int k = 0; k < N3m; ++k)
       for (int i = 0; i < N1m; ++i)
-        elms.push_back(MLGE[i + k*N1m*N2m + (lIndex-3)*(N1m*(N2m-1))] - 1);
+        elms.push_back(i + k*N1m*N2m + (lIndex-3)*(N1m*(N2m-1)));
     break;
   case 5:
   case 6:
     elms.reserve(N1m*N2m);
     for (int j = 0; j < N2m; ++j)
       for (int i = 0; i < N1m; ++i)
-        elms.push_back(MLGE[i + j*N1m + (lIndex-5)*(N1m*N2m*(N3m-1))] - 1);
+        elms.push_back(i + j*N1m + (lIndex-5)*(N1m*N2m*(N3m-1)));
   }
 }
 

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -96,10 +96,9 @@ protected:
     virtual ~BasisFunctionCache() = default;
 
     //! \brief Returns number of elements in each direction.
-    const std::array<size_t,3>& noElms() const
-    { return nel; }
+    const std::array<size_t,3>& noElms() const { return nel; }
 
- protected:
+  protected:
     //! \brief Implementation specific initialization.
     bool internalInit() override;
 
@@ -108,7 +107,7 @@ protected:
 
     //! \brief Calculates basis function info in a single integration point.
     //! \param el Element of integration point (0-indexed)
-    //! \param gp Integratin point on element (0-indexed)
+    //! \param gp Integration point on element (0-indexed)
     //! \param reduced If true, returns values for reduced integration scheme
     BasisFunctionVals calculatePt(size_t el, size_t gp, bool reduced) const override;
 
@@ -129,7 +128,7 @@ protected:
     int basis; //!< Basis to use
     std::array<size_t,3> nel; //!< Number of elements in each direction
 
-private:
+  private:
     //! \brief Obtain structured element indices.
     //! \param el Global element index
     std::array<size_t,3> elmIndex(size_t el) const;
@@ -210,9 +209,9 @@ public:
   //! \param[in] dir Parameter direction defining which boundary to return
   virtual Go::SplineSurface* getBoundary(int dir, int = 1);
   //! \brief Returns the spline volume representing a basis of this patch.
-  virtual const Go::SplineVolume* getBasis(int basis = 1) const;
-  //! \brief Returns the spline volume representing a basis of this patch.
   virtual Go::SplineVolume* getBasis(int basis = 1);
+  //! \brief Returns the spline volume representing a basis of this patch.
+  virtual const Go::SplineVolume* getBasis(int basis = 1) const;
   //! \brief Copies the parameter domain from the \a other patch.
   virtual void copyParameterDomain(const ASMbase* other);
 
@@ -253,16 +252,17 @@ public:
   virtual int getNodeID(size_t inod, bool noAddedNodes = false) const;
 
   //! \brief Returns a matrix with nodal coordinates for an element.
-  //! \param[in] iel Element index
   //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes
   //! in one element
-  //! \param[in] forceItg If true return integration basis element coordinates
+  //! \param[in] iel 1-based element index local to current patch
+  //! \param[in] forceItg If \e true, return the integration basis coordinates
+  //! otherwise the geometry basis coordinates are returned
   virtual bool getElementCoordinates(Matrix& X, int iel, bool forceItg = false) const;
 
   //! \brief Returns a matrix with all nodal coordinates within the patch.
   //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes
-  //! \param[in] geo If true returns coordinates for geometry basis
-  //! in the patch
+  //! \param[in] geo If \e true, coordinates for the geometry basis are returned
+  //! otherwise the integration basis coordinates are returned
   virtual void getNodalCoordinates(Matrix& X, bool geo = false) const;
 
   //! \brief Returns the global coordinates for the given node.
@@ -290,11 +290,6 @@ public:
   //! \param[in] open If \e true, exclude edge end points
   virtual void getBoundary1Nodes(int lEdge, IntVec& nodes, int basis, int = 0,
                                  bool local = false, bool open = false) const;
-
-  //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
-  //! \param[in] lIndex Local index of the boundary face/edge
-  //! \param[out] elms Array of element numbers
-  virtual void getBoundaryElms(int lIndex, int, IntVec& elms) const;
 
   //! \brief Returns the node index for a given corner.
   //! \param[in] I -1 or +1 for either umin or umax corner
@@ -659,6 +654,11 @@ protected:
 
   // Internal utility methods
   // ========================
+
+  //! \brief Finds the patch-local element numbers on a patch boundary.
+  //! \param[out] elms Array of element numbers
+  //! \param[in] lIndex Local index of the boundary face
+  virtual void findBoundaryElms(IntVec& elms, int lIndex, int = 0) const;
 
   //! \brief Assembles L2-projection matrices for the secondary solution.
   //! \param[out] A Left-hand-side matrix

--- a/src/ASM/ASMs3DLag.h
+++ b/src/ASM/ASMs3DLag.h
@@ -128,17 +128,23 @@ public:
   //! \param[in] nSegSpan Number of visualization segments over each knot-span
   virtual bool getGridParameters(RealArray& prm, int dir, int nSegSpan) const;
 
-  //! \brief Find element for parameter, and optionally calculate local coordinates.
-  virtual int findElement(double u, double v, double w, double* xi = nullptr,
-                          double* eta = nullptr, double* zeta = nullptr) const;
-
 protected:
   //! \brief Assigned global coordinates for the given node.
   //! \param[in] inod 1-based node index local to current patch
   //! \param[in] Xnod Coordinates of the node
   void setCoord(size_t inod, const Vec3& Xnod);
 
+  //! \brief Finds the patch-local element numbers on a patch boundary.
+  //! \param[out] elms Array of element numbers
+  //! \param[in] lIndex Local index of the boundary face
+  virtual void findBoundaryElms(IntVec& elms, int lIndex, int = 0) const;
+
 public:
+  //! \brief Find element for parameter, and optionally calculate local coordinates.
+  virtual int findElement(double u, double v, double w,
+                          double* xi = nullptr, double* eta = nullptr,
+                          double* zeta = nullptr) const;
+
   //! \brief Updates the nodal coordinates for this patch.
   //! \param[in] displ Incremental displacements to update the coordinates with
   virtual bool updateCoords(const Vector& displ);

--- a/src/ASM/ASMsupel.h
+++ b/src/ASM/ASMsupel.h
@@ -76,7 +76,7 @@ public:
                                 int, int, int, bool local) const;
 
   //! \brief Dummy method doing nothing.
-  virtual void getBoundaryElms(int, int, IntVec&) const {}
+  virtual void findBoundaryElms(IntVec&, int, int) const {}
   //! \brief Dummy method doing nothing.
   virtual bool getParameterDomain(Real2DMat&, IntVec*) const { return false; }
   //! \brief Dummy method doing nothing.

--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -2928,7 +2928,7 @@ void ASMu2D::getElmConnectivities (IntMat& neigh) const
 }
 
 
-void ASMu2D::getBoundaryElms (int lIndex, int orient, IntVec& elms) const
+void ASMu2D::findBoundaryElms (IntVec& elms, int lIndex, int orient) const
 {
   std::vector<LR::Element*> elements;
   switch (lIndex) {
@@ -2939,18 +2939,18 @@ void ASMu2D::getBoundaryElms (int lIndex, int orient, IntVec& elms) const
   default: return;
   }
 
-  // Lambda function for sorting wrt. element centre coordinate
-  auto&& onMidPoint = [orient,lIndex](LR::Element* a, LR::Element* b)
-  {
-    int index = lIndex < 3 ? 1 : 0;
-    double am = a->midpoint()[index];
-    double bm = b->midpoint()[index];
-    return orient == 1 ? bm < am : am < bm;
-  };
+  if (orient >= 0)
+    std::sort(elements.begin(), elements.end(),
+              [orient,lIndex](LR::Element* a, LR::Element* b)
+              {
+                int index = lIndex < 3 ? 1 : 0;
+                double am = a->midpoint()[index];
+                double bm = b->midpoint()[index];
+                return orient == 1 ? bm < am : am < bm;
+              });
 
-  std::sort(elements.begin(),elements.end(),onMidPoint);
   for (const LR::Element* elem : elements)
-    elms.push_back(MLGE[elem->getId()]-1);
+    elms.push_back(elem->getId());
 }
 
 

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -190,12 +190,6 @@ public:
   virtual void getBoundaryNodes(int lIndex, IntVec& nodes, int basis, int = 1,
                                 int orient = 0, bool local = false) const;
 
-  //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
-  //! \param[in] lIndex Local index of the boundary face/edge
-  //! \param[in] orient Orientation of boundary (used for sorting)
-  //! \param[out] elms Array of element numbers
-  virtual void getBoundaryElms(int lIndex, int orient, IntVec& elms) const;
-
   //! \brief Returns the polynomial order in each parameter direction.
   //! \param[out] p1 Order in first (u) direction
   //! \param[out] p2 Order in second (v) direction
@@ -559,6 +553,12 @@ protected:
 
   // Internal utility methods
   // ========================
+
+  //! \brief Finds the patch-local element numbers on a patch boundary.
+  //! \param[out] elms Array of element numbers
+  //! \param[in] lIndex Local index of the boundary edge
+  //! \param[in] orient Orientation of boundary (used for sorting)
+  virtual void findBoundaryElms(IntVec& elms, int lIndex, int orient) const;
 
   //! \brief Assembles L2-projection matrices for the secondary solution.
   //! \param[out] A Left-hand-side matrix

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -617,15 +617,6 @@ protected:
   //! \param[out] XC Coordinates and parameters of the element corners
   void getCornerPoints(int iel, std::vector<utl::Point>& XC) const;
 
-  //! \brief Returns the node indices for a given edge.
-  //! \param nodes Array of node numbers
-  //! \param[in] edge Local index of the boundary edge
-  //! \param[in] basis Which basis to grab nodes for
-  //! \param[in] orient Orientation of boundary (used for sorting)
-  //! \param[in] local If \e true, return patch-local node numbers
-  void getEdgeNodes(IntVec& nodes, int edge, int basis,
-                    int orient, bool local) const;
-
   //! \brief Evaluates the basis functions and derivatives of an element.
   //! \param[in] iel 0-based element index
   //! \param fe Integration point data for current element

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -2355,33 +2355,32 @@ void ASMu3D::getElmConnectivities (IntMat& neigh) const
 }
 
 
-void ASMu3D::getBoundaryElms (int lIndex, int orient, IntVec& elms) const
+void ASMu3D::findBoundaryElms (IntVec& elms, int lIndex, int orient) const
 {
   std::vector<LR::Element*> elements;
   this->getBasis(1)->getEdgeElements(elements,getFaceEnum(lIndex));
 
-  std::sort(elements.begin(), elements.end(),
-            [lIndex,orient](const LR::Element* a, const LR::Element* b)
-            {
-              int dir = (lIndex - 1) / 2;
-              int u = dir == 0 ? 1 : 0;
-              int v = 1 + (dir != 2 ? 1 : 0);
-              int idx = (orient & 4) ? v : u;
-              auto A = a->midpoint();
-              auto B = b->midpoint();
-              if (A[idx] != B[idx])
-                return (orient & 2) ? A[idx] > B[idx] : A[idx] < B[idx];
+  if (orient >= 0)
+    std::sort(elements.begin(), elements.end(),
+              [lIndex,orient](const LR::Element* a, const LR::Element* b)
+              {
+                int u = lIndex <= 2 ? 1 : 0;
+                int v = lIndex >= 5 ? 1 : 2;
+                int idx = (orient & 4) ? v : u;
+                std::vector<double> A = a->midpoint();
+                std::vector<double> B = b->midpoint();
+                if (A[idx] != B[idx])
+                  return (orient & 2) ? A[idx] > B[idx] : A[idx] < B[idx];
 
-              idx = (orient & 4) ? u : v;
-              if (A[idx] != B[idx])
-                return (orient & 1) ? A[idx] > B[idx] : A[idx] < B[idx];
+                idx = (orient & 4) ? u : v;
+                if (A[idx] != B[idx])
+                  return (orient & 1) ? A[idx] > B[idx] : A[idx] < B[idx];
 
-              return false;
-            });
-
+                return false;
+              });
 
   for (const LR::Element* elem : elements)
-    elms.push_back(MLGE[elem->getId()]-1);
+    elms.push_back(elem->getId());
 }
 
 

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -189,12 +189,6 @@ public:
                                  int orient, bool local,
                                  bool open = false) const;
 
-  //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
-  //! \param[in] lIndex Local index of the boundary face/edge
-  //! \param[in] orient Orientation of boundary (used for sorting)
-  //! \param[out] elms Array of element numbers
-  virtual void getBoundaryElms(int lIndex, int orient, IntVec& elms) const;
-
   //! \brief Returns the node index for a given corner.
   //! \param[in] I -1 or +1 for either umin or umax corner
   //! \param[in] J -1 or +1 for either vmin or vmax corner
@@ -571,6 +565,12 @@ protected:
 
   // Internal utility methods
   // ========================
+
+  //! \brief Finds the patch-local element numbers on a patch boundary.
+  //! \param[out] elms Array of element numbers
+  //! \param[in] lIndex Local index of the boundary face
+  //! \param[in] orient Orientation of boundary (used for sorting)
+  virtual void findBoundaryElms(IntVec& elms, int lIndex, int orient) const;
 
   //! \brief Assembles L2-projection matrices for the secondary solution.
   //! \param[out] A Left-hand-side matrix

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -166,9 +166,6 @@ public:
   //! \param[in] displ Incremental displacements to update the coordinates with
   virtual bool updateCoords(const Vector& displ);
 
-  //! \brief Returns the node indices for a given face.
-  IntVec getFaceNodes(int face, int basis = 1, int orient = -1) const;
-
   //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
   //! \param[in] lIndex Local index of the boundary face
   //! \param nodes Array of node numbers

--- a/src/ASM/Test/TestASMs1D.C
+++ b/src/ASM/Test/TestASMs1D.C
@@ -134,7 +134,7 @@ TEST(TestASMs1D, BoundaryElements)
   IntMat neigh(3);
   std::array<IntVec,2> n;
   for (size_t i = 1; i <= 2; ++i) {
-    pch1.getBoundaryElms(i, 0, n[i-1]);
+    pch1.getBoundaryElms(i, n[i-1]);
     ASSERT_EQ(n[i-1].size(), 1U);
     EXPECT_EQ(n[i-1][0], i == 1 ? 0 : 2);
   }

--- a/src/ASM/Test/TestASMs2D.C
+++ b/src/ASM/Test/TestASMs2D.C
@@ -50,7 +50,7 @@ TEST(TestASMs2D, BoundaryElements)
 
   std::array<IntVec,4> n;
   for (size_t i = 1; i <= 4; ++i) {
-    pch1.getBoundaryElms(i, 0, n[i-1]);
+    pch1.getBoundaryElms(i, n[i-1]);
     ASSERT_EQ(n[i-1].size(), ref[i-1].size());
     for (size_t j = 0; j < ref[i-1].size(); ++j)
       EXPECT_EQ(n[i-1][j], ref[i-1][j]);

--- a/src/ASM/Test/TestASMs3D.C
+++ b/src/ASM/Test/TestASMs3D.C
@@ -64,7 +64,7 @@ TEST(TestASMs3D, BoundaryElements)
 
   std::array<IntVec,6> n;
   for (size_t i = 1; i <= 6; ++i) {
-    pch1.getBoundaryElms(i, 0, n[i-1]);
+    pch1.getBoundaryElms(i, n[i-1]);
     ASSERT_EQ(n[i-1].size(), ref[i-1].size());
     for (size_t j = 0; j < ref[i-1].size(); ++j)
       EXPECT_EQ(n[i-1][j], ref[i-1][j]);

--- a/src/SIM/SIMinput.C
+++ b/src/SIM/SIMinput.C
@@ -1854,8 +1854,8 @@ IntMat SIMinput::getElmConnectivities () const
     if (iface.dim == static_cast<int>(nsd)-1)
     {
       IntVec sElms, mElms;
-      myModel[iface.slave-1]->getBoundaryElms(iface.sidx, iface.orient, sElms);
-      myModel[iface.master-1]->getBoundaryElms(iface.midx, 0, mElms);
+      myModel[iface.slave-1]->getBoundaryElms(iface.sidx, sElms, iface.orient);
+      myModel[iface.master-1]->getBoundaryElms(iface.midx, mElms, 0);
       DomainDecomposition::OrientIterator iter(myModel[iface.slave-1],
                                                iface.orient, iface.sidx);
 


### PR DESCRIPTION
That is the last commit, using the oneGroup() method. Hopefully this will remove the data race encountered now and then for the SSUprofil test.

The rest here is some cleaning/fixing of the `getBoundaryElms()` method, including implementation for Lagrange. Notice that this method now also is used when setting up the thread group for boundary integrals. Think it is equivalent to the code it replaces.