### PR TITLE
avoid VLAs

### DIFF
--- a/Apps/Common/SIMExplicitRKE.h
+++ b/Apps/Common/SIMExplicitRKE.h
@@ -121,9 +121,9 @@ public:
       error -= this->solver.getSolution();
 
       const size_t nf = this->solver.getNoFields(1);
-      size_t iMax[nf];
-      double dMax[nf];
-      prevEst = this->solver.solutionNorms(error,dMax,iMax,nf);
+      std::vector<size_t> iMax(nf);
+      std::vector<double> dMax(nf);
+      prevEst = this->solver.solutionNorms(error, dMax.data(), iMax.data(), nf);
       this->solver.getProcessAdm().cout << "Error estimate: " << prevEst << std::endl;
       if (prevEst > errTol) {
         if (!tp.cutback())

--- a/src/ASM/LR/ASMLRSpline.C
+++ b/src/ASM/LR/ASMLRSpline.C
@@ -350,10 +350,10 @@ bool ASMLRSpline::doRefine (const LR::RefineData& prm, LR::LRSpline* lrspline)
 
 Go::BsplineBasis ASMLRSpline::getBezierBasis (int p, double start, double end)
 {
-  double knot[2*p];
-  std::fill(knot,   knot+p,   start);
-  std::fill(knot+p, knot+2*p, end);
-  return Go::BsplineBasis(p,p,knot);
+  std::vector<double> knot(2*p);
+  std::fill(knot.begin(),     knot.begin() + p,   start);
+  std::fill(knot.begin() + p, knot.begin() + 2*p, end);
+  return Go::BsplineBasis(p, p, knot.data());
 }
 
 

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -1751,12 +1751,10 @@ bool ASMu3D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
     fe.v   = gpar[1][i];
     fe.w   = gpar[2][i];
 
-    double u[2*p1];
-    double v[2*p2];
-    double w[2*p3];
-    basis1.computeBasisValues(gpar[0][i], u, 1);
-    basis2.computeBasisValues(gpar[1][i], v, 1);
-    basis3.computeBasisValues(gpar[2][i], w, 1);
+    std::vector<double> u(2*p1), v(2*p2), w(2*p3);
+    basis1.computeBasisValues(gpar[0][i], u.data(), 1);
+    basis2.computeBasisValues(gpar[1][i], v.data(), 1);
+    basis3.computeBasisValues(gpar[2][i], w.data(), 1);
 
     size_t ib=1; // basis function iterator
     for(int kk=0; kk<p3; kk++) {
@@ -2448,7 +2446,7 @@ bool ASMu3D::BasisFunctionCache::internalInit ()
   auto&& extractBezier = [order](const Quadrature& q,
                                  BezierExtract& b)
   {
-    double u[2*order[0]], v[2*order[1]], w[2*order[2]];
+    std::vector<double> u(2*order[0]), v(2*order[1]), w(2*order[2]);
     Go::BsplineBasis basis1 = getBezierBasis(order[0]);
     Go::BsplineBasis basis2 = getBezierBasis(order[1]);
     Go::BsplineBasis basis3 = getBezierBasis(order[2]);
@@ -2462,9 +2460,9 @@ bool ASMu3D::BasisFunctionCache::internalInit ()
     for (int zeta = 0; zeta < q.ng[2]; zeta++)
       for (int eta = 0; eta < q.ng[1]; eta++)
         for (int xi = 0; xi < q.ng[0]; xi++, ig++) {
-          basis1.computeBasisValues(q.xg[0][xi],   u, 1);
-          basis2.computeBasisValues(q.xg[1][eta],  v, 1);
-          basis3.computeBasisValues(q.xg[2][zeta], w, 1);
+          basis1.computeBasisValues(q.xg[0][xi],   u.data(), 1);
+          basis2.computeBasisValues(q.xg[1][eta],  v.data(), 1);
+          basis3.computeBasisValues(q.xg[2][zeta], w.data(), 1);
           int ib = 1; // basis function iterator
           for (int k = 0; k < order[2]; k++)
             for (int j = 0; j < order[1]; j++)

--- a/src/LinAlg/MatVec.C
+++ b/src/LinAlg/MatVec.C
@@ -92,7 +92,7 @@ bool utl::transform (Matrix& A, const Matrix& Tn, size_t K)
   if (M < A.cols() || N > Tn.cols()) return false;
   if (K < 1 || K+N-1 > M || N > 3) return false;
 
-  Real WA[N];
+  std::vector<Real> WA(N);
   size_t i, ii, j, jj, l, KN = K+N-1;
   for (jj = K; jj <= M; jj++)
   {
@@ -147,7 +147,7 @@ bool utl::transform (Vector& V, const Matrix& Tn, size_t K, bool transpose)
   if (N > Tn.cols()) return false;
   if (K < 1 || K+N-1 > M || N > 3) return false;
 
-  Real WA[N];
+  std::vector<Real> WA(N);
   size_t i, ii, j;
   if (transpose)
     for (i = 1; i <= N; i++)

--- a/src/LinAlg/SparseMatrix.C
+++ b/src/LinAlg/SparseMatrix.C
@@ -1217,7 +1217,7 @@ bool SparseMatrix::solveSLUx (Vector& B, Real* rcond)
 
   void* work = 0;
   int  lwork = 0;
-  Real ferr[nrhs], berr[nrhs];
+  std::vector<Real> ferr(nrhs), berr(nrhs);
   mem_usage_t mem_usage;
 
   SuperLUStat_t stat;
@@ -1228,11 +1228,11 @@ bool SparseMatrix::solveSLUx (Vector& B, Real* rcond)
   GlobalLU_t Glu;
   dgssvx(slu->opts, &slu->A, slu->perm_c, slu->perm_r, slu->etree, &slu->equed,
          slu->R, slu->C, &slu->L, &slu->U, work, lwork, &Bmat, &Xmat,
-         &slu->rpg, &slu->rcond, ferr, berr, &Glu, &mem_usage, &stat, &ierr);
+         &slu->rpg, &slu->rcond, ferr.data(), berr.data(), &Glu, &mem_usage, &stat, &ierr);
 #else
   dgssvx(slu->opts, &slu->A, slu->perm_c, slu->perm_r, slu->etree, &slu->equed,
          slu->R, slu->C, &slu->L, &slu->U, work, lwork, &Bmat, &Xmat,
-         &slu->rpg, &slu->rcond, ferr, berr, &mem_usage, &stat, &ierr);
+         &slu->rpg, &slu->rcond, ferr.data(), berr.data(), &mem_usage, &stat, &ierr);
 #endif
 
   B.swap(X);

--- a/src/SIM/NewmarkSIM.C
+++ b/src/SIM/NewmarkSIM.C
@@ -194,9 +194,9 @@ bool NewmarkSIM::initAcc (double zero_tolerance, std::streamsize outPrec)
     return true;
 
   size_t d, nf = model.getNoFields(1);
-  size_t kMax[nf];
-  double aMax[nf];
-  double accL2 = model.solutionNorms(accVec,aMax,kMax,nf);
+  std::vector<size_t> kMax(nf);
+  std::vector<double> aMax(nf);
+  double accL2 = model.solutionNorms(accVec, aMax.data(), kMax.data(), nf);
 
   utl::LogStream& cout = model.getProcessAdm().cout;
   std::streamsize stdPrec = outPrec > 0 ? cout.precision(outPrec) : 0;
@@ -571,11 +571,11 @@ bool NewmarkSIM::solutionNorms (const TimeDomain&,
   size_t v = newSol.size() > 2 ? newSol.size()-2 : 0;
 
   size_t d, nf = model.getNoFields(1);
-  size_t iMax[nf], jMax[nf], kMax[nf];
-  double dMax[nf], vMax[nf], aMax[nf];
-  double disL2 = model.solutionNorms(newSol.front(),dMax,iMax,nf);
-  double velL2 = v > 0 ? model.solutionNorms(newSol[v],vMax,jMax,nf) : 0.0;
-  double accL2 = a > 0 ? model.solutionNorms(newSol[a],aMax,kMax,nf) : 0.0;
+  std::vector<size_t> iMax(nf), jMax(nf), kMax(nf);
+  std::vector<double> dMax(nf), vMax(nf), aMax(nf);
+  double disL2 = model.solutionNorms(newSol.front(), dMax.data(), iMax.data(), nf);
+  double velL2 = v > 0 ? model.solutionNorms(newSol[v], vMax.data(), jMax.data(), nf) : 0.0;
+  double accL2 = a > 0 ? model.solutionNorms(newSol[a], aMax.data(), kMax.data(), nf) : 0.0;
 
   utl::LogStream& cout = model.getProcessAdm().cout;
   std::streamsize stdPrec = outPrec > 0 ? cout.precision(outPrec) : 0;

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -1298,9 +1298,9 @@ void SIMbase::printSolutionSummary (const Vector& solution, int printSol,
 {
   // Compute and print solution norms
   const size_t nf = this->getNoFields(1);
-  size_t iMax[nf > 0 ? nf : nsd];
-  double dMax[nf > 0 ? nf : nsd];
-  double dNorm = this->solutionNorms(solution,dMax,iMax,nf);
+  std::vector<size_t> iMax(nf > 0 ? nf : nsd);
+  std::vector<double> dMax(nf > 0 ? nf : nsd);
+  double dNorm = this->solutionNorms(solution, dMax.data(), iMax.data(), nf);
 
   int oldPrec = adm.cout.precision();
   if (outPrec > 0)


### PR DESCRIPTION
these are not portable and causes warnings with newer compilers.

In particular VLAs is a C extension that just happens to be available in gcc and clang. However, never versions warns when they are used, so let's not.