### PR TITLE
Fix VTF output of element results for mixed Lagrange meshes

### DIFF
--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -1356,14 +1356,36 @@ void ASMbase::shiftGlobalElmNums (int eshift)
 }
 
 
-void ASMbase::extractElmRes (const Matrix& globRes, Matrix& elmRes) const
+void ASMbase::extractElmRes (const Vector& globRes, Vector& elmRes,
+                             bool internalOrder) const
+{
+  elmRes.clear();
+  elmRes.reserve(MLGE.size());
+
+  size_t jel = 0;
+  for (int iel : MLGE)
+    if (iel > 0)
+    {
+      size_t idx = internalOrder ? jel++ : iel-1;
+      elmRes.push_back(idx < globRes.size() ? globRes[idx] : 0.0);
+    }
+}
+
+
+void ASMbase::extractElmRes (const Matrix& globRes, Matrix& elmRes,
+                             bool internalOrder) const
 {
   elmRes.resize(globRes.rows(),MLGE.size(),true);
 
-  size_t ivel = 0;
+  size_t ivel = 0, jel = 0;
   for (int iel : MLGE)
     if (iel > 0)
-      elmRes.fillColumn(++ivel,globRes.getColumn(iel));
+    {
+      ++ivel;
+      size_t icol = internalOrder ? ++jel : iel;
+      if (icol <= globRes.cols())
+        elmRes.fillColumn(ivel,globRes.getColumn(icol));
+    }
 
   elmRes.resize(globRes.rows(),ivel);
 }

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -722,9 +722,19 @@ public:
   // =============================
 
   //! \brief Extracts element results for this patch from a global vector.
+  //! \param[in] globRes Global vector of element results
+  //! \param[out] elmRes Element results for this patch
+  //! \param[in] internalOrder If \e true, the data in \a globRes are assumed to
+  //! be ordered w.r.t. the internal element ordering
+  void extractElmRes(const Vector& globRes, Vector& elmRes,
+                     bool internalOrder = false) const;
+  //! \brief Extracts element results for this patch from a global vector.
   //! \param[in] globRes Global matrix of element results
   //! \param[out] elmRes Element results for this patch
-  void extractElmRes(const Matrix& globRes, Matrix& elmRes) const;
+  //! \param[in] internalOrder If \e true, the data in \a globRes are assumed to
+  //! be ordered w.r.t. the internal element ordering
+  void extractElmRes(const Matrix& globRes, Matrix& elmRes,
+                     bool internalOrder = false) const;
 
   //! \brief Extracts nodal results for this patch from the global vector.
   //! \param[in] globVec Global solution vector in DOF-order

--- a/src/ASM/ASMu2DLag.C
+++ b/src/ASM/ASMu2DLag.C
@@ -132,7 +132,7 @@ IntVec& ASMu2DLag::getNodeSet (const std::string& setName, int& idx)
     else if (idx)
       ++idx;
 
-  nodeSets.push_back(std::make_pair(setName,IntVec()));
+  nodeSets.emplace_back(setName,IntVec());
   return nodeSets.back().second;
 }
 
@@ -174,6 +174,44 @@ int ASMu2DLag::parseNodeBox (const std::string& setName, const char* data)
 
   nodeSets.push_back(std::make_pair(setName,nodes));
   return nodeSets.size();
+}
+
+
+int ASMu2DLag::getElementSetIdx (const std::string& setName) const
+{
+  int idx = 1;
+  for (const ASM::NodeSet& es : elemSets)
+    if (es.first == setName)
+      return idx;
+    else
+      ++idx;
+
+  return 0;
+}
+
+
+const IntVec& ASMu2DLag::getElementSet (int idx) const
+{
+  int count = 0;
+  for (const ASM::NodeSet& es : elemSets)
+    if (++count == idx)
+      return es.second;
+
+  return this->ASMbase::getElementSet(idx);
+}
+
+
+IntVec& ASMu2DLag::getElementSet (const std::string& setName, int& idx)
+{
+  idx = 1;
+  for (ASM::NodeSet& es : nodeSets)
+    if (es.first == setName)
+      return es.second;
+    else if (idx)
+      ++idx;
+
+  elemSets.push_back(std::make_pair(setName,IntVec()));
+  return elemSets.back().second;
 }
 
 

