### PR TITLE
Fix VTF output for staggered solvers sharing VTF

### DIFF
--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -738,8 +738,8 @@ public:
   //! \param[out] elmRes Element results for this patch
   //! \param[in] internalOrder If \e true, the data in \a globRes are assumed to
   //! be ordered w.r.t. the internal element ordering
-  void extractElmRes(const Matrix& globRes, Matrix& elmRes,
-                     bool internalOrder = false) const;
+  virtual void extractElmRes(const Matrix& globRes, Matrix& elmRes,
+                             bool internalOrder = false) const;
 
   //! \brief Extracts nodal results for this patch from the global vector.
   //! \param[in] globVec Global solution vector in DOF-order

--- a/src/ASM/LR/ASMLRSpline.h
+++ b/src/ASM/LR/ASMLRSpline.h
@@ -25,6 +25,8 @@ namespace LR //! Utilities for LR-splines.
 {
   class Basisfunction;
   class LRSpline;
+  class LRSplineSurface;
+  class LRSplineVolume;
 
   //! \brief Expands the basis coefficients of an LR-spline object.
   //! \param basis The spline object to extend
@@ -59,6 +61,22 @@ namespace LR //! Utilities for LR-splines.
   void generateThreadGroups(ThreadGroups& threadGroups,
                             const LRSpline* lr,
                             const std::vector<LRSpline*>& addConstraints = {});
+
+  //! \brief Copies the refinement to another surface.
+  //! \param from Surface to copy refinement from
+  //! \param to Surface to copy refinement to
+  //! \param[in] multiplicity Wanted multiplicity
+  void copyRefinement(const LR::LRSplineSurface* from,
+                      LR::LRSplineSurface* to,
+                      int multiplicity);
+
+  //! \brief Copies the refinement to another volume.
+  //! \param from Volume to copy refinement from
+  //! \param to Volume to copy refinement to
+  //! \param[in] multiplicity Wanted multiplicity
+  void copyRefinement(const LR::LRSplineVolume* from,
+                      LR::LRSplineVolume* to,
+                      int multiplicity);
 }
 
 

--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -1944,6 +1944,9 @@ bool ASMu2D::getGridParameters (RealArray& prm, int dir, int nSegPerSpan) const
 {
   if (!lrspline) return false;
 
+  if (outputMaster)
+    return outputMaster->getGridParameters(prm, dir, nSegPerSpan);
+
   double eps = ElementBlock::eps;
 
   for (const LR::Element* el : lrspline->getAllElements())
@@ -3015,6 +3018,16 @@ void ASMu2D::storeMesh (const std::string& fName, int fType) const
     else
       lrspline->writePostscriptMeshWithControlPoints(meshFile);
   }
+}
+
+
+void ASMu2D::extractElmRes (const Matrix& globRes, Matrix& elmRes,
+                            bool internalOrder) const
+{
+  if (outputMaster)
+    outputMaster->extractElmRes(globRes, elmRes, internalOrder);
+  else
+    this->ASMbase::extractElmRes(globRes, elmRes, internalOrder);
 }
 
 

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -246,6 +246,13 @@ public:
   //! \param[in] globalNum If \e true, \a elmId is global otherwise patch-local
   virtual bool checkElementSize(int elmId, bool globalNum = true) const;
 
+  //! \brief Extracts element results for this patch from a global vector.
+  //! \param[in] globRes Global matrix of element results
+  //! \param[out] elmRes Element results for this patch
+  //! \param[in] internalOrder If \e true, the data in \a globRes are assumed to
+  //! be ordered w.r.t. the internal element ordering
+  virtual void extractElmRes(const Matrix& globRes, Matrix& elmRes,
+                             bool internalOrder = false) const;
 
   // Various methods for preprocessing of boundary conditions and patch topology
   // ===========================================================================
@@ -465,6 +472,11 @@ public:
   //! \param[in] fName Prefix for file names
   //! \param[in] fType Flag telling which file type(s) to write
   virtual void storeMesh(const std::string& fName, int fType) const;
+
+  //! \brief Set master patch for VTF output.
+  //! \param pch Master patch to use
+  void setOutputMaster(const ASMu2D* pch)
+  { outputMaster = pch; }
 
 protected:
   //! \brief Struct representing an inhomogeneous Dirichlet boundary condition.
@@ -734,6 +746,8 @@ protected:
   std::shared_ptr<LR::LRSplineSurface> lrspline; //!< The LR-spline surface object
 
   bool is_rational = false; //!< True if basis is rational
+
+  const ASMu2D* outputMaster = nullptr; //!< Master patch to use for VTF output
 
   Go::SplineSurface* tensorspline; //!< Pointer to original tensor spline object
   Go::SplineSurface* tensorPrjBas; //!< Pointer to tensor spline projection base

