### PR TITLE
Small beam extensions

### DIFF
--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -38,7 +38,8 @@ double ASMbase::modelSize = 1.0;
 
 int ASMbase::gEl = 0;
 int ASMbase::gNod = 0;
-std::map<int,int> ASMbase::xNode;
+IntMap ASMbase::xNode;
+IntVec ASMbase::Empty;
 
 ASM::CachePolicy ASM::cachePolicy = ASM::PRE_CACHE;
 

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -162,8 +162,8 @@ public:
   void setGauss(int ng) { nGauss = ng; }
 
   //! \brief Defines the number of solution fields in the patch.
-  //! \details This method is to be used by simulators where \ref nf is not known
-  //! when the patch is constructed, e.g., it depends on the input file content.
+  //! \details This method is used by simulators where \ref nf is not known when
+  //! the patch is constructed, e.g., it depends on the input file content.
   //! It must be invoked only before SIMbase::preprocess() is invoked.
   void setNoFields(unsigned char n) { nf = n; }
 
@@ -270,20 +270,20 @@ public:
   //! \brief Returns (1-based) index of a predefined node set in the patch.
   virtual int getNodeSetIdx(const std::string&) const { return 0; }
   //! \brief Returns an indexed predefined node set.
-  virtual const IntVec& getNodeSet(int) const { static IntVec v; return v; }
+  virtual const IntVec& getNodeSet(int) const { return Empty; }
   //! \brief Returns a named node set for update.
-  virtual IntVec& getNodeSet(const std::string&, int&)
-  { static IntVec v; return v; }
+  virtual IntVec& getNodeSet(const std::string&, int&) { return Empty; }
   //! \brief Defines a node set by parsing a 3D bounding box.
   virtual int parseNodeBox(const std::string&, const char*) { return 0; }
 
   //! \brief Returns (1-based) index of a predefined element set in the patch.
   virtual int getElementSetIdx(const std::string&) const { return 0; }
   //! \brief Returns an indexed predefined element set.
-  virtual const IntVec& getElementSet(int) const { static IntVec v; return v; }
+  virtual const IntVec& getElementSet(int) const { return Empty; }
   //! \brief Returns a named element set for update.
-  virtual IntVec& getElementSet(const std::string&, int&)
-  { static IntVec v; return v; }
+  virtual IntVec& getElementSet(const std::string&, int&) { return Empty; }
+  //! \brief Defines an element set by parsing a 3D bounding box.
+  virtual int parseElemBox(const std::string&, const char*) { return 0; }
 
   //! \brief Finds the node that is closest to the given point.
   virtual std::pair<size_t,double> findClosestNode(const Vec3&) const
@@ -733,8 +733,8 @@ public:
   //! \param[out] elmRes Element results for this patch
   //! \param[in] internalOrder If \e true, the data in \a globRes are assumed to
   //! be ordered w.r.t. the internal element ordering
-  void extractElmRes(const Vector& globRes, Vector& elmRes,
-                     bool internalOrder = false) const;
+  virtual void extractElmRes(const Vector& globRes, Vector& elmRes,
+                             bool internalOrder = false) const;
   //! \brief Extracts element results for this patch from a global vector.
   //! \param[in] globRes Global matrix of element results
   //! \param[out] elmRes Element results for this patch
@@ -1000,6 +1000,8 @@ protected:
 private:
   std::vector<char> myLMTypes; //!< Type of %Lagrange multiplier ('L' or 'G')
   std::set<size_t>  myLMs;     //!< Nodal indices of the %Lagrange multipliers
+
+  static IntVec Empty; //!< Empty integer vector used when a reference is needed
 
 protected:
   typedef std::array<double,3> XYZ; //!< Convenience type definition

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -378,7 +378,7 @@ protected:
 
   //! \brief Initializes the local element axes for a patch of beam elements.
   //! \param[in] Zaxis Vector defining a point in the local XZ-plane
-  bool initLocalElementAxes(const Vec3& Zaxis);
+  virtual bool initLocalElementAxes(const Vec3& Zaxis);
 
   //! \brief Connects matching nodes on two adjacent vertices.
   //! \param neighbor The neighbor patch

--- a/src/ASM/ASMu2DLag.h
+++ b/src/ASM/ASMu2DLag.h
@@ -82,6 +82,8 @@ public:
   virtual const IntVec& getElementSet(int idx) const;
   //! \brief Returns a named element set for update.
   virtual IntVec& getElementSet(const std::string& setName, int& idx);
+  //! \brief Defines an element set by parsing a 3D bounding box.
+  virtual int parseElemBox(const std::string& setName, const char* bbox);
 
   //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
   //! \param[in] lIndex Local index of the boundary node set

--- a/src/ASM/FiniteElement.C
+++ b/src/ASM/FiniteElement.C
@@ -32,13 +32,15 @@ std::ostream& FiniteElement::write (std::ostream& os) const
   if (!d3NdX3.empty()) os <<"d3NdX3: "<< d3NdX3;
   if (!G.empty())      os <<"G:"<< G;
   if (!H.empty())      os <<"H:"<< H;
+  if (!P.empty())      os <<"P:"<< P;
+  if (!dPdX.empty())   os <<"dPdX:"<< dPdX;
   if (!Navg.empty())   os <<"Navg:"<< Navg;
   if (!Xn.empty())     os <<"Xn:"<< Xn;
   if (!Te.isZero(0.0)) os <<"Te:\n"<< Te;
   for (size_t i = 0; i < Tn.size(); i++)
     os <<"Tn_"<< i+1 <<":\n"<< Tn[i];
-  if (!P.empty())     os << "P:\n"<< P;
-  if (!dPdX.empty())  os << "dPdX:\n"<< dPdX;
+  for (size_t j = 0; j < En.size(); j++)
+    os <<"En_"<< j+1 <<": "<< En[j] << std::endl;
   return os;
 }
 

--- a/src/ASM/FiniteElement.h
+++ b/src/ASM/FiniteElement.h
@@ -105,6 +105,7 @@ public:
   Matrix              Xn;   //!< Matrix of element nodal coordinates
   Tensor              Te;   //!< Local-to-global element transformation matrix
   std::vector<Tensor> Tn;   //!< Array of element nodal rotation matrices
+  Vec3Vec             En;   //!< Array of nodal eccentricity vectors
 };
 
 


### PR DESCRIPTION
Basically, adding nodal eccentricity vectors as member in class `FiniteElement`.

Also in this PR (totally unrelated, I know) is the option to specify an element set (for unstructured 2D Lagrange meshes) through one or more bounding boxes (third commit).