### PR TITLE
 Facilitate splitting the assembly step in two or more parts

### DIFF
--- a/src/ASM/ASMLagBase.C
+++ b/src/ASM/ASMLagBase.C
@@ -34,3 +34,15 @@ bool ASMLagBase::nodalField (Matrix& field, const Vector& sol, size_t nno) const
 
   return true;
 }
+
+
+Vec3 ASMLagBase::getGeometricCenter (const std::vector<int>& MNPC) const
+{
+  Vec3 X0;
+
+  for (int inod : MNPC)
+    X0 += coord[inod];
+  X0 *= 1.0 / static_cast<double>(MNPC.size());
+
+  return X0;
+}

--- a/src/ASM/ASMLagBase.h
+++ b/src/ASM/ASMLagBase.h
@@ -36,6 +36,9 @@ protected:
   //! \brief Direct nodal evaluation of a solution field.
   bool nodalField(Matrix& field, const Vector& sol, size_t nno) const;
 
+  //! \brief Returns the geometric center of an element.
+  Vec3 getGeometricCenter(const std::vector<int>& MNPC) const;
+
 protected:
   const Vec3Vec& coord; //!< Const reference to the nodal coordinate container
   Vec3Vec      myCoord; //!< Nodal coordinate container

--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -57,7 +57,7 @@ static bool Aerror (const char* name)
 
 
 ASMbase::ASMbase (unsigned char n_p, unsigned char n_s, unsigned char n_f)
