### PR TITLE
fixed: reset error array to appropriate size

### DIFF
--- a/src/SIM/AdaptiveSetup.C
+++ b/src/SIM/AdaptiveSetup.C
@@ -329,7 +329,7 @@ int AdaptiveSetup::calcRefinement (LR::RefineData& prm, int iStep,
   if (scheme == ISOTROPIC_FUNCTION) // use errors per function
   {
     if (thePatch->getNoRefineNodes() == thePatch->getNoNodes(1))
-      error.resize(model.getNoNodes(),DblIdx(0.0,0));
+      error.resize(model.getNoNodes(1),DblIdx(0.0,0));
     else if (model.getNoPatches() == 1)
       error.resize(thePatch->getNoRefineNodes(),DblIdx(0.0,0));
     else


### PR DESCRIPTION
we have to use getNodes(1) to get the proper size. In general this resulted in the wrong number of functions being refined
for single basis methods and mixed methods projecting on the first basis. It also lead to crashes if 100% of function were to be refined since it selected too many functions / non-existing functions for refinement.