### PR TITLE
Added: ASMbase::addRigidCouplings()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ else()
                          src/ASM/LocalIntegral.h src/ASM/SAMpatch.h
                          src/ASM/SplineField?D.h src/ASM/SplineFields?D.h
                          src/ASM/TimeDomain.h src/ASM/ASMs?D.h src/ASM/ASM?D.h
-                         src/ASM/ASMs?DLag.h src/ASM/ASMutils.h
+                         src/ASM/ASMs?DLag.h src/ASM/ASMu2DLag.h src/ASM/ASMutils.h
                          src/ASM/DomainDecomposition.h src/ASM/ItgPoint.h
                          src/ASM/ReactionsOnly.h
                          src/LinAlg/*.h src/SIM/*.h src/Utility/*.h

--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -646,7 +646,15 @@ bool ASMbase::addRigidCpl (int lindx, int ldim, int basis,
 
   IntVec nodes;
   this->getBoundaryNodes(lindx,nodes,basis,1,0,true);
-  for (int node : nodes)
+  this->addRigidCouplings(gMaster,Xmaster,nodes);
+  return extraPt;
+}
+
+
+void ASMbase::addRigidCouplings (int gMaster, const Vec3& Xmaster,
+                                 const IntVec& slaveNodes)
+{
+  for (int node : slaveNodes)
   {
     Vec3 dX = this->getCoord(node) - Xmaster;
     if (nsd == 3)
@@ -674,8 +682,6 @@ bool ASMbase::addRigidCpl (int lindx, int ldim, int basis,
       }
     }
   }
-
-  return extraPt;
 }
 
 
@@ -1217,7 +1223,7 @@ int ASMbase::renumberNodes (std::map<int,int>& old2new, int& nNod)
       if (utl::renumber(node,nNod,old2new))
         renum++;
 
-  if (renum == 0)
+  if (renum == 0 && !MLGN.empty())
     nNod = std::max(nNod,*std::max_element(MLGN.begin(),MLGN.end()));
 
   return renum;

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -552,9 +552,10 @@ public:
   //! \param[in] locSol Solution vector local to current patch
   //! \param[in] npe Number of visualization nodes over each knot span
   //! \param[in] nf If nonzero, mixed evaluates nf fields on first basis
-  //! \param[in] piola If true, use piola mapping
+  //! \param[in] piola If \e true, use piola mapping
   virtual bool evalSolution(Matrix& sField, const Vector& locSol,
-                            const int* npe, int nf = 0, bool piola = false) const;
+                            const int* npe, int nf = 0,
+                            bool piola = false) const;
 
   //! \brief Evaluates the projected solution field at all visualization points.
   //! \param[out] sField Solution field
@@ -582,7 +583,7 @@ public:
                             const RealArray* gpar, bool regular = true,
                             int deriv = 0, int nf = 0) const;
 
-  //! \brief Evaluates the primary solution field at the given points with Piola mapping.
+  //! \brief Evaluates the primary solution field with Piola mapping.
   //! \param[out] sField Solution field
   //! \param[in] locSol Solution vector local to current patch
   //! \param[in] gpar Parameter values of the result sampling points
@@ -594,7 +595,7 @@ public:
   //! Otherwise, we assume that it contains the \a u, \a v and \a w parameters
   //! directly for each sampling point.
   virtual bool evalSolutionPiola(Matrix& sField, const Vector& locSol,
-                                 const RealArray* gpar, bool regular = true) const;
+                                 const RealArray* gpar, bool regular) const;
 
   //! \brief Evaluates and interpolates a field over a given geometry.
   //! \param[in] basis The basis of the field to evaluate
@@ -779,6 +780,13 @@ public:
   virtual bool addRigidCpl(int lindx, int ldim, int basis,
                            int& gMaster, const Vec3& Xmaster,
                            bool extraPt = true);
+
+  //! \brief Adds MPCs representing a rigid coupling to this patch.
+  //! \param[in] gMaster Global node number of the master node
+  //! \param[in] slaveNodes Local node numbers of the slave nodes
+  //! \param[in] Xmaster Position of the master node
+  void addRigidCouplings(int gMaster, const Vec3& Xmaster,
+                         const IntVec& slaveNodes);
 
 protected:
 

--- a/src/ASM/ASMs2DLag.C
+++ b/src/ASM/ASMs2DLag.C
@@ -225,7 +225,7 @@ void ASMs2DLag::setCoord (size_t inod, const Vec3& Xnod)
 
 bool ASMs2DLag::getElementCoordinates (Matrix& X, int iel, bool) const
 {
-  if (iel < 1 || (size_t)iel > MNPC.size())
+  if (iel < 1 || static_cast<size_t>(iel) > MNPC.size())
   {
     std::cerr <<" *** ASMs2DLag::getElementCoordinates: Element index "<< iel
               <<" out of range [1,"<< MNPC.size() <<"]."<< std::endl;
@@ -233,8 +233,7 @@ bool ASMs2DLag::getElementCoordinates (Matrix& X, int iel, bool) const
   }
 
   // Number of nodes per element
-  size_t nen = p1*p2;
-  if (nen > MNPC[--iel].size()) nen = MNPC[iel].size();
+  size_t nen = std::min(static_cast<size_t>(p1*p2),MNPC[--iel].size());
 
   X.resize(nsd,nen);
   for (size_t i = 0; i < nen; i++)
@@ -337,7 +336,7 @@ bool ASMs2DLag::integrate (Integrand& integrand,
 #pragma omp parallel for schedule(static)
     for (size_t t = 0; t < threadGroups[g].size(); t++)
     {
-      FiniteElement fe(p1*p2);
+      FiniteElement fe;
       Matrix Jac;
       Vec4 X(nullptr,time.t);
       for (size_t e = 0; e < threadGroups[g][t].size() && ok; e++)
@@ -366,7 +365,7 @@ bool ASMs2DLag::integrate (Integrand& integrand,
 
         // Initialize element quantities
         fe.iel = MLGE[iel];
-        LocalIntegral* A = integrand.getLocalIntegral(fe.N.size(),fe.iel);
+        LocalIntegral* A = integrand.getLocalIntegral(fe.Xn.cols(),fe.iel);
         int nRed = cache.nGauss(true)[0];
         if (!integrand.initElement(MNPC[iel],fe,X,nRed*nRed,*A))
         {
@@ -482,7 +481,7 @@ bool ASMs2DLag::integrate (Integrand& integrand, int lIndex,
   const int nelx = (nx-1)/(p1-1);
   const int nely = (ny-1)/(p2-1);
 
-  FiniteElement fe(p1*p2);
+  FiniteElement fe;
   RealArray upar, vpar;
   if (surf)
   {
@@ -543,7 +542,7 @@ bool ASMs2DLag::integrate (Integrand& integrand, int lIndex,
 
       // Initialize element quantities
       fe.iel = abs(MLGE[doXelms+iel-1]);
-      LocalIntegral* A = integrand.getLocalIntegral(fe.N.size(),fe.iel,true);
+      LocalIntegral* A = integrand.getLocalIntegral(fe.Xn.cols(),fe.iel,true);
       bool ok = integrand.initElementBou(MNPC[doXelms+iel-1],*A);
 
 

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -3130,7 +3130,7 @@ bool ASMs3D::evalSolution (Matrix& sField, const Vector& locSol,
 
   // Evaluate the primary solution at all sampling points
   if (piola)
-    return this->evalSolutionPiola(sField,locSol,gpar.data());
+    return this->evalSolutionPiola(sField,locSol,gpar.data(),true);
   else
     return this->evalSolution(sField,locSol,gpar.data(),true,0,nf);
 }

--- a/src/ASM/ASMu2DLag.C
+++ b/src/ASM/ASMu2DLag.C
@@ -23,6 +23,7 @@ ASMu2DLag::ASMu2DLag (unsigned char n_s,
                       unsigned char n_f, char fType) : ASMs2DLag(n_s,n_f)
 {
   fileType = fType;
+  swapNode34 = false;
 }
 
 
@@ -30,6 +31,7 @@ ASMu2DLag::ASMu2DLag (const ASMu2DLag& p, unsigned char n_f) :
   ASMs2DLag(p,n_f), nodeSets(p.nodeSets)
 {
   fileType = 0;
+  swapNode34 = p.swapNode34;
 }
 
 
@@ -37,6 +39,7 @@ ASMu2DLag::ASMu2DLag (const ASMu2DLag& p) :
   ASMs2DLag(p), nodeSets(p.nodeSets)
 {
   fileType = 0;
+  swapNode34 = p.swapNode34;
 }
 
 
@@ -45,6 +48,7 @@ bool ASMu2DLag::read (std::istream& is)
   switch (fileType) {
   case 'm':
   case 'M':
+    swapNode34 = true;
     return ASM::readMatlab(is,myMNPC,myCoord,nodeSets);
   case 'x':
   case 'X':
@@ -143,7 +147,7 @@ bool ASMu2DLag::tesselate (ElementBlock& grid, const int*) const
 
   for (i = k = 0; i < nel; i++)
     for (j = 0; j < MNPC[i].size(); j++)
-      if (j > 1 && MNPC[i].size() == 4)
+      if (j > 1 && swapNode34 && MNPC[i].size() == 4)
         grid.setNode(k++,MNPC[i][5-j]);
       else
         grid.setNode(k++,MNPC[i][j]);
@@ -153,7 +157,7 @@ bool ASMu2DLag::tesselate (ElementBlock& grid, const int*) const
 
 
 ASMu2DLag::BasisFunctionCache::BasisFunctionCache (const ASMu2DLag& pch,
-                                                  ASM::CachePolicy plcy) :
+                                                   ASM::CachePolicy plcy) :
   ::BasisFunctionCache<2>(plcy),
   patch(pch)
 {
@@ -198,7 +202,8 @@ bool ASMu2DLag::BasisFunctionCache::setupQuadrature ()
     reducedQ->xg[0] = reducedQ->xg[1] = GaussQuadrature::getCoord(nRed);
     reducedQ->wg[0] = reducedQ->wg[1] = GaussQuadrature::getWeight(nRed);
     if (!reducedQ->xg[0] || !reducedQ->wg[0]) return false;
-  } else if (nRed < 0)
+  }
+  else if (nRed < 0)
     nRed = mainQ->ng[0]; // The integrand needs to know nGauss
 
   reducedQ->ng[0] = reducedQ->ng[1] = nRed;

--- a/src/ASM/ASMu2DLag.h
+++ b/src/ASM/ASMu2DLag.h
@@ -112,6 +112,9 @@ public:
   //! \note The number of element nodes must be set in \a grid on input.
   virtual bool tesselate(ElementBlock& grid, const int*) const;
 
+protected:
+  bool swapNode34; //!< If \e true, element nodes 3 and 4 should be swapped
+
 private:
   char                      fileType; //!< Mesh file format
   std::vector<ASM::NodeSet> nodeSets; //!< Node sets for Dirichlet BCs

--- a/src/ASM/IntegrandBase.C
+++ b/src/ASM/IntegrandBase.C
@@ -12,6 +12,7 @@
 //==============================================================================
 
 #include "IntegrandBase.h"
+#include "ASMbase.h"
 #include "GlobalIntegral.h"
 #include "FiniteElement.h"
 #include "ElmMats.h"
@@ -22,6 +23,18 @@
 #include "Fields.h"
 #include <cstring>
 #include <cstdio>
+
+
+/*!
+  Override this method if the integrand needs some patch-specific data
+  to be initialized before performing the numerical integration.
+  The default version only passes the patch index to the initPatch() method.
+*/
+
+void IntegrandBase::initForPatch (const ASMbase* pch)
+{
+  if (pch) this->initPatch(pch->idx);
+}
 
 
 /*!

--- a/src/ASM/IntegrandBase.h
+++ b/src/ASM/IntegrandBase.h
@@ -21,6 +21,7 @@
 #include "MatVec.h"
 #include <map>
 
+class ASMbase;
 class NormBase;
 class ForceBase;
 class GlobalIntegral;
@@ -88,6 +89,8 @@ public:
   virtual void setSecondaryInt(GlobalIntegral* = nullptr) {}
   //! \brief Returns the system quantity to be integrated by \a *this.
   virtual GlobalIntegral& getGlobalInt(GlobalIntegral* gq) const;
+  //! \brief Interface for initialization of integrand with patch-specific data.
+  virtual void initForPatch(const ASMbase* pch);
 
 
   // Element-level initialization interface

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -985,7 +985,8 @@ bool SIMbase::assembleSystem (const TimeDomain& time, const Vectors& prevSol,
         myProblem->getExtractionField()->clear();
     }
 
-    integrand->initPatch(pch->idx);
+    integrand->initForPatch(pch);
+
     if (mySol)
       mySol->initPatch(pch->idx);
 
@@ -1084,7 +1085,8 @@ bool SIMbase::assembleSystem (const TimeDomain& time, const Vectors& prevSol,
             break;
           }
 
-          it->second->initPatch(pch->idx);
+          it->second->initForPatch(pch);
+
           if (mySol)
             mySol->initPatch(pch->idx);
 


### PR DESCRIPTION
For use when reading rigid element definitions from external mesh file.
Also fixed a crash if MLGN is empty.
The support for 2D Lagrangian patches with a mix of 3- and 4-noded elements is also included here.
This is sufficient for the regression tests in OPM/IFEM-ShellEx to pass.