### PR TITLE
Dump system matrices and RHS-vector in the start of each load/time step only

### DIFF
--- a/src/LinAlg/Test/TestSparseMatrix.C
+++ b/src/LinAlg/Test/TestSparseMatrix.C
@@ -53,6 +53,10 @@ TEST(TestSparseMatrix, split)
   Amat(5,7) = Amat(7,5) = 8.0;
   Amat(6,7) = Amat(7,6) = 9.0;
 
+  Amat.dump(std::cout,LinAlg::MATRIX_MARKET,"A_mmarket");
+  Amat.dump(std::cout,LinAlg::MATLAB,"A_matlab");
+  Amat.dump(std::cout,LinAlg::FLAT,"A");
+
   std::array<SparseMatrix,4> Asub;
   ASSERT_TRUE(Amat.split(Asub,{2,5,7}));
   std::cout <<"A11: "<< Asub[0];

--- a/src/SIM/NewmarkSIM.C
+++ b/src/SIM/NewmarkSIM.C
@@ -170,8 +170,8 @@ bool NewmarkSIM::initAcc (double zero_tolerance, std::streamsize outPrec)
     model.addToRHSvector(0,*Rext);
 
   // Solve for the initial accelerations
-  size_t iA = solution.size() - 1;
-  if (!model.solveSystem(solution[iA],msgLevel-1,"acceleration"))
+  Vector& accVec = solution.back();
+  if (!model.solveEqSystem(accVec,0,nullptr,msgLevel-1,false,"acceleration"))
     return false;
   else if (msgLevel < 1)
     return true;
@@ -179,7 +179,7 @@ bool NewmarkSIM::initAcc (double zero_tolerance, std::streamsize outPrec)
   size_t d, nf = model.getNoFields(1);
   size_t kMax[nf];
   double aMax[nf];
-  double accL2 = model.solutionNorms(solution[iA],aMax,kMax,nf);
+  double accL2 = model.solutionNorms(accVec,aMax,kMax,nf);
 
   utl::LogStream& cout = model.getProcessAdm().cout;
   std::streamsize stdPrec = outPrec > 0 ? cout.precision(outPrec) : 0;
@@ -362,7 +362,7 @@ SIM::ConvStatus NewmarkSIM::solveStep (TimeStep& param, SIM::SolutionMode,
     return SIM::FAILURE;
 
   double* rCondPtr = rCond < 0.0 ? nullptr : &rCond;
-  if (!model.solveSystem(linsol,msgLevel-1,rCondPtr))
+  if (!model.solveEqSystem(linsol,0,rCondPtr,msgLevel-1,true))
     return SIM::FAILURE;
 
   while (param.iter <= maxit)
@@ -408,7 +408,7 @@ SIM::ConvStatus NewmarkSIM::solveStep (TimeStep& param, SIM::SolutionMode,
         if (!model.extractLoadVec(residual))
           return SIM::FAILURE;
 
-        if (!model.solveSystem(linsol,msgLevel-1,rCondPtr))
+        if (!model.solveEqSystem(linsol,0,rCondPtr,msgLevel-1))
           return SIM::FAILURE;
       }
 
@@ -445,7 +445,7 @@ SIM::ConvStatus NewmarkSIM::solveIteration (TimeStep& param)
     return SIM::FAILURE;
 
   double* rCondPtr = rCond < 0.0 ? nullptr : &rCond;
-  if (!model.solveSystem(linsol,msgLevel-1,rCondPtr))
+  if (!model.solveEqSystem(linsol,0,rCondPtr,msgLevel-1))
     return SIM::FAILURE;
 
   SIM::ConvStatus result = this->checkConvergence(param);

--- a/src/SIM/NonLinSIM.C
+++ b/src/SIM/NonLinSIM.C
@@ -234,7 +234,7 @@ ConvStatus NonLinSIM::solveStep (TimeStep& param, SolutionMode mode,
       return FAILURE;
 
   double* rCondPtr = rCond < 0.0 ? nullptr : &rCond;
-  if (!model.solveSystem(linsol,msgLevel-1,rCondPtr))
+  if (!model.solveEqSystem(linsol,0,rCondPtr,msgLevel-1,true))
     return FAILURE;
 
   while (param.iter <= maxit)
@@ -272,7 +272,7 @@ ConvStatus NonLinSIM::solveStep (TimeStep& param, SolutionMode mode,
 	if (!model.extractLoadVec(residual))
 	  return FAILURE;
 
-	if (!model.solveSystem(linsol,msgLevel-1,rCondPtr))
+	if (!model.solveEqSystem(linsol,0,rCondPtr,msgLevel-1))
 	  return FAILURE;
 
 	if (!this->lineSearch(param))
@@ -301,7 +301,7 @@ SIM::ConvStatus NonLinSIM::solveIteration (TimeStep& param)
     return SIM::FAILURE;
 
   double* rCondPtr = rCond < 0.0 ? nullptr : &rCond;
-  if (!model.solveSystem(linsol,msgLevel-1,rCondPtr))
+  if (!model.solveEqSystem(linsol,0,rCondPtr,msgLevel-1))
     return SIM::FAILURE;
 
   if (!this->lineSearch(param))

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -302,13 +302,27 @@ public:
 
   //! \brief Solves the assembled linear system of equations for a given load.
   //! \param[out] solution Global primary solution vector
+  //! \param[in] idxRHS Index to the right-hand-side vector to solve for
+  //! \param[out] rCond Reciprocal condition number
+  //! \param[in] compName Solution name to be used in norm output
+  //! \param[in] printSol Print solution if its size is less than \a printSol
+  //! \param[in] dumpEqSys If \e true, activate dump of equation system to file
+  bool solveEqSystem(Vector& solution, size_t idxRHS, double* rCond,
+                     int printSol = 0, bool dumpEqSys = false,
+                     const char* compName = "displacement");
+
+  //! \brief Solves the assembled linear system of equations for a given load.
+  //! \param[out] solution Global primary solution vector
   //! \param[in] printSol Print solution if its size is less than \a printSol
   //! \param[out] rCond Reciprocal condition number
   //! \param[in] compName Solution name to be used in norm output
   //! \param[in] idxRHS Index to the right-hand-side vector to solve for
   virtual bool solveSystem(Vector& solution, int printSol, double* rCond,
                            const char* compName = "displacement",
-                           size_t idxRHS = 0);
+                           size_t idxRHS = 0)
+  {
+    return this->solveEqSystem(solution,idxRHS,nullptr,printSol,true,compName);
+  }
 
   //! \brief Solves the assembled linear system of equations for a given load.
   //! \param[out] solution Global primary solution vector
@@ -711,7 +725,7 @@ public:
   bool isFirst() const { return mdFlag <= 1; }
 
   //! \brief Dump left-hand-side matrix and right-hand-side vector to file.
-  void dumpEqSys();
+  void dumpEqSys(bool initialBlankLine = false);
 
 protected:
   //! \brief Returns the multi-dimension simulator sequence flag.


### PR DESCRIPTION
Instead of dumping them every iteration which is not that useful for Nonlinear/Newmark simulations.
But consider that as an option later, if/when needed.