### PR TITLE
ResidualOps: flip sign of Divergence term

### DIFF
--- a/Apps/Common/EqualOrderOperators.C
+++ b/Apps/Common/EqualOrderOperators.C
@@ -284,7 +284,7 @@ void EqualOrderOperators::Residual::Divergence (Vector& EV,
                                                 const Tensor& dUdX,
                                                 double scale, size_t basis)
 {
-  EV.add(fe.basis(basis),scale*dUdX.trace()*fe.detJxW);
+  EV.add(fe.basis(basis),-scale*dUdX.trace()*fe.detJxW);
 }
 
 


### PR DESCRIPTION
while technically this makes no difference, it is
better to be consistent