### PR TITLE
Added: Option for Cartesian grid output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ else()
                          src/ASM/LocalIntegral.h src/ASM/SAMpatch.h
                          src/ASM/SplineField?D.h src/ASM/SplineFields?D.h
                          src/ASM/TimeDomain.h src/ASM/ASMs?D.h src/ASM/ASM?D.h
-                         src/ASM/ASMs?DLag.h src/ASM/ASMu2DLag.h src/ASM/ASMutils.h
+                         src/ASM/ASM??DLag.h src/ASM/ASMLagBase.h src/ASM/ASMutils.h
                          src/ASM/DomainDecomposition.h src/ASM/ItgPoint.h
                          src/ASM/ReactionsOnly.h
                          src/LinAlg/*.h src/SIM/*.h src/Utility/*.h

--- a/src/ASM/ASMLagBase.C
+++ b/src/ASM/ASMLagBase.C
@@ -1,0 +1,36 @@
+// $Id$
+//==============================================================================
+//!
+//! \file ASMLagBase.C
+//!
+//! \date May 1 2024
+//!
+//! \author Knut Morten Okstad / SINTEF
+//!
+//! \brief Common base class for %Lagrange FE models.
+//!
+//==============================================================================
+
+#include "ASMLagBase.h"
+
+
+ASMLagBase::ASMLagBase (const ASMLagBase& patch, bool cpCoord) : coord(myCoord)
+{
+  if (cpCoord) myCoord = patch.coord;
+}
+
+
+bool ASMLagBase::nodalField (Matrix& field, const Vector& sol, size_t nno) const
+{
+  size_t nPnts = coord.size();
+  size_t nComp = sol.size() / nno;
+  if (nno < nPnts || nComp*nno != sol.size())
+    return false;
+
+  field.resize(nComp,nPnts);
+  const double* u = sol.ptr();
+  for (size_t iPt = 1; iPt <= nPnts; iPt++, u += nComp)
+    field.fillColumn(iPt,u);
+
+  return true;
+}

--- a/src/ASM/ASMLagBase.h
+++ b/src/ASM/ASMLagBase.h
@@ -1,0 +1,44 @@
+// $Id$
+//==============================================================================
+//!
+//! \file ASMLagBase.h
+//!
+//! \date May 1 2024
+//!
+//! \author Knut Morten Okstad / SINTEF
+//!
+//! \brief Common base class for %Lagrange FE models.
+//!
+//==============================================================================
+
+#ifndef _ASM_LAG_BASE_H
+#define _ASM_LAG_BASE_H
+
+#include "MatVec.h"
+#include "Vec3.h"
+
+
+/*!
+  \brief Common base class for %Lagrange FE models.
+  \details This class contains a container for storing the nodal coordinates.
+*/
+
+class ASMLagBase
+{
+protected:
+  //! \brief Default constructor.
+  ASMLagBase() : coord(myCoord) {}
+  //! \brief Copy constructor.
+  ASMLagBase(const ASMLagBase& patch, bool cpCoord = true);
+  //! \brief Empty destructor.
+  virtual ~ASMLagBase() {}
+
+  //! \brief Direct nodal evaluation of a solution field.
+  bool nodalField(Matrix& field, const Vector& sol, size_t nno) const;
+
+protected:
+  const Vec3Vec& coord; //!< Const reference to the nodal coordinate container
+  Vec3Vec      myCoord; //!< Nodal coordinate container
+};
+
+#endif

--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -444,7 +444,7 @@ class fixed
   int myDofs; //!< The local DOFs to compare with
 
 public:
-  //! \brief Constructor initializing the node and local dof index.
+  //! \brief Constructor initializing the node and local DOF index.
   fixed(int node, int dof) : myNode(node), myDofs(dof) {}
   //! \brief Returns \e true if the DOF has the same fixed status as \a bc.
   bool operator()(const ASMbase::BC& bc)
@@ -484,7 +484,7 @@ bool ASMbase::addMPC (MPC*& mpc, int code, bool verbose)
 
   if (this->isFixed(mpc->getSlave().node,mpc->getSlave().dof))
   {
-    // Silently ignore MPC's on dofs that already are marked as FIXED
+    // Silently ignore MPCs on DOFs that already are marked as FIXED
     delete mpc;
     mpc = nullptr;
     return true;
@@ -504,7 +504,7 @@ bool ASMbase::addMPC (MPC*& mpc, int code, bool verbose)
   if (verbose) std::cout <<"Ignored constraint (duplicated slave): "<< *mpc;
 #endif
   delete mpc;
-  mpc = *mit.first; // This dof is already a slave in another MPC
+  mpc = *mit.first; // This DOF is already a slave in another MPC-equation
   return false;
 }
 
