### PR TITLE
Pointwise velocity and acceleration output, element center output

### DIFF
--- a/src/ASM/ASMs1DLag.h
+++ b/src/ASM/ASMs1DLag.h
@@ -132,11 +132,13 @@ public:
   virtual bool evalSolution(Matrix& sField, const IntegrandBase& integrand,
                             const int*, char) const;
 
-  //! \brief Evaluates the secondary solution field at the nodal points.
+  //! \brief Evaluates the secondary solution field at the nodes/elements.
   //! \param[out] sField Solution field
   //! \param[in] integrand Object with problem-specific data and methods
+  //! \param[in] regular If \e true, evaluate at all element centers.
+  //! Otherwise, evaluate at all nodal points.
   virtual bool evalSolution(Matrix& sField, const IntegrandBase& integrand,
-                            const RealArray*, bool) const;
+                            const RealArray*, bool regular) const;
 
   using ASMs1D::getSize;
   //! \brief Returns the number of nodal points in the patch.

--- a/src/ASM/ASMs2DLag.h
+++ b/src/ASM/ASMs2DLag.h
@@ -235,11 +235,14 @@ public:
   //! \param[out] sField Solution field
   //! \param[in] integrand Object with problem-specific data and methods
   //! \param[in] gpar Parameter values of the result sampling points
+  //! \param[in] regular Flag indicating how the sampling points are defined
   //!
   //! \details We assume that the parameter value array \a gpar contains
   //! the \a u and \a v parameters directly for each sampling point.
+  //! If \a gpar is null or empty and \a regular is \e true,
+  //! the solution is instead evaluated at all element centers.
   virtual bool evalSolution(Matrix& sField, const IntegrandBase& integrand,
-                            const RealArray* gpar, bool) const;
+                            const RealArray* gpar, bool regular) const;
 
   //! \brief Evaluates and interpolates a field over a given geometry.
   //! \param[in] basis The basis of the field to evaluate

--- a/src/ASM/ASMs3DLag.h
+++ b/src/ASM/ASMs3DLag.h
@@ -248,11 +248,14 @@ public:
   //! \param[out] sField Solution field
   //! \param[in] integrand Object with problem-specific data and methods
   //! \param[in] gpar Parameter values of the result sampling points
+  //! \param[in] regular Flag indicating how the sampling points are defined
   //!
   //! \details We assume that the parameter value array \a gpar contains
   //! the \a u \a v and \a w parameters directly for each sampling point.
+  //! If \a gpar is null or empty and \a regular is \e true,
+  //! the solution is instead evaluated at all element centers.
   virtual bool evalSolution(Matrix& sField, const IntegrandBase& integrand,
-                            const RealArray* gpar, bool) const;
+                            const RealArray* gpar, bool regular) const;
 
   //! \brief Evaluates and interpolates a field over a given geometry.
   //! \param[in] basis The basis of the field to evaluate

--- a/src/LinAlg/DenseMatrix.C
+++ b/src/LinAlg/DenseMatrix.C
@@ -73,17 +73,6 @@ DenseMatrix::DenseMatrix (const Matrix& A, bool s) : myMat(A)
 }
 
 
-size_t DenseMatrix::dim (int idim) const
-{
-  if (idim == 1)
-    return myMat.rows();
-  else if (idim == 2)
-    return myMat.cols();
-  else
-    return myMat.size();
-}
-
-
 void DenseMatrix::initAssembly (const SAM& sam, bool)
 {
   myMat.resize(sam.neq,sam.neq,true);
@@ -229,7 +218,8 @@ bool DenseMatrix::assemble (const Matrix& eM, const SAM& sam, int e)
   else
     ierr = 1;
 #endif
-  return ierr == 0;
+  if (ierr != 0) return false;
+  return haveContributions = true;
 }
 
 
@@ -256,7 +246,8 @@ bool DenseMatrix::assemble (const Matrix& eM, const SAM& sam,
   else
     ierr = 1;
 #endif
-  return ierr == 0;
+  if (ierr != 0) return false;
+  return haveContributions = true;
 }
 
 
