### PR TITLE
Element matrix cache fix

### DIFF
--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -339,6 +339,12 @@ size_t ASMbase::getNoElms (bool includeZeroVolElms, bool includeXElms) const
 }
 
 
+int ASMbase::getMaxElmNo () const
+{
+  return MLGE.empty() ? 0 : *std::max_element(MLGE.begin(),MLGE.end());
+}
+
+
 void ASMbase::getNoIntPoints (size_t& nPt, size_t& nIPt)
 {
   size_t nGp = 1;

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -322,6 +322,8 @@ public:
   //! in the patch (contact and interface elements, but no zero-volume elements)
   size_t getNoElms(bool includeZeroVolElms = false,
                    bool includeXElms = false) const;
+  //! \brief Returns the highest external element number in this patch.
+  int getMaxElmNo() const;
   //! \brief Returns the number of elements on a boundary.
   virtual size_t getNoBoundaryElms(char, char) const { return 0; }
   //! \brief Returns the total number of multi-point constraint equations.

--- a/src/ASM/ElmMats.C
+++ b/src/ASM/ElmMats.C
@@ -97,11 +97,9 @@ void ElmMats::printScl (std::ostream& os, size_t idx) const
 {
   if (idx >= c.size()) return;
 
-  os <<"Element scalar";
-  if (idx > 0) os <<" "<< idx;
-
+  os <<"Element scalar "<< idx+1;
   if (idx < Cname.size() && Cname[idx])
-    os <<" ("<< Cname[idx] <<"): ";
+    os <<" ("<< Cname[idx] <<")";
 
-  os << c[idx] << std::endl;
+  os <<": "<< c[idx] << std::endl;
 }

--- a/src/LinAlg/SAM.C
+++ b/src/LinAlg/SAM.C
@@ -447,6 +447,9 @@ bool SAM::assembleSystem (SystemMatrix& sysK, SystemVector& sysRHS,
                           const Matrix& eK, int iel,
                           RealArray* reactionForces) const
 {
+  if (eK.empty())
+    return true; // silently ignore empty element matrices
+
   if (reactionForces)
   {
     Vector eS;
@@ -483,7 +486,7 @@ bool SAM::assembleSystem (SystemMatrix& sysK, SystemVector& sysRHS,
 bool SAM::assembleSystem (SystemMatrix& sysM,
 			  const Matrix& eM, int iel) const
 {
-  return sysM.assemble(eM,*this,iel);
+  return eM.empty() ? true : sysM.assemble(eM,*this,iel);
 }
 
 
@@ -491,6 +494,9 @@ bool SAM::assembleSystem (SystemVector& sysRHS,
                           const Matrix& eK, int iel,
                           RealArray* reactionForces) const
 {
+  if (eK.empty())
+    return true; // silently ignore empty element matrices
+
   IntVec meen;
   if (!this->getElmEqns(meen,iel,eK.rows()))
     return false;

--- a/src/SIM/NewmarkSIM.C
+++ b/src/SIM/NewmarkSIM.C
@@ -127,6 +127,13 @@ void NewmarkSIM::printProblem () const
 
   IFEM::cout <<"Newmark predictor/multicorrector: beta = "<< beta
              <<" gamma = "<< gamma;
+  if (nupdat <= 0)
+    IFEM::cout <<"\n- using constant coefficient matrices";
+  else if (nupdat == 1)
+    IFEM::cout <<"\n- updating coefficient matrices each time step";
+  else
+    IFEM::cout <<"\n- updating coefficient matrices in the first "<< nupdat
+               <<" iterations in each time step";
   switch (predictor) {
   case 'd': IFEM::cout <<"\n- using constant displacement predictor"; break;
   case 'v': IFEM::cout <<"\n- using constant velocity predictor"; break;

--- a/src/SIM/NonLinSIM.C
+++ b/src/SIM/NonLinSIM.C
@@ -32,7 +32,7 @@ NonLinSIM::NonLinSIM (SIMbase& sim, CNORM n) : MultiStepSIM(sim), iteNorm(n)
   fromIni = iteNorm <= NONE;
   maxIncr = 2;
   maxit   = 20;
-  nupdat  = 20;
+  nupdat  = fromIni ? 0 : 20;
   prnSlow = 0;
   rTol    = 0.000001;
   aTol    = 0.0;
@@ -161,6 +161,9 @@ void NonLinSIM::initPrm ()
 {
   if (iteNorm <= NONE) // Flag to integrand that a linear solver is used
     model.setIntegrationPrm(3,1.0);
+
+  if (iteNorm <= NONE && nupdat < maxit)
+    model.initLHSbuffers(); // Cache the constant element matrices
 }
 
 

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -563,8 +563,13 @@ bool SIMbase::initSystem (const SIMbase* that)
 
 void SIMbase::initLHSbuffers ()
 {
-  if (myProblem)
-    myProblem->initLHSbuffers(this->getNoElms());
+  if (!myProblem) return;
+
+  int nElms = 0;
+  for (ASMbase* pch : myModel)
+    nElms = std::max(nElms,pch->getMaxElmNo());
+
+  myProblem->initLHSbuffers(nElms);
 }
 
 


### PR DESCRIPTION
In case the external element numbers are truly external, and not just a generated sequence [1,nel], like when importing Nastran input files, we need to account for that when allocating the buffers.

Also use element matrix buffers when doing linear multi-load-case simulation using the NonLinSIM driver.