@@ -572,7 +572,7 @@ void ASMbase::addLocal2GlobalCpl (int iSlave, int master, const Tensor& Tlg)
       if (cons->getNoMaster() == 0)
       {
         // All master DOFs are fixed.
-        // Then the MPC is not needed, fix the slave DOF instead.
+        // Then the MPC-equation is not needed, fix the slave DOF instead.
         mpcs.erase(cons);
         delete cons;
         fixDirs = d + 10*fixDirs;
@@ -948,18 +948,18 @@ void ASMbase::mergeAndGetAllMPCs (const ASMVec& model, MPCSet& allMPCs)
 
 /*!
   Recursive resolving of (possibly multi-level) chaining in the multi-point
-  constraint equations (MPCs). If a master dof in one MPC is specified as a
-  slave by another MPC, it is replaced by the master(s) of that other equation.
-  Since an MPC-equation may couple nodes belonging to different patches,
-  this method must have access to all patches in the model.
+  constraint (MPC) equations. If a master DOF in one MPC-equation is specified
+  as a slave by another one, it is replaced by the master(s) of that other
+  equation. Since an MPC-equation may couple nodes belonging to different
+  patches, this method must have access to all patches in the model.
 
-  If \a setPtrOnly is \e true, the MPC equations are not modified. Instead
-  the pointers to the next MPC in the chain is assigned for the master DOFs
-  which are slaves in other MPCs.
+  If \a setPtrOnly is \e true, the MPC-equations are not modified.
+  Instead the pointers to the next %MPC object in the chain is assigned for
+  the master DOFs which are slaves in other MPCs.
 
   This is used in time-dependent/nonlinear simulators where the constraint
   coefficients might be updated due to time variation. The resolving is then
-  done directly in the MMCEQ/TTCC arrays of the SAM data object.
+  done directly in the \a MMCEQ/TTCC arrays of the SAM object.
   \sa SAMpatch::updateConstraintEqs.
 */
 
@@ -986,8 +986,8 @@ void ASMbase::resolveMPCchains (const MPCSet& allMPCs,
       MPCIter cit = allMPCs.find(&master);
       if (cit != allMPCs.end())
       {
-        // We have a master dof which is a slave in another constraint equation.
-        // Invoke resolve() recursively to ensure that all master dofs of that
+        // We have a master DOF which is a slave in another constraint equation.
+        // Invoke resolve() recursively to ensure that all master DOFs of that
         // equation are not slaves themselves.
         resolve(*cit);
 
@@ -1243,10 +1243,10 @@ int ASMbase::renumberNodes (std::map<int,int>& old2new, int& nNod)
   condition- and multi-point constraint equation objects in the patch,
   according to the provided mapping \a old2new.
 
-  The nodes themselves (in \a MLGN) are assumed already to be up to date, unless
-  \a renumGN is greater than zero. If \a renumGN equals one, all node numbers
-  are assumed present in the \a old2new mapping and an error is flagged if
-  that is not the case.
+  The nodes themselves (in \ref MLGN) are assumed already to be up to date,
+  unless \a renumGN is greater than zero. If \a renumGN equals one,
+  all node numbers are assumed present in the \a old2new mapping
+  and an error is flagged if that is not the case.
 
   If \a renumGN is less than zero, the element connectivities are also updated
   such that that only the first instance of a duplicated node is referred.

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -23,9 +23,9 @@
 
 typedef std::vector<int>       IntVec;  //!< General integer vector
 typedef std::vector<IntVec>    IntMat;  //!< General 2D integer matrix
-typedef std::map<MPC*,int,MPCLess> MPCMap; //!< MPC to function code mapping
-typedef std::set<MPC*,MPCLess> MPCSet;  //!< Sorted set of MPC equations
-typedef MPCSet::const_iterator MPCIter; //!< Iterator over an MPC equation set
+typedef std::map<MPC*,int,MPCLess> MPCMap; //!< MPC-to-function code mapping
+typedef std::set<MPC*,MPCLess> MPCSet;  //!< Sorted set of MPC-equations
+typedef MPCSet::const_iterator MPCIter; //!< Iterator over an MPC-equation set
 
 struct TimeDomain;
 class ElementBlock;
@@ -138,7 +138,7 @@ public:
   virtual void clear(bool retainGeometry = false);
 
   //! \brief Adds extraordinary elements associated with a patch boundary.
-  //! \param[in] dim Dimension of the boundary (should be \a nsd - 1)
+  //! \param[in] dim Dimension of the boundary (should equal \ref nsd - 1)
   //! \param[in] item Local index of the boundary face/edge
   //! \param[in] nXn Number of extraordinary nodes
   //! \param[out] nodes Global numbers assigned to the extraordinary nodes
@@ -158,11 +158,11 @@ public:
   bool addGlobalLagrangeMultipliers(const IntVec& mGLag,
                                     unsigned char nnLag = 1);
 
-  //! \brief Defines the numerical integration scheme \a nGauss in the patch.
+  //! \brief Defines the numerical integration scheme \ref nGauss in the patch.
   void setGauss(int ng) { nGauss = ng; }
 
-  //! \brief Defines the number of solution fields \a nf in the patch.
-  //! \details This method is to be used by simulators where \a nf is not known
+  //! \brief Defines the number of solution fields in the patch.
+  //! \details This method is to be used by simulators where \ref nf is not known
   //! when the patch is constructed, e.g., it depends on the input file content.
   //! It must be invoked only before SIMbase::preprocess() is invoked.
   void setNoFields(unsigned char n) { nf = n; }
@@ -324,7 +324,7 @@ public:
                    bool includeXElms = false) const;
   //! \brief Returns the number of elements on a boundary.
   virtual size_t getNoBoundaryElms(char, char) const { return 0; }
-  //! \brief Returns the total number of MPC equations in this patch.
+  //! \brief Returns the total number of multi-point constraint equations.
   size_t getNoMPCs() const { return mpcs.size(); }
 
   //! \brief Computes the total number of integration points in this patch.
@@ -332,21 +332,21 @@ public:
   //! \brief Computes the number of boundary integration points in this patch.
   virtual void getNoBouPoints(size_t& nPt, char ldim, char lindx);
 
-  //! \brief Returns the beginning of the BC array.
+  //! \brief Returns the beginning of the \ref BCode array.
   BCVec::const_iterator begin_BC() const { return BCode.begin(); }
-  //! \brief Returns the end of the BC array.
+  //! \brief Returns the end of the \ref BCode array.
   BCVec::const_iterator end_BC() const { return BCode.end(); }
 
-  //! \brief Returns the beginning of the MNPC array.
+  //! \brief Returns the beginning of the \ref MNPC array.
   IntMat::const_iterator begin_elm() const { return MNPC.begin(); }
-  //! \brief Returns the end of the MNPC array.
+  //! \brief Returns the end of the \ref MNPC array.
   IntMat::const_iterator end_elm() const { return MNPC.end(); }
 
-  //! \brief Returns the beginning of the MPC set.
+  //! \brief Returns the beginning of the \ref mpcs set.
   MPCIter begin_MPC() const { return mpcs.begin(); }
-  //! \brief Returns the end of the MPC set.
+  //! \brief Returns the end of the \ref mpcs set.
   MPCIter end_MPC() const { return mpcs.end(); }
-  //! \brief Returns the MPC equation for a specified slave, if any.
+  //! \brief Returns a pointer to the MPC object for a specified slave, if any.
   //! \param[in] node Global node number of the slave node
   //! \param[in] dof Which local DOF which is constrained (1, 2, 3)
   MPC* findMPC(int node, int dof) const;
@@ -407,24 +407,24 @@ public:
   //! \brief Renumbers the global node numbers referred by this patch.
   //! \param[in] old2new Old-to-new node number mapping
   //! \param[in] new2old New-to-old node number mapping
-  //! \param[in] renumGN Flag for renumbering the node number array \a MLGN
+  //! \param[in] renumGN Flag for renumbering the node number array \ref MLGN
   //! \param[out] degenElm Global node to degenerated element number mapping
   bool renumberNodes(const std::map<int,int>& old2new,
                      const std::vector<int>& new2old = {}, int renumGN = 0,
                      std::map<int,int>* degenElm = nullptr);
 
-  //! \brief Computes the set of all MPCs over the whole model.
+  //! \brief Computes the set of all MPC-equations over the whole model.
   //! \param[in] model All spline patches in the model
   //! \param[out] allMPCs All multi-point constraint equations in the model
   //!
-  //! \details The MPC equations are stored distributed over the patches,
+  //! \details The MPC-equations are stored distributed over the patches,
   //! based on the slave DOF of the constraint. Therefore, constraints on the
   //! interface nodes between patches (to enforce higher order regularity) may
   //! be defined on both neighboring patches. This method will also merge such
   //! multiply defined equations into a single equation.
   static void mergeAndGetAllMPCs(const ASMVec& model, MPCSet& allMPCs);
 
-  //! \brief Resolves (possibly multi-level) chaining in MPC equations.
+  //! \brief Resolves (possibly multi-level) chaining in MPC-equations.
   //! \param[in] allMPCs All multi-point constraint equations in the model
   //! \param[in] model All spline patches in the model
   //! \param[in] setPtrOnly If \e true, only set pointer to next MPC in chain
@@ -461,7 +461,7 @@ public:
   //! \brief Applies a transformation matrix from local to global system.
   virtual bool transform(const Matrix&) { return true; }
 
-  //! \brief Initializes the patch level MADOF array for mixed problems.
+  //! \brief Initializes the patch level \a MADOF array for mixed problems.
   virtual void initMADOF(const int*) {}
 
   //! \brief Generates element groups for multi-threading of interior integrals.
@@ -531,6 +531,11 @@ public:
   //! \param[in] param The parameters of the point in the knot-span domain
   //! \return Local element number within the patch that contains the point
   virtual int findElementContaining(const double* param) const = 0;
+  //! \brief Searches for the specified Cartesian point in the patch.
+  //! \param X The Cartesian coordinates of the point, updated on output
+  //! \param[out] param The parameters of the point in the knot-span domain
+  //! \return Distance from the point \a X to the found point
+  virtual double findPoint(Vec3& X, double* param) const = 0;
 
   //! \brief Creates a standard FE model of this patch for visualization.
   //! \param[out] grid The generated finite element grid
@@ -553,20 +558,20 @@ public:
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector local to current patch
   //! \param[in] npe Number of visualization nodes over each knot span
-  //! \param[in] nf If nonzero, mixed evaluates nf fields on first basis
+  //! \param[in] n_f If nonzero, mixed evaluates \a n_f fields on first basis
   //! \param[in] piola If \e true, use piola mapping
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-                            const int* npe, int nf = 0,
+                            const int* npe, int n_f = 0,
                             bool piola = false) const;
 
   //! \brief Evaluates the projected solution field at all visualization points.
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector local to current patch
   //! \param[in] npe Number of visualization nodes over each knot span
-  //! \param[in] nf If nonzero, mixed evaluates nf fields on first basis
+  //! \param[in] n_f If nonzero, mixed evaluates \a n_f fields on first basis
   virtual bool evalProjSolution(Matrix& sField, const Vector& locSol,
-                                const int* npe, int nf = 0) const
-  { return this->evalSolution(sField, locSol, npe, nf); }
+                                const int* npe, int n_f = 0) const
+  { return this->evalSolution(sField, locSol, npe, n_f); }
 
   //! \brief Evaluates the primary solution field at the given points.
   //! \param[out] sField Solution field