@@ -274,7 +265,7 @@ bool DenseMatrix::assemble (const Matrix& eM, const SAM& sam,
   if (!Bptr) return false;
 
   assemDense(eM,myMat,*Bptr,meen,sam.meqn,sam.mpmceq,sam.mmceq,sam.ttcc);
-  return true;
+  return haveContributions = true;
 #else
   return this->SystemMatrix::assemble(eM,sam,B,meen); // for error message
 #endif
@@ -357,12 +348,13 @@ bool DenseMatrix::add (const SystemMatrix& B, Real alpha)
 {
   const DenseMatrix* Bptr = dynamic_cast<const DenseMatrix*>(&B);
   if (!Bptr) return false;
+  if (B.isZero()) return true;
 
   if (myMat.rows() != Bptr->myMat.rows()) return false;
   if (myMat.cols() <  Bptr->myMat.cols()) return false;
 
   myMat.add(Bptr->myMat,alpha);
-  return true;
+  return haveContributions = true;
 }
 
 
@@ -372,7 +364,7 @@ bool DenseMatrix::add (Real sigma)
   size_t inc = myMat.rows()+1;
   for (size_t i = 0; i < myMat.size(); i += inc)
     v[i] += sigma;
-  return true;
+  return haveContributions = true;
 }
 
 

--- a/src/LinAlg/DenseMatrix.h
+++ b/src/LinAlg/DenseMatrix.h
@@ -53,7 +53,10 @@ public:
 
   //! \brief Returns the dimension of the system matrix.
   //! \param[in] idim Which direction to return the dimension in
-  virtual size_t dim(int idim = 1) const;
+  virtual size_t dim(int idim) const
+  {
+    return idim > 0 && idim < 3 ? myMat.dim(idim) : myMat.size();
+  }
 
   //! \brief Access to the matrix itself.
   Matrix& getMat() { return myMat; }

--- a/src/LinAlg/DiagMatrix.C
+++ b/src/LinAlg/DiagMatrix.C
@@ -79,7 +79,7 @@ bool DiagMatrix::assemble (const Matrix& eM, const SAM& sam, int e)
   }
 
   myMat(ieq) += eM(1,1);
-  return true;
+  return haveContributions = true;
 }
 
 
@@ -107,7 +107,7 @@ bool DiagMatrix::add (const SystemMatrix& B, Real alpha)
     return false;
 
   myMat.add(Bptr->myMat,alpha);
-  return true;
+  return haveContributions = true;
 }
 
 
@@ -115,7 +115,7 @@ bool DiagMatrix::add (Real sigma)
 {
   for (Real& v : myMat)
     v += sigma;
-  return true;
+  return haveContributions = true;
 }
 
 
@@ -125,8 +125,8 @@ bool DiagMatrix::multiply (const SystemVector& B, SystemVector& C) const
   const Real* b = B.getRef();
   Real*       c = C.getPtr();
 
-  for (size_t i = 0; i < C.size(); i++)
-    c[i] = i < B.size() && i < myMat.size() ? a[i]*b[i] : Real(0);
+  for (size_t i = 0; i < C.dim(); i++)
+    c[i] = i < B.dim() && i < myMat.size() ? a[i]*b[i] : Real(0);
 
   return true;
 }

--- a/src/LinAlg/ISTLMatrix.C
+++ b/src/LinAlg/ISTLMatrix.C
@@ -24,17 +24,19 @@ ISTLVector::ISTLVector(const ProcessAdm& padm) : adm(padm)
 }
 
 
-ISTLVector::ISTLVector(const ProcessAdm& padm, size_t n) : adm(padm)
+ISTLVector::ISTLVector(const ProcessAdm& padm, size_t n)
+  : StdVector(n), adm(padm)
 {
   x.resize(n);
   LinAlgInit::increfs();
 }
 
 