--- a/src/ASM/ASMu2DLag.h
+++ b/src/ASM/ASMu2DLag.h
@@ -76,6 +76,13 @@ public:
   //! \brief Defines a node set by parsing a 3D bounding box.
   virtual int parseNodeBox(const std::string& setName, const char* bbox);
 
+  //! \brief Returns (1-based) index of a predefined element set in the patch.
+  virtual int getElementSetIdx(const std::string& setName) const;
+  //! \brief Returns an indexed pre-defined element set.
+  virtual const IntVec& getElementSet(int idx) const;
+  //! \brief Returns a named element set for update.
+  virtual IntVec& getElementSet(const std::string& setName, int& idx);
+
   //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
   //! \param[in] lIndex Local index of the boundary node set
   //! \param nodes Array of node numbers
@@ -101,6 +108,7 @@ protected:
 private:
   char                      fileType; //!< Mesh file format
   std::vector<ASM::NodeSet> nodeSets; //!< Node sets for Dirichlet BCs
+  std::vector<ASM::NodeSet> elemSets; //!< Element sets for properties
 };
 
 #endif

--- a/src/LinAlg/SystemMatrix.C
+++ b/src/LinAlg/SystemMatrix.C
@@ -63,28 +63,26 @@ SystemVector& SystemVector::copy (const SystemVector& x)
 }
 
 
-void StdVector::dump (std::ostream& os, LinAlg::StorageFormat format, const char* label)
+void StdVector::dump (const utl::vector<Real>& x, const char* label,
+                      LinAlg::StorageFormat format, std::ostream& os)
 {
   switch (format)
-  {
+    {
     case LinAlg::MATLAB:
-      utl::writeMatlab(label,*this,os);
+      utl::writeMatlab(label,x,os);
       break;
 
     case LinAlg::MATRIX_MARKET:
-    {
-      os << "%%MatrixMarket matrix array real general\n" << this->size() << " 1";
-      int old = utl::nval_per_line;
-      utl::nval_per_line = 1;
-      os << *this;
-      utl::nval_per_line = old;
+      os <<"%%MatrixMarket matrix array real general\n"<< x.size() <<" 1";
+      for (Real v : x) os <<"\n"<< v;
+      os << std::endl;
       break;
-    }
 
     case LinAlg::FLAT:
-      if (label) os << label <<" =";
-      os << *this;
-  }
+      if (label)
+        os << label <<" =";
+      os << x;
+    }
 }
 
 

--- a/src/LinAlg/SystemMatrix.h
+++ b/src/LinAlg/SystemMatrix.h
@@ -181,7 +181,11 @@ public:
 
   //! \brief Dumps the system vector on a specified format.
   virtual void dump(std::ostream& os, LinAlg::StorageFormat format,
-                    const char* label);
+                    const char* label) { dump(*this,label,format,os); }
+
+  //! \brief Dumps a standard vector to given output stream on specified format.
+  static void dump(const utl::vector<Real>& x, const char* label,
+                   LinAlg::StorageFormat format, std::ostream& os);
 
 protected:
   //! \brief Writes the system vector to the given output stream.

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -726,10 +726,8 @@ public:
 
   //! \brief Dumps left-hand-side matrix and right-hand-side vector to file.
   void dumpEqSys(bool initialBlankLine = false);
-  //! \brief Dumps a system vector to file.
-  void dumpSysVec(SystemVector& vec);
   //! \brief Dumps a solution vector to file.
-  void dumpSolVec(const RealArray& vec);
+  void dumpSolVec(const Vector& vec);
 
 protected:
   //! \brief Returns the multi-dimension simulator sequence flag.
