### PR TITLE
C++20 fixes

### DIFF
--- a/3rdparty/autodiff/autodiff/reverse/var/var.hpp
+++ b/3rdparty/autodiff/autodiff/reverse/var/var.hpp
@@ -1028,7 +1028,7 @@ struct BooleanExpr
 
     void update() { val = expr(); }
 
-    auto operator! () const { return BooleanExpr([=]() { return !(expr()); }); }
+    auto operator! () const { return BooleanExpr([this]() { return !(expr()); }); }
 };
 
 /// Capture numeric comparison between two expression trees

--- a/src/LinAlg/matrix.h
+++ b/src/LinAlg/matrix.h
@@ -61,11 +61,11 @@ namespace utl //! General utility classes and functions.
   {
   public:
     //! \brief Constructor creating an empty vector.
-    vector<T>() {}
+    vector() {}
     //! \brief Constructor creating a vector of length \a n.
-    explicit vector<T>(size_t n) { this->resize(n); }
+    explicit vector(size_t n) { this->resize(n); }
     //! \brief Constructor creating a vector from an array.
-    vector<T>(const T* values, size_t n) { this->fill(values,n); }
+    vector(const T* values, size_t n) { this->fill(values,n); }
 
     //! \brief Overloaded assignment operator.
     vector<T>& operator=(const std::vector<T>& X)

--- a/src/Utility/HDF5Restart.C
+++ b/src/Utility/HDF5Restart.C
@@ -78,13 +78,13 @@ bool HDF5Restart::writeData (const SerializeData& data)
        int len, const void* data, hid_t type)
   {
 #ifdef HAVE_MPI
-    int lens[ptot], lens2[ptot];
-    std::fill(lens,lens+ptot,len);
-    MPI_Alltoall(lens,1,MPI_INT,lens2,1,MPI_INT,*m_adm.getCommunicator());
-    hsize_t siz   = (hsize_t)std::accumulate(lens2,lens2+ptot,0);
-    hsize_t start = (hsize_t)std::accumulate(lens2,lens2+pid,0);
+    std::vector<int> lens(ptot), lens2(ptot);
+    std::fill(lens.begin(), lens.end(),len);
+    MPI_Alltoall(lens.data(),1,MPI_INT,lens2.data(),1,MPI_INT,*m_adm.getCommunicator());
+    hsize_t siz   = std::accumulate(lens2.begin(), lens2.end(), hsize_t(0));
+    hsize_t start = std::accumulate(lens2.begin(), lens2.begin() + pid, hsize_t(0));
 #else
-    hsize_t siz   = (hsize_t)len;
+    hsize_t siz   = static_cast<hsize_t>(len);
     hsize_t start = 0;
 #endif
     hid_t space = H5Screate_simple(1,&siz,nullptr);

--- a/src/Utility/HDF5Writer.C
+++ b/src/Utility/HDF5Writer.C
@@ -148,11 +148,11 @@ void HDF5Writer::writeArray(hid_t group, const std::string& name, int patch,
     siz = static_cast<hsize_t>(len);
     start = 0;
   } else {
-    int lens[m_size], lens2[m_size];
-    std::fill(lens,lens+m_size,len);
-    MPI_Alltoall(lens,1,MPI_INT,lens2,1,MPI_INT,*m_adm.getCommunicator());
-    siz   = (hsize_t)std::accumulate(lens2,lens2+m_size,0);
-    start = (hsize_t)std::accumulate(lens2,lens2+m_rank,0);
+    std::vector<int> lens(m_size), lens2(m_size);
+    std::fill(lens.begin(), lens.end(), len);
+    MPI_Alltoall(lens.data(),1,MPI_INT,lens2.data(),1,MPI_INT,*m_adm.getCommunicator());
+    siz   = std::accumulate(lens2.begin(), lens2.end(), hsize_t(0));
+    start = std::accumulate(lens2.begin(), lens2.begin() + m_rank, hsize_t(0));
   }
 #else
   hsize_t siz   = (hsize_t)len;


### PR DESCRIPTION
While bumping to c++-20 won't happen before Ubuntu 26.04 (ie when 22.04 is out of support), I tried and it's mostly straight forward. One fix and one warning quell which are already valid under c++-17 so we may as well merge them now.

Also avoid some VLAs in HDF5Writer