-ISTLVector::ISTLVector(const ProcessAdm& padm, const Real* values, size_t n) : adm(padm)
+ISTLVector::ISTLVector(const ProcessAdm& padm, const Real* values, size_t n)
+  : StdVector(values,n), adm(padm)
 {
   x.resize(n);
-  this->restore(values);
+  this->endAssembly();
   LinAlgInit::increfs();
 }
 

--- a/src/LinAlg/PETScMatrix.C
+++ b/src/LinAlg/PETScMatrix.C
@@ -27,26 +27,28 @@ PETScVector::PETScVector(const ProcessAdm& padm) : adm(padm)
 }
 
 
-PETScVector::PETScVector(const ProcessAdm& padm, size_t n) :
-  StdVector(n), adm(padm)
+PETScVector::PETScVector(const ProcessAdm& padm, size_t n)
+  : StdVector(n), adm(padm)
 {
-  VecCreate(*adm.getCommunicator(),&x);
   if (adm.isParallel())
-    VecSetSizes(x,adm.dd.getMaxEq()-adm.dd.getMinEq()+1,PETSC_DECIDE);
-  else
-    VecSetSizes(x,n,PETSC_DECIDE);
+    n = adm.dd.getMaxEq() - adm.dd.getMinEq() + 1;
+
+  VecCreate(*adm.getCommunicator(),&x);
+  VecSetSizes(x,n,PETSC_DECIDE);
   VecSetFromOptions(x);
   LinAlgInit::increfs();
 }
 
 
-PETScVector::PETScVector(const ProcessAdm& padm, const Real* values, size_t n) :
-  StdVector(values, n), adm(padm)
+PETScVector::PETScVector(const ProcessAdm& padm, const Real* values, size_t n)
+  : StdVector(values,n), adm(padm)
 {
+  if (adm.isParallel())
+    n = adm.dd.getMaxEq() - adm.dd.getMinEq() + 1;
+
   VecCreate(*adm.getCommunicator(),&x);
-  VecSetSizes(x,adm.dd.getMaxEq()-adm.dd.getMinEq() + 1,PETSC_DECIDE);
+  VecSetSizes(x,n,PETSC_DECIDE);
   VecSetFromOptions(x);
-  this->restore(values);
   LinAlgInit::increfs();
 }
 

--- a/src/LinAlg/SPRMatrix.h
+++ b/src/LinAlg/SPRMatrix.h
@@ -44,7 +44,7 @@ public:
   virtual SystemMatrix* copy() const { return new SPRMatrix(*this); }
 
   //! \brief Returns the dimension of the system matrix.
-  virtual size_t dim(int) const { return mpar[7]; }
+  virtual size_t dim(int idim) const;
 
   //! \brief Initializes the element assembly process.
   //! \param[in] sam Auxiliary data describing the FE model topology, etc.

--- a/src/LinAlg/SparseMatrix.C
+++ b/src/LinAlg/SparseMatrix.C
@@ -261,14 +261,12 @@ bool SparseMatrix::redim (size_t r, size_t c)
 
 size_t SparseMatrix::dim (int idim) const
 {
-  if (idim == 1)
-    return nrow;
-  else if (idim == 2)
-    return ncol;
-  else if (idim == 3)
-    return nrow*ncol;
-  else
-    return this->size();
+  switch (idim) {
+  case 1: return nrow;
+  case 2: return ncol;
+  case 3: return nrow*ncol;
+  default: return this->size();
+  }
 }
 
 
@@ -533,6 +531,7 @@ bool SparseMatrix::add (const SystemMatrix& B, Real alpha)
 {
   const SparseMatrix* Bptr = dynamic_cast<const SparseMatrix*>(&B);
   if (!Bptr) return false;
+  if (B.isZero()) return true;
 
   if (Bptr->nrow > nrow || Bptr->ncol > ncol) return false;
 
@@ -564,7 +563,7 @@ bool SparseMatrix::add (const SystemMatrix& B, Real alpha)
   else
     return false;
 
-  return true;
+  return haveContributions = true;
 }
 
 
@@ -573,7 +572,7 @@ bool SparseMatrix::add (Real sigma)
   for (size_t i = 1; i <= nrow && i <= ncol; i++)
     this->operator()(i,i) += sigma;
 