@@ -574,7 +579,7 @@ public:
   //! \param[in] gpar Parameter values of the result sampling points
   //! \param[in] regular Flag indicating how the sampling points are defined
   //! \param[in] deriv Derivative order to return
-  //! \param[in] nf If non-zero, mixed evaluates \a nf fields on first basis
+  //! \param[in] n_f If nonzero, mixed evaluates \a n_f fields on first basis
   //!
   //! \details When \a regular is \e true, it is assumed that the parameter
   //! value array \a gpar forms a regular tensor-product point grid of dimension
@@ -583,7 +588,7 @@ public:
   //! directly for each sampling point.
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
                             const RealArray* gpar, bool regular = true,
-                            int deriv = 0, int nf = 0) const;
+                            int deriv = 0, int n_f = 0) const;
 
   //! \brief Evaluates the primary solution field with Piola mapping.
   //! \param[out] sField Solution field
@@ -747,7 +752,7 @@ public:
   //! \brief Extracts nodal results for this patch from the global vector.
   //! \param[in] globVec Global solution vector in DOF-order
   //! \param[out] nodeVec Nodal result vector for this patch
-  //! \param[in] nndof Number of DOFs per node (the default is \a nf)
+  //! \param[in] nndof Number of DOFs per node (the default is \ref nf)
   //! \param[in] basis Which basis to extract nodal values for (mixed methods)
   virtual void extractNodeVec(const RealArray& globVec, RealArray& nodeVec,
                               unsigned char nndof = 0, int basis = 0) const;
