### PR TITLE
Changed: Replace non-const getNodeSet() methods by parseNodeSet().

### DIFF
--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -271,8 +271,8 @@ public:
   virtual int getNodeSetIdx(const std::string&) const { return 0; }
   //! \brief Returns an indexed predefined node set.
   virtual const IntVec& getNodeSet(int) const { return Empty; }
-  //! \brief Returns a named node set for update.
-  virtual IntVec& getNodeSet(const std::string&, int&) { return Empty; }
+  //! \brief Defines a node set by parsing a list of node numbers.
+  virtual int parseNodeSet(const std::string&, const char*) { return 0; }
   //! \brief Defines a node set by parsing a 3D bounding box.
   virtual int parseNodeBox(const std::string&, const char*) { return 0; }
 
@@ -280,10 +280,10 @@ public:
   virtual int getElementSetIdx(const std::string&) const { return 0; }
   //! \brief Returns an indexed predefined element set.
   virtual const IntVec& getElementSet(int) const { return Empty; }
-  //! \brief Checks if an element is within a predefined element.
+  //! \brief Checks if an element is within a predefined element set.
   virtual bool isInElementSet(int, int) const { return false; }
-  //! \brief Returns a named element set for update.
-  virtual IntVec& getElementSet(const std::string&, int&) { return Empty; }
+  //! \brief Defines an element set by parsing a list of element numbers.
+  virtual int parseElemSet(const std::string&, const char*) { return 0; }
   //! \brief Defines an element set by parsing a 3D bounding box.
   virtual int parseElemBox(const std::string&, const char*) { return 0; }
 

--- a/src/ASM/ASMsupel.C
+++ b/src/ASM/ASMsupel.C
@@ -14,6 +14,7 @@
 #include "ASMsupel.h"
 #include "GlobalIntegral.h"
 #include "ElementBlock.h"
+#include "Utilities.h"
 #include "Vec3Oper.h"
 #include <numeric>
 
@@ -144,17 +145,18 @@ const IntVec& ASMsupel::getNodeSet (int idx) const
 }
 
 
-IntVec& ASMsupel::getNodeSet (const std::string& setName, int& idx)
+int ASMsupel::parseNodeSet (const std::string& setName, const char* cset)
 {
-  idx = 1;
-  for (ASM::NodeSet& ns : nodeSets)
-    if (ns.first == setName)
-      return ns.second;
-    else if (idx)
-      ++idx;
+  int idx = this->getNodeSetIdx(setName)-1;
+  if (idx < 0)
+  {
+    idx = nodeSets.size();
+    nodeSets.emplace_back(setName,IntVec());
+  }
 
-  nodeSets.push_back(std::make_pair(setName,IntVec()));
-  return nodeSets.back().second;
+  utl::parseIntegers(nodeSets[idx].second,cset);
+
+  return 1+idx;
 }
 
 

--- a/src/ASM/ASMsupel.h
+++ b/src/ASM/ASMsupel.h
@@ -51,8 +51,8 @@ public:
   virtual int getNodeSetIdx(const std::string& setName) const;
   //! \brief Returns an indexed pre-defined node set.
   virtual const IntVec& getNodeSet(int idx) const;
-  //! \brief Returns a named node set for update.
-  virtual IntVec& getNodeSet(const std::string& setName, int& idx);
+  //! \brief Defines a node set by parsing a list of node numbers.
+  virtual int parseNodeSet(const std::string& setName, const char* cset);
 
   //! \brief Returns the global coordinates for the given node.
   //! \param[in] inod 1-based node index local to current patch.

--- a/src/ASM/ASMu1DLag.h
+++ b/src/ASM/ASMu1DLag.h
@@ -56,8 +56,8 @@ public:
   virtual const IntVec& getElementSet(int idx) const;
   //! \brief Checks if element \e iel is within predefined element set \a idx.
   virtual bool isInElementSet(int idx, int iel) const;
-  //! \brief Returns a named element set for update.
-  virtual IntVec& getElementSet(const std::string& setName, int& idx);
+  //! \brief Defines an element set by parsing a list of element numbers.
+  virtual int parseElemSet(const std::string& setName, const char* cset);
 
   //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
   //! \param[in] lIndex Local index of the boundary node set

--- a/src/ASM/ASMu2DLag.h
+++ b/src/ASM/ASMu2DLag.h
@@ -71,10 +71,12 @@ public:
   virtual int getNodeSetIdx(const std::string& setName) const;
   //! \brief Returns an indexed predefined node set.
   virtual const IntVec& getNodeSet(int idx) const;
-  //! \brief Returns a named node set for update.
-  virtual IntVec& getNodeSet(const std::string& setName, int& idx);
+  //! \brief Defines a node set by parsing a list of node numbers.
+  virtual int parseNodeSet(const std::string& setName, const char* cset);
   //! \brief Defines a node set by parsing a 3D bounding box.
   virtual int parseNodeBox(const std::string& setName, const char* bbox);
+  //! \brief Adds nodal index \a inod to the node set named \a setName.
+  void addToNodeSet(const std::string& setName, int inod);
 
   //! \brief Returns (1-based) index of a predefined element set in the patch.
   virtual int getElementSetIdx(const std::string& setName) const;