--- a/src/ASM/LR/ASMu2Dmx.C
+++ b/src/ASM/LR/ASMu2Dmx.C
@@ -1342,15 +1342,7 @@ void ASMu2Dmx::copyRefinement (LR::LRSplineSurface* basis,
                                int multiplicity) const
 {
   const LR::LRSplineSurface* ref = this->getBasis(ASM::REFINEMENT_BASIS);
-  for (const LR::Meshline* line : ref->getAllMeshlines()) {
-    int mult = line->multiplicity_ > 1 ? line->multiplicity_ : multiplicity;
-    if (line->span_u_line_)
-      basis->insert_const_v_edge(line->const_par_,
-                                 line->start_, line->stop_, mult);
-    else
-      basis->insert_const_u_edge(line->const_par_,
-                                 line->start_, line->stop_, mult);
-  }
+  LR::copyRefinement(ref, basis, multiplicity);
 }
 
 

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -1411,6 +1411,9 @@ bool ASMu3D::getGridParameters (RealArray& prm, int dir, int nSegPerSpan) const
 {
   if (!lrspline) return false;
 
+  if (outputMaster)
+    return outputMaster->getGridParameters(prm, dir, nSegPerSpan);
+
   double eps = ElementBlock::eps;
 
   for (const LR::Element* el : lrspline->getAllElements())
@@ -2406,6 +2409,16 @@ void ASMu3D::generateThreadGroupsFromElms (const IntVec& elms)
     projThreadGroups = threadGroups;
 
   threadGroups = threadGroups.filter(myElms);
+}
+
+
+void ASMu3D::extractElmRes (const Matrix& globRes, Matrix& elmRes,
+                            bool internalOrder) const
+{
+  if (outputMaster)
+    outputMaster->extractElmRes(globRes, elmRes, internalOrder);
+  else
+    this->ASMbase::extractElmRes(globRes, elmRes, internalOrder);
 }
 
 

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -470,6 +470,19 @@ public:
   //! \param[in] coefs The coefficients for the field
   virtual Fields* getProjectedFields(const Vector& coefs, size_t = 0) const;
 
+  //! \brief Set master patch for VTF output.
+  //! \param pch Master patch to use
+  void setOutputMaster(const ASMu3D* pch)
+  { outputMaster = pch; }
+
+  //! \brief Extracts element results for this patch from a global vector.
+  //! \param[in] globRes Global matrix of element results
+  //! \param[out] elmRes Element results for this patch
+  //! \param[in] internalOrder If \e true, the data in \a globRes are assumed to
+  //! be ordered w.r.t. the internal element ordering
+  virtual void extractElmRes(const Matrix& globRes, Matrix& elmRes,
+                             bool internalOrder = false) const;
+
 protected:
   //! \brief Struct representing an inhomogeneous Dirichlet boundary condition.
   struct DirichletFace
@@ -690,6 +703,8 @@ public:
 
 protected:
   std::shared_ptr<LR::LRSplineVolume> lrspline; //!< The LR-spline volume object
+
+  const ASMu3D* outputMaster = nullptr; //!< Master patch to use for VTF output
 
   Go::SplineVolume* tensorspline; //!< Pointer to original tensor spline object
   Go::SplineVolume* tensorPrjBas; //!< Pointer to tensor spline projection base

--- a/src/ASM/LR/ASMu3Dmx.C
+++ b/src/ASM/LR/ASMu3Dmx.C
@@ -1014,14 +1014,7 @@ void ASMu3Dmx::copyRefinement (LR::LRSplineVolume* basis,
                                int multiplicity) const
 {
   const LR::LRSplineVolume* ref = this->getBasis(ASM::REFINEMENT_BASIS);
-  for (const LR::MeshRectangle* rect : ref->getAllMeshRectangles()) {
-    int mult = rect->multiplicity_ > 1 ? basis->order(rect->constDirection())
-                                       : multiplicity;
-    LR::MeshRectangle* newRect = rect->copy();
-    newRect->multiplicity_ = mult;
-
-    basis->insert_line(newRect);
-  }
+  LR::copyRefinement(ref, basis, multiplicity);
 }
 
 


### PR DESCRIPTION
sharing VTF output between different ASMs, element orders
may differ. we need to order things in the VTF in the correct
output by using the correct gridParameters and MLGE.

for element norm outputs these have to externally been
reordered to the master patch order before being sent
to writeGlvN.

Also move the copyRefinement implementation to free functions to facility reuse in such staggered solvers.
I need to reuse these functions in adaptive staggered equal-order Boussinesq.