@@ -755,7 +760,7 @@ public:
   //! \brief Injects nodal results for this patch into the global vector.
   //! \param[in] nodeVec Nodal result vector for this patch
   //! \param globVec Global solution vector in DOF-order
-  //! \param[in] nndof Number of DOFs per node (the default is \a nf)
+  //! \param[in] nndof Number of DOFs per node (the default is \ref nf)
   //! \param[in] basis Which basis to inject nodal values for (mixed methods)
   virtual bool injectNodeVec(const RealArray& nodeVec, RealArray& globVec,
                              unsigned char nndof = 0, int basis = 0) const;
@@ -776,12 +781,12 @@ public:
   bool add2PC(int slave, int dir, int master, int code = 0);
 
   //! \brief Adds a general multi-point-constraint (MPC) equation to this patch.
-  //! \param mpc Pointer to an MPC-object
+  //! \param mpc Pointer to an MPC object
   //! \param[in] code Identifier for inhomogeneous Dirichlet condition field
   //! \param[in] verbose If \e true, print out added constraint (debug build)
   bool addMPC(MPC*& mpc, int code = 0, bool verbose = false);
 
-  //! \brief Adds MPCs representing a rigid coupling to this patch.
+  //! \brief Adds MPC-equations representing a rigid coupling to this patch.
   //! \param[in] lindx Local index of the boundary item that should be rigid
   //! \param[in] ldim Dimension of the boundary item that should be rigid
   //! \param[in] basis Which basis to add rigid coupling for (mixed methods)
@@ -793,7 +798,7 @@ public:
                            int& gMaster, const Vec3& Xmaster,
                            bool extraPt = true);
 
-  //! \brief Adds MPCs representing a rigid coupling to this patch.
+  //! \brief Adds MPC-equations representing a rigid coupling to this patch.
   //! \param[in] gMaster Global node number of the master node
   //! \param[in] slaveNodes Local node numbers of the slave nodes
   //! \param[in] Xmaster Position of the master node
@@ -835,7 +840,7 @@ protected:
   //! \param[in] Xmaster Position of the master nodal point
   //! \return \e true if a new global node was added, otherwise \e false
   bool createRgdMasterNode(int& gMaster, const Vec3& Xmaster);
-  //! \brief Adds MPC equations representing a rigid arm to a 6-DOF node
+  //! \brief Adds MPC-equations representing a rigid arm to a 6-DOF node
   //! \param[in] gSlave Global node number of the 3-DOF slave node
   //! \param[in] gMaster Global node number of the 6-DOF master node
   //! \param[in] dX Relative position of the slave w.r.t. the master node
@@ -958,7 +963,7 @@ protected:
   //! 'F' means this patch uses FE data and spline geometry of another patch.
   const char shareFE; //!< If \e true, this patch uses FE data of another patch
 
-  BCVec  BCode; //!< Array of Boundary condition codes
+  BCVec  BCode; //!< Array of Boundary Condition codes
   MPCMap dCode; //!< Inhomogeneous Dirichlet condition codes for the MPCs
   MPCSet mpcs;  //!< All multi-point constraints with the slave in this patch
 

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -236,6 +236,12 @@ public:
   //! \return Local element number within the patch that contains the point
   virtual int findElementContaining(const double* param) const;
 
+  //! \brief Searches for the specified Cartesian point in the patch.
+  //! \param X The Cartesian coordinates of the point, updated on output
+  //! \param[out] param The parameters of the point in the knot-span domain
+  //! \return Distance from the point \a X to the found point
+  virtual double findPoint(Vec3& X, double* param) const;
+
   //! \brief Creates a line element model of this patch for visualization.
   //! \param[out] grid The generated line grid
   //! \param[in] npe Number of visualization nodes over each knot span

--- a/src/ASM/ASMs1DLag.C
+++ b/src/ASM/ASMs1DLag.C
@@ -26,8 +26,7 @@
 #include "Utilities.h"
 
 