-  return true;
+  return haveContributions = true;
 }
 
 
@@ -819,7 +818,7 @@ bool SparseMatrix::assemble (const Matrix& eM, const SAM& sam, int e)
 
   Vector dummyB;
   assemSparse(eM,*this,dummyB,meen,sam.meqn,sam.mpmceq,sam.mmceq,sam.ttcc);
-  return true;
+  return haveContributions = true;
 }
 
 
@@ -834,7 +833,7 @@ bool SparseMatrix::assemble (const Matrix& eM, const SAM& sam,
     return false;
 
   assemSparse(eM,*this,*Bptr,meen,sam.meqn,sam.mpmceq,sam.mmceq,sam.ttcc);
-  return true;
+  return haveContributions = true;
 }
 
 
@@ -848,7 +847,7 @@ bool SparseMatrix::assemble (const Matrix& eM, const SAM& sam,
     return false;
 
   assemSparse(eM,*this,*Bptr,meen,sam.meqn,sam.mpmceq,sam.mmceq,sam.ttcc);
-  return true;
+  return haveContributions = true;
 }
 
 
@@ -861,7 +860,7 @@ bool SparseMatrix::assembleCol (const RealArray& V, const SAM& sam,
   if (!sam.getNodeEqns(mnen,n)) return false;
 
   assemSparse(V,*this,col,mnen,sam.meqn,sam.mpmceq,sam.mmceq,sam.ttcc);
-  return true;
+  return haveContributions = true;
 }
 
 
