### PR TITLE
VTF output of syste load vector for mulit-step simulators

### DIFF
--- a/src/ASM/ASMLagBase.C
+++ b/src/ASM/ASMLagBase.C
@@ -34,3 +34,15 @@ bool ASMLagBase::nodalField (Matrix& field, const Vector& sol, size_t nno) const
 
   return true;
 }
+
+
+Vec3 ASMLagBase::getGeometricCenter (const std::vector<int>& MNPC) const
+{
+  Vec3 X0;
+
+  for (int inod : MNPC)
+    X0 += coord[inod];
+  X0 *= 1.0 / static_cast<double>(MNPC.size());
+
+  return X0;
+}

--- a/src/ASM/ASMLagBase.h
+++ b/src/ASM/ASMLagBase.h
@@ -36,6 +36,9 @@ protected:
   //! \brief Direct nodal evaluation of a solution field.
   bool nodalField(Matrix& field, const Vector& sol, size_t nno) const;
 
+  //! \brief Returns the geometric center of an element.
+  Vec3 getGeometricCenter(const std::vector<int>& MNPC) const;
+
 protected:
   const Vec3Vec& coord; //!< Const reference to the nodal coordinate container
   Vec3Vec      myCoord; //!< Nodal coordinate container

--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -57,7 +57,7 @@ static bool Aerror (const char* name)
 
 
 ASMbase::ASMbase (unsigned char n_p, unsigned char n_s, unsigned char n_f)
-  : MLGE(myMLGE), MLGN(myMLGN), MNPC(myMNPC), shareFE(0)
+  : MLGE(myMLGE), MLGN(myMLGN), MNPC(myMNPC), shareFE(0), myActiveEls(nullptr)
 {
   nf = n_f;
   nsd = n_s > 3 ? 3 : n_s;
@@ -73,7 +73,7 @@ ASMbase::ASMbase (unsigned char n_p, unsigned char n_s, unsigned char n_f)
 ASMbase::ASMbase (const ASMbase& patch, unsigned char n_f)
   : MLGE(patch.MLGE), MLGN(patch.MLGN), MNPC(patch.MNPC), shareFE('F'),
     firstBp(patch.firstBp), myLMTypes(patch.myLMTypes), myLMs(patch.myLMs),
-    myRmaster(patch.myRmaster)
+    myActiveEls(nullptr), myRmaster(patch.myRmaster)
 {
   nf = n_f > 0 ? n_f : patch.nf;
   nsd = patch.nsd;
@@ -90,7 +90,7 @@ ASMbase::ASMbase (const ASMbase& patch, unsigned char n_f)
 
 ASMbase::ASMbase (const ASMbase& patch)
   : MLGE(myMLGE), MLGN(myMLGN), MNPC(myMNPC), shareFE('S'),
-    BCode(patch.BCode), firstBp(patch.firstBp)
+    BCode(patch.BCode), firstBp(patch.firstBp), myActiveEls(nullptr)
 {
   nf = patch.nf;
   nsd = patch.nsd;
@@ -178,6 +178,8 @@ void ASMbase::clear (bool retainGeometry)
   BCode.clear();
   dCode.clear();
   mpcs.clear();
+
+  myActiveEls = nullptr;
 }
 
 
@@ -1742,4 +1744,14 @@ void ASMbase::getBoundaryElms (int lIndex, IntVec& elms,
 
   for (int& elm : elms)
     elm = MLGE[elm]-1;
+}
+
+
+bool ASMbase::isElementActive (int elmId) const
+{
+  if (elmId < 1) return false;
+  if (!myActiveEls) return true;
+
+  return std::find(myActiveEls->begin(),
+                   myActiveEls->end(),elmId) != myActiveEls->end();
 }

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -236,6 +236,8 @@ public:
   //! otherwise the geometry basis coordinates are returned
   virtual bool getElementCoordinates(Matrix& X, int iel,
                                      bool forceItg = false) const = 0;
+  //! \brief Returns the coordinates of the element center.
+  virtual Vec3 getElementCenter(int) const = 0;
 
   //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
   //! \param[in] lIndex Local index of the boundary face/edge
@@ -309,6 +311,11 @@ public:
   virtual void shiftGlobalElmNums(int eshift);
   //! \brief Returns the global element numbers of this patch.
   const IntVec& getGlobalElementNums() const { return MLGE; }
+
+  //! \brief Sets the list of active elements during assembly.
+  void setActiveElements(IntVec* active) { myActiveEls = active; }
+  //! \brief Returns \e true if element with global id \a elmId is active.
+  bool isElementActive(int elmId) const;
 
   //! \brief Returns the nodal point correspondance array for an element.
   //! \param[in] iel 1-based element index local to current patch
@@ -1003,6 +1010,7 @@ private:
   std::vector<char> myLMTypes; //!< Type of %Lagrange multiplier ('L' or 'G')
   std::set<size_t>  myLMs;     //!< Nodal indices of the %Lagrange multipliers
 
+  IntVec* myActiveEls; //!< List of active elements during element assembly
   static IntVec Empty; //!< Empty integer vector used when a reference is needed
 
 protected:

--- a/src/ASM/ASMs1DLag.C
+++ b/src/ASM/ASMs1DLag.C
@@ -123,9 +123,26 @@ bool ASMs1DLag::generateOrientedFEModel (const Vec3& Zaxis)
 
 Vec3 ASMs1DLag::getCoord (size_t inod) const
 {
-  if (inod < 1 || inod > coord.size()) return Vec3();
+  if (inod < 1 || inod > coord.size())
+    return Vec3();
 
   return coord[inod-1];
+}
+
+
+Vec3 ASMs1DLag::getElementCenter (int iel) const
+{
+  if (iel < 1 || static_cast<size_t>(iel) > MNPC.size())
+  {
+    std::cerr <<" *** ASMs1DLag::getElementCenter: Element index "<< iel
+              <<" out of range [1,"<< MNPC.size() <<"]."<< std::endl;
+    return Vec3();
+  }
+
+  if (curv && p1 > 2)
+    return this->ASMs1D::getElementCenter(iel);
+
+  return this->getGeometricCenter(MNPC[--iel]);
 }
 
 
@@ -235,7 +252,7 @@ bool ASMs1DLag::integrate (Integrand& integrand,
   for (size_t iel = 0; iel < nel && ok; iel++)
   {
     fe.iel = MLGE[iel];
-    if (fe.iel < 1) continue; // zero-length element
+    if (!this->isElementActive(fe.iel)) continue; // zero-length element
 
     // Set up nodal point coordinates for current element
     ok = this->getElementCoordinates(fe.Xn,1+iel);
@@ -364,7 +381,7 @@ bool ASMs1DLag::integrate (Integrand& integrand, int lIndex,
     }
 
   fe.iel = MLGE[iel];
-  if (fe.iel < 1) return true; // zero-length element
+  if (!this->isElementActive(fe.iel)) return true; // zero-length element
 
   // Set up nodal point coordinates for current element
   bool ok = this->getElementCoordinates(fe.Xn,1+iel);

--- a/src/ASM/ASMs1DLag.h
+++ b/src/ASM/ASMs1DLag.h
@@ -66,6 +66,9 @@ public:
   //! \param[in] inod 1-based node index local to current patch
   virtual Vec3 getCoord(size_t inod) const;
 
+  //! \brief Returns the geometric center of an element.
+  virtual Vec3 getElementCenter(int iel) const;
+
   //! \brief Updates the nodal coordinates for this patch.
   //! \param[in] displ Incremental displacements to update the coordinates with
   virtual bool updateCoords(const Vector& displ);

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -1467,6 +1467,14 @@ bool ASMs2D::updateCoords (const Vector& displ)
 }
 
 
+Vec3 ASMs2D::getElementCenter (int iel) const
+{
+  std::cerr <<" *** ASMs2D::getElementCenter("<< iel
+            <<"): Not implemented yet."<< std::endl;
+  return Vec3(); //TODO: Maybe later, if needed
+}
+
+
 void ASMs2D::getBoundaryNodes (int lIndex, IntVec& nodes, int basis,
                                int thick, int, bool local) const
 {
@@ -1759,7 +1767,7 @@ bool ASMs2D::integrate (Integrand& integrand,
       {
         int iel = groups[g][t][e];
         fe.iel = MLGE[iel];
-        if (fe.iel < 1) continue; // zero-area element
+        if (!this->isElementActive(fe.iel)) continue; // zero-area element
 
 #ifdef SP_DEBUG
         if (dbgElm < 0 && 1+iel != -dbgElm)
@@ -2044,7 +2052,7 @@ bool ASMs2D::integrate (Integrand& integrand,
         if (itgPts[iel].empty()) continue; // no points in this element
 
         fe.iel = MLGE[iel];
-        if (fe.iel < 1) continue; // zero-area element
+        if (!this->isElementActive(fe.iel)) continue; // zero-area element
 
 #ifdef SP_DEBUG
         if (dbgElm < 0 && 1+iel != -dbgElm)
@@ -2220,7 +2228,7 @@ bool ASMs2D::integrate (Integrand& integrand,
       if (!hasInterfaceElms) jel = iel;
 
       fe.iel = abs(MLGE[jel]);
-      if (fe.iel < 1) continue; // zero-area element
+      if (!this->isElementActive(fe.iel)) continue; // zero-area element
 
       short int status = iChk.hasContribution(iel,i1,i2);
       if (!status) continue; // no interface contributions for this element
@@ -2429,7 +2437,7 @@ bool ASMs2D::integrate (Integrand& integrand, int lIndex,
     for (int i1 = p1; i1 <= n1; i1++, iel++)
     {
       fe.iel = abs(MLGE[doXelms+iel-1]);
-      if (fe.iel < 1) continue; // zero-area element
+      if (!this->isElementActive(fe.iel)) continue; // zero-area element
 
       if (!myElms.empty() && !glInt.threadSafe() &&
           std::find(myElms.begin(), myElms.end(), iel-1) == myElms.end())

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -250,6 +250,9 @@ public:
   //! \param[in] inod 1-based node index local to current patch
   virtual Vec3 getCoord(size_t inod) const;
 
+  //! \brief Returns the coordinate of the element center.
+  virtual Vec3 getElementCenter(int iel) const;
+
   //! \brief Updates the nodal coordinates for this patch.
   //! \param[in] displ Incremental displacements to update the coordinates with
   virtual bool updateCoords(const Vector& displ);

--- a/src/ASM/ASMs2DLag.h
+++ b/src/ASM/ASMs2DLag.h
@@ -119,6 +119,9 @@ public:
   //! \param[in] inod 1-based node index local to current patch
   virtual Vec3 getCoord(size_t inod) const;
 
+  //! \brief Returns the geometric center of an element.
+  virtual Vec3 getElementCenter(int iel) const;
+
   //! \brief Constrains all DOFs on a given boundary edge.
   //! \param[in] dir Parameter direction defining the edge to constrain
   //! \param[in] open If \e true, exclude the end points of the edge

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -1741,6 +1741,14 @@ bool ASMs3D::updateCoords (const Vector& displ)
 }
 
 
+Vec3 ASMs3D::getElementCenter (int iel) const
+{
+  std::cerr <<" *** ASMs3D::getElementCenter("<< iel
+            <<"): Not implemented yet."<< std::endl;
+  return Vec3(); //TODO: Maybe later, if needed
+}
+
+
 void ASMs3D::getBoundaryNodes (int lIndex, IntVec& nodes,
                                int basis, int thick, int, bool local) const
 {
@@ -2114,7 +2122,7 @@ bool ASMs3D::integrate (Integrand& integrand,
       {
         int iel = groups[g][t][l];
         fe.iel = MLGE[iel];
-        if (fe.iel < 1) continue; // zero-volume element
+        if (!this->isElementActive(fe.iel)) continue; // zero-volume element
 
 #ifdef SP_DEBUG
         if (dbgElm < 0 && 1+iel != -dbgElm)
@@ -2388,7 +2396,7 @@ bool ASMs3D::integrate (Integrand& integrand,
         if (itgPts[iel].empty()) continue; // no points in this element
 
         fe.iel = MLGE[iel];
-        if (fe.iel < 1) continue; // zero-volume element
+        if (!this->isElementActive(fe.iel)) continue; // zero-volume element
 
 #ifdef SP_DEBUG
         if (dbgElm < 0 && 1+iel != -dbgElm)
@@ -2646,7 +2654,7 @@ bool ASMs3D::integrate (Integrand& integrand, int lIndex,
       {
         int iel = threadGrp[g][t][l];
         fe.iel = abs(MLGE[doXelms+iel]);
-        if (fe.iel < 1) continue; // zero-volume element
+        if (!this->isElementActive(fe.iel)) continue; // zero-volume element
 
 #ifdef SP_DEBUG
         if (dbgElm < 0 && 1+iel != -dbgElm)
@@ -2879,8 +2887,8 @@ bool ASMs3D::integrateEdge (Integrand& integrand, int lEdge,
     for (int i2 = p2; i2 <= n2; i2++)
       for (int i1 = p1; i1 <= n1; i1++, iel++)
       {
-	fe.iel = MLGE[iel-1];
-	if (fe.iel < 1) continue; // zero-volume element
+        fe.iel = MLGE[iel-1];
+        if (!this->isElementActive(fe.iel)) continue; // zero-volume element
 
         if (!myElms.empty() &&
             std::find(myElms.begin(), myElms.end(), fe.iel-1) == myElms.end())

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -266,6 +266,9 @@ public:
   //! \param[in] inod 1-based node index local to current patch
   virtual Vec3 getCoord(size_t inod) const;
 
+  //! \brief Returns the coordinate of the element center.
+  virtual Vec3 getElementCenter(int iel) const;
+
   //! \brief Updates the nodal coordinates for this patch.
   //! \param[in] displ Incremental displacements to update the coordinates with
   virtual bool updateCoords(const Vector& displ);

--- a/src/ASM/ASMs3DLag.h
+++ b/src/ASM/ASMs3DLag.h
@@ -119,6 +119,9 @@ public:
   //! \param[in] inod 1-based node index local to current patch
   virtual Vec3 getCoord(size_t inod) const;
 
+  //! \brief Returns the geometric center of an element.
+  virtual Vec3 getElementCenter(int iel) const;
+
   //! \brief Calculates parameter values for visualization nodal points.
   //! \param[out] prm Parameter values in given direction for all points
   //! \param[in] dir Parameter direction (0,1,2)

--- a/src/ASM/ASMsupel.h
+++ b/src/ASM/ASMsupel.h
@@ -83,6 +83,8 @@ public:
   virtual void getElmConnectivities(IntMat&) const {}
   //! \brief Dummy method doing nothing.
   virtual bool updateCoords(const Vector&) { return false; }
+  //! \brief Dummy method doing nothing.
+  virtual Vec3 getElementCenter(int) const { return Vec3(); }
 
   //! \brief Evaluates an integral over the interior patch domain.
   //! \param integrand Object with problem-specific data and methods

--- a/src/ASM/AlgEqSystem.h
+++ b/src/ASM/AlgEqSystem.h
@@ -34,9 +34,18 @@ class AlgEqSystem : public GlobalIntegral
 public:
   //! \brief The constructor sets its reference to SAM and ProcessAdm objects.
   explicit AlgEqSystem(const SAM& s, const ProcessAdm* a = nullptr);
-
+  //! \brief Copy constructor.
+  AlgEqSystem(const AlgEqSystem& a) : sam(a.sam), adm(a.adm) { this->copy(a); }
   //! \brief The destructor frees the dynamically allocated objects.
   virtual ~AlgEqSystem() { this->clear(); }
+
+  //! \brief Assignment operator.
+  AlgEqSystem& operator=(const AlgEqSystem& s) { return this->copy(s); }
+
+  //! \brief Makes \a *this a copy of \a that.
+  AlgEqSystem& copy(const AlgEqSystem& that);
+  //! \brief Adds \a that to \a *this (assuming similar structure).
+  AlgEqSystem& add(const AlgEqSystem& that);
 
   //! \brief Allocates the system matrices of the specified format.
   //! \param[in] mtype The matrix format to use for all matrices

--- a/src/LinAlg/DenseMatrix.C
+++ b/src/LinAlg/DenseMatrix.C
@@ -44,7 +44,8 @@ DenseMatrix::DenseMatrix (size_t m, size_t n, bool s) : myMat(m,n)
 }
 
 
-DenseMatrix::DenseMatrix (const DenseMatrix& A) : myMat(A.myMat)
+DenseMatrix::DenseMatrix (const DenseMatrix& A)
+  : SystemMatrix(A), myMat(A.myMat)
 {
   ipiv = nullptr;
   symm = A.symm;
@@ -99,13 +100,14 @@ void DenseMatrix::dump (std::ostream& os, LinAlg::StorageFormat format,
       break;
 
     case LinAlg::MATRIX_MARKET:
-      os << "%%MatrixMarket matrix array real general\n";
+      os <<"%%MatrixMarket matrix array real general";
       if (label)
-        os << "% label = " << label << '\n';
-      os << myMat.rows() << ' ' << myMat.cols();
-      for (size_t j = 1; j <= myMat.rows(); ++j)
-        for (size_t i = 1; i <= myMat.cols(); ++i)
-          os << '\n' << myMat(i,j);
+        os <<"\n% label = "<< label;
+      os <<'\n' << myMat.rows() <<' '<< myMat.cols();
+      for (size_t j = 1; j <= myMat.rows(); j++)
+        for (size_t i = 1; i <= myMat.cols(); i++)
+          os <<'\n'<< myMat(i,j);
+      os << std::endl;
       break;
 
     case LinAlg::FLAT:

--- a/src/LinAlg/DiagMatrix.C
+++ b/src/LinAlg/DiagMatrix.C
@@ -40,12 +40,13 @@ void DiagMatrix::dump (std::ostream& os, LinAlg::StorageFormat format,
       break;
 
     case LinAlg::MATRIX_MARKET:
-      os << "%%MatrixMarket matrix coordinate real general\n";
+      os <<"%%MatrixMarket matrix coordinate real general";
       if (label)
-        os << "% label = " << label << '\n';
-      os << myMat.size() << ' ' << myMat.size() << ' ' << myMat.size();
-      for (size_t row = 1; row <= myMat.size(); ++row)
-        os << '\n' << row << ' ' << row << ' ' << myMat(row);
+        os <<"\n% label = "<< label;
+      os <<'\n'<< myMat.size() <<' '<< myMat.size() <<' '<< myMat.size();
+      for (size_t row = 1; row <= myMat.size(); row++)
+        os <<'\n'<< row <<' '<< row <<' '<< myMat(row);
+      os << std::endl;
       break;
 
     case LinAlg::FLAT:

--- a/src/LinAlg/DiagMatrix.h
+++ b/src/LinAlg/DiagMatrix.h
@@ -27,7 +27,7 @@ public:
   //! \brief Default constructor.
   DiagMatrix(size_t m = 0) : myMat(m) {}
   //! \brief Copy constructor.
-  DiagMatrix(const DiagMatrix& A) : myMat(A.myMat) {}
+  DiagMatrix(const DiagMatrix& A) : SystemMatrix(A), myMat(A.myMat) {}
   //! \brief Special constructor taking data from a one-dimensional array.
   DiagMatrix(const RealArray& data, size_t nrows = 0);
   //! \brief Empty destructor.

--- a/src/LinAlg/SPRMatrix.C
+++ b/src/LinAlg/SPRMatrix.C
@@ -139,7 +139,7 @@ SPRMatrix::SPRMatrix () : rWork(1)
 }
 
 
-SPRMatrix::SPRMatrix (const SPRMatrix& A) : rWork(1)
+SPRMatrix::SPRMatrix (const SPRMatrix& A) : SystemMatrix(A), rWork(1)
 {
   ierr   = 0;
   msica  = new int[A.mpar[1]];

--- a/src/LinAlg/SparseMatrix.C
+++ b/src/LinAlg/SparseMatrix.C
@@ -167,8 +167,8 @@ SparseMatrix::SparseMatrix (size_t m, size_t n)
 }
 
 
-SparseMatrix::SparseMatrix (const SparseMatrix& B) :
-  elem(B.elem), IA(B.IA), JA(B.JA), A(B.A)
+SparseMatrix::SparseMatrix (const SparseMatrix& B)
+  : SystemMatrix(B), elem(B.elem), IA(B.IA), JA(B.JA), A(B.A)
 {
   editable = B.editable;
   factored = false;
@@ -395,8 +395,8 @@ void SparseMatrix::dump (std::ostream& os, LinAlg::StorageFormat format,
           os << end << i <<' '<< JA[j-1] <<' '<< A[i-1];
   }
 
-  if (format == LinAlg::MATLAB)
-    os <<"];\n";
+  if (format == LinAlg::MATLAB) os <<"]";
+  os << end;
 }
 
 

--- a/src/LinAlg/SparseMatrix.h
+++ b/src/LinAlg/SparseMatrix.h
@@ -224,6 +224,12 @@ public:
   //! \param[out] col Extracted column data
   bool getColumn(size_t c, Vector& col) const;
 
+  //! \brief Returns the L-infinity norm of the matrix.
+  virtual Real Linfnorm() const;
+
+  //! \brief Returns whether the matrix has been factored or not.
+  bool isFactored() const { return factored; }
+
 protected:
   //! \brief Converts the matrix to an optimized row-oriented format.
   //! \details The optimized format is suitable for the SAMG equation solver.
@@ -261,9 +267,6 @@ protected:
 
   //! \brief Writes the system matrix to the given output stream.
   virtual std::ostream& write(std::ostream& os) const;
-
-  //! \brief Returns the L-infinity norm of the matrix.
-  virtual Real Linfnorm() const;
 
 public:
   static bool printSLUstat; //!< Print solution statistics for SuperLU?

--- a/src/LinAlg/SystemMatrix.h
+++ b/src/LinAlg/SystemMatrix.h
@@ -211,6 +211,8 @@ public:
 protected:
   //! \brief Default constructor.
   SystemMatrix() : haveContributions(false) {}
+  //! \brief Copy constructor.
+  SystemMatrix(const SystemMatrix& a) : haveContributions(a.haveContributions){}
 
 public:
   //! \brief Empty destructor.

--- a/src/SIM/MultiStepSIM.C
+++ b/src/SIM/MultiStepSIM.C
@@ -123,11 +123,18 @@ bool MultiStepSIM::saveStep (int iStep, double time, const char* vecName)
     if (!model.writeGlvT(iStep,geoBlk,nBlock))
       return false;
 
-  // Write residual force vector, but only when no extra visualization points
-  if (!opt.pSolOnly && residual.size() == model.getNoDOFs())
-    if (opt.nViz[0] == 2 && opt.nViz[1] <= 2 && opt.nViz[2] <= 2)
-      if (!model.writeGlvV(residual,"Residual forces",iStep,nBlock))
+  // Write load and residual force vectors,
+  // but only when no extra visualization points
+  if (!opt.pSolOnly && opt.nViz[0] == 2 && opt.nViz[1] <= 2 && opt.nViz[2] <= 2)
+  {
+    if (loadVec.size() == model.getNoDOFs())
+      if (!model.writeGlvV(loadVec,"Load vector",iStep,nBlock,2))
         return false;
+
+    if (residual.size() == model.getNoDOFs())
+      if (!model.writeGlvV(residual,"Residual forces",iStep,nBlock,3))
+        return false;
+  }
 
   // Write solution fields
   if (this->numSolution())

--- a/src/SIM/MultiStepSIM.h
+++ b/src/SIM/MultiStepSIM.h
@@ -190,9 +190,10 @@ public:
   const double* getRefNorm() const { return &refNorm; }
 
 protected:
-  SIMoutput& model;    //!< The isogeometric FE model
-  Vector     residual; //!< Residual force vector
-  Vector     linsol;   //!< Linear solution vector
+  SIMoutput& model; //!< The isogeometric FE model
+  Vector loadVec;   //!< System load vector (for output to VTF)
+  Vector residual;  //!< Residual force vector
+  Vector linsol;    //!< Linear solution vector
 
   NormOp refNopt; //!< Reference norm option
   double refNorm; //!< Reference norm value used in convergence checks

--- a/src/SIM/NewmarkSIM.C
+++ b/src/SIM/NewmarkSIM.C
@@ -390,7 +390,7 @@ SIM::ConvStatus NewmarkSIM::solveStep (TimeStep& param, SIM::SolutionMode,
     return SIM::FAILURE;
 
   double* rCondPtr = rCond < 0.0 ? nullptr : &rCond;
-  if (!model.solveEqSystem(linsol,0,rCondPtr,msgLevel-1,true))
+  if (!model.solveSystem(linsol,msgLevel-1,rCondPtr))
     return SIM::FAILURE;
 
   while (param.iter <= maxit)

--- a/src/SIM/NewmarkSIM.h
+++ b/src/SIM/NewmarkSIM.h
@@ -72,7 +72,7 @@ protected:
   //! \brief Updates configuration variables (solution vector) in an iteration.
   virtual bool correctStep(TimeStep& param, bool = false);
   //! \brief Finalizes the right-hand-side vector on the system level.
-  virtual void finalizeRHSvector(bool) {}
+  virtual void finalizeRHSvector(bool);
 
 public:
   //! \brief Returns a const reference to current velocity vector.

--- a/src/SIM/NonLinSIM.C
+++ b/src/SIM/NonLinSIM.C
@@ -237,7 +237,7 @@ ConvStatus NonLinSIM::solveStep (TimeStep& param, SolutionMode mode,
       return FAILURE;
 
   double* rCondPtr = rCond < 0.0 ? nullptr : &rCond;
-  if (!model.solveEqSystem(linsol,0,rCondPtr,msgLevel-1,true))
+  if (!model.solveSystem(linsol,msgLevel-1,rCondPtr))
     return FAILURE;
 
   while (param.iter <= maxit)

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -321,7 +321,7 @@ public:
                            const char* compName = "displacement",
                            size_t idxRHS = 0)
   {
-    return this->solveEqSystem(solution,idxRHS,nullptr,printSol,true,compName);
+    return this->solveEqSystem(solution,idxRHS,rCond,printSol,true,compName);
   }
 
   //! \brief Solves the assembled linear system of equations for a given load.
@@ -823,8 +823,7 @@ protected:
     double        eps;    //!< Zero tolerance for printing small values
 
     //! \brief Default constructor.
-    DumpData() : format(LinAlg::FLAT), expand(false), count(0), eps(1.0e-6)
-    { step.insert(1); }
+    DumpData() : format(LinAlg::FLAT), expand(false), count(0), eps(1.0e-6) {}
 
     //! \brief Checks if the matrix or vector should be dumped now.
     bool doDump() { return !fname.empty() && step.find(++count) != step.end(); }

--- a/src/SIM/SIMinput.C
+++ b/src/SIM/SIMinput.C
@@ -705,7 +705,6 @@ bool SIMinput::parseOutputTag (const tinyxml2::XMLElement* elem)
     utl::getAttribute(elem,"format",format);
     utl::getAttribute(elem,"step",steps);
     utl::getAttribute(elem,"eps",dmp.eps);
-    dmp.step.insert(steps.begin(),steps.end());
     if (format == "matlab")
       dmp.format = LinAlg::MATLAB;
     else if (format == "matrix_market")
@@ -717,6 +716,10 @@ bool SIMinput::parseOutputTag (const tinyxml2::XMLElement* elem)
       return true;
     }
     dmp.fname = elem->FirstChild()->Value();
+    if (steps.empty())
+      dmp.step.insert(1);
+    else
+      dmp.step.insert(steps.begin(),steps.end());
     if (toupper(elem->Value()[5]) == 'R')
       rhsDump.push_back(dmp);
     else if (toupper(elem->Value()[5]) == 'L')

--- a/src/Utility/Vec3.h
+++ b/src/Utility/Vec3.h
@@ -155,10 +155,20 @@ public:
     for (int i = 2; i >= 0; i--)
       if (v[i]+tol < a.v[i])
         return true;
-      else if (v[i] > a.v[i]+tol)
+      else if (v[i]-tol > a.v[i])
         return false;
 
     return false;
+  }
+
+  //! \brief Check if a vector is inside the box defined by two other vectors.
+  bool inside(const Vec3& a, const Vec3& b, double tol = 1.0e-6) const
+  {
+    for (int i = 0; i < 3; i++)
+      if (v[i]+tol < a.v[i] || v[i]-tol > b.v[i])
+        return false;
+
+    return true;
   }
 
   //! \brief Print out a vector.


### PR DESCRIPTION
The load vector then needs to be extracted separately in the fist iteration to avoid it is being overwritten by the residual forces during iterations.

The rest in this PR are some LinAlg fixes and adjustments to facilitate splitting the assembly step in two (or more parts), to assess the coefficient matrix parts resulting from different regions of the whole domain (for ROM analysis of structures with sudden holes, etc.).