-ASMs1DLag::ASMs1DLag (unsigned char n_s, unsigned char n_f)
-  : ASMs1D(n_s,n_f), coord(myCoord)
+ASMs1DLag::ASMs1DLag (unsigned char n_s, unsigned char n_f) : ASMs1D(n_s,n_f)
 {
   nx = 0;
   p1 = 0;
@@ -35,7 +34,7 @@ ASMs1DLag::ASMs1DLag (unsigned char n_s, unsigned char n_f)
 
 
 ASMs1DLag::ASMs1DLag (const ASMs1DLag& patch, unsigned char n_f)
-  : ASMs1D(patch,n_f), coord(patch.myCoord)
+  : ASMs1D(patch,n_f), ASMLagBase(patch,false)
 {
   nx = patch.nx;
   p1 = patch.p1;
@@ -43,7 +42,7 @@ ASMs1DLag::ASMs1DLag (const ASMs1DLag& patch, unsigned char n_f)
 
 
 ASMs1DLag::ASMs1DLag (const ASMs1DLag& patch)
-  : ASMs1D(patch), coord(myCoord), myCoord(patch.coord)
+  : ASMs1D(patch), ASMLagBase(patch)
 {
   nx = patch.nx;
   p1 = patch.p1;
@@ -482,24 +481,15 @@ bool ASMs1DLag::evalSolution (Matrix& sField, const Vector& locSol,
 bool ASMs1DLag::evalSolution (Matrix& sField, const Vector& locSol,
                               const RealArray*, bool, int, int) const
 {
-  size_t nPoints = coord.size();
-  size_t nComp = locSol.size() / nPoints;
-  if (nComp*nPoints != locSol.size())
-    return false;
-
-  sField.resize(nComp,nPoints);
-  const double* u = locSol.ptr();
-  for (size_t n = 1; n <= nPoints; n++, u += nComp)
-    sField.fillColumn(n,u);
-
-  return true;
+  // Direct nodal evaluation
+  return this->nodalField(sField,locSol,coord.size());
 }
 
 
 bool ASMs1DLag::evalSolution (Matrix& sField, const IntegrandBase& integrand,
 			      const int*, char) const
 {
-  return this->evalSolution(sField,integrand,(const RealArray*)nullptr,0);
+  return this->evalSolution(sField,integrand,nullptr,false);
 }
 
 

--- a/src/ASM/ASMs1DLag.h
+++ b/src/ASM/ASMs1DLag.h
@@ -15,7 +15,7 @@
 #define _ASM_S1D_LAG_H
 
 #include "ASMs1D.h"
-#include "Vec3.h"
+#include "ASMLagBase.h"
 
 
 /*!
@@ -23,7 +23,7 @@
   \details This class contains methods for 1D %Lagrange patches.
 */
 
-class ASMs1DLag : public ASMs1D
+class ASMs1DLag : public ASMs1D, protected ASMLagBase
 {
 public:
   //! \brief Default constructor.
@@ -145,12 +145,6 @@ public:
 protected:
   size_t nx; //!< Number of nodes
   int    p1; //!< Polynomial order of the basis
-
-private:
-  const Vec3Vec& coord; //!< Nodal coordinates
-
-protected:
-  Vec3Vec myCoord; //!< The actual nodal coordinates
 };
 
 #endif

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -454,6 +454,12 @@ public:
   //! \return Local element number within the patch that contains the point
   virtual int findElementContaining(const double* param) const;
 
+  //! \brief Searches for the specified Cartesian point in the patch.
+  //! \param X The Cartesian coordinates of the point, updated on output
+  //! \param[out] param The parameters of the point in the knot-span domain
+  //! \return Distance from the point \a X to the found point
+  virtual double findPoint(Vec3& X, double* param) const;
+
   //! \brief Calculates parameter values for visualization nodal points.
   //! \param[out] prm Parameter values in given direction for all points
   //! \param[in] dir Parameter direction (0,1)
@@ -470,10 +476,10 @@ public:
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector in DOF-order
   //! \param[in] npe Number of visualization nodes over each knot span
-  //! \param[in] nf If nonzero, mixed evaluates nf fields on first basis
-  //! \param[in] piola If true, use piola mapping
+  //! \param[in] n_f If nonzero, mixed evaluates \a n_f fields on first basis
+  //! \param[in] piola If \e true, use piola mapping
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-                            const int* npe, int nf, bool piola) const;
+                            const int* npe, int n_f, bool piola) const;
 
   //! \brief Evaluates the primary solution field at the given points.
   //! \param[out] sField Solution field
@@ -495,9 +501,9 @@ public:
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector local to current patch
   //! \param[in] npe Number of visualization nodes over each knot span
-  //! \param[in] nf If nonzero, mixed evaluates nf fields on first basis
+  //! \param[in] n_f If nonzero, mixed evaluates \a n_f fields on first basis
   virtual bool evalProjSolution(Matrix& sField, const Vector& locSol,
-                                const int* npe, int nf) const;
+                                const int* npe, int n_f) const;
 
   //! \brief Evaluates and interpolates a field over a given geometry.
   //! \param[in] basis The basis of the field to evaluate

--- a/src/ASM/ASMs2DLag.h
+++ b/src/ASM/ASMs2DLag.h
@@ -15,7 +15,7 @@
 #define _ASM_S2D_LAG_H
 
 #include "ASMs2D.h"
-#include "Vec3.h"
+#include "ASMLagBase.h"
 
 
 /*!
@@ -23,7 +23,7 @@
   \details This class contains methods for structured 2D %Lagrange patches.
 */
 
-class ASMs2DLag : public ASMs2D
+class ASMs2DLag : public ASMs2D, protected ASMLagBase
 {
 protected:
   //! \brief Implementation of basis function cache.
@@ -201,19 +201,26 @@ public:
   //! \brief Evaluates the primary solution field at all visualization points.
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector in DOF-order
-  //! \param[in] nf If nonzero, mixed evaluates nf fields on first basis
+  //! \param[in] n_f If nonzero, mixed evaluates \a n_f fields on first basis
   //!
   //! \details The number of visualization points is the same as the order of
   //! the %Lagrange elements by default.
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-                            const int*, int nf, bool) const;
+                            const int*, int n_f, bool) const;
 
-  //! \brief Evaluates the primary solution field at the nodal points.
+  //! \brief Evaluates the primary solution field at the given points.
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector local to current patch
   //! \param[in] gpar Parameter values of the result sampling points
+  //! \param[in] regular Flag indicating how the sampling points are defined
+  //!
+  //! \details If \a gpar is null, the nodal point values for the solution are
+  //! returned if \a regular is \e false and the element center values are
+  //! returned if \a regular is \e true. If \a gpar is not null, we assume that
+  //! it contains the \a u and \a v parameters for each sampling point.
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-                            const RealArray* gpar, bool, int, int) const;
+                            const RealArray* gpar, bool regular,
+                            int, int) const;
 
   //! \brief Evaluates the secondary solution field at all visualization points.
   //! \param[out] sField Solution field
@@ -266,12 +273,6 @@ protected:
   size_t ny; //!< Number of nodes in second parameter direction
   int    p1; //!< Polynomial order in first parameter direction
   int    p2; //!< Polynomial order in second parameter direction
-
-private:
-  const Vec3Vec& coord; //!< Nodal coordinates
-
-protected:
-  Vec3Vec myCoord; //!< The actual nodal coordinates
 };
 
 #endif

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -528,6 +528,12 @@ public:
   //! \return Local element number within the patch that contains the point
   virtual int findElementContaining(const double* param) const;
 
+  //! \brief Searches for the specified Cartesian point in the patch.
+  //! \param X The Cartesian coordinates of the point, updated on output
+  //! \param[out] param The parameters of the point in the knot-span domain
+  //! \return Distance from the point \a X to the found point
+  virtual double findPoint(Vec3& X, double* param) const;
+
   //! \brief Calculates parameter values for visualization nodal points.
   //! \param[out] prm Parameter values in given direction for all points
   //! \param[in] dir Parameter direction (0,1,2)
