### PR TITLE
Coupling fields: Support Piola mapping

### DIFF
--- a/src/ASM/ASMmxBase.h
+++ b/src/ASM/ASMmxBase.h
@@ -78,6 +78,7 @@ public:
 
   static MixedType Type; //!< Type of mixed formulation used
   static char  itgBasis; //!< 1-based index of basis representing the integration elements
+  bool piola = false;    //!< True if last used integrand was Piola mapped
 
 protected:
   typedef std::vector<std::shared_ptr<Go::SplineSurface>> SurfaceVec; //!< Convenience type

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -444,7 +444,7 @@ bool ASMs2Dmx::integrate (Integrand& integrand,
   bool use2ndDer = integrand.getIntegrandType() & Integrand::SECOND_DERIVATIVES;
   bool useElmVtx = integrand.getIntegrandType() & Integrand::ELEMENT_CORNERS;
   const bool separateGeometry = this->getBasis(ASM::GEOMETRY_BASIS) != surf;
-  const bool piolaMapping = integrand.getIntegrandType() & Integrand::PIOLA_MAPPING;
+  const bool piolaMapping = piola = integrand.getIntegrandType() & Integrand::PIOLA_MAPPING;
 
   if (myCache.empty()) {
     myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this));

--- a/src/ASM/ASMs2Dmx.h
+++ b/src/ASM/ASMs2Dmx.h
@@ -237,6 +237,9 @@ public:
   virtual void getBoundaryNodes(int lIndex, IntVec& nodes, int basis,
                                 int thick, int, bool local) const;
 
+  //! \brief Returns true if the last passed integrand used Piola mapping.
+  bool usePiola() const { return piola; }
+
 protected:
   //! \brief Returns 0-based index of first node on integration basis.
   virtual int getFirstItgElmNode() const;

--- a/src/ASM/LR/ASMu2Dmx.C
+++ b/src/ASM/LR/ASMu2Dmx.C
@@ -324,7 +324,7 @@ bool ASMu2Dmx::integrate (Integrand& integrand,
 
   bool use2ndDer = integrand.getIntegrandType() & Integrand::SECOND_DERIVATIVES;
   const bool separateGeometry = this->getBasis(ASM::GEOMETRY_BASIS) != lrspline.get();
-  const bool piolaMapping = integrand.getIntegrandType() & Integrand::PIOLA_MAPPING;
+  const bool piolaMapping = piola = integrand.getIntegrandType() & Integrand::PIOLA_MAPPING;
 
   if (myCache.empty()) {
     myCache.emplace_back(std::make_unique<BasisFunctionCache>(*this, 1));

--- a/src/ASM/LR/ASMu2Dmx.h
+++ b/src/ASM/LR/ASMu2Dmx.h
@@ -230,6 +230,9 @@ public:
   //! \brief Checks if a separate projection basis is used for this patch.
   virtual bool separateProjectionBasis() const;
 
+  //! \brief Returns true if the last passed integrand used Piola mapping.
+  bool usePiola() const { return piola; }
+
 private:
   //! \brief Finds the elements and associted sizes at given parametric point.
   //! \param[in] param Parametric point to find elements at

--- a/src/ASM/LR/LRSplineFields2Dmx.C
+++ b/src/ASM/LR/LRSplineFields2Dmx.C
@@ -67,6 +67,14 @@ bool LRSplineFields2Dmx::valueFE (const ItgPoint& x, Vector& vals) const
   if (!surf) return false;
 
   vals.resize(2);
+  if (surf->usePiola()) {
+    Matrix tmp;
+    const RealArray gpar[2] = {RealArray{x.u}, RealArray{x.v}};
+    if (!surf->evalSolutionPiola(tmp, this->values, gpar, false))
+      return false;
+    vals = tmp;
+    return true;
+  }
 
   // Evaluate the basis functions at the given point
   size_t ofs = 0;
@@ -99,6 +107,11 @@ bool LRSplineFields2Dmx::valueFE (const ItgPoint& x, Vector& vals) const
 bool LRSplineFields2Dmx::gradFE (const ItgPoint& x, Matrix& grad) const
 {
   if (!surf)  return false;
+
+  if (surf->usePiola()) { // TODO: implement if needed
+    std::cerr << "*** LRSplineFields2Dmx::gradFE: Not implemented with Piola" << std::endl;
+    return false;
+  }
 
   // Evaluate the basis functions at the given point
   Matrix Xnod, Jac, dNdX;
@@ -137,6 +150,11 @@ bool LRSplineFields2Dmx::gradFE (const ItgPoint& x, Matrix& grad) const
 bool LRSplineFields2Dmx::hessianFE (const ItgPoint& x, Matrix3D& H) const
 {
   if (!surf)  return false;
+
+  if (surf->usePiola()) { // TODO: implement if needed
+    std::cerr << "*** LRSplineFields2Dmx::hessianFE: Not implemented with Piola" << std::endl;
+    return false;
+  }
 
   // Evaluate the basis functions at the given point
   Matrix Xnod, Jac, dNdX;

--- a/src/ASM/SplineFields2Dmx.C
+++ b/src/ASM/SplineFields2Dmx.C
@@ -74,6 +74,14 @@ bool SplineFields2Dmx::valueFE (const ItgPoint& x, Vector& vals) const
   if (!surf) return false;
 
   vals.resize(2);
+  if (surf->usePiola()) {
+    Matrix tmp;
+    const RealArray gpar[2] = {RealArray{x.u}, RealArray{x.v}};
+    if (!surf->evalSolutionPiola(tmp, this->values, gpar, false))
+      return false;
+    vals = tmp;
+    return true;
+  }
 
   // Evaluate the basis functions at the given point
   auto vit = values.begin();
@@ -105,6 +113,11 @@ bool SplineFields2Dmx::valueFE (const ItgPoint& x, Vector& vals) const
 bool SplineFields2Dmx::gradFE (const ItgPoint& x, Matrix& grad) const
 {
   if (!surf) return false;
+
+  if (surf->usePiola()) { // TODO: implement if needed
+    std::cerr << "*** SplineFields2Dmx::gradFE: Not implemented with Piola" << std::endl;
+    return false;
+  }
 
   // Evaluate the basis functions at the given point
   Matrix Xnod, Jac, dNdX;
@@ -141,6 +154,11 @@ bool SplineFields2Dmx::gradFE (const ItgPoint& x, Matrix& grad) const
 bool SplineFields2Dmx::hessianFE (const ItgPoint& x, Matrix3D& H) const
 {
   if (!surf)  return false;
+
+  if (surf->usePiola()) { // TODO: implement if needed
+    std::cerr << "*** SplineFields2Dmx::hessianFE: Not implemented with Piola" << std::endl;
+    return false;
+  }
 
   // Evaluate the basis functions at the given point
   Matrix Xnod, Jac, dNdX;


### PR DESCRIPTION
Running staggered Boussinesq simulations with Piola mapped velocities we need to apply the forward Piola mapping when evaluating the velocity field in the temperature advection equation.

I'm not too thrilled about putting the flag in the ASM but I cannot see any cleaner way. At least it's sort of kept private, but the field and ASM both know the secret.