@@ -82,8 +84,8 @@ public:
   virtual const IntVec& getElementSet(int idx) const;
   //! \brief Checks if element \e iel is within predefined element set \a idx.
   virtual bool isInElementSet(int idx, int iel) const;
-  //! \brief Returns a named element set for update.
-  virtual IntVec& getElementSet(const std::string& setName, int& idx);
+  //! \brief Defines an element set by parsing a list of element numbers.
+  virtual int parseElemSet(const std::string& setName, const char* cset);
   //! \brief Defines an element set by parsing a 3D bounding box.
   virtual int parseElemBox(const std::string& setName, const char* bbox);
 

--- a/src/ASM/Test/TestMatlabPatch.C
+++ b/src/ASM/Test/TestMatlabPatch.C
@@ -116,8 +116,7 @@ TEST(TestMatlabPatch, IO)
   ASSERT_TRUE(pch2 != nullptr);
   int idx1 = pch2->getNodeSetIdx("Boundary");
   int idx2 = pch2->getNodeSetIdx("Edge2");
-  int idx3 = 0;
-  pch2->getNodeSet("ACorner",idx3).push_back(1);
+  int idx3 = pch2->parseNodeSet("ACorner","1");
   EXPECT_EQ(idx1,1);
   EXPECT_EQ(idx2,2);
   EXPECT_EQ(idx3,3);

--- a/src/LinAlg/SAM.C
+++ b/src/LinAlg/SAM.C
@@ -118,11 +118,14 @@ std::ostream& operator<< (std::ostream& os, const std::pair<int,int>& p)
 void SAM::printCEQ (std::ostream& os, int iceq) const
 {
   int ip = mpmceq[iceq++]-1;
-  os << this->getNodeAndLocalDof(mmceq[ip]) <<" =";
+  std::pair<int,int> nodeDof = this->getNodeAndLocalDof(mmceq[ip]);
+  std::string indent(11+log10(nodeDof.first),' ');
+  os << nodeDof <<" =";
   if (ttcc[ip] || ip+2 >= mpmceq[iceq])
     os <<" "<< ttcc[ip];
   for (int jp = ip+1; jp < mpmceq[iceq]-1; jp++)
   {
+    if ((jp-ip)%10 == 1 && jp > ip+1) os <<"\n"<< indent;
     if (ttcc[ip] || jp > ip+1) os <<" +";
     os <<" "<< ttcc[jp] <<"*"<< this->getNodeAndLocalDof(mmceq[jp]);
   }

--- a/src/LinAlg/SAM.h
+++ b/src/LinAlg/SAM.h
@@ -53,11 +53,14 @@ public:
     if (heading)
       os <<"\n"<< heading <<":";
     for (int inod = 1; inod <= nnod; inod++)
-    {
-      os <<"\nNode "<< inod <<":";
-      for (int idof = madof[inod-1]; idof < madof[inod]; idof++)
-        os <<" "<< utl::trunc(vec[idof-1]);
-    }
+      for (int jdof = madof[inod-1]; jdof < madof[inod]; jdof++)
+        if (utl::trunc(vec[jdof-1]) != Real(0))
+        {
+          os <<"\nNode "<< inod <<":";
+          for (int idof = madof[inod-1]; idof < madof[inod]; idof++)
+            os <<" "<< utl::trunc(vec[idof-1]);
+          break;
+        }
     os << std::endl;
   }
 

--- a/src/SIM/SIMinput.C
+++ b/src/SIM/SIMinput.C
@@ -282,8 +282,7 @@ bool SIMinput::parseGeometryTag (const tinyxml2::XMLElement* elem)
                 if (!child)
                   setIndex = pch->getNodeSetIdx(name);
                 else
-                  utl::parseIntegers(pch->getNodeSet(name,setIndex),
-                                     child->Value());
+                  setIndex = pch->parseNodeSet(name,child->Value());
                 if (setIndex > 0)
                   top.emplace(pid,setIndex,idim);
               }
@@ -294,8 +293,7 @@ bool SIMinput::parseGeometryTag (const tinyxml2::XMLElement* elem)
                 else if (utl::getAttribute(item,"type",type) && type == "bbox")
                   setIndex = pch->parseElemBox(name,child->Value());
                 else
-                  utl::parseIntegers(pch->getElementSet(name,setIndex),
-                                     child->Value());
+                  setIndex = pch->parseElemSet(name,child->Value());
                 if (setIndex > 0)
                   top.emplace(pid,setIndex,idim);
               }

--- a/src/SIM/SIMsupel.C
+++ b/src/SIM/SIMsupel.C
@@ -93,8 +93,7 @@ bool SIMsupel::parse (const tinyxml2::XMLElement* elem)
   if (result && !sup.MVP.empty())
     if ((result = myModel.back()->transform(sup.MVP)) && !supNodeSet.empty())
     {
-      int topIdx = 0;
-      myModel.back()->getNodeSet(supNodeSet,topIdx);
+      int topIdx = myModel.back()->parseNodeSet(supNodeSet,nullptr);
       if (topIdx > 0)
         myEntitys[supNodeSet].insert(TopItem(myModel.size(),topIdx,4));
     }


### PR DESCRIPTION
And similarly `getElementSet()` --> `parseElemSet()`.
The new methods also map from external node/elem numbers to local indices.
Added: `ASMu2DLag::addToNodeSet()`.