### PR TITLE
ASMuxD::evalSolution(P): do not use MNPC directly if there are multipliers

### DIFF
--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -2038,8 +2038,8 @@ bool ASMu2D::evalSolution (Matrix& sField, const Vector& locSol,
 {
   PROFILE2("ASMu2D::evalSol(P)");
 
-  size_t nComp = locSol.size() / this->getNoNodes();
-  if (nComp*this->getNoNodes() != locSol.size())
+  size_t nComp = locSol.size() / this->getNoNodes(-1);
+  if (nComp*this->getNoNodes(-1) > locSol.size())
     return false;
 
   size_t nPoints = gpar[0].size();
@@ -2073,9 +2073,12 @@ bool ASMu2D::evalSolution (Matrix& sField, const Vector& locSol,
         return false;
     }
 
+    const LR::Element* el = lrspline->getElement(iel);
+
     // Evaluate basis function values/derivatives at current parametric point
     // and multiply with control point values to get the point-wise solution
-    utl::gather(MNPC[iel],nComp,locSol,eSol);
+    utl::gather({MNPC[iel].begin(), MNPC[iel].begin() + el->nBasisFunctions()},
+                nComp,locSol,eSol);
     switch (deriv)
     {
     case 0: // Evaluate the solution

--- a/src/ASM/LR/ASMu2Drecovery.C
+++ b/src/ASM/LR/ASMu2Drecovery.C
@@ -111,7 +111,8 @@ bool ASMu2D::assembleL2matrices (SparseMatrix& A, StdVector& B,
   const LR::LRSplineSurface* geo = this->getBasis(ASM::GEOMETRY_BASIS);
   const LR::LRSplineSurface* proj = this->getBasis(ASM::PROJECTION_BASIS);
   const bool separateProjBasis = proj != geo;
-  const bool useModelMNPC = !separateProjBasis && this->getNoBasis() == 1;
+  const bool useModelMNPC = !separateProjBasis && this->getNoBasis() == 1 &&
+                            this->getNoNodes(0) == this->getNoNodes(1);
 
   const int p1 = proj->order(0);
   const int p2 = proj->order(1);

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -1518,8 +1518,8 @@ bool ASMu3D::evalSolution (Matrix& sField, const Vector& locSol,
 {
   PROFILE2("ASMu3D::evalSol(P)");
 
-  size_t nComp = locSol.size() / this->getNoNodes();
-  if (nComp*this->getNoNodes() != locSol.size())
+  size_t nComp = locSol.size() / this->getNoNodes(-1);
+  if (nComp*this->getNoNodes(-1) > locSol.size())
     return false;
 
   size_t nPoints = gpar[0].size();
@@ -1547,7 +1547,10 @@ bool ASMu3D::evalSolution (Matrix& sField, const Vector& locSol,
                 << gpar[1][i] <<", "<< gpar[2][i] <<") not found."<< std::endl;
       return false;
     }
-    utl::gather(MNPC[iel],nComp,locSol,eSol);
+    const LR::Element* el = lrspline->getElement(iel);
+
+    utl::gather({MNPC[iel].begin(),MNPC[iel].begin()+el->nBasisFunctions()},
+                nComp,locSol,eSol);
 
     if (iel != lel && deriv > 0)
     {

--- a/src/ASM/LR/ASMu3Drecovery.C
+++ b/src/ASM/LR/ASMu3Drecovery.C
@@ -113,7 +113,8 @@ bool ASMu3D::assembleL2matrices (SparseMatrix& A, StdVector& B,
   const LR::LRSplineVolume* geo = this->getBasis(ASM::GEOMETRY_BASIS);
   const LR::LRSplineVolume* proj = this->getBasis(ASM::PROJECTION_BASIS);
   const bool separateProjBasis = proj != geo;
-  const bool useModelMNPC = !separateProjBasis && this->getNoBasis() == 1;
+  const bool useModelMNPC = !separateProjBasis && this->getNoBasis() == 1 &&
+                            this->getNoNodes(0) == this->getNoNodes(1);
 
   const int p1 = proj->order(0);
   const int p2 = proj->order(1);


### PR DESCRIPTION
We cannot use the MNPC directly if there are additional DOFs in the model.