@@ -544,10 +550,10 @@ public:
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector in DOF-order
   //! \param[in] npe Number of visualization nodes over each knot span
-  //! \param[in] nf If nonzero, mixed evaluates nf fields on first basis
-  //! \param[in] piola True for a piola mapped solution
+  //! \param[in] n_f If nonzero, mixed evaluates \a n_f fields on first basis
+  //! \param[in] piola If \e true, use piola mapping
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-                            const int* npe, int nf, bool piola) const;
+                            const int* npe, int n_f, bool piola) const;
 
   //! \brief Evaluates the primary solution field at the given points.
   //! \param[out] sField Solution field
@@ -569,9 +575,9 @@ public:
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector local to current patch
   //! \param[in] npe Number of visualization nodes over each knot span
-  //! \param[in] nf If nonzero, mixed evaluates nf fields on first basis
+  //! \param[in] n_f If nonzero, mixed evaluates \a n_f fields on first basis
   virtual bool evalProjSolution(Matrix& sField, const Vector& locSol,
-                                const int* npe, int nf) const;
+                                const int* npe, int n_f) const;
 
   //! \brief Evaluates and interpolates a field over a given geometry.
   //! \param[in] basis The basis of the field to evaluate

--- a/src/ASM/ASMs3DLag.h
+++ b/src/ASM/ASMs3DLag.h
@@ -15,7 +15,7 @@
 #define _ASM_S3D_LAG_H
 
 #include "ASMs3D.h"
-#include "Vec3.h"
+#include "ASMLagBase.h"
 
 
 /*!
@@ -23,7 +23,7 @@
   \details This class contains methods for structured 3D %Lagrange patches.
 */
 
-class ASMs3DLag : public ASMs3D
+class ASMs3DLag : public ASMs3D, protected ASMLagBase
 {
 protected:
   //! \brief Implementation of basis function cache.
@@ -214,19 +214,26 @@ public:
   //! \brief Evaluates the primary solution field at all visualization points.
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector in DOF-order
-  //! \param[in] nf If nonzero, mixed evaluates nf fields on first basis
+  //! \param[in] n_f If nonzero, mixed evaluates \a n_f fields on first basis
   //!
   //! \details The number of visualization points is the same as the order of
   //! the %Lagrange elements by default.
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-                            const int*, int nf, bool) const;
+                            const int*, int n_f, bool) const;
 
-  //! \brief Evaluates the primary solution field at the nodal points.
+  //! \brief Evaluates the primary solution field at the given points.
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector local to current patch
   //! \param[in] gpar Parameter values of the result sampling points
+  //! \param[in] regular Flag indicating how the sampling points are defined
+  //!
+  //! \details If \a gpar is null, the nodal point values for the solution are
+  //! returned if \a regular is \e false and the element center values are
+  //! returned if \a regular is \e true. If \a gpar is not null, we assume that
+  //! it contains the \a u and \a v parameters for each sampling point.
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-                            const RealArray* gpar, bool, int, int) const;
+                            const RealArray* gpar, bool regular,
+                            int, int) const;
 
   //! \brief Evaluates the secondary solution field at all visualization points.
   //! \param[out] sField Solution field
@@ -299,10 +306,6 @@ protected:
   int    p1; //!< Polynomial order in first parameter direction
   int    p2; //!< Polynomial order in second parameter direction
   int    p3; //!< Polynomial order in third parameter direction
-
-  const Vec3Vec& coord; //!< Nodal coordinates
-
-  Vec3Vec myCoord; //!< The actual nodal coordinates
 };
 
 #endif

--- a/src/ASM/ASMsupel.h
+++ b/src/ASM/ASMsupel.h
@@ -98,6 +98,8 @@ public:
   virtual int evalPoint(const double*, double*, Vec3&) const { return 0; }
   //! \brief Dummy method doing nothing.
   virtual int findElementContaining(const double*) const { return 0; }
+  //! \brief Dummy method doing nothing.
+  virtual double findPoint(Vec3&, double*) const { return -1.0; }
 
   //! \brief Creates a standard FE model of this patch for visualization.
   //! \param[out] grid The generated finite element grid

--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -1933,6 +1933,13 @@ int ASMu2D::findElementContaining (const double* param) const
 }
 
 
+double ASMu2D::findPoint (Vec3&, double*) const
+{
+  std::cerr <<" *** ASMu2D::findPoint: Not implemented yet"<< std::endl;
+  return -1.0;
+}
+
+
 bool ASMu2D::getGridParameters (RealArray& prm, int dir, int nSegPerSpan) const
 {
   if (!lrspline) return false;
@@ -2017,7 +2024,7 @@ bool ASMu2D::tesselate (ElementBlock& grid, const int* npe) const
 
 
 bool ASMu2D::evalSolution (Matrix& sField, const Vector& locSol,
-                           const int* npe, int nf, bool piola) const
+                           const int* npe, int n_f, bool piola) const
 {
   // Compute parameter values of the result sampling points
   std::array<RealArray,2> gpar;
@@ -2029,7 +2036,7 @@ bool ASMu2D::evalSolution (Matrix& sField, const Vector& locSol,
   if (piola)
     return this->evalSolutionPiola(sField,locSol,gpar.data(),false);
   else
-    return this->evalSolution(sField,locSol,gpar.data(),false,0,nf);
+    return this->evalSolution(sField,locSol,gpar.data(),false,0,n_f);
 }
 
 
@@ -2113,7 +2120,7 @@ bool ASMu2D::evalSolution (Matrix& sField, const Vector& locSol,
 
 
 bool ASMu2D::evalProjSolution (Matrix& sField, const Vector& locSol,
-                               const int* npe, int nf) const
+                               const int* npe, int n_f) const
 {
   // Compute parameter values of the result sampling points
   std::array<RealArray,2> gpar;
@@ -2123,7 +2130,7 @@ bool ASMu2D::evalProjSolution (Matrix& sField, const Vector& locSol,
 
   // Evaluate the projected solution at all sampling points
   if (!this->separateProjectionBasis())
-    return this->evalSolution(sField,locSol,gpar.data(),false,0,nf);
+    return this->evalSolution(sField,locSol,gpar.data(),false,0,n_f);
 
   // The projection uses a separate basis, need to interpolate
   size_t nPoints = gpar[0].size();
@@ -2397,7 +2404,7 @@ bool ASMu2D::updateDirichlet (const std::map<int,RealFunc*>& func,
         for (int dofs = dedg.dof; dofs > 0; dofs /= 10)
         {
           int dof = dofs%10;
-          // Find the constraint equation for current (node,dof)
+          // Find the constraint equation for current (node, local DOF)
           MPC pDOF(MLGN[dedg.MLGN[j]-1],dof);
           MPCIter mit = mpcs.find(&pDOF);
           if (mit != mpcs.end())

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -85,7 +85,7 @@ protected:
   protected:
     const ASMu2D& patch; //!< Reference to patch cache is for
 
-private:
+  private:
     //! \brief Configure quadratures.
     bool setupQuadrature();
   };
@@ -382,6 +382,12 @@ public:
   //! \return Local element number within the patch that contains the point
   virtual int findElementContaining(const double* param) const;
 
+  //! \brief Searches for the specified Cartesian point in the patch.
+  //! \param X The Cartesian coordinates of the point, updated on output
+  //! \param[out] param The parameters of the point in the knot-span domain
+  //! \return Distance from the point \a X to the found point
+  virtual double findPoint(Vec3& X, double* param) const;
+
   //! \brief Calculates parameter values for visualization nodal points.
   //! \param[out] prm Parameter values in given direction for all points
   //! \param[in] dir Parameter direction (0,1)
@@ -398,10 +404,10 @@ public:
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector in DOF-order
   //! \param[in] npe Number of visualization nodes over each knot span
-  //! \param[in] nf If nonzero, mixed evaluates nf fields on first basis
-  //! \param[in] piola True if solution uses Piola mapping
+  //! \param[in] n_f If nonzero, mixed evaluates \a n_f fields on first basis
+  //! \param[in] piola If \e true, use piola mapping
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-                            const int* npe, int nf, bool piola) const;
+                            const int* npe, int n_f, bool piola) const;
 
   //! \brief Evaluates the primary solution field at the given points.
   //! \param[out] sField Solution field
@@ -416,9 +422,9 @@ public:
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector local to current patch
   //! \param[in] npe Number of visualization nodes over each knot span
-  //! \param[in] nf If nonzero, mixed evaluates nf fields on first basis
+  //! \param[in] n_f If nonzero, mixed evaluates \a n_f fields on first basis
   virtual bool evalProjSolution(Matrix& sField, const Vector& locSol,
-                                const int* npe, int nf) const;
+                                const int* npe, int n_f) const;
 
   //! \brief Evaluates and interpolates a function over a given geometry.
   //! \param[in] func The function to evaluate

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -1400,6 +1400,13 @@ int ASMu3D::findElementContaining (const double* param) const
 }
 
 