@@ -1017,7 +1016,7 @@ bool SparseMatrix::optimiseSLU (const std::vector<IntSet>& dofc)
 
 bool SparseMatrix::solve (SystemVector& B, Real* rc)
 {
-  if (this->size() < 1) return true; // No equations to solve
+  if (this->dim(1) < 1) return true; // No equations to solve
 
   StdVector* Bptr = dynamic_cast<StdVector*>(&B);
   if (!Bptr) return false;

--- a/src/LinAlg/SystemMatrix.C
+++ b/src/LinAlg/SystemMatrix.C
@@ -55,10 +55,7 @@ SystemVector* SystemVector::create (const ProcessAdm* adm,
 SystemVector& SystemVector::copy (const SystemVector& x)
 {
   this->redim(x.dim());
-  Real* vec = this->getPtr();
-  memcpy(vec,x.getRef(),x.dim()*sizeof(Real));
-  this->restore(vec);
-
+  memcpy(this->getPtr(),x.getRef(),x.dim()*sizeof(Real));
   return *this;
 }
 

--- a/src/LinAlg/SystemMatrix.C
+++ b/src/LinAlg/SystemMatrix.C
@@ -54,7 +54,7 @@ SystemVector* SystemVector::create (const ProcessAdm* adm,
 
 SystemVector& SystemVector::copy (const SystemVector& x)
 {
-  this->redim(x.size());
+  this->redim(x.dim());
   Real* vec = this->getPtr();
   memcpy(vec,x.getRef(),x.dim()*sizeof(Real));
   this->restore(vec);

--- a/src/LinAlg/SystemMatrix.h
+++ b/src/LinAlg/SystemMatrix.h
@@ -46,7 +46,7 @@ public:
   //! \brief Creates a copy of the system vector and returns a pointer to it.
   virtual SystemVector* copy() const = 0;
 
-  //! \brief Returns the dimension of the system vector.
+  //! \brief Returns the dimension/size of the system vector.
   virtual size_t dim() const = 0;
 
   //! \brief Sets the dimension of the system vector.
@@ -57,9 +57,6 @@ public:
 
   //! \brief Checks if the vector is empty.
   virtual bool empty() const { return this->dim() == 0; }
-
-  //! \brief Returns the size of the system vector.
-  size_t size() const { return this->dim(); }
 
   //! \brief Access through pointer.
   virtual Real* getPtr() = 0;
@@ -100,7 +97,7 @@ public:
 
   //! \brief Dumps the system vector on a specified format.
   virtual void dump(std::ostream&, LinAlg::StorageFormat,
-                    const char* = nullptr) {}
+                    const char* = nullptr) const {}
 
 protected:
   //! \brief Writes the system vector to the given output stream.
@@ -129,7 +126,9 @@ public:
   StdVector(const Real* values, size_t n) : utl::vector<Real>(values,n) {}
   //! \brief Overloaded copy constructor.
   explicit StdVector(const std::vector<Real>& vec)
-  { this->insert(this->end(),vec.begin(),vec.end()); }
+  {
+    this->insert(this->end(),vec.begin(),vec.end());
+  }
 
   //! \brief Returns the vector type.
   virtual LinAlg::MatrixType getType() const { return LinAlg::DENSE; }
@@ -143,9 +142,6 @@ public:
   //! \brief Returns the dimension of the system vector.
   virtual size_t dim() const { return this->std::vector<Real>::size(); }
 
-  //! \brief Returns the dimension of the system vector.
-  virtual size_t size() const { return this->std::vector<Real>::size(); }
-
   //! \brief Sets the dimension of the system vector.
   virtual void redim(size_t n) { this->std::vector<Real>::resize(n,Real(0)); }
 
@@ -153,7 +149,9 @@ public:
   //! \details Will erase the previous content, but only if the size changed,
   //! unless \a forceClear is \e true.
   virtual void resize(size_t n, bool forceClear = false)
-  { this->utl::vector<Real>::resize(n,forceClear); }
+  {
+    this->utl::vector<Real>::resize(n,forceClear);
+  }
 
   //! \brief Access through pointer.
   virtual Real* getPtr() { return this->ptr(); }
@@ -168,7 +166,9 @@ public:
 
   //! \brief Addition of another system vector to this one.
   virtual void add(const SystemVector& vec, Real scale)
-  { this->utl::vector<Real>::add(static_cast<const StdVector&>(vec),scale); }
+  {
+    this->utl::vector<Real>::add(static_cast<const StdVector&>(vec),scale);
+  }
 
   //! \brief L1-norm of the vector.
   virtual Real L1norm() const { return this->asum(); }
@@ -181,7 +181,7 @@ public:
 
   //! \brief Dumps the system vector on a specified format.
   virtual void dump(std::ostream& os, LinAlg::StorageFormat format,
-                    const char* label) { dump(*this,label,format,os); }
+                    const char* label) const { dump(*this,label,format,os); }
 
   //! \brief Dumps a standard vector to given output stream on specified format.
   static void dump(const utl::vector<Real>& x, const char* label,
@@ -190,7 +190,9 @@ public:
 protected:
   //! \brief Writes the system vector to the given output stream.
   virtual std::ostream& write(std::ostream& os) const
-  { return os << static_cast<const utl::vector<Real>&>(*this); }
+  {
+    return os << static_cast<const utl::vector<Real>&>(*this);
+  }
 };
 
 
@@ -214,7 +216,7 @@ public:
 
 protected:
   //! \brief Default constructor.
-  SystemMatrix() {}
+  SystemMatrix() : haveContributions(false) {}
 
 public:
   //! \brief Empty destructor.
@@ -231,6 +233,8 @@ public:
 
   //! \brief Checks if the matrix is empty.
   virtual bool empty() const { return this->dim(0) == 0; }
+  //! \brief Checks if the matrix have no non-zero contributions.
+  bool isZero() const { return !haveContributions && this->dim(1) > 0; }
 
   //! \brief Returns the dimension of the system matrix.
   virtual size_t dim(int idim = 1) const = 0;
@@ -295,7 +299,8 @@ public:
   virtual bool add(Real) { return false; }
 
   //! \brief Performs a matrix-vector multiplication.
-  virtual bool multiply(const SystemVector&, SystemVector&) const { return false; }
+  virtual bool multiply(const SystemVector&, SystemVector&) const
+  { return false; }
 
   //! \brief Solves the linear system of equations for a given right-hand-side.
   //! \param b Right-hand-side vector on input, solution vector on output
@@ -332,6 +337,8 @@ protected:
   {
     return A.write(os);
   }
+
+  bool haveContributions; //!< If \e true, the matrix have some non-zero terms
 };
 
 #endif

--- a/src/LinAlg/SystemMatrix.h
+++ b/src/LinAlg/SystemMatrix.h
@@ -63,12 +63,6 @@ public:
   //! \brief Reference through pointer.
   virtual const Real* getRef() const = 0;
 
-  //! \brief Restores the vector contents from an array.
-  //! \details This method must only be implemented by sub-classes for which the
-  //! getPtr() and getRef() methods do not return a pointer to the actual
-  //! internal memory segment containing the actual vector data.
-  virtual void restore(const Real*) {}
-
   //! \brief Initializes the vector assuming it is properly dimensioned.
   virtual void init(Real value = Real(0)) = 0;
 

--- a/src/SIM/MultiStepSIM.h
+++ b/src/SIM/MultiStepSIM.h
@@ -182,7 +182,7 @@ public:
   //! solution space during the response integration than the actual FE space.
   //! This method is then supposed to return the expanded solution vectors.
   //! The default implementation is the same as SIMsolution::theSolutions().
-  virtual const Vectors& realSolutions() { return solution; }
+  virtual const Vectors& realSolutions(bool = false) { return solution; }
 
   //! \brief Returns a pointer to the reference norm variable.
   double* theRefNorm() { return &refNorm; }

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -1209,13 +1209,25 @@ bool SIMbase::applyDirichlet (Vector& glbVec) const
 bool SIMbase::solveEqSystem (Vector& solution, size_t idxRHS, double* rCond,
 			     int printSol, bool dumpEqSys, const char* compName)
 {
-  if (!myEqSys) return false;
+  if (!myEqSys)
+  {
+    std::cerr <<" *** SIMbase::solveEqSystem: No equation system."<< std::endl;
+    return false;
+  }
 
   SystemMatrix* A = myEqSys->getMatrix();
+  if (!A || A->isZero())
+  {
+    std::cerr <<" *** SIMbase::solveEqSystem: All-zero LHS matrix."<< std::endl;
+    return false;
+  }
+
   SystemVector* b = myEqSys->getVector(idxRHS);
-  if (!A) std::cerr <<" *** SIMbase::solveEqSystem: No LHS matrix."<< std::endl;
-  if (!b) std::cerr <<" *** SIMbase::solveEqSystem: No RHS vector."<< std::endl;
-  if (!A || !b) return false;
+  if (!b)
+  {
+    std::cerr <<" *** SIMbase::solveEqSystem: No RHS vector."<< std::endl;
+    return false;
+  }
 
   // Dump equation system to file(s) if requested
   if (dumpEqSys)

--- a/src/SIM/SIMmodal.h
+++ b/src/SIM/SIMmodal.h
@@ -60,6 +60,8 @@ public:
   //! \brief Expands and returns the current dynamic solution.
   virtual const Vectors& expandSolution(const Vectors&, bool = false) = 0;
   //! \brief Returns the current expanded dynamic solution.
+  const Vectors& expandedSolution() const { return sol; }
+  //! \brief Returns the current expanded dynamic solution.
   //! \param[in] idx Solution vector index
   const Vector& expandedSolution(int idx) const;
   //! \brief Returns the number of expanded dynamic solution vectors.

--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -1927,7 +1927,7 @@ bool SIMoutput::evalResults (const Vector& psol, const ResPointVec& gPoints,
     return false;
 
   // Evaluate the secondary solution variables
-  if (!patch->evalSolution(tmp,*myProblem,params.data(),false))
+  if (!patch->evalSolution(tmp,*myProblem,params.data(),points.empty()))
     return false;
 
   return augment(sol2,tmp);

--- a/src/SIM/SIMoutput.h
+++ b/src/SIM/SIMoutput.h
@@ -287,10 +287,10 @@ public:
   bool savePoints(const Vector& psol, double time, int step) const;
 
   //! \brief Saves result components to output files for a given time step.
-  //! \param[in] psol Primary solution vector
+  //! \param[in] psol Primary solution vectors
   //! \param[in] time Load/time step parameter
   //! \param[in] step Load/time step counter
-  bool saveResults(const Vector& psol, double time, int step) const;
+  bool saveResults(const Vectors& psol, double time, int step) const;
 
   //! \brief Sets the file name for result point output.
   //! \param[in] filename The file name prefix (optionally with extension)
@@ -374,14 +374,14 @@ protected:
                    bool formatted, std::streamsize precision) const;
 
   //! \brief Evaluate solution results at specified points for a given patch.
-  //! \param[in] psol Primary solution vector to derive other quantities from
+  //! \param[in] psol Primary solution vectors to derive other quantities from
   //! \param[in] gPoints Result point definitions
   //! \param[in] patch The patch to evaluate result points for
   //! \param[out] points List of result points within this patch
   //! \param[out] Xp Coordinates of result points within this patch
   //! \param[out] sol1 Matrix of primary solution values at result points
   //! \param[out] sol2 Matrix of secondary solution values at result points
-  bool evalResults(const Vector& psol, const ResPointVec& gPoints,
+  bool evalResults(const Vectors& psol, const ResPointVec& gPoints,
                    const ASMbase* patch, std::vector<int>& points, Vec3Vec& Xp,
                    Matrix& sol1, Matrix& sol2) const;
 

--- a/src/SIM/SIMoutput.h
+++ b/src/SIM/SIMoutput.h
@@ -353,9 +353,12 @@ protected:
   //! \brief File name to result point group mapping.
   using ResPtPair = std::pair<std::string,ResPointVec>;
 
+  std::vector<ResPtPair> myPoints; //!< User-defined result sampling points
+
   //! \brief Preprocesses the result sampling points.
   virtual void preprocessResultPoints();
 
+private:
   //! \brief Preprocesses a result sampling point group.
   //! \param ptFile Name of file that these result points are dumped to
   //! \param points Group of result points that are dumped to the given file
@@ -373,7 +376,7 @@ protected:
                    utl::LogStream& os, const ResPointVec& gPoints,
                    bool formatted, std::streamsize precision) const;
 
-  //! \brief Evaluate solution results at specified points for a given patch.
+  //! \brief Evaluates solution results at specified points for a given patch.
   //! \param[in] psol Primary solution vectors to derive other quantities from
   //! \param[in] gPoints Result point definitions
   //! \param[in] patch The patch to evaluate result points for
@@ -381,13 +384,12 @@ protected:
   //! \param[out] Xp Coordinates of result points within this patch
   //! \param[out] sol1 Matrix of primary solution values at result points
   //! \param[out] sol2 Matrix of secondary solution values at result points
+  //! \param[out] compNames Names of solution components in \a sol1 and \a sol2
   bool evalResults(const Vectors& psol, const ResPointVec& gPoints,
                    const ASMbase* patch, std::vector<int>& points, Vec3Vec& Xp,
-                   Matrix& sol1, Matrix& sol2) const;
+                   Matrix& sol1, Matrix& sol2,
+                   std::vector<std::string>* compNames = nullptr) const;
 
-  std::vector<ResPtPair> myPoints; //!< User-defined result sampling points
-
-private:
   std::map<std::string,RealFunc*> myAddScalars; //!< Scalar functions to output
 
   int    myPrec;   //!< Output precision for result sampling


### PR DESCRIPTION
The first commit adds the possibility of evaluating the secondary solution at the center of each element for subsequent OSP calculations. The next two commits facilitate evaluation of nodal velocity and accelerations for OSP. This works under the assumption that if the array of solution vectors have 3 or more vectors, then the last two of them are the velocity and acceleration vectors, respectively.

The last two commits make it possible to detect that a system matrix has not received any contributions and then perform an early exit with a specific error message, instead of that standard factorization error which does not point to the actual problem, or even worse; continuing without solving assuming all is fine.