@@ -820,11 +818,14 @@ protected:
     std::string   fname;  //!< File name
     LinAlg::StorageFormat format; //!< File format flag
     std::set<int> step;   //!< Dump step identifiers
+    bool          expand; //!< If \e true, dump expanded solution vectors
     int           count;  //!< Internal step counter, dump only when step==count
     double        eps;    //!< Zero tolerance for printing small values
 
     //! \brief Default constructor.
-    DumpData() : format(LinAlg::FLAT), count(0), eps(1.0e-6) { step.insert(1); }
+    DumpData() : format(LinAlg::FLAT), expand(false), count(0), eps(1.0e-6)
+    { step.insert(1); }
+
     //! \brief Checks if the matrix or vector should be dumped now.
     bool doDump() { return !fname.empty() && step.find(++count) != step.end(); }
   };

--- a/src/SIM/SIMoutput.h
+++ b/src/SIM/SIMoutput.h
@@ -190,7 +190,12 @@ public:
   //! \param[in] iStep Load/time step identifier
   //! \param nBlock Running result block counter
   //! \param[in] name Name of field
-  bool writeGlvE(const Vector& field, int iStep, int& nBlock, const char* name);
+  //! \param[in] idBlock Starting value of result block numbering
+  //! \param[in] internalOrder If \e true, the data in \a field are assumed to
+  //! be ordered w.r.t. the internal element ordering
+  bool writeGlvE(const Vector& field, int iStep, int& nBlock,
+                 const char* name, int idBlock = 300,
+                 bool internalOrder = false) const;
 
   //! \brief Writes element norms for a given load/time step to the VTF-file.
   //! \param[in] norms The element norms to output

--- a/src/Utility/ElementBlock.h
+++ b/src/Utility/ElementBlock.h
@@ -69,6 +69,8 @@ public:
   void setElmId(size_t i, int iel) { MINEX[i-1] = iel; }
   //! \brief Returns the external id of an element.
   int getElmId(size_t i) const { return MINEX[i-1]; }
+  //! \brief Returns the internal index of an element in case of mixed types.
+  size_t getElmIndex(size_t i) const { return i < elmIdx.size() ? elmIdx[i]:i; }
 
   //! \brief Returns the total number of nodes in the block.
   size_t getNoNodes() const { return coord.size(); }
@@ -114,6 +116,9 @@ protected:
   std::vector<int>  MMNPC; //!< Matrix of Matrices of Nodal Point Correspondance
   std::vector<int>  MINEX; //!< Matrix of Internal to External element numbers
   size_t            nen;   //!< Number of Element Nodes
+
+private:
+  std::vector<size_t> elmIdx; //!< Internal element order in case of mixed types
 
 public:
   static double eps; //!< Element shrinkage factor

--- a/src/Utility/VTF.C
+++ b/src/Utility/VTF.C
@@ -366,7 +366,7 @@ bool VTF::writeEres (const std::vector<Real>& elementResult,
   // Cast to float
   std::vector<float> resVec(nres);
   for (size_t i = 0; i < nres; i++)
-    resVec[i] = elementResult[i];
+    resVec[grid->getElmIndex(i)] = elementResult[i];
 
 #if HAS_VTFAPI == 1
   VTFAResultBlock dBlock(idBlock,VTFA_DIM_SCALAR,VTFA_RESMAP_ELEMENT,0);


### PR DESCRIPTION
When a Lagrange mesh consists of a mixture of quads and triangles (and possibly beams as well). The elements are written to the VTF-file block-wise, ordered by increasing number of element nodes. Thus, the element output order is different than the internal ordering of the elements in the patch and a permutation of the result arrays is needed. This will take care of it.

The `SIMoutput::writeGlvNo()` method is extended to also write out the global element numbers as element results - useful for debugging complex models.

Finally (last commit), the option to define explicit element sets as topological items is added for `ASMu2DLag`, similar as already available for `ASMu1DLag`.