### PR TITLE
added: allow specifying number of current DOFs in AdaptiveSetup::calcRefinement

### DIFF
--- a/src/SIM/AdaptiveSetup.C
+++ b/src/SIM/AdaptiveSetup.C
@@ -250,7 +250,7 @@ typedef std::pair<double,int> DblIdx;
 
 int AdaptiveSetup::calcRefinement (LR::RefineData& prm, int iStep,
                                    const Vectors& gNorm,
-                                   const Vector& refIn) const
+                                   const Vector& refIn, int currDofs) const
 {
   prm.clear();
 
@@ -273,13 +273,16 @@ int AdaptiveSetup::calcRefinement (LR::RefineData& prm, int iStep,
   else if (refNorm < epsZ)
     return 0; // Zero reference norm, probably no load on the model
 
+  if (currDofs == -1)
+    currDofs = model.getNoDOFs();
+
   // Check if further refinement is required
   if (iStep > maxStep)
   {
     IFEM::cout << "\n   * Stopping the adaptive cycles as max steps " << maxStep << " was reached." << std::endl;
     return 0;
   }
-  else if (model.getNoDOFs() > (size_t)maxDOFs)
+  else if (currDofs > maxDOFs)
   {
     IFEM::cout << "\n   * Stopping the adaptive cycles as max DOFs " << maxDOFs <<" was reached." << std::endl;
     return 0; // Refinement cycle or model size limit reached

--- a/src/SIM/AdaptiveSetup.h
+++ b/src/SIM/AdaptiveSetup.h
@@ -54,11 +54,13 @@ public:
   //! \param[in] iStep Refinement step counter
   //! \param[in] gNorm Global norms
   //! \param[in] refIn Element refinement indicators (element error norms)
+  //! \param[in] currDofs Current number of model DOFs. -1 to use SIMbase::getNoDOFs()
   //! \return Number of elements to be refined
   //! \return If zero, no refinement needed
   //! \return Negative value on error
   int calcRefinement(LR::RefineData& prm, int iStep,
-                     const Vectors& gNorm, const Vector& refIn) const;
+                     const Vectors& gNorm, const Vector& refIn,
+                     int currDofs = -1) const;
 
   //! \brief Parses a data section from an input stream.
   //! \param[in] keyWord Keyword of current data section to read


### PR DESCRIPTION
useful for staggered solvers where model number of DOFs is not the total number of DOFs