### PR TITLE
Cache simpification for Lagrange patches

### DIFF
--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -12,6 +12,7 @@
 //==============================================================================
 
 #include "ASMbase.h"
+#include "ASMenums.h"
 #include "ASM2D.h"
 #include "ASM3D.h"
 #include "IFEM.h"
@@ -28,7 +29,6 @@
 
 bool ASMbase::fixHomogeneousDirichlet = true;
 int  ASMbase::dbgElm = 0;
-ASM::CachePolicy ASMbase::cachePolicy = ASM::PRE_CACHE;
 
 //! This quantitiy is used to scale the characteristic element sizes which
 //! are used by residual error estimates, etc., such that they always are in
@@ -39,6 +39,8 @@ double ASMbase::modelSize = 1.0;
 int ASMbase::gEl = 0;
 int ASMbase::gNod = 0;
 std::map<int,int> ASMbase::xNode;
+
+ASM::CachePolicy ASM::cachePolicy = ASM::PRE_CACHE;
 
 
 /*!

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -14,7 +14,6 @@
 #ifndef _ASM_BASE_H
 #define _ASM_BASE_H
 
-#include "ASMenums.h"
 #include "MatVec.h"
 #include "MPCLess.h"
 #include <map>
@@ -161,9 +160,6 @@ public:
 
   //! \brief Defines the numerical integration scheme \a nGauss in the patch.
   void setGauss(int ng) { nGauss = ng; }
-
-  //! \brief Defines the policy used for the basis function cache.
-  static void setCachePolicy(ASM::CachePolicy policy) { cachePolicy = policy; }
 
   //! \brief Defines the number of solution fields \a nf in the patch.
   //! \details This method is to be used by simulators where \a nf is not known
@@ -964,8 +960,6 @@ protected:
   //! If the value is set larger than 10, the number of quadrature points
   //! in each parameter direction is set to \a p+nGauss%10.
   int nGauss; //!< \sa getNoGaussPt
-
-  static ASM::CachePolicy cachePolicy; //!< Basis function cache policy
 
   size_t firstIp; //!< Global index to first interior integration point
 

--- a/src/ASM/ASMenums.h
+++ b/src/ASM/ASMenums.h
@@ -46,6 +46,8 @@ namespace ASM //! Assembly scope
     FULL_CACHE  //!< Cache basis function values up front
   };
 
+  extern CachePolicy cachePolicy; //!< Chosen basis function cache policy
+
   //! \brief Enumeration of different basis types.
   //! \details Entries should have non-positive values
   enum BasisType {

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -1718,7 +1718,7 @@ bool ASMs2D::integrate (Integrand& integrand,
   if (myCache.empty())
     myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this, cachePolicy, 1));
 
-  ::BasisFunctionCache<2>& cache = *myCache.front();
+  BasisFunctionCache& cache = *myCache.front();
   cache.setIntegrand(&integrand);
   if (!cache.init(use3rdDer ? 3 : (use2ndDer ? 2 : 1)))
     return false;

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -1716,7 +1716,7 @@ bool ASMs2D::integrate (Integrand& integrand,
   bool useElmVtx = integrand.getIntegrandType() & Integrand::ELEMENT_CORNERS;
 
   if (myCache.empty())
-    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this, cachePolicy, 1));
+    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this));
 
   BasisFunctionCache& cache = *myCache.front();
   cache.setIntegrand(&integrand);
@@ -3297,11 +3297,9 @@ int ASMs2D::getLastItgElmNode () const
 }
 
 
-ASMs2D::BasisFunctionCache::BasisFunctionCache (const ASMs2D& pch,
-                                                ASM::CachePolicy plcy, int b) :
-  ::BasisFunctionCache<2>(plcy), patch(pch)
+ASMs2D::BasisFunctionCache::BasisFunctionCache (const ASMs2D& pch) :
+  ::BasisFunctionCache<2>(), patch(pch)
 {
-  basis = b;
   if (patch.surf)
   {
     nel[0] = patch.surf->numCoefs_u() - patch.surf->order_u() + 1;

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -67,9 +67,7 @@ protected:
   public:
     //! \brief The constructor initializes the class.
     //! \param pch Patch the cache is for
-    //! \param plcy Cache policy to use
-    //! \param b Basis to use
-    BasisFunctionCache(const ASMs2D& pch, ASM::CachePolicy plcy, int b = 1);
+    BasisFunctionCache(const ASMs2D& pch);
 
     //! \brief Constructor reusing quadrature info from another instance.
     //! \param cache Instance holding quadrature information

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -815,7 +815,7 @@ protected:
   ThreadGroups threadGroups;
 
   //! Basis function cache
-  std::vector<std::unique_ptr<::BasisFunctionCache<2>>> myCache;
+  std::vector<std::unique_ptr<BasisFunctionCache>> myCache;
 };
 
 #endif

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -107,6 +107,9 @@ protected:
     //! \brief Setup integration point parameters.
     virtual void setupParameters();
 
+    //! \brief Configure quadratures.
+    bool setupQuadrature();
+
     const ASMs2D& patch; //!< Reference to patch cache is for
 
     std::array<size_t,2> nel{}; //!< Number of elements in each direction
@@ -115,9 +118,6 @@ protected:
     //! \brief Obtain structured element indices.
     //! \param el Global element index
     std::array<size_t,2> elmIndex(size_t el) const;
-
-    //! \brief Configure quadratures.
-    bool setupQuadrature();
   };
 
 public:
@@ -702,10 +702,13 @@ public:
   static void scatterInd(int n1, int n2, int p1, int p2,
 			 const int* start, IntVec& index);
 
+private:
   //! \brief Returns the polynomial order in each parameter direction.
   //! \param[out] p1 Order in first (u) direction
   //! \param[out] p2 Order in second (v) direction
   bool getOrder(int& p1, int& p2) const;
+
+public:
   //! \brief Returns the polynomial order in each parameter direction.
   //! \param[out] p1 Order in first (u) direction
   //! \param[out] p2 Order in second (v) direction

--- a/src/ASM/ASMs2DLag.C
+++ b/src/ASM/ASMs2DLag.C
@@ -319,7 +319,7 @@ bool ASMs2DLag::integrate (Integrand& integrand,
   if (myCache.empty())
     myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this, cachePolicy, 1));
 
-  ::BasisFunctionCache<2>& cache = static_cast<::BasisFunctionCache<2>&>(*myCache.front());
+  ASMs2D::BasisFunctionCache& cache = *myCache.front();
   cache.setIntegrand(&integrand);
   if (!cache.init(1))
     return false;
@@ -935,7 +935,7 @@ bool ASMs2DLag::assembleL2matrices (SparseMatrix& A, StdVector& B,
                                     const L2Integrand& integrand,
                                     bool continuous) const
 {
-  BasisFunctionCache& cache = static_cast<BasisFunctionCache&>(*myCache.front());
+  ASMs2D::BasisFunctionCache& cache = *myCache.front();
   if (!cache.init(1))
     return false;
 

--- a/src/ASM/ASMs2DLag.C
+++ b/src/ASM/ASMs2DLag.C
@@ -317,7 +317,7 @@ bool ASMs2DLag::integrate (Integrand& integrand,
   if (this->empty()) return true; // silently ignore empty patches
 
   if (myCache.empty())
-    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this, cachePolicy, 1));
+    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this));
 
   ASMs2D::BasisFunctionCache& cache = *myCache.front();
   cache.setIntegrand(&integrand);
@@ -1002,10 +1002,8 @@ bool ASMs2DLag::assembleL2matrices (SparseMatrix& A, StdVector& B,
 }
 
 
-ASMs2DLag::BasisFunctionCache::BasisFunctionCache (const ASMs2DLag& pch,
-                                                   ASM::CachePolicy plcy,
-                                                   int b) :
-  ASMs2D::BasisFunctionCache(pch,plcy,b)
+ASMs2DLag::BasisFunctionCache::BasisFunctionCache (const ASMs2DLag& pch)
+  : ASMs2D::BasisFunctionCache(pch)
 {
   nel[0] = (pch.nx-1) / (pch.p1-1);
   nel[1] = (pch.ny-1) / (pch.p2-1);

--- a/src/ASM/ASMs2DLag.h
+++ b/src/ASM/ASMs2DLag.h
@@ -34,12 +34,12 @@ protected:
     //! \param pch Patch the cache is for
     //! \param plcy Cache policy to use
     //! \param b Basis to use
-    BasisFunctionCache(const ASMs2DLag& pch, ASM::CachePolicy plcy, int b);
+    BasisFunctionCache(const ASMs2DLag& pch, ASM::CachePolicy plcy, int b = 1);
 
     //! \brief Constructor reusing quadrature info from another instance.
     //! \param cache Instance holding quadrature information
     //! \param b Basis to use
-    BasisFunctionCache(const BasisFunctionCache& cache, int b);
+    BasisFunctionCache(const ASMs2D::BasisFunctionCache& cache, int b);
 
     //! \brief Empty destructor.
     virtual ~BasisFunctionCache() = default;
@@ -52,18 +52,17 @@ protected:
     double getParam(int dir, size_t el, size_t gp, bool reduced = false) const override;
 
   protected:
+    //! \brief Implementation specific initialization.
+    bool internalInit() override;
+
     //! \brief Obtain global integration point index.
-    //! \param el Element of integration point (0-indexed)
-    //! \param gp Integration point on element (0-indexed)
-    //! \param reduced True to return index for reduced quadrature
-    size_t index(size_t el, size_t gp, bool reduced) const override
-    { return ::BasisFunctionCache<2>::index(el,gp,reduced); }
+    //! \param[in] gp Integration point on element (0-indexed)
+    size_t index(size_t, size_t gp, bool) const override { return gp; }
 
     //! \brief Calculates basis function info in a single integration point.
-    //! \param el Element of integration point (0-indexed)
-    //! \param gp Integratin point on element (0-indexed)
-    //! \param reduced If true, returns values for reduced integration scheme
-    BasisFunctionVals calculatePt(size_t el, size_t gp, bool reduced) const override;
+    //! \param[in] gp Integration point on element (0-indexed)
+    //! \param[in] red If \e true, returns for reduced integration scheme
+    BasisFunctionVals calculatePt(size_t, size_t gp, bool red) const override;
 
     //! \brief Calculates basis function info in all integration points.
     void calculateAll() override;
@@ -244,6 +243,12 @@ public:
   //! \param[in] basisNum The basis to evaluate for (mixed)
   virtual bool evaluate(const ASMbase* basis, const Vector& locVec,
                         RealArray& vec, int basisNum) const;
+
+  //! \brief Returns the polynomial order in each parameter direction.
+  //! \param[out] pu Order in first (u) direction
+  //! \param[out] pv Order in second (v) direction
+  //! \param[out] pw Order in third (w) direction (always zero)
+  virtual bool getOrder(int& pu, int& pv, int& pw) const;
 
   using ASMs2D::getSize;
   //! \brief Returns the number of nodal points in each parameter direction.

--- a/src/ASM/ASMs2DLag.h
+++ b/src/ASM/ASMs2DLag.h
@@ -32,9 +32,7 @@ protected:
   public:
     //! \brief The constructor initializes the class.
     //! \param pch Patch the cache is for
-    //! \param plcy Cache policy to use
-    //! \param b Basis to use
-    BasisFunctionCache(const ASMs2DLag& pch, ASM::CachePolicy plcy, int b = 1);
+    BasisFunctionCache(const ASMs2DLag& pch);
 
     //! \brief Constructor reusing quadrature info from another instance.
     //! \param cache Instance holding quadrature information

--- a/src/ASM/ASMs2DLag.h
+++ b/src/ASM/ASMs2DLag.h
@@ -49,7 +49,7 @@ protected:
     //! \param el Element number in given direction
     //! \param gp Integration point in given direction
     //! \param reduced True to return parameter for reduced quadrature
-    double getParam(int dir, size_t el, size_t gp, bool reduced = false) const override;
+    double getParam(int dir, size_t el, size_t gp, bool reduced) const override;
 
   protected:
     //! \brief Implementation specific initialization.

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -447,7 +447,7 @@ bool ASMs2Dmx::integrate (Integrand& integrand,
   const bool piolaMapping = integrand.getIntegrandType() & Integrand::PIOLA_MAPPING;
 
   if (myCache.empty()) {
-    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this, cachePolicy, 1));
+    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this));
     for (size_t b = 2; b <= this->getNoBasis(); ++b)
       myCache.emplace_back(std::make_unique<BasisFunctionCache>(*myCache.front(), b));
     if (separateGeometry)

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -448,21 +448,20 @@ bool ASMs2Dmx::integrate (Integrand& integrand,
 
   if (myCache.empty()) {
     myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this, cachePolicy, 1));
-    const BasisFunctionCache& bc = static_cast<BasisFunctionCache&>(*myCache.front());
     for (size_t b = 2; b <= this->getNoBasis(); ++b)
-      myCache.emplace_back(std::make_unique<BasisFunctionCache>(bc, b));
+      myCache.emplace_back(std::make_unique<BasisFunctionCache>(*myCache.front(), b));
     if (separateGeometry)
-      myCache.emplace_back(std::make_unique<BasisFunctionCache>(bc,
+      myCache.emplace_back(std::make_unique<BasisFunctionCache>(*myCache.front(),
                                                                 ASM::GEOMETRY_BASIS));
   }
 
-  for (std::unique_ptr<::BasisFunctionCache<2>>& cache : myCache) {
+  for (std::unique_ptr<BasisFunctionCache>& cache : myCache) {
     cache->setIntegrand(&integrand);
     cache->init(use2ndDer ||
                 (piolaMapping && cache->basis == ASM::GEOMETRY_BASIS) ? 2 : 1);
   }
 
-  ::BasisFunctionCache<2>& cache = *myCache.front();
+  BasisFunctionCache& cache = *myCache.front();
 
   // Get Gaussian quadrature points and weights
   const std::array<int,2>& ng = cache.nGauss();
@@ -598,7 +597,7 @@ bool ASMs2Dmx::integrate (Integrand& integrand,
       }
     }
 
-  for (std::unique_ptr<::BasisFunctionCache<2>>& cache : myCache)
+  for (std::unique_ptr<BasisFunctionCache>& cache : myCache)
     cache->finalizeAssembly();
   return ok;
 }

--- a/src/ASM/ASMs2DmxLag.C
+++ b/src/ASM/ASMs2DmxLag.C
@@ -242,7 +242,7 @@ bool ASMs2DmxLag::integrate (Integrand& integrand,
   bool useElmVtx = integrand.getIntegrandType() & Integrand::ELEMENT_CORNERS;
 
   if (myCache.empty()) {
-    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this, cachePolicy, 1));
+    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this));
     for (size_t b = 2; b <= this->getNoBasis(); ++b)
       myCache.emplace_back(std::make_unique<BasisFunctionCache>(*myCache.front(), b));
   }
@@ -605,10 +605,8 @@ bool ASMs2DmxLag::evalSolution (Matrix& sField, const IntegrandBase& integrand,
 }
 
 
-ASMs2DmxLag::BasisFunctionCache::BasisFunctionCache (const ASMs2DLag& pch,
-                                                     ASM::CachePolicy plcy,
-                                                     int b) :
-  ASMs2DLag::BasisFunctionCache(pch,plcy,b)
+ASMs2DmxLag::BasisFunctionCache::BasisFunctionCache (const ASMs2DLag& pch)
+  : ASMs2DLag::BasisFunctionCache(pch)
 {
 }
 

--- a/src/ASM/ASMs2DmxLag.C
+++ b/src/ASM/ASMs2DmxLag.C
@@ -247,12 +247,12 @@ bool ASMs2DmxLag::integrate (Integrand& integrand,
       myCache.emplace_back(std::make_unique<BasisFunctionCache>(*myCache.front(), b));
   }
 
-  for (std::unique_ptr<::BasisFunctionCache<2>>& cache : myCache) {
+  for (std::unique_ptr<ASMs2D::BasisFunctionCache>& cache : myCache) {
     cache->setIntegrand(&integrand);
     cache->init(1);
   }
 
-  BasisFunctionCache& cache = static_cast<BasisFunctionCache&>(*myCache.front());
+  ASMs2D::BasisFunctionCache& cache = *myCache.front();
 
   // Get Gaussian quadrature points and weights
   const std::array<int,2>& ng = cache.nGauss();
@@ -624,7 +624,7 @@ BasisFunctionVals ASMs2DmxLag::BasisFunctionCache::calculatePt (size_t,
                                                                 size_t gp,
                                                                 bool red) const
 {
-  std::array<size_t,2> gpIdx = this->gpIndex(gp,reduced);
+  std::array<size_t,2> gpIdx = this->gpIndex(gp,red);
   const Quadrature& q = red ? *reducedQ : *mainQ;
 
   const ASMs2DmxLag& pch = static_cast<const ASMs2DmxLag&>(patch);

--- a/src/ASM/ASMs2DmxLag.h
+++ b/src/ASM/ASMs2DmxLag.h
@@ -35,9 +35,7 @@ protected:
   public:
     //! \brief The constructor initializes the class.
     //! \param pch Patch the cache is for
-    //! \param plcy Cache policy to use
-    //! \param b Basis to use
-    BasisFunctionCache(const ASMs2DLag& pch, ASM::CachePolicy plcy, int b);
+    BasisFunctionCache(const ASMs2DLag& pch);
 
     //! \brief Constructor reusing quadrature info from another instance.
     //! \param cache Instance holding quadrature information

--- a/src/ASM/ASMs2DmxLag.h
+++ b/src/ASM/ASMs2DmxLag.h
@@ -7,7 +7,7 @@
 //!
 //! \author Knut Morten Okstad / SINTEF
 //!
-//! \brief Driver for assembly of structured 2D Lagrange mixed FE models.
+//! \brief Driver for assembly of structured 2D %Lagrange mixed FE models.
 //!
 //==============================================================================
 
@@ -20,7 +20,7 @@
 
 
 /*!
-  \brief Driver for assembly of structured 2D Lagrange mixed FE models.
+  \brief Driver for assembly of structured 2D %Lagrange mixed FE models.
   \details This class implements a two-field mixed formulation with Lagrangian
   basis functions. The geometry and the first field are of equal order and
   is one order higher than the second field.
@@ -42,17 +42,19 @@ protected:
     //! \brief Constructor reusing quadrature info from another instance.
     //! \param cache Instance holding quadrature information
     //! \param b Basis to use
-    BasisFunctionCache(const BasisFunctionCache& cache, int b);
+    BasisFunctionCache(const ASMs2D::BasisFunctionCache& cache, int b);
 
     //! \brief Empty destructor.
     virtual ~BasisFunctionCache() = default;
 
   protected:
     //! \brief Calculates basis function info in a single integration point.
-    //! \param el Element of integration point (0-indexed)
-    //! \param gp Integratin point on element (0-indexed)
-    //! \param reduced If true, returns values for reduced integration scheme
-    BasisFunctionVals calculatePt(size_t el, size_t gp, bool reduced) const override;
+    //! \param[in] gp Integration point on element (0-indexed)
+    //! \param[in] red If \e true, returns for reduced integration scheme
+    BasisFunctionVals calculatePt(size_t, size_t gp, bool red) const override;
+
+    //! \brief Calculates basis function info in all integration points.
+    void calculateAll() override;
   };
 
 public:
@@ -141,10 +143,11 @@ public:
 
   using ASMs2DLag::evalSolution;
   //! \brief Evaluates the secondary solution field at all visualization points.
-  //! \details The number of visualization points is the same as the order of
-  //! the Lagrange elements by default.
   //! \param[out] sField Solution field
   //! \param[in] integrand Object with problem-specific data and methods
+  //!
+  //! \details The number of visualization points is the same as the order of
+  //! the %Lagrange elements by default.
   virtual bool evalSolution(Matrix& sField, const IntegrandBase& integrand,
                             const int*, char = 0) const;
 

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -3840,10 +3840,8 @@ bool ASMs3D::addRigidCpl (int lindx, int ldim, int basis,
 
 
 ASMs3D::BasisFunctionCache::BasisFunctionCache (const ASMs3D& pch,
-                                                ASM::CachePolicy plcy,
-                                                int b) :
-  ::BasisFunctionCache<3>(plcy),
-  patch(pch)
+                                                ASM::CachePolicy plcy, int b) :
+  ::BasisFunctionCache<3>(plcy), patch(pch)
 {
   basis = b;
   for (size_t d = 0; d < 3 && patch.svol; ++d)
@@ -3853,9 +3851,7 @@ ASMs3D::BasisFunctionCache::BasisFunctionCache (const ASMs3D& pch,
 
 ASMs3D::BasisFunctionCache::BasisFunctionCache (const BasisFunctionCache& cache,
                                                 int b) :
-  ::BasisFunctionCache<3>(cache),
-  patch(cache.patch),
-  nel(cache.nel)
+  ::BasisFunctionCache<3>(cache), patch(cache.patch), nel(cache.nel)
 {
   basis = b;
 }
@@ -3866,9 +3862,9 @@ bool ASMs3D::BasisFunctionCache::internalInit ()
   if (!mainQ->xg[0])
     this->setupQuadrature();
 
-  nTotal = nel[0]*nel[1]*nel[2]*mainQ->ng[0]*mainQ->ng[1]*mainQ->ng[2];
+  nTotal = patch.nel * mainQ->ng[0]*mainQ->ng[1]*mainQ->ng[2];
   if (reducedQ->xg[0])
-    nTotalRed = nel[0]*nel[1]*nel[2]*reducedQ->ng[0]*reducedQ->ng[1]*reducedQ->ng[2];
+    nTotalRed = patch.nel * reducedQ->ng[0]*reducedQ->ng[1]*reducedQ->ng[2];
 
   return true;
 }
@@ -3885,10 +3881,13 @@ void ASMs3D::BasisFunctionCache::internalCleanup ()
 
 bool ASMs3D::BasisFunctionCache::setupQuadrature ()
 {
+   int p[3];
+   patch.getOrder(p[0],p[1],p[2]);
+
   // Get Gaussian quadrature points and weights
   for (int d = 0; d < 3; d++)
   {
-    mainQ->ng[d] = patch.getNoGaussPt(patch.svol ? patch.svol->order(d) : 2);
+    mainQ->ng[d] = patch.getNoGaussPt(p[d]);
     mainQ->xg[d] = GaussQuadrature::getCoord(mainQ->ng[d]);
     mainQ->wg[d] = GaussQuadrature::getWeight(mainQ->ng[d]);
     if (!mainQ->xg[d] || !mainQ->wg[d]) return false;
@@ -3901,7 +3900,8 @@ bool ASMs3D::BasisFunctionCache::setupQuadrature ()
     reducedQ->xg[0] = reducedQ->xg[1] = reducedQ->xg[2] = GaussQuadrature::getCoord(nRed);
     reducedQ->wg[0] = reducedQ->wg[1] = reducedQ->wg[2] = GaussQuadrature::getWeight(nRed);
     if (!reducedQ->xg[0] || !reducedQ->wg[0]) return false;
-  } else if (nRed < 0)
+  }
+   else if (nRed < 0)
     nRed = mainQ->ng[0];
 
   reducedQ->ng[0] = reducedQ->ng[1] = reducedQ->ng[2] = nRed;

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -2069,7 +2069,7 @@ bool ASMs3D::integrate (Integrand& integrand,
   bool useElmVtx = integrand.getIntegrandType() & Integrand::ELEMENT_CORNERS;
 
   if (myCache.empty())
-    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this, cachePolicy, 1));
+    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this));
 
   BasisFunctionCache& cache = *myCache.front();
   cache.setIntegrand(&integrand);
@@ -3839,11 +3839,9 @@ bool ASMs3D::addRigidCpl (int lindx, int ldim, int basis,
 }
 
 
-ASMs3D::BasisFunctionCache::BasisFunctionCache (const ASMs3D& pch,
-                                                ASM::CachePolicy plcy, int b) :
-  ::BasisFunctionCache<3>(plcy), patch(pch)
+ASMs3D::BasisFunctionCache::BasisFunctionCache (const ASMs3D& pch) :
+  ::BasisFunctionCache<3>(), patch(pch)
 {
-  basis = b;
   for (size_t d = 0; d < 3 && patch.svol; ++d)
     nel[d] = patch.svol->numCoefs(d) - patch.svol->order(d) + 1;
 }

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -123,6 +123,9 @@ protected:
     //! \brief Setup integration point parameters.
     virtual void setupParameters();
 
+    //! \brief Configure quadratures.
+    bool setupQuadrature();
+
     const ASMs3D& patch; //!< Reference to patch cache is for
 
     std::array<size_t,3> nel{}; //!< Number of elements in each direction
@@ -131,9 +134,6 @@ protected:
     //! \brief Obtain structured element indices.
     //! \param el Global element index
     std::array<size_t,3> elmIndex(size_t el) const;
-
-    //! \brief Configure quadratures.
-    bool setupQuadrature();
   };
 
 public:

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -83,9 +83,7 @@ protected:
   public:
     //! \brief The constructor initializes the class.
     //! \param pch Patch the cache is for
-    //! \param plcy Cache policy to use
-    //! \param b Basis to use
-    BasisFunctionCache(const ASMs3D& pch, ASM::CachePolicy plcy, int b);
+    BasisFunctionCache(const ASMs3D& pch);
 
     //! \brief Constructor reusing quadrature info from another instance.
     //! \param cache Instance holding quadrature information

--- a/src/ASM/ASMs3DLag.C
+++ b/src/ASM/ASMs3DLag.C
@@ -354,7 +354,7 @@ bool ASMs3DLag::integrate (Integrand& integrand,
   if (this->empty()) return true; // silently ignore empty patches
 
   if (myCache.empty())
-    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this, cachePolicy, 1));
+    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this));
 
   ASMs3D::BasisFunctionCache& cache = *myCache.front();
   cache.setIntegrand(&integrand);
@@ -1378,10 +1378,8 @@ bool ASMs3DLag::assembleL2matrices (SparseMatrix& A, StdVector& B,
 }
 
 
-ASMs3DLag::BasisFunctionCache::BasisFunctionCache (const ASMs3DLag& pch,
-                                                   ASM::CachePolicy plcy,
-                                                   int b) :
-  ASMs3D::BasisFunctionCache(pch,plcy,b)
+ASMs3DLag::BasisFunctionCache::BasisFunctionCache (const ASMs3DLag& pch)
+  : ASMs3D::BasisFunctionCache(pch)
 {
   nel[0] = (pch.nx-1) / (pch.p1-1);
   nel[1] = (pch.ny-1) / (pch.p2-1);

--- a/src/ASM/ASMs3DLag.h
+++ b/src/ASM/ASMs3DLag.h
@@ -34,12 +34,12 @@ protected:
     //! \param pch Patch the cache is for
     //! \param plcy Cache policy to use
     //! \param b Basis to use
-    BasisFunctionCache(const ASMs3DLag& pch, ASM::CachePolicy plcy, int b);
+    BasisFunctionCache(const ASMs3DLag& pch, ASM::CachePolicy plcy, int b = 1);
 
     //! \brief Constructor reusing quadrature info from another instance.
     //! \param cache Instance holding quadrature information
     //! \param b Basis to use
-    BasisFunctionCache(const BasisFunctionCache& cache, int b);
+    BasisFunctionCache(const ASMs3D::BasisFunctionCache& cache, int b);
 
     //! \brief Empty destructor.
     virtual ~BasisFunctionCache() = default;
@@ -52,18 +52,17 @@ protected:
     double getParam(int dir, size_t el, size_t gp, bool reduced = false) const override;
 
   protected:
+    //! \brief Implementation specific initialization.
+    bool internalInit() override;
+
     //! \brief Obtain global integration point index.
-    //! \param el Element of integration point (0-indexed)
-    //! \param gp Integration point on element (0-indexed)
-    //! \param reduced True to return index for reduced quadrature
-    size_t index(size_t el, size_t gp, bool reduced) const override
-    { return ::BasisFunctionCache<3>::index(el,gp,reduced); }
+    //! \param[in] gp Integration point on element (0-indexed)
+    size_t index(size_t, size_t gp, bool) const override { return gp; }
 
     //! \brief Calculates basis function info in a single integration point.
-    //! \param el Element of integration point (0-indexed)
-    //! \param gp Integratin point on element (0-indexed)
-    //! \param reduced If true, returns values for reduced integration scheme
-    BasisFunctionVals calculatePt(size_t el, size_t gp, bool reduced) const override;
+    //! \param[in] gp Integration point on element (0-indexed)
+    //! \param[in] reduced If \e true, returns for reduced integration scheme
+    BasisFunctionVals calculatePt(size_t, size_t gp, bool red) const override;
 
     //! \brief Calculates basis function info in all integration points.
     void calculateAll() override;
@@ -257,6 +256,12 @@ public:
   //! \param[in] basisNum The basis to evaluate for (mixed)
   virtual bool evaluate(const ASMbase* basis, const Vector& locVec,
                         RealArray& vec, int basisNum) const;
+
+  //! \brief Returns the polynomial order in each parameter direction.
+  //! \param[out] pu Order in first (u) direction
+  //! \param[out] pv Order in second (v) direction
+  //! \param[out] pw Order in third (w) direction
+  virtual bool getOrder(int& pu, int& pv, int& pw) const;
 
   //! \brief Returns the number of nodal points in each parameter direction.
   //! \param[out] n1 Number of nodes in first (u) direction

--- a/src/ASM/ASMs3DLag.h
+++ b/src/ASM/ASMs3DLag.h
@@ -32,9 +32,7 @@ protected:
   public:
     //! \brief The constructor initializes the class.
     //! \param pch Patch the cache is for
-    //! \param plcy Cache policy to use
-    //! \param b Basis to use
-    BasisFunctionCache(const ASMs3DLag& pch, ASM::CachePolicy plcy, int b = 1);
+    BasisFunctionCache(const ASMs3DLag& pch);
 
     //! \brief Constructor reusing quadrature info from another instance.
     //! \param cache Instance holding quadrature information

--- a/src/ASM/ASMs3Dmx.C
+++ b/src/ASM/ASMs3Dmx.C
@@ -470,7 +470,7 @@ bool ASMs3Dmx::integrate (Integrand& integrand,
   const bool separateGeometry = this->getBasis(ASM::GEOMETRY_BASIS) != svol;
 
   if (myCache.empty()) {
-    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this, cachePolicy, 1));
+    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this));
     for (size_t b = 2; b <= this->getNoBasis(); ++b)
       myCache.emplace_back(std::make_unique<BasisFunctionCache>(*myCache.front(), b));
     if (separateGeometry)

--- a/src/ASM/ASMs3DmxLag.C
+++ b/src/ASM/ASMs3DmxLag.C
@@ -269,7 +269,7 @@ bool ASMs3DmxLag::integrate (Integrand& integrand,
   bool useElmVtx = integrand.getIntegrandType() & Integrand::ELEMENT_CORNERS;
 
   if (myCache.empty()) {
-    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this, cachePolicy, 1));
+    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this));
     for (size_t b = 2; b <= this->getNoBasis(); ++b)
       myCache.emplace_back(std::make_unique<BasisFunctionCache>(*myCache.front(), b));
   }
@@ -676,10 +676,8 @@ bool ASMs3DmxLag::evalSolution (Matrix& sField, const IntegrandBase& integrand,
 }
 
 
-ASMs3DmxLag::BasisFunctionCache::BasisFunctionCache (const ASMs3DLag& pch,
-                                                     ASM::CachePolicy plcy,
-                                                     int b) :
-  ASMs3DLag::BasisFunctionCache(pch,plcy,b)
+ASMs3DmxLag::BasisFunctionCache::BasisFunctionCache (const ASMs3DLag& pch)
+  : ASMs3DLag::BasisFunctionCache(pch)
 {
 }
 

--- a/src/ASM/ASMs3DmxLag.h
+++ b/src/ASM/ASMs3DmxLag.h
@@ -7,7 +7,7 @@
 //!
 //! \author Knut Morten Okstad / SINTEF
 //!
-//! \brief Driver for assembly of structured 3D Lagrange mixed FE models.
+//! \brief Driver for assembly of structured 3D %Lagrange mixed FE models.
 //!
 //==============================================================================
 
@@ -20,7 +20,7 @@
 
 
 /*!
-  \brief Driver for assembly of structured 3D Lagrange mixed FE models.
+  \brief Driver for assembly of structured 3D %Lagrange mixed FE models.
   \details This class implements a two-field mixed formulation with Lagrangian
   basis functions. The geometry and the first field are of equal order and
   is one order higher than the second field.
@@ -41,17 +41,19 @@ class ASMs3DmxLag : public ASMs3DLag, private ASMmxBase
     //! \brief Constructor reusing quadrature info from another instance.
     //! \param cache Instance holding quadrature information
     //! \param b Basis to use
-    BasisFunctionCache(const BasisFunctionCache& cache, int b);
+    BasisFunctionCache(const ASMs3D::BasisFunctionCache& cache, int b);
 
     //! \brief Empty destructor.
     virtual ~BasisFunctionCache() = default;
 
   protected:
     //! \brief Calculates basis function info in a single integration point.
-    //! \param el Element of integration point (0-indexed)
-    //! \param gp Integratin point on element (0-indexed)
-    //! \param reduced If true, returns values for reduced integration scheme
-    BasisFunctionVals calculatePt(size_t el, size_t gp, bool reduced) const override;
+    //! \param[in] gp Integration point on element (0-indexed)
+    //! \param[in] red If \e true, returns for reduced integration scheme
+    BasisFunctionVals calculatePt(size_t, size_t gp, bool red) const override;
+
+    //! \brief Calculates basis function info in all integration points.
+    void calculateAll() override;
   };
 
 public:
@@ -140,10 +142,11 @@ public:
 
   using ASMs3DLag::evalSolution;
   //! \brief Evaluates the secondary solution field at all visualization points.
-  //! \details The number of visualization points is the same as the order of
-  //! the Lagrange elements by default.
   //! \param[out] sField Solution field
   //! \param[in] integrand Object with problem-specific data and methods
+  //!
+  //! \details The number of visualization points is the same as the order of
+  //! the %Lagrange elements by default.
   virtual bool evalSolution(Matrix& sField, const IntegrandBase& integrand,
                             const int*, char = 0) const;
 

--- a/src/ASM/ASMs3DmxLag.h
+++ b/src/ASM/ASMs3DmxLag.h
@@ -34,9 +34,7 @@ class ASMs3DmxLag : public ASMs3DLag, private ASMmxBase
   public:
     //! \brief The constructor initializes the class.
     //! \param pch Patch the cache is for
-    //! \param plcy Cache policy to use
-    //! \param b Basis to use
-    BasisFunctionCache(const ASMs3DLag& pch, ASM::CachePolicy plcy, int b);
+    BasisFunctionCache(const ASMs3DLag& pch);
 
     //! \brief Constructor reusing quadrature info from another instance.
     //! \param cache Instance holding quadrature information

--- a/src/ASM/ASMu2DLag.C
+++ b/src/ASM/ASMu2DLag.C
@@ -73,7 +73,7 @@ bool ASMu2DLag::generateFEMTopology ()
   gNod += nnod;
   gEl  += nel;
 
-  myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this, cachePolicy));
+  myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this));
 
   return true;
 }

--- a/src/ASM/ASMu2DLag.h
+++ b/src/ASM/ASMu2DLag.h
@@ -33,9 +33,8 @@ class ASMu2DLag : public ASMs2DLag
   public:
     //! \brief The constructor forwards to the parent class constructor.
     //! \param pch Patch the cache is for
-    //! \param plcy Cache policy to use
-    BasisFunctionCache(const ASMu2DLag& pch, ASM::CachePolicy plcy)
-      : ASMs2DLag::BasisFunctionCache(pch,plcy) {}
+    BasisFunctionCache(const ASMu2DLag& pch)
+      : ASMs2DLag::BasisFunctionCache(pch) {}
 
     //! \brief Empty destructor.
     virtual ~BasisFunctionCache() = default;

--- a/src/ASM/ASMu2DLag.h
+++ b/src/ASM/ASMu2DLag.h
@@ -28,42 +28,24 @@
 class ASMu2DLag : public ASMs2DLag
 {
   //! \brief Implementation of basis function cache.
-  class BasisFunctionCache : public ::BasisFunctionCache<2>
+  class BasisFunctionCache : public ASMs2DLag::BasisFunctionCache
   {
   public:
-    //! \brief The constructor initializes the class.
+    //! \brief The constructor forwards to the parent class constructor.
     //! \param pch Patch the cache is for
     //! \param plcy Cache policy to use
-    BasisFunctionCache(const ASMu2DLag& pch, ASM::CachePolicy plcy);
+    BasisFunctionCache(const ASMu2DLag& pch, ASM::CachePolicy plcy)
+      : ASMs2DLag::BasisFunctionCache(pch,plcy) {}
 
     //! \brief Empty destructor.
     virtual ~BasisFunctionCache() = default;
 
-    //! \brief Obtain a single integration point parameter.
-    double getParam(int, size_t, size_t, bool = false) const override
-    { return 0.0; }
+    //! \brief No integration point parameters for unstructured patches.
+    double getParam(int, size_t, size_t, bool) const override { return 0.0; }
 
   protected:
-    //! \brief Implementation specific initialization.
-    bool internalInit() override;
-
-    //! \brief Implementation specific cleanup.
-    void internalCleanup() override;
-
-    //! \brief Calculates basis function info in a single integration point.
-    //! \param el Element of integration point (0-indexed)
-    //! \param gp Integratin point on element (0-indexed)
-    //! \param reduced If true, returns values for reduced integration scheme
-    BasisFunctionVals calculatePt(size_t el, size_t gp, bool reduced) const override;
-
-    //! \brief Calculates basis function info in all integration points.
-    void calculateAll() override;
-
-    const ASMu2DLag& patch; //!< Reference to patch
-
-private:
-    //! \brief Configure quadratures.
-    bool setupQuadrature();
+    //! \brief No integration point parameters for unstructured patches.
+    void setupParameters() override {}
   };
 
 public:

--- a/src/ASM/BasisFunctionCache.C
+++ b/src/ASM/BasisFunctionCache.C
@@ -19,19 +19,15 @@
 
 
 template<size_t Dim>
-BasisFunctionCache<Dim>::BasisFunctionCache (ASM::CachePolicy policy)
-  : policy(policy)
-  , mainQ(std::make_shared<Quadrature>())
-  , reducedQ(std::make_shared<Quadrature>())
+BasisFunctionCache<Dim>::BasisFunctionCache ()
+  : mainQ(std::make_shared<Quadrature>()),
+    reducedQ(std::make_shared<Quadrature>())
 {
 }
 
 template<size_t Dim>
 BasisFunctionCache<Dim>::BasisFunctionCache (const BasisFunctionCache<Dim>& rhs)
-  : basis(rhs.basis)
-  , policy(rhs.policy)
-  , mainQ(rhs.mainQ)
-  , reducedQ(rhs.reducedQ)
+  : basis(rhs.basis), mainQ(rhs.mainQ), reducedQ(rhs.reducedQ)
 {
 }
 
@@ -49,7 +45,7 @@ bool BasisFunctionCache<Dim>::init (int nd)
   if (!this->internalInit())
     return false;
 
-  if (policy == ASM::NO_CACHE) {
+  if (ASM::cachePolicy == ASM::NO_CACHE) {
 #ifdef USE_OPENMP
     size_t size = omp_get_max_threads();
 #else
@@ -63,7 +59,7 @@ bool BasisFunctionCache<Dim>::init (int nd)
   values.resize(nTotal);
   if (this->hasReduced())
     valuesRed.resize(nTotalRed);
-  if (policy != ASM::ON_THE_FLY)
+  if (ASM::cachePolicy != ASM::ON_THE_FLY)
     this->calculateAll();
 
   return true;
@@ -73,7 +69,7 @@ bool BasisFunctionCache<Dim>::init (int nd)
 template<size_t Dim>
 void BasisFunctionCache<Dim>::finalizeAssembly ()
 {
-  if (policy == ASM::PRE_CACHE) {
+  if (ASM::cachePolicy == ASM::PRE_CACHE) {
     values.clear();
     valuesRed.clear();
     internalCleanup();
@@ -86,7 +82,7 @@ const BasisFunctionVals& BasisFunctionCache<Dim>::
 getVals (size_t el, size_t gp, bool reduced)
 {
   std::vector<BasisFunctionVals>& vals = reduced ? valuesRed : values;
-  if (policy == ASM::NO_CACHE) {
+  if (ASM::cachePolicy == ASM::NO_CACHE) {
 #ifdef USE_OPENMP
     size_t idx = omp_get_thread_num();
 #else
@@ -97,7 +93,7 @@ getVals (size_t el, size_t gp, bool reduced)
   }
 
   size_t idx = this->index(el, gp, reduced);
-  if (policy == ASM::ON_THE_FLY && vals[idx].N.empty())
+  if (ASM::cachePolicy == ASM::ON_THE_FLY && vals[idx].N.empty())
     vals[idx] = this->calculatePt(el,gp,reduced);
 
   return vals[idx];

--- a/src/ASM/BasisFunctionCache.h
+++ b/src/ASM/BasisFunctionCache.h
@@ -30,8 +30,8 @@ class Integrand;
 template<size_t Dim> class BasisFunctionCache
 {
 public:
-  //! \brief The constructor defines the caching policy.
-  BasisFunctionCache(ASM::CachePolicy plcy);
+  //! \brief Default constructor.
+  BasisFunctionCache();
 
   //! \brief Copy-constructor.
   BasisFunctionCache(const BasisFunctionCache& rhs);
@@ -130,7 +130,6 @@ protected:
   //! \param reduced If true, returns values for reduced integration scheme
   std::array<size_t,Dim> gpIndex(size_t gp, bool reduced) const;
 
-  ASM::CachePolicy policy; //!< Cache policy to use
   std::vector<BasisFunctionVals> values; //!< Cache for main quadrature
   std::vector<BasisFunctionVals> valuesRed; //!< Cache for reduced quadrature
   const Integrand* integrand = nullptr; //!< Integrand to use

--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -1102,7 +1102,7 @@ bool ASMu2D::integrate (Integrand& integrand,
   bool use3rdDer = integrand.getIntegrandType() & Integrand::THIRD_DERIVATIVES;
 
   if (myCache.empty())
-    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this, cachePolicy, 1));
+    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this));
 
   BasisFunctionCache& cache = *myCache.front();
   cache.setIntegrand(&integrand);
@@ -3011,20 +3011,15 @@ void ASMu2D::storeMesh (const std::string& fName, int fType) const
 }
 
 
-ASMu2D::BasisFunctionCache::BasisFunctionCache (const ASMu2D& pch,
-                                                ASM::CachePolicy plcy,
-                                                int b) :
-  ::BasisFunctionCache<2>(plcy),
-  patch(pch)
+ASMu2D::BasisFunctionCache::BasisFunctionCache (const ASMu2D& pch) :
+  ::BasisFunctionCache<2>(), patch(pch)
 {
-  basis = b;
 }
 
 
 ASMu2D::BasisFunctionCache::BasisFunctionCache (const BasisFunctionCache& cache,
                                                 int b) :
-  ::BasisFunctionCache<2>(cache),
-  patch(cache.patch)
+  ::BasisFunctionCache<2>(cache), patch(cache.patch)
 {
   basis = b;
 }

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -56,9 +56,7 @@ protected:
   public:
     //! \brief The constructor initializes the class.
     //! \param pch Patch the cache is for
-    //! \param plcy Cache policy to use
-    //! \param b Basis to use
-    BasisFunctionCache(const ASMu2D& pch, ASM::CachePolicy plcy, int b);
+    BasisFunctionCache(const ASMu2D& pch);
 
     //! \brief Constructor reusing quadrature info from another instance.
     //! \param cache Instance holding quadrature information

--- a/src/ASM/LR/ASMu2Dmx.C
+++ b/src/ASM/LR/ASMu2Dmx.C
@@ -327,7 +327,7 @@ bool ASMu2Dmx::integrate (Integrand& integrand,
   const bool piolaMapping = integrand.getIntegrandType() & Integrand::PIOLA_MAPPING;
 
   if (myCache.empty()) {
-    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this, cachePolicy, 1));
+    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this, 1));
     const BasisFunctionCache& c = static_cast<const BasisFunctionCache&>(*myCache.front());
     for (size_t b = 2; b <= this->getNoBasis(); ++b)
       myCache.emplace_back(std::make_unique<BasisFunctionCache>(c,b));

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -910,7 +910,7 @@ bool ASMu3D::integrate (Integrand& integrand,
   bool use2ndDer = integrand.getIntegrandType() & Integrand::SECOND_DERIVATIVES;
 
   if (myCache.empty())
-    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this, cachePolicy, 1));
+    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this));
 
   BasisFunctionCache& cache = *myCache.front();
   cache.setIntegrand(&integrand);
@@ -2402,22 +2402,15 @@ void ASMu3D::generateThreadGroupsFromElms (const IntVec& elms)
 }
 
 
-ASMu3D::BasisFunctionCache::BasisFunctionCache (const ASMu3D& pch,
-                                                ASM::CachePolicy plcy,
-                                                int b, bool useBezier) :
-  ::BasisFunctionCache<3>(plcy),
-  bezierEnabled(useBezier),
-  patch(pch)
+ASMu3D::BasisFunctionCache::BasisFunctionCache (const ASMu3D& pch, bool useBezier) :
+  ::BasisFunctionCache<3>(), bezierEnabled(useBezier), patch(pch)
 {
-  basis = b;
 }
 
 
 ASMu3D::BasisFunctionCache::BasisFunctionCache (const BasisFunctionCache& cache,
                                                 int b) :
-  ::BasisFunctionCache<3>(cache),
-  bezierEnabled(cache.bezierEnabled),
-  patch(cache.patch)
+  ::BasisFunctionCache<3>(cache), bezierEnabled(cache.bezierEnabled), patch(cache.patch)
 {
   basis = b;
 }

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -50,11 +50,8 @@ protected:
   public:
     //! \brief The constructor initializes the class.
     //! \param pch Patch the cache is for
-    //! \param plcy Cache policy to use
-    //! \param b Basis to use
     //! \param useBezier True to use bezier extraction
-    BasisFunctionCache(const ASMu3D& pch, ASM::CachePolicy plcy,
-                       int b, bool useBezier = true);
+    BasisFunctionCache(const ASMu3D& pch, bool useBezier = true);
 
     //! \brief Constructor reusing quadrature info from another instance.
     //! \param cache Instance holding quadrature information

--- a/src/ASM/LR/ASMu3Dmx.C
+++ b/src/ASM/LR/ASMu3Dmx.C
@@ -313,8 +313,7 @@ bool ASMu3Dmx::integrate (Integrand& integrand,
   const bool separateGeometry = this->getBasis(ASM::GEOMETRY_BASIS) != lrspline.get();
 
   if (myCache.empty()) {
-    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this, cachePolicy, 1,
-                                                              ASMmxBase::Type != SUBGRID));
+    myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this, ASMmxBase::Type != SUBGRID));
     const BasisFunctionCache& c = static_cast<const BasisFunctionCache&>(*myCache.front());
     for (size_t b = 2; b <= this->getNoBasis(); ++b)
       myCache.emplace_back(std::make_unique<BasisFunctionCache>(c,b));

--- a/src/ASM/LagrangeField2D.C
+++ b/src/ASM/LagrangeField2D.C
@@ -23,10 +23,10 @@ LagrangeField2D::LagrangeField2D (const ASMs2DLag* patch,
                                   const char* name) : FieldBase(name)
 {
   patch->getNodalCoordinates(coord);
+  patch->getOrder(p1,p2,n2);
   patch->getSize(n1,n2);
-  patch->getOrder(p1,p2);
-  nno = n1*n2;
   nelm = (n1-1)*(n2-1)/(p1*p2);
+  nno = n1*n2;
 
   // Ensure the values array has compatible length, pad with zeros if necessary
   values.resize(nno);

--- a/src/ASM/LagrangeFields2D.C
+++ b/src/ASM/LagrangeFields2D.C
@@ -23,10 +23,10 @@ LagrangeFields2D::LagrangeFields2D (const ASMs2DLag* patch,
                                     const char* name) : Fields(name)
 {
   patch->getNodalCoordinates(coord);
+  patch->getOrder(p1,p2,n2);
   patch->getSize(n1,n2);
-  patch->getOrder(p1,p2);
-  nno = n1*n2;
   nelm = (n1-1)*(n2-1)/(p1*p2);
+  nno = n1*n2;
   nf = v.size()/nno;
 
   // Ensure the values array has compatible length, pad with zeros if necessary

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -616,7 +616,6 @@ void SIMbase::setQuadratureRule (size_t ng, bool redimBuffers, bool printQP)
     if (!pch->empty())
     {
       pch->setGauss(ng);
-      pch->setCachePolicy(opt.policy);
       // Count the interior integration points
       pch->getNoIntPoints(nIntGP,nInterfaceGP);
     }

--- a/src/SIM/SIMoptions.h
+++ b/src/SIM/SIMoptions.h
@@ -69,7 +69,6 @@ public:
 
 public:
   int nGauss[2]; //!< Gaussian quadrature rules
-  ASM::CachePolicy policy; //!< Cache policy
 
   ASM::Discretization discretization; //!< Spatial discretization option
   LinAlg::MatrixType  solver;         //!< The linear equation solver to use


### PR DESCRIPTION
Sits on top of #674 so only look at the last three commits here.

This was discovered during the work on the Gunnerus boat model, which is a large single-patch 2D Lagrange model.
It will simplify the handling of the basis function cache for Lagrange patches. As far I can see the basis functions stored in the cache will be identical for all elements in a Lagrange patch. Therefore it will be a waste to store a copy for each element and better to let each one use the same instance. Might save some memory footprint for large patches, but probably not a critical amount. The main motivation is to make the logic more clear and less prone for misinterpretation, etc.

Can't rule there are some aspects I overlooked such that separate copies are needed anyway, but at least this works for the Gunnerus model it seems.