### PR TITLE
Fixed: Extraction of patch-level element results with internal ordering

### DIFF
--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -1366,32 +1366,32 @@ void ASMbase::shiftGlobalElmNums (int eshift)
 
 
 void ASMbase::extractElmRes (const Vector& globRes, Vector& elmRes,
-                             bool internalOrder) const
+                             size_t internalFirst) const
 {
   elmRes.clear();
   elmRes.reserve(MLGE.size());
 
-  size_t jel = 0;
+  size_t jel = internalFirst;
   for (int iel : MLGE)
     if (iel > 0)
     {
-      size_t idx = internalOrder ? jel++ : iel-1;
-      elmRes.push_back(idx < globRes.size() ? globRes[idx] : 0.0);
+      size_t idx = internalFirst ? jel++ : iel;
+      elmRes.push_back(idx <= globRes.size() ? globRes(idx) : 0.0);
     }
 }
 
 
 void ASMbase::extractElmRes (const Matrix& globRes, Matrix& elmRes,
-                             bool internalOrder) const
+                             size_t internalFirst) const
 {
   elmRes.resize(globRes.rows(),MLGE.size(),true);
 
-  size_t ivel = 0, jel = 0;
+  size_t ivel = 0, jel = internalFirst;
   for (int iel : MLGE)
     if (iel > 0)
     {
       ++ivel;
-      size_t icol = internalOrder ? ++jel : iel;
+      size_t icol = internalFirst ? jel++ : iel;
       if (icol <= globRes.cols())
         elmRes.fillColumn(ivel,globRes.getColumn(icol));
     }

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -743,17 +743,19 @@ public:
   //! \brief Extracts element results for this patch from a global vector.
   //! \param[in] globRes Global vector of element results
   //! \param[out] elmRes Element results for this patch
-  //! \param[in] internalOrder If \e true, the data in \a globRes are assumed to
-  //! be ordered w.r.t. the internal element ordering
+  //! \param[in] internalFirst If non-zero, the data in \a globRes are assumed
+  //! to be ordered w.r.t. the internal element ordering, and the actual value
+  //! is the global index of the first element in the patch
   virtual void extractElmRes(const Vector& globRes, Vector& elmRes,
-                             bool internalOrder = false) const;
+                             size_t internalFirst = 0) const;
   //! \brief Extracts element results for this patch from a global vector.
   //! \param[in] globRes Global matrix of element results
   //! \param[out] elmRes Element results for this patch
-  //! \param[in] internalOrder If \e true, the data in \a globRes are assumed to
-  //! be ordered w.r.t. the internal element ordering
+  //! \param[in] internalFirst If non-zero, the data in \a globRes are assumed
+  //! to be ordered w.r.t. the internal element ordering, and the actual value
+  //! is the global index of the first element in the patch
   virtual void extractElmRes(const Matrix& globRes, Matrix& elmRes,
-                             bool internalOrder = false) const;
+                             size_t internalFirst = 0) const;
 
   //! \brief Extracts nodal results for this patch from the global vector.
   //! \param[in] globVec Global solution vector in DOF-order

--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -3018,12 +3018,12 @@ void ASMu2D::storeMesh (const std::string& fName, int fType) const
 
 
 void ASMu2D::extractElmRes (const Matrix& globRes, Matrix& elmRes,
-                            bool internalOrder) const
+                            size_t internalFirst) const
 {
   if (outputMaster)
-    outputMaster->extractElmRes(globRes, elmRes, internalOrder);
+    outputMaster->extractElmRes(globRes, elmRes, internalFirst);
   else
-    this->ASMbase::extractElmRes(globRes, elmRes, internalOrder);
+    this->ASMbase::extractElmRes(globRes, elmRes, internalFirst);
 }
 
 

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -249,10 +249,9 @@ public:
   //! \brief Extracts element results for this patch from a global vector.
   //! \param[in] globRes Global matrix of element results
   //! \param[out] elmRes Element results for this patch
-  //! \param[in] internalOrder If \e true, the data in \a globRes are assumed to
-  //! be ordered w.r.t. the internal element ordering
+  //! \param[in] internalFirst Global index of first element in the patch
   virtual void extractElmRes(const Matrix& globRes, Matrix& elmRes,
-                             bool internalOrder = false) const;
+                             size_t internalFirst) const;
 
   // Various methods for preprocessing of boundary conditions and patch topology
   // ===========================================================================

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -2409,12 +2409,12 @@ void ASMu3D::generateThreadGroupsFromElms (const IntVec& elms)
 
 
 void ASMu3D::extractElmRes (const Matrix& globRes, Matrix& elmRes,
-                            bool internalOrder) const
+                            size_t internalFirst) const
 {
   if (outputMaster)
-    outputMaster->extractElmRes(globRes, elmRes, internalOrder);
+    outputMaster->extractElmRes(globRes, elmRes, internalFirst);
   else
-    this->ASMbase::extractElmRes(globRes, elmRes, internalOrder);
+    this->ASMbase::extractElmRes(globRes, elmRes, internalFirst);
 }
 
 

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -478,10 +478,9 @@ public:
   //! \brief Extracts element results for this patch from a global vector.
   //! \param[in] globRes Global matrix of element results
   //! \param[out] elmRes Element results for this patch
-  //! \param[in] internalOrder If \e true, the data in \a globRes are assumed to
-  //! be ordered w.r.t. the internal element ordering
+  //! \param[in] internalFirst Global index of first element in the patch
   virtual void extractElmRes(const Matrix& globRes, Matrix& elmRes,
-                             bool internalOrder = false) const;
+                             size_t internalFirst) const;
 
 protected:
   //! \brief Struct representing an inhomogeneous Dirichlet boundary condition.

--- a/src/LinAlg/SparseMatrix.h
+++ b/src/LinAlg/SparseMatrix.h
@@ -172,7 +172,7 @@ public:
   //! correspond to the equation ordering from the provided \a sam object.
   bool assembleCol(Real val, const SAM& sam, int n, size_t col)
   {
-    return this->assembleCol({val},sam,n,col);
+    return this->assembleCol(RealArray(1,val),sam,n,col);
   }
 
   //! \brief Augments a similar matrix symmetrically to the current matrix.


### PR DESCRIPTION
Was incorrect for multi-patch models, where we need to add an offset to the element index equal to the total number of elements in the previous patches when accessing the global array.