+double ASMu3D::findPoint (Vec3&, double*) const
+{
+  std::cerr <<" *** ASMu3D::findPoint: Not implemented yet"<< std::endl;
+  return -1.0;
+}
+
+
 bool ASMu3D::getGridParameters (RealArray& prm, int dir, int nSegPerSpan) const
 {
   if (!lrspline) return false;
@@ -1497,7 +1504,7 @@ bool ASMu3D::tesselate (ElementBlock& grid, const int* npe) const
 
 
 bool ASMu3D::evalSolution (Matrix& sField, const Vector& locSol,
-                           const int* npe, int nf, bool piola) const
+                           const int* npe, int n_f, bool piola) const
 {
   // Compute parameter values of the result sampling points
   std::array<RealArray,3> gpar;
@@ -1509,7 +1516,7 @@ bool ASMu3D::evalSolution (Matrix& sField, const Vector& locSol,
   if (piola)
     return this->evalSolutionPiola(sField,locSol,gpar.data(),false);
   else
-    return this->evalSolution(sField,locSol,gpar.data(),false,0,nf);
+    return this->evalSolution(sField,locSol,gpar.data(),false,0,n_f);
 }
 
 
@@ -1596,7 +1603,7 @@ bool ASMu3D::evalSolution (Matrix& sField, const Vector& locSol,
 
 
 bool ASMu3D::evalProjSolution (Matrix& sField, const Vector& locSol,
-                               const int* npe, int nf) const
+                               const int* npe, int n_f) const
 {
   // Compute parameter values of the result sampling points
   std::array<RealArray,3> gpar;
@@ -1606,7 +1613,7 @@ bool ASMu3D::evalProjSolution (Matrix& sField, const Vector& locSol,
 
   // Evaluate the projected solution at all sampling points
   if (!this->separateProjectionBasis())
-    return this->evalSolution(sField,locSol,gpar.data(),false,0,nf);
+    return this->evalSolution(sField,locSol,gpar.data(),false,0,n_f);
 
   // The projection uses a separate basis, need to interpolate
   size_t nPoints = gpar[0].size();
@@ -1940,7 +1947,7 @@ bool ASMu3D::updateDirichlet (const std::map<int,RealFunc*>& func,
         for (int dofs = dfac.dof; dofs > 0; dofs /= 10)
         {
           int dof = dofs%10;
-          // Find the constraint equation for current (node,dof)
+          // Find the constraint equation for current (node, local DOF)
           MPC pDOF(MLGN[dfac.MLGN[j]-1],dof);
           MPCIter mit = mpcs.find(&pDOF);
           if (mit != mpcs.end())

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -61,7 +61,7 @@ protected:
     //! \brief Empty destructor.
     virtual ~BasisFunctionCache() = default;
 
- protected:
+  protected:
     //! \brief Implementation specific initialization.
     bool internalInit() override;
 
@@ -101,7 +101,7 @@ protected:
 
     const ASMu3D& patch; //!< Reference to patch cache is for
 
-private:
+  private:
     //! \brief Configure quadratures.
     bool setupQuadrature();
   };
@@ -391,6 +391,12 @@ public:
   //! \return Local element number within the patch that contains the point
   virtual int findElementContaining(const double* param) const;
 
+  //! \brief Searches for the specified Cartesian point in the patch.
+  //! \param X The Cartesian coordinates of the point, updated on output
+  //! \param[out] param The parameters of the point in the knot-span domain
+  //! \return Distance from the point \a X to the found point
+  virtual double findPoint(Vec3& X, double* param) const;
+
   //! \brief Calculates parameter values for visualization nodal points.
   //! \param[out] prm Parameter values in given direction for all points
   //! \param[in] dir Parameter direction (0,1,2)
@@ -407,10 +413,10 @@ public:
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector in DOF-order
   //! \param[in] npe Number of visualization nodes over each knot span
-  //! \param[in] nf If nonzero, mixed evaluates nf fields on first basis
-  //! \param[in] piola True if solution uses Piola mapping
+  //! \param[in] n_f If nonzero, mixed evaluates \a n_f fields on first basis
+  //! \param[in] piola If \e true, use piola mapping
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-                            const int* npe, int nf, bool piola) const;
+                            const int* npe, int n_f, bool piola) const;
 
   //! \brief Evaluates the primary solution field at the given points.
   //! \param[out] sField Solution field
@@ -425,9 +431,9 @@ public:
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector local to current patch
   //! \param[in] npe Number of visualization nodes over each knot span
-  //! \param[in] nf If nonzero, mixed evaluates nf fields on first basis
+  //! \param[in] n_f If nonzero, mixed evaluates \a n_f fields on first basis
   virtual bool evalProjSolution(Matrix& sField, const Vector& locSol,
-                                const int* npe, int nf = 0) const;
+                                const int* npe, int n_f) const;
 
   //! \brief Evaluates and interpolates a function over a given geometry.
   //! \param[in] func The function to evaluate

--- a/src/ASM/NewmarkMats.h
+++ b/src/ASM/NewmarkMats.h
@@ -38,7 +38,7 @@ public:
   //! \brief Empty destructor.
   virtual ~NewmarkMats() {}
 
-  //! \brief Updates the time step size and the \a isPredictor flag.
+  //! \brief Updates the time step size and the \ref isPredictor flag.
   //! \param[in] dt New time step size
   //! \param[in] it Newton-Raphson iteration counter
   virtual void setStepSize(double dt, int it) { h = dt; isPredictor = it == 0; }

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -727,7 +727,7 @@ public:
   //! \brief Dumps left-hand-side matrix and right-hand-side vector to file.
   void dumpEqSys(bool initialBlankLine = false);
   //! \brief Dumps a solution vector to file.
-  void dumpSolVec(const Vector& vec);
+  void dumpSolVec(const Vector& x,bool isExpanded = true, bool expOnly = false);
 
 protected:
   //! \brief Returns the multi-dimension simulator sequence flag.

--- a/src/SIM/SIMoutput.h
+++ b/src/SIM/SIMoutput.h
@@ -24,9 +24,9 @@ class VTF;
 /*!
   \brief Sub-class with additional functionality for result output.
   \details This class extends the SIMbase class with some added functionalities
-  for dumping simulation results to VTF-file, and terminal printout. These items
-  are put in a separate sub-class here to hide them away from the SIMbase class,
-  which contains the main simulation driver.
+  for dumping simulation results to VTF and ASCII files, and terminal printout.
+  These items are put in a separate sub-class to hide them from the SIMbase
+  class, which contains the main simulation driver.
 */
 
 class SIMoutput : public SIMinput
@@ -317,7 +317,7 @@ public:
   virtual bool writeAddFuncs(int iStep, int& nBlock, int idBlock, double time);
 
 protected:
-  //! \brief Adds an additional function for VTF output.
+  //! \brief Adds an additional function for VTF-file output.
   void addAddFunc(const std::string& name, RealFunc* f);
 
 private:
@@ -338,14 +338,14 @@ protected:
   //! \brief Struct defining a result sampling point.
   struct ResultPoint
   {
-    unsigned char npar;  //!< Number of parameters
-    size_t        patch; //!< Patch index [1,nPatch]
-    int           inod;  //!< Local node number of the closest node
-    double        u[3];  //!< Parameters of the point (u,v,w)
-    Vec3          X;     //!< Spatial coordinates of the point
+    short int    npar;  //!< Number of parameters
+    unsigned int patch; //!< Patch index [1,nPatch]
+    int          inod;  //!< Local node number of the closest node
+    double       u[3];  //!< Parameters of the point (u,v,w)
+    Vec3         X;     //!< Spatial coordinates of the point
 
     //! \brief Default constructor.
-    ResultPoint() : npar(0), patch(1), inod(0) { u[0] = u[1] = u[2] = 0.0; }
+    ResultPoint() : npar(3), patch(1), inod(0) { u[0] = u[1] = u[2] = 0.0; }
   };
 
   //! \brief Result point container.
@@ -391,8 +391,8 @@ private:
   std::map<std::string,RealFunc*> myAddScalars; //!< Scalar functions to output
 
   int    myPrec;   //!< Output precision for result sampling
-  double myPtSize; //!< Size of result point visualization in VTF file
-  int    myGeomID; //!< VTF geometry block ID for the first patch
+  double myPtSize; //!< Size of result point visualization in VTF-file
+  int    myGeomID; //!< Geometry block ID for the first patch in the VTF-file
   VTF*   myVtf;    //!< VTF-file for result visualization
   bool   logRpMap; //!< If \e true, print out the result point mapping
   int    idxGrid;  //!< Index into \ref myPoints for grid result output


### PR DESCRIPTION
If we have a non-rectangular domain and want to output results in a 2D raster image.
(For optimal sensor placement calculations).

Also the option to dump the results in either all nodal points, or at all element centers.