### PR TITLE
Fix xml include files

### DIFF
--- a/src/SIM/Test/TestXMLInputBase.C
+++ b/src/SIM/Test/TestXMLInputBase.C
@@ -62,6 +62,7 @@ TEST(TestXMLInputBase, IncludeFiles)
     "dirichlet", "set", "foo", "comp", "12",
     "dirichlet", "set", "bar", "comp", "12", "type", "expression", "a*b*c",
     "neumann", "set", "foobar", "type", "constant", "1.0",
+    "someothertag", "is_here"
   };
 
   EXPECT_EQ(x.strings, ref);

--- a/src/SIM/Test/with_include.xml
+++ b/src/SIM/Test/with_include.xml
@@ -1,3 +1,4 @@
 <simulation>
   <include>src/SIM/Test/included.xml</include>
+  <someothertag>is_here</someothertag>
 </simulation>

--- a/src/SIM/XMLInputBase.C
+++ b/src/SIM/XMLInputBase.C
@@ -48,39 +48,39 @@ struct IncludeInjector : public tinyxml2::XMLVisitor
   bool VisitEnter(const tinyxml2::XMLElement& elem,
                   const tinyxml2::XMLAttribute* attribute) override
   {
-      tinyxml2::XMLElement* e;
-      if (std::string(elem.Value()) == "include") {
-        tinyxml2::XMLDocument inc_doc(true, tinyxml2::COLLAPSE_WHITESPACE);
-          if (inc_doc.LoadFile(elem.GetText()) != tinyxml2::XML_SUCCESS) {
-            std::cerr << "** Error parsing include file " << elem.GetText() << std::endl;
-            return false;
-        }
-        currElem->InsertEndChild(inc_doc.RootElement()->DeepClone(&new_doc));
-        include_found = true;
-      } else {
-        e = new_doc.NewElement(elem.Name());
-        if (elem.GetText())
-          e->SetText(elem.GetText());
-        if (!currElem)
-          new_doc.InsertEndChild(e);
-        else
-          currElem->InsertEndChild(e);
-        while (attribute)
-        {
-          e->SetAttribute(attribute->Name(), attribute->Value());
-          attribute = attribute->Next();
-        }
-        currElem = e;
+    tinyxml2::XMLElement* e;
+    if (std::string(elem.Value()) == "include") {
+      tinyxml2::XMLDocument inc_doc(true, tinyxml2::COLLAPSE_WHITESPACE);
+        if (inc_doc.LoadFile(elem.GetText()) != tinyxml2::XML_SUCCESS) {
+          std::cerr << "** Error parsing include file " << elem.GetText() << std::endl;
+          return false;
       }
-      return true;
+      currElem->InsertEndChild(inc_doc.RootElement()->DeepClone(&new_doc));
+      include_found = true;
+    } else {
+      e = new_doc.NewElement(elem.Name());
+      if (elem.GetText())
+        e->SetText(elem.GetText());
+      if (!currElem)
+        new_doc.InsertEndChild(e);
+      else
+        currElem->InsertEndChild(e);
+      while (attribute)
+      {
+        e->SetAttribute(attribute->Name(), attribute->Value());
+        attribute = attribute->Next();
+      }
+      currElem = e;
+    }
+    return true;
   }
 
   //! brief Set element to insert into to the parent.
   bool VisitExit(const tinyxml2::XMLElement& elem) override
   {
-      if (currElem && currElem->Parent())
-        currElem = const_cast<tinyxml2::XMLElement*>(currElem->Parent()->ToElement());
-      return true;
+    if (currElem && currElem->Parent())
+      currElem = const_cast<tinyxml2::XMLElement*>(currElem->Parent()->ToElement());
+    return true;
   }
 
   tinyxml2::XMLDocument new_doc; //!< New document


### PR DESCRIPTION
"Small" bug introduced when we moved to tinyxml2. After include was injected a closing tag was added for the currently processed element. This meant we got an early closing tag which broke the structure of the XML document.