-  : MLGE(myMLGE), MLGN(myMLGN), MNPC(myMNPC), shareFE(0)
+  : MLGE(myMLGE), MLGN(myMLGN), MNPC(myMNPC), shareFE(0), myActiveEls(nullptr)
 {
   nf = n_f;
   nsd = n_s > 3 ? 3 : n_s;
@@ -73,7 +73,7 @@ ASMbase::ASMbase (unsigned char n_p, unsigned char n_s, unsigned char n_f)
 ASMbase::ASMbase (const ASMbase& patch, unsigned char n_f)
   : MLGE(patch.MLGE), MLGN(patch.MLGN), MNPC(patch.MNPC), shareFE('F'),
     firstBp(patch.firstBp), myLMTypes(patch.myLMTypes), myLMs(patch.myLMs),
-    myRmaster(patch.myRmaster)
+    myActiveEls(nullptr), myRmaster(patch.myRmaster)
 {
   nf = n_f > 0 ? n_f : patch.nf;
   nsd = patch.nsd;
@@ -90,7 +90,7 @@ ASMbase::ASMbase (const ASMbase& patch, unsigned char n_f)
 
 ASMbase::ASMbase (const ASMbase& patch)
   : MLGE(myMLGE), MLGN(myMLGN), MNPC(myMNPC), shareFE('S'),
-    BCode(patch.BCode), firstBp(patch.firstBp)
+    BCode(patch.BCode), firstBp(patch.firstBp), myActiveEls(nullptr)
 {
   nf = patch.nf;
   nsd = patch.nsd;
@@ -178,6 +178,8 @@ void ASMbase::clear (bool retainGeometry)
   BCode.clear();
   dCode.clear();
   mpcs.clear();
+
+  myActiveEls = nullptr;
 }
 
 
@@ -1742,4 +1744,14 @@ void ASMbase::getBoundaryElms (int lIndex, IntVec& elms,
 
   for (int& elm : elms)
     elm = MLGE[elm]-1;
+}
+
+
+bool ASMbase::isElementActive (int elmId) const
+{
+  if (elmId < 1) return false;
+  if (!myActiveEls) return true;
+
+  return std::find(myActiveEls->begin(),
+                   myActiveEls->end(),elmId) != myActiveEls->end();
 }

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -236,6 +236,8 @@ public:
   //! otherwise the geometry basis coordinates are returned
   virtual bool getElementCoordinates(Matrix& X, int iel,
                                      bool forceItg = false) const = 0;
+  //! \brief Returns the coordinates of the element center.
+  virtual Vec3 getElementCenter(int) const = 0;
 
   //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
   //! \param[in] lIndex Local index of the boundary face/edge
@@ -309,6 +311,11 @@ public:
   virtual void shiftGlobalElmNums(int eshift);
   //! \brief Returns the global element numbers of this patch.
   const IntVec& getGlobalElementNums() const { return MLGE; }
+
+  //! \brief Sets the list of active elements during assembly.
+  void setActiveElements(IntVec* active) { myActiveEls = active; }
+  //! \brief Returns \e true if element with global id \a elmId is active.
+  bool isElementActive(int elmId) const;
 
   //! \brief Returns the nodal point correspondance array for an element.
   //! \param[in] iel 1-based element index local to current patch
@@ -1003,6 +1010,7 @@ private:
   std::vector<char> myLMTypes; //!< Type of %Lagrange multiplier ('L' or 'G')
   std::set<size_t>  myLMs;     //!< Nodal indices of the %Lagrange multipliers
 
+  IntVec* myActiveEls; //!< List of active elements during element assembly
   static IntVec Empty; //!< Empty integer vector used when a reference is needed
 
 protected:

--- a/src/ASM/ASMs1DLag.C
+++ b/src/ASM/ASMs1DLag.C
@@ -123,9 +123,26 @@ bool ASMs1DLag::generateOrientedFEModel (const Vec3& Zaxis)
 
 Vec3 ASMs1DLag::getCoord (size_t inod) const
 {
-  if (inod < 1 || inod > coord.size()) return Vec3();
+  if (inod < 1 || inod > coord.size())
+    return Vec3();
 
   return coord[inod-1];
+}
+
+
+Vec3 ASMs1DLag::getElementCenter (int iel) const
+{
+  if (iel < 1 || static_cast<size_t>(iel) > MNPC.size())
+  {
+    std::cerr <<" *** ASMs1DLag::getElementCenter: Element index "<< iel
+              <<" out of range [1,"<< MNPC.size() <<"]."<< std::endl;
+    return Vec3();
+  }
+
+  if (curv && p1 > 2)
+    return this->ASMs1D::getElementCenter(iel);
+
+  return this->getGeometricCenter(MNPC[--iel]);
 }
 
 
@@ -235,7 +252,7 @@ bool ASMs1DLag::integrate (Integrand& integrand,
   for (size_t iel = 0; iel < nel && ok; iel++)
   {
     fe.iel = MLGE[iel];
-    if (fe.iel < 1) continue; // zero-length element
+    if (!this->isElementActive(fe.iel)) continue; // zero-length element
 
     // Set up nodal point coordinates for current element
     ok = this->getElementCoordinates(fe.Xn,1+iel);
@@ -364,7 +381,7 @@ bool ASMs1DLag::integrate (Integrand& integrand, int lIndex,
     }
 
   fe.iel = MLGE[iel];
-  if (fe.iel < 1) return true; // zero-length element
+  if (!this->isElementActive(fe.iel)) return true; // zero-length element
 
   // Set up nodal point coordinates for current element
   bool ok = this->getElementCoordinates(fe.Xn,1+iel);

--- a/src/ASM/ASMs1DLag.h
+++ b/src/ASM/ASMs1DLag.h
@@ -66,6 +66,9 @@ public:
   //! \param[in] inod 1-based node index local to current patch
   virtual Vec3 getCoord(size_t inod) const;
 
+  //! \brief Returns the geometric center of an element.
+  virtual Vec3 getElementCenter(int iel) const;
+
   //! \brief Updates the nodal coordinates for this patch.
   //! \param[in] displ Incremental displacements to update the coordinates with
   virtual bool updateCoords(const Vector& displ);

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -1467,6 +1467,14 @@ bool ASMs2D::updateCoords (const Vector& displ)
 }
 
 
+Vec3 ASMs2D::getElementCenter (int iel) const
+{
+  std::cerr <<" *** ASMs2D::getElementCenter("<< iel
+            <<"): Not implemented yet."<< std::endl;
+  return Vec3(); //TODO: Maybe later, if needed
+}
+
+
 void ASMs2D::getBoundaryNodes (int lIndex, IntVec& nodes, int basis,
                                int thick, int, bool local) const
 {
@@ -1759,7 +1767,7 @@ bool ASMs2D::integrate (Integrand& integrand,
       {
         int iel = groups[g][t][e];
         fe.iel = MLGE[iel];
-        if (fe.iel < 1) continue; // zero-area element
+        if (!this->isElementActive(fe.iel)) continue; // zero-area element
 
 #ifdef SP_DEBUG
         if (dbgElm < 0 && 1+iel != -dbgElm)
@@ -2044,7 +2052,7 @@ bool ASMs2D::integrate (Integrand& integrand,
         if (itgPts[iel].empty()) continue; // no points in this element
 
         fe.iel = MLGE[iel];
-        if (fe.iel < 1) continue; // zero-area element
+        if (!this->isElementActive(fe.iel)) continue; // zero-area element
 
 #ifdef SP_DEBUG
         if (dbgElm < 0 && 1+iel != -dbgElm)
@@ -2220,7 +2228,7 @@ bool ASMs2D::integrate (Integrand& integrand,
       if (!hasInterfaceElms) jel = iel;
 
       fe.iel = abs(MLGE[jel]);
-      if (fe.iel < 1) continue; // zero-area element
+      if (!this->isElementActive(fe.iel)) continue; // zero-area element
 
       short int status = iChk.hasContribution(iel,i1,i2);
       if (!status) continue; // no interface contributions for this element
@@ -2429,7 +2437,7 @@ bool ASMs2D::integrate (Integrand& integrand, int lIndex,
     for (int i1 = p1; i1 <= n1; i1++, iel++)
     {
       fe.iel = abs(MLGE[doXelms+iel-1]);
-      if (fe.iel < 1) continue; // zero-area element
+      if (!this->isElementActive(fe.iel)) continue; // zero-area element
 
       if (!myElms.empty() && !glInt.threadSafe() &&
           std::find(myElms.begin(), myElms.end(), iel-1) == myElms.end())

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -250,6 +250,9 @@ public:
   //! \param[in] inod 1-based node index local to current patch
   virtual Vec3 getCoord(size_t inod) const;
 
+  //! \brief Returns the coordinate of the element center.
+  virtual Vec3 getElementCenter(int iel) const;
+
   //! \brief Updates the nodal coordinates for this patch.
   //! \param[in] displ Incremental displacements to update the coordinates with
   virtual bool updateCoords(const Vector& displ);

--- a/src/ASM/ASMs2DLag.h
+++ b/src/ASM/ASMs2DLag.h
@@ -119,6 +119,9 @@ public:
   //! \param[in] inod 1-based node index local to current patch
   virtual Vec3 getCoord(size_t inod) const;
 
+  //! \brief Returns the geometric center of an element.
+  virtual Vec3 getElementCenter(int iel) const;
+
   //! \brief Constrains all DOFs on a given boundary edge.
   //! \param[in] dir Parameter direction defining the edge to constrain
   //! \param[in] open If \e true, exclude the end points of the edge

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -1741,6 +1741,14 @@ bool ASMs3D::updateCoords (const Vector& displ)
 }
 
 
+Vec3 ASMs3D::getElementCenter (int iel) const
+{
+  std::cerr <<" *** ASMs3D::getElementCenter("<< iel
+            <<"): Not implemented yet."<< std::endl;
+  return Vec3(); //TODO: Maybe later, if needed
+}
+
+
 void ASMs3D::getBoundaryNodes (int lIndex, IntVec& nodes,
                                int basis, int thick, int, bool local) const
 {
@@ -2114,7 +2122,7 @@ bool ASMs3D::integrate (Integrand& integrand,
       {
         int iel = groups[g][t][l];
         fe.iel = MLGE[iel];
-        if (fe.iel < 1) continue; // zero-volume element
+        if (!this->isElementActive(fe.iel)) continue; // zero-volume element
 
 #ifdef SP_DEBUG
         if (dbgElm < 0 && 1+iel != -dbgElm)
@@ -2388,7 +2396,7 @@ bool ASMs3D::integrate (Integrand& integrand,
         if (itgPts[iel].empty()) continue; // no points in this element
 
         fe.iel = MLGE[iel];
-        if (fe.iel < 1) continue; // zero-volume element
+        if (!this->isElementActive(fe.iel)) continue; // zero-volume element
 
 #ifdef SP_DEBUG
         if (dbgElm < 0 && 1+iel != -dbgElm)
@@ -2646,7 +2654,7 @@ bool ASMs3D::integrate (Integrand& integrand, int lIndex,
       {
         int iel = threadGrp[g][t][l];
         fe.iel = abs(MLGE[doXelms+iel]);
-        if (fe.iel < 1) continue; // zero-volume element
+        if (!this->isElementActive(fe.iel)) continue; // zero-volume element
 
 #ifdef SP_DEBUG
         if (dbgElm < 0 && 1+iel != -dbgElm)
@@ -2879,8 +2887,8 @@ bool ASMs3D::integrateEdge (Integrand& integrand, int lEdge,
     for (int i2 = p2; i2 <= n2; i2++)
       for (int i1 = p1; i1 <= n1; i1++, iel++)
       {
-	fe.iel = MLGE[iel-1];
-	if (fe.iel < 1) continue; // zero-volume element
+        fe.iel = MLGE[iel-1];
+        if (!this->isElementActive(fe.iel)) continue; // zero-volume element
 
         if (!myElms.empty() &&
             std::find(myElms.begin(), myElms.end(), fe.iel-1) == myElms.end())

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -266,6 +266,9 @@ public:
   //! \param[in] inod 1-based node index local to current patch
   virtual Vec3 getCoord(size_t inod) const;
 
+  //! \brief Returns the coordinate of the element center.
+  virtual Vec3 getElementCenter(int iel) const;
+
   //! \brief Updates the nodal coordinates for this patch.
   //! \param[in] displ Incremental displacements to update the coordinates with
   virtual bool updateCoords(const Vector& displ);

--- a/src/ASM/ASMs3DLag.h
+++ b/src/ASM/ASMs3DLag.h
@@ -119,6 +119,9 @@ public:
   //! \param[in] inod 1-based node index local to current patch
   virtual Vec3 getCoord(size_t inod) const;
 
+  //! \brief Returns the geometric center of an element.
+  virtual Vec3 getElementCenter(int iel) const;
+
   //! \brief Calculates parameter values for visualization nodal points.
   //! \param[out] prm Parameter values in given direction for all points
   //! \param[in] dir Parameter direction (0,1,2)

--- a/src/ASM/ASMsupel.h
+++ b/src/ASM/ASMsupel.h
@@ -83,6 +83,8 @@ public:
   virtual void getElmConnectivities(IntMat&) const {}
   //! \brief Dummy method doing nothing.
   virtual bool updateCoords(const Vector&) { return false; }
+  //! \brief Dummy method doing nothing.
+  virtual Vec3 getElementCenter(int) const { return Vec3(); }
 
   //! \brief Evaluates an integral over the interior patch domain.
   //! \param integrand Object with problem-specific data and methods

--- a/src/ASM/AlgEqSystem.h
+++ b/src/ASM/AlgEqSystem.h
@@ -34,9 +34,18 @@ class AlgEqSystem : public GlobalIntegral
 public:
   //! \brief The constructor sets its reference to SAM and ProcessAdm objects.
   explicit AlgEqSystem(const SAM& s, const ProcessAdm* a = nullptr);
-
+  //! \brief Copy constructor.
+  AlgEqSystem(const AlgEqSystem& a) : sam(a.sam), adm(a.adm) { this->copy(a); }
   //! \brief The destructor frees the dynamically allocated objects.
   virtual ~AlgEqSystem() { this->clear(); }
+
+  //! \brief Assignment operator.
+  AlgEqSystem& operator=(const AlgEqSystem& s) { return this->copy(s); }
+
+  //! \brief Makes \a *this a copy of \a that.
+  AlgEqSystem& copy(const AlgEqSystem& that);
+  //! \brief Adds \a that to \a *this (assuming similar structure).
+  AlgEqSystem& add(const AlgEqSystem& that);
 
   //! \brief Allocates the system matrices of the specified format.
   //! \param[in] mtype The matrix format to use for all matrices

--- a/src/LinAlg/DenseMatrix.C
+++ b/src/LinAlg/DenseMatrix.C
@@ -44,7 +44,8 @@ DenseMatrix::DenseMatrix (size_t m, size_t n, bool s) : myMat(m,n)
 }
 
 
-DenseMatrix::DenseMatrix (const DenseMatrix& A) : myMat(A.myMat)
+DenseMatrix::DenseMatrix (const DenseMatrix& A)
+  : SystemMatrix(A), myMat(A.myMat)
 {
   ipiv = nullptr;
   symm = A.symm;
@@ -99,13 +100,14 @@ void DenseMatrix::dump (std::ostream& os, LinAlg::StorageFormat format,
       break;
 
     case LinAlg::MATRIX_MARKET:
-      os << "%%MatrixMarket matrix array real general\n";
+      os <<"%%MatrixMarket matrix array real general";
       if (label)
-        os << "% label = " << label << '\n';
-      os << myMat.rows() << ' ' << myMat.cols();
-      for (size_t j = 1; j <= myMat.rows(); ++j)
-        for (size_t i = 1; i <= myMat.cols(); ++i)
-          os << '\n' << myMat(i,j);
+        os <<"\n% label = "<< label;
+      os <<'\n' << myMat.rows() <<' '<< myMat.cols();
+      for (size_t j = 1; j <= myMat.rows(); j++)
+        for (size_t i = 1; i <= myMat.cols(); i++)
+          os <<'\n'<< myMat(i,j);
+      os << std::endl;
       break;
 
     case LinAlg::FLAT:

--- a/src/LinAlg/DiagMatrix.C
+++ b/src/LinAlg/DiagMatrix.C
@@ -40,12 +40,13 @@ void DiagMatrix::dump (std::ostream& os, LinAlg::StorageFormat format,
       break;
 
     case LinAlg::MATRIX_MARKET:
-      os << "%%MatrixMarket matrix coordinate real general\n";
+      os <<"%%MatrixMarket matrix coordinate real general";
       if (label)
-        os << "% label = " << label << '\n';
-      os << myMat.size() << ' ' << myMat.size() << ' ' << myMat.size();
-      for (size_t row = 1; row <= myMat.size(); ++row)
-        os << '\n' << row << ' ' << row << ' ' << myMat(row);
+        os <<"\n% label = "<< label;
+      os <<'\n'<< myMat.size() <<' '<< myMat.size() <<' '<< myMat.size();
+      for (size_t row = 1; row <= myMat.size(); row++)
+        os <<'\n'<< row <<' '<< row <<' '<< myMat(row);
+      os << std::endl;
       break;
 
     case LinAlg::FLAT:

--- a/src/LinAlg/DiagMatrix.C
+++ b/src/LinAlg/DiagMatrix.C
@@ -20,7 +20,7 @@ DiagMatrix::DiagMatrix (const RealArray& data, size_t nrows)
   if (nrows == 0) nrows = data.size();
 
   myMat.resize(nrows);
-  memcpy(myMat.ptr(),&data.front(),nrows*sizeof(Real));
+  memcpy(myMat.data(),data.data(),nrows*sizeof(Real));
 }
 
 

--- a/src/LinAlg/DiagMatrix.h
+++ b/src/LinAlg/DiagMatrix.h
@@ -27,7 +27,7 @@ public:
   //! \brief Default constructor.
   DiagMatrix(size_t m = 0) : myMat(m) {}
   //! \brief Copy constructor.
-  DiagMatrix(const DiagMatrix& A) : myMat(A.myMat) {}
+  DiagMatrix(const DiagMatrix& A) : SystemMatrix(A), myMat(A.myMat) {}
   //! \brief Special constructor taking data from a one-dimensional array.
   DiagMatrix(const RealArray& data, size_t nrows = 0);
   //! \brief Empty destructor.

--- a/src/LinAlg/MatVec.C
+++ b/src/LinAlg/MatVec.C
@@ -92,7 +92,7 @@ bool utl::transform (Matrix& A, const Matrix& Tn, size_t K)
   if (M < A.cols() || N > Tn.cols()) return false;
   if (K < 1 || K+N-1 > M || N > 3) return false;
 
-  std::vector<Real> WA(N);
+  Real* WA = (Real*)alloca(N*sizeof(Real));
   size_t i, ii, j, jj, l, KN = K+N-1;
   for (jj = K; jj <= M; jj++)
   {
@@ -147,7 +147,7 @@ bool utl::transform (Vector& V, const Matrix& Tn, size_t K, bool transpose)
   if (N > Tn.cols()) return false;
   if (K < 1 || K+N-1 > M || N > 3) return false;
 
-  std::vector<Real> WA(N);
+  Real* WA = (Real*)alloca(N*sizeof(Real));
   size_t i, ii, j;
   if (transpose)
     for (i = 1; i <= N; i++)
@@ -187,11 +187,10 @@ bool utl::invert (Matrix& A)
 
   // Use LAPack/BLAS for larger matrices
   int INFO, N = A.rows() > A.cols() ? A.rows() : A.cols();
-  int* IPIV = new int[N];
+  int* IPIV = (int*)alloca(N*sizeof(int));
   dgetrf_(N,N,A.ptr(),A.rows(),IPIV,INFO);
   if (INFO != 0)
   {
-    delete[] IPIV;
     std::cerr <<" *** utl::invert:DGETRF: INFO = "<< INFO << std::endl;
     return false;
   }
@@ -199,7 +198,6 @@ bool utl::invert (Matrix& A)
   dgetri_(N,A.ptr(),A.rows(),IPIV,&NWORK,-1,INFO);
   double* WORK = new double[int(NWORK)];
   dgetri_(N,A.ptr(),A.rows(),IPIV,WORK,int(NWORK),INFO);
-  delete[] IPIV;
   delete[] WORK;
   if (INFO == 0) return true;
   std::cerr <<" *** utl::invert:DGETRI: INFO = "<< INFO << std::endl;

--- a/src/LinAlg/SPRMatrix.C
+++ b/src/LinAlg/SPRMatrix.C
@@ -139,7 +139,7 @@ SPRMatrix::SPRMatrix () : rWork(1)
 }
 
 
-SPRMatrix::SPRMatrix (const SPRMatrix& A) : rWork(1)
+SPRMatrix::SPRMatrix (const SPRMatrix& A) : SystemMatrix(A), rWork(1)
 {
   ierr   = 0;
   msica  = new int[A.mpar[1]];

--- a/src/LinAlg/SparseMatrix.C
+++ b/src/LinAlg/SparseMatrix.C
@@ -1043,7 +1043,7 @@ bool SparseMatrix::solveSLU (Vector& B)
     // Create a new SuperLU matrix
     slu = new SuperLUdata(nrow,ncol);
     dCreate_CompCol_Matrix(&slu->A, nrow, ncol, this->size(),
-                           &A.front(), &JA.front(), &IA.front(),
+                           A.data(), JA.data(), IA.data(),
                            SLU_NC, SLU_D, SLU_GE);
   }
   else {
@@ -1051,7 +1051,7 @@ bool SparseMatrix::solveSLU (Vector& B)
     Destroy_SuperNode_Matrix(&slu->L);
     Destroy_CompCol_Matrix(&slu->U);
     dCreate_CompCol_Matrix(&slu->A, nrow, ncol, this->size(),
-                           &A.front(), &JA.front(), &IA.front(),
+                           A.data(), JA.data(), IA.data(),
                            SLU_NC, SLU_D, SLU_GE);
   }
 
@@ -1066,7 +1066,7 @@ bool SparseMatrix::solveSLU (Vector& B)
   // Create right-hand-side/solution vector(s)
   size_t nrhs = B.size() / nrow;
   SuperMatrix Bmat;
-  dCreate_Dense_Matrix(&Bmat, nrow, nrhs, B.ptr(), nrow,
+  dCreate_Dense_Matrix(&Bmat, nrow, nrhs, B.data(), nrow,
                        SLU_DN, SLU_D, SLU_GE);
 
   // Invoke the simple driver
@@ -1079,7 +1079,7 @@ bool SparseMatrix::solveSLU (Vector& B)
     // Create a new SuperLU matrix
     slu = new SuperLUdata(nrow,ncol,1);
     dCreate_CompCol_Matrix(&slu->A, nrow, ncol, this->size(),
-                           &A.front(), &JA.front(), &IA.front(),
+                           A.data(), JA.data(), IA.data(),
                            SLU_NC, SLU_D, SLU_GE);
   }
   else if (factored)
@@ -1089,14 +1089,14 @@ bool SparseMatrix::solveSLU (Vector& B)
     Destroy_SuperNode_Matrix(&slu->L);
     Destroy_CompCol_Matrix(&slu->U);
     dCreate_CompCol_Matrix(&slu->A, nrow, ncol, this->size(),
-                           &A.front(), &JA.front(), &IA.front(),
+                           A.data(), JA.data(), IA.data(),
                            SLU_NC, SLU_D, SLU_GE);
   }
 
   // Create right-hand-side/solution vector(s)
   size_t nrhs = B.size() / nrow;
   SuperMatrix Bmat;
-  dCreate_Dense_Matrix(&Bmat, nrow, nrhs, B.ptr(), nrow,
+  dCreate_Dense_Matrix(&Bmat, nrow, nrhs, B.data(), nrow,
                        SLU_DN, SLU_D, SLU_GE);
 
   SuperLUStat_t stat;
@@ -1142,7 +1142,7 @@ bool SparseMatrix::solveSLUx (Vector& B, Real* rcond)
     memset(slu->opts->part_super_h, 0, ncol*sizeof(int));
     memset(slu->opts->etree, 0, ncol*sizeof(int));
     dCreate_CompCol_Matrix(&slu->A, nrow, ncol, this->size(),
-                           &A.front(), &JA.front(), &IA.front(),
+                           A.data(), JA.data(), IA.data(),
                            SLU_NC, SLU_D, SLU_GE);
 
     // Get column permutation vector perm_c[], according to permc_spec:
@@ -1162,9 +1162,9 @@ bool SparseMatrix::solveSLUx (Vector& B, Real* rcond)
   Vector      X(B.size());
   SuperMatrix Bmat, Xmat;
   const size_t nrhs = B.size() / nrow;
-  dCreate_Dense_Matrix(&Bmat, nrow, nrhs, B.ptr(), nrow,
+  dCreate_Dense_Matrix(&Bmat, nrow, nrhs, B.data(), nrow,
                        SLU_DN, SLU_D, SLU_GE);
-  dCreate_Dense_Matrix(&Xmat, nrow, nrhs, X.ptr(), nrow,
+  dCreate_Dense_Matrix(&Xmat, nrow, nrhs, X.data(), nrow,
                        SLU_DN, SLU_D, SLU_GE);
 
   Real ferr[nrhs], berr[nrhs];
@@ -1188,7 +1188,7 @@ bool SparseMatrix::solveSLUx (Vector& B, Real* rcond)
     slu->C = new Real[ncol];
     slu->R = new Real[nrow];
     dCreate_CompCol_Matrix(&slu->A, nrow, ncol, this->size(),
-                           &A.front(), &JA.front(), &IA.front(),
+                           A.data(), JA.data(), IA.data(),
                            SLU_NC, SLU_D, SLU_GE);
   }
   else if (factored)
@@ -1198,7 +1198,7 @@ bool SparseMatrix::solveSLUx (Vector& B, Real* rcond)
     Destroy_SuperNode_Matrix(&slu->L);
     Destroy_CompCol_Matrix(&slu->U);
     dCreate_CompCol_Matrix(&slu->A, nrow, ncol, this->size(),
-                           &A.front(), &JA.front(), &IA.front(),
+                           A.data(), JA.data(), IA.data(),
                            SLU_NC, SLU_D, SLU_GE);
     slu->opts->Fact = SamePattern;
   }
@@ -1207,9 +1207,9 @@ bool SparseMatrix::solveSLUx (Vector& B, Real* rcond)
   Vector      X(B.size());
   SuperMatrix Bmat, Xmat;
   const  size_t nrhs = B.size() / nrow;
-  dCreate_Dense_Matrix(&Bmat, nrow, nrhs, B.ptr(), nrow,
+  dCreate_Dense_Matrix(&Bmat, nrow, nrhs, B.data(), nrow,
                        SLU_DN, SLU_D, SLU_GE);
-  dCreate_Dense_Matrix(&Xmat, nrow, nrhs, X.ptr(), nrow,
+  dCreate_Dense_Matrix(&Xmat, nrow, nrhs, X.data(), nrow,
                        SLU_DN, SLU_D, SLU_GE);
 
   slu->opts->ConditionNumber = printSLUstat || rcond ? YES : NO;
@@ -1360,7 +1360,7 @@ bool SparseMatrix::solveSAMG (Vector& B)
   Vector X(B.size());
 
   SAMG(&nnu, &nna, &nsys,
-       &IA.front(), &JA.front(), &A.front(), B.ptr(), X.ptr(),
+       IA.data(), JA.data(), A.data(), B.data(), X.data(),
        &iu, &ndiu, &ip, &ndip, &matrix, &iscale,
        &res_in, &res_out, &ncyc_done, &ierr,
        &nsolve, &ifirst, &eps, &ncyc, &iswitch,

--- a/src/LinAlg/SparseMatrix.h
+++ b/src/LinAlg/SparseMatrix.h
@@ -224,6 +224,12 @@ public:
   //! \param[out] col Extracted column data
   bool getColumn(size_t c, Vector& col) const;
 
+  //! \brief Returns the L-infinity norm of the matrix.
+  virtual Real Linfnorm() const;
+
+  //! \brief Returns whether the matrix has been factored or not.
+  bool isFactored() const { return factored; }
+
 protected:
   //! \brief Converts the matrix to an optimized row-oriented format.
   //! \details The optimized format is suitable for the SAMG equation solver.
@@ -261,9 +267,6 @@ protected:
 
   //! \brief Writes the system matrix to the given output stream.
   virtual std::ostream& write(std::ostream& os) const;
-
-  //! \brief Returns the L-infinity norm of the matrix.
-  virtual Real Linfnorm() const;
 
 public:
   static bool printSLUstat; //!< Print solution statistics for SuperLU?

--- a/src/LinAlg/SystemMatrix.h
+++ b/src/LinAlg/SystemMatrix.h
@@ -211,6 +211,8 @@ public:
 protected:
   //! \brief Default constructor.
   SystemMatrix() : haveContributions(false) {}
+  //! \brief Copy constructor.
+  SystemMatrix(const SystemMatrix& a) : haveContributions(a.haveContributions){}
 
 public:
   //! \brief Empty destructor.

--- a/src/LinAlg/Test/TestSPRMatrix.C
+++ b/src/LinAlg/Test/TestSPRMatrix.C
@@ -35,7 +35,7 @@ public:
     mpmnpc = new int[2]; mpmnpc[0] = 1; mpmnpc[1] = 2;
     madof  = new int[2]; madof[0] = 1; madof[1] = 2;
     msc    = new int[1]; msc[0] = 1;
-    mpmceq = new int[1]; mpmceq[1] = 0;
+    mpmceq = new int[1]; mpmceq[0] = 1;
     EXPECT_TRUE(this->initSystemEquations());
   }
   virtual ~SAM1DOF() {}
@@ -57,7 +57,7 @@ public:
     mpmnpc = new int[3]; mpmnpc[0] = 1; mpmnpc[1] = 3; mpmnpc[2] = 5;
     madof  = new int[4]; madof[0] = 1; madof[1] = 3; madof[2] = 5; madof[3] = 7;
     msc    = new int[6]; msc[0]=msc[1]=msc[4]=msc[5] = 0; msc[2]=msc[3] = 1;
-    mpmceq = new int[1]; mpmceq[1] = 0;
+    mpmceq = new int[1]; mpmceq[0] = 1;
     EXPECT_TRUE(this->initSystemEquations());
   }
   virtual ~SAM2DOF() {}
@@ -172,7 +172,7 @@ TEST(TestSPRMatrix, SingleDOF)
 #endif
   ASSERT_TRUE(simulator.assembleSystem());
   ASSERT_TRUE(simulator.solveSystem(solution,1));
-  std::cout <<"Solution vector:" << solution.front();
+  std::cout <<"Solution vector:"<< solution.front();
 }
 
 
@@ -187,5 +187,5 @@ TEST(TestSPRMatrix, TwoDOF)
 #endif
   ASSERT_TRUE(simulator.assembleSystem());
   ASSERT_TRUE(simulator.solveSystem(solution,1));
-  std::cout <<"Solution vector:" << solution.front();
+  std::cout <<"Solution vector:"<< solution.front();
 }

--- a/src/LinAlg/matrixnd.h
+++ b/src/LinAlg/matrixnd.h
@@ -114,7 +114,7 @@ namespace utl
       CHECK_INDEX("matrix3d::getColumn: Third index " ,i3,this->n[2]);
       if (this->n[1] < 2 && this->n[2] < 2) return this->elem;
       vector<T> col(this->n[0]);
-      memcpy(col.ptr(),this->ptr(i2-1+this->n[1]*(i3-1)),col.size()*sizeof(T));
+      memcpy(col.data(),this->ptr(i2-1+this->n[1]*(i3-1)),col.size()*sizeof(T));
       return col;
     }
 
@@ -124,7 +124,7 @@ namespace utl
       CHECK_INDEX("matrix3d::fillColumn: Second index ",i2,this->n[1]);
       CHECK_INDEX("matrix3d::fillColumn: Third index " ,i3,this->n[2]);
       size_t ndata = this->n[0] > data.size() ? data.size() : this->n[0];
-      memcpy(this->ptr(i2-1+this->n[1]*(i3-1)),&data.front(),ndata*sizeof(T));
+      memcpy(this->ptr(i2-1+this->n[1]*(i3-1)),data.data(),ndata*sizeof(T));
     }
 
     //! \brief Return the trace of the \a i1'th sub-matrix.
@@ -310,7 +310,7 @@ namespace utl
       CHECK_INDEX("matrix4d::getColumn: Fourth index ",i4,this->n[3]);
       if (this->n[1] < 2 && this->n[2] < 2 && this->n[3] < 2) return this->elem;
       vector<T> col(this->n[0]);
-      memcpy(col.ptr(),
+      memcpy(col.data(),
              this->ptr(i2-1 + this->n[1]*((i3-1) + this->n[2]*(i4-1))),
              col.size()*sizeof(T));
       return col;
@@ -324,7 +324,7 @@ namespace utl
       CHECK_INDEX("matrix4d::fillColumn: Fourth index ",i4,this->n[3]);
       size_t ndata = this->n[0] > data.size() ? data.size() : this->n[0];
       memcpy(this->ptr(i2-1 + this->n[1]*((i3-1)) + this->n[2]*(i4-1)),
-             &data.front(),ndata*sizeof(T));
+             data.data(),ndata*sizeof(T));
     }
 
   protected:

--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -1853,6 +1853,7 @@ bool SIMoutput::evalResults (const Vectors& psol, const ResPointVec& gPoints,
   std::array<RealArray,3> params;
 
   size_t jPoint = 0;
+  bool allElems = false;
   for (const ResultPoint& pt : gPoints)
   {
     ++jPoint;
@@ -1872,13 +1873,13 @@ bool SIMoutput::evalResults (const Vectors& psol, const ResPointVec& gPoints,
       }
       else if (pt.npar < 0)
       {
-        jPoint = patch->getNoElms(); // Flag evaluation at all element centers
+        allElems = true; // Evaluation at all element centers
         points.clear();
         break;
       }
       else if (pt.npar == 0)
       {
-        jPoint = patch->getNoElms(); // Flag evaluation at all nodes
+        // Evaluation at all nodes
         points.resize(patch->getNoNodes());
         std::iota(points.begin(),points.end(),1);
         break;
@@ -1886,7 +1887,7 @@ bool SIMoutput::evalResults (const Vectors& psol, const ResPointVec& gPoints,
     }
   }
 
-  if (points.empty() && jPoint < patch->getNoElms())
+  if (points.empty() && !allElems)
     return true; // no points in this patch
 
   bool getNames = compNames && compNames->empty();

--- a/src/Utility/Vec3.h
+++ b/src/Utility/Vec3.h
@@ -155,10 +155,20 @@ public:
     for (int i = 2; i >= 0; i--)
       if (v[i]+tol < a.v[i])
         return true;
-      else if (v[i] > a.v[i]+tol)
+      else if (v[i]-tol > a.v[i])
         return false;
 
     return false;
+  }
+
+  //! \brief Check if a vector is inside the box defined by two other vectors.
+  bool inside(const Vec3& a, const Vec3& b, double tol = 1.0e-6) const
+  {
+    for (int i = 0; i < 3; i++)
+      if (v[i]+tol < a.v[i] || v[i]-tol > b.v[i])
+        return false;
+
+    return true;
   }
 
   //! \brief Print out a vector.


### PR DESCRIPTION
Added a virtual method `getElementCenter()` in `ASMbase` for calculation of geometric center of a specified element. Implemented for all Lagrange patches. In addition the LRSpline patches already had these implemented, but they are now also available via the `ASMbase` interface.

Also added methods to assign a list of currently active elements. This can be used to split the assembly stage into several sub-steps, in case some manipulation is desired in between the assembly of various element groups, for instance.

Also added missing newline in the matrix_market output format for system matrices.

Finally, a  consistent copy constructor and assignment operator are added for `AlgEqSystem`. This includes some fixes of the copy constructors for `SystemMatrix` sub-classes.