### PR TITLE
Added: Option to save result components on grid files

### DIFF
--- a/src/LinAlg/Test/TestMatrix.C
+++ b/src/LinAlg/Test/TestMatrix.C
@@ -10,7 +10,7 @@
 //!
 //==============================================================================
 
-#include "MatVec.h"
+#include "matrixnd.h"
 
 #include "gtest/gtest.h"
 #include <numeric>
@@ -83,7 +83,29 @@ TEST(TestMatrix, AddRows)
 }
 
 
-TEST(TestMatrix, Augment)
+TEST(TestMatrix, AugmentRows)
+{
+  utl::matrix<int> a(5,3), b(4,3), c(3,2);
+  std::iota(a.begin(),a.end(),1);
+  std::iota(b.begin(),b.end(),16);
+  std::cout <<"A:"<< a;
+  std::cout <<"B:"<< b;
+  size_t nA = a.size();
+  size_t na = a.rows();
+  size_t nb = b.rows();
+  ASSERT_TRUE(a.augmentRows(b));
+  ASSERT_FALSE(a.augmentRows(c));
+  std::cout <<"C:"<< a;
+  for (size_t j = 1; j <= a.cols(); j++)
+    for (size_t i = 1; i <= a.rows(); i++)
+      if (i <= na)
+        EXPECT_EQ(a(i,j), i+na*(j-1));
+      else
+        EXPECT_EQ(a(i,j), nA-na+i+nb*(j-1));
+}
+
+
+TEST(TestMatrix, AugmentCols)
 {
   utl::matrix<int> a(3,5), b(3,4), c(2,3);
   std::iota(a.begin(),a.end(),1);
@@ -128,7 +150,9 @@ TEST(TestMatrix, Multiply)
   EXPECT_FLOAT_EQ(y.sum(),0.0);
 
   u.std::vector<double>::resize(5);
-  v = 0.5*A*u;
+  ASSERT_TRUE(A.multiply(u,v));
+  v *= 0.5;
+
   EXPECT_FLOAT_EQ(v(1),67.5);
   EXPECT_FLOAT_EQ(v(2),75.0);
   EXPECT_FLOAT_EQ(v(3),82.5);

--- a/src/LinAlg/matrix.h
+++ b/src/LinAlg/matrix.h
@@ -437,11 +437,31 @@ namespace utl //! General utility classes and functions.
       return *this;
     }
 
+    //! \brief Increase the number of rows by augmenting the given matrix.
+    bool augmentRows(const matrix<T>& B)
+    {
+      if (B.ncol != ncol)
+        return false;
+
+      size_t oldRows = nrow;
+      nrow += B.nrow;
+      this->elem.std::template vector<T>::resize(nrow*ncol,T(0));
+      T* oldMat = this->ptr() + oldRows*(ncol-1);
+      for (size_t c = ncol; c > 0; c--, oldMat -= oldRows)
+      {
+        if (c > 1)
+          memmove(this->ptr(c-1),oldMat,oldRows*sizeof(T));
+        for (size_t r = nrow; r > oldRows; r--)
+          this->elem[r-1+nrow*(c-1)] = B(r-oldRows,c);
+      }
+      return true;
+    }
+
     //! \brief Increase the number of columns by augmenting the given matrix.
     bool augmentCols(const matrix<T>& B)
     {
       if (B.nrow != nrow)
-	return false;
+        return false;
 
       this->elem.insert(this->elem.end(),B.elem.begin(),B.elem.end());
       ncol += B.ncol;
@@ -568,8 +588,7 @@ namespace utl //! General utility classes and functions.
 
     //! \brief Extract a block of the matrix to another matrix.
     void extractBlock(matrix<T>& block, size_t r, size_t c,
-                      bool addTo = false,
-                      bool transposed = false) const
+                      bool addTo = false, bool transposed = false) const
     {
       size_t nr = transposed ? block.cols() : block.rows();
       size_t nc = transposed ? block.rows() : block.cols();

--- a/src/SIM/SIMoutput.h
+++ b/src/SIM/SIMoutput.h
@@ -20,9 +20,6 @@
 class ElementBlock;
 class VTF;
 
-typedef std::pair<Vec3,double>  PointValue;  //!< Convenience type
-typedef std::vector<PointValue> PointValues; //!< Convenience type
-
 
 /*!
   \brief Sub-class with additional functionality for result output.
@@ -335,8 +332,10 @@ protected:
     ResultPoint() : npar(0), patch(1), inod(0) { u[0] = u[1] = u[2] = 0.0; }
   };
 
-  typedef std::vector<ResultPoint> ResPointVec; //!< Result point container
-  typedef std::pair<std::string,ResPointVec> ResPtPair; //!< Result point group
+  //! \brief Result point container.
+  using ResPointVec = std::vector<ResultPoint>;
+  //! \brief File name to result point group mapping.
+  using ResPtPair = std::pair<std::string,ResPointVec>;
 
   //! \brief Preprocesses the result sampling points.
   virtual void preprocessResultPoints();

--- a/src/SIM/SIMoutput.h
+++ b/src/SIM/SIMoutput.h
@@ -379,6 +379,7 @@ private:
   int    myGeomID; //!< VTF geometry block ID for the first patch
   VTF*   myVtf;    //!< VTF-file for result visualization
   bool   logRpMap; //!< If \e true, print out the result point mapping
+  int    idxGrid;  //!< Index into \ref myPoints for grid result output
 };
 
 #endif

--- a/src/SIM/SIMoutput.h
+++ b/src/SIM/SIMoutput.h
@@ -276,6 +276,12 @@ public:
   //! \param[in] step Load/time step counter
   bool savePoints(const Vector& psol, double time, int step) const;
 
+  //! \brief Saves result components to output files for a given time step.
+  //! \param[in] psol Primary solution vector
+  //! \param[in] time Load/time step parameter
+  //! \param[in] step Load/time step counter
+  bool saveResults(const Vector& psol, double time, int step) const;
+
   //! \brief Sets the file name for result point output.
   //! \param[in] filename The file name prefix (optionally with extension)
   //! \param[in] dumpCoord If \e true, write point coordinates to separate file

--- a/src/Utility/Vec3.h
+++ b/src/Utility/Vec3.h
@@ -290,7 +290,9 @@ public:
 };
 
 
-typedef std::pair<Vec3,Vec3> Vec3Pair; //!< A pair of two point vectors
-typedef std::vector<Vec3>    Vec3Vec;  //!< An array of point vectors
+using Vec3Pair    = std::pair<Vec3,Vec3>;    //!< A pair of two point vectors
+using PointValue  = std::pair<Vec3,double>;  //!< A point with associated value
+using Vec3Vec     = std::vector<Vec3>;       //!< An array of point vectors
+using PointValues = std::vector<PointValue>; //!< An array of point values
 
 #endif


### PR DESCRIPTION
Firstly, a new `<grid>` tag within the `<resultpoints>` scope is added, to enable easy definition of result points in a grid pattern. Each result component (primary and secondary variables) is the saved to separate files, one column for each grid point (the physical time as the first column) and the time/load steps as rows. Then these files can be used as input to the python script for calculation of optimal sensor placement.
