### PR TITLE
Small changes regarding element/node sets for Lagrange patches

### DIFF
--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -159,7 +159,7 @@ public:
                                     unsigned char nnLag = 1);
 
   //! \brief Defines the numerical integration scheme \ref nGauss in the patch.
-  void setGauss(int ng) { nGauss = ng; }
+  virtual void setGauss(int ng) { nGauss = ng; }
 
   //! \brief Defines the number of solution fields in the patch.
   //! \details This method is used by simulators where \ref nf is not known when

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -437,39 +437,23 @@ bool ASMs1D::generateTwistedFEModel (const RealFunc& twist, const Vec3& Zaxis)
 
 int ASMs1D::getNodeSetIdx (const std::string& setName) const
 {
-  int idx = 1;
+  int iset = 1;
   for (const ASM::NodeSet& ns : nodeSets)
     if (ns.first == setName)
-      return idx;
+      return iset;
     else
-      ++idx;
+      ++iset;
 
   return 0;
 }
 
 
-const IntVec& ASMs1D::getNodeSet (int idx) const
+const IntVec& ASMs1D::getNodeSet (int iset) const
 {
-  int count = 0;
-  for (const ASM::NodeSet& ns : nodeSets)
-    if (++count == idx)
-      return ns.second;
+  if (iset > 0 && iset <= static_cast<int>(nodeSets.size()))
+    return nodeSets[iset-1].second;
 
-  return this->ASMbase::getNodeSet(idx);
-}
-
-
-IntVec& ASMs1D::getNodeSet (const std::string& setName, int& idx)
-{
-  idx = 1;
-  for (ASM::NodeSet& ns : nodeSets)
-    if (ns.first == setName)
-      return ns.second;
-    else
-      ++idx;
-
-  nodeSets.push_back(std::make_pair(setName,IntVec()));
-  return nodeSets.back().second;
+  return this->ASMbase::getNodeSet(iset);
 }
 
 

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -129,9 +129,7 @@ public:
   //! \brief Returns (1-based) index of a predefined node set in the patch.
   virtual int getNodeSetIdx(const std::string& setName) const;
   //! \brief Returns an indexed pre-defined node set.
-  virtual const IntVec& getNodeSet(int idx) const;
-  //! \brief Returns a named node set for update.
-  virtual IntVec& getNodeSet(const std::string& setName, int& idx);
+  virtual const IntVec& getNodeSet(int iset) const;
 
   //! \brief Finds the node that is closest to the given point.
   //! \param[in] X Global coordinates of point to search for

--- a/src/ASM/ASMsupel.C
+++ b/src/ASM/ASMsupel.C
@@ -123,40 +123,38 @@ bool ASMsupel::generateFEMTopology ()
 
 int ASMsupel::getNodeSetIdx (const std::string& setName) const
 {
-  int idx = 1;
+  int iset = 1;
   for (const ASM::NodeSet& ns : nodeSets)
     if (ns.first == setName)
-      return idx;
+      return iset;
     else
-      ++idx;
+      ++iset;
 
   return 0;
 }
 
 
-const IntVec& ASMsupel::getNodeSet (int idx) const
+const IntVec& ASMsupel::getNodeSet (int iset) const
 {
-  int count = 0;
-  for (const ASM::NodeSet& ns : nodeSets)
-    if (++count == idx)
-      return ns.second;
+  if (iset > 0 && iset <= static_cast<int>(nodeSets.size()))
+    return nodeSets[iset-1].second;
 
-  return this->ASMbase::getNodeSet(idx);
+  return this->ASMbase::getNodeSet(iset);
 }
 
 
 int ASMsupel::parseNodeSet (const std::string& setName, const char* cset)
 {
-  int idx = this->getNodeSetIdx(setName)-1;
-  if (idx < 0)
+  int iset = this->getNodeSetIdx(setName)-1;
+  if (iset < 0)
   {
-    idx = nodeSets.size();
+    iset = nodeSets.size();
     nodeSets.emplace_back(setName,IntVec());
   }
 
-  utl::parseIntegers(nodeSets[idx].second,cset);
+  utl::parseIntegers(nodeSets[iset].second,cset);
 
-  return 1+idx;
+  return 1+iset;
 }
 
 

--- a/src/ASM/ASMsupel.h
+++ b/src/ASM/ASMsupel.h
@@ -50,7 +50,7 @@ public:
   //! \brief Returns (1-based) index of a predefined node set in the patch.
   virtual int getNodeSetIdx(const std::string& setName) const;
   //! \brief Returns an indexed pre-defined node set.
-  virtual const IntVec& getNodeSet(int idx) const;
+  virtual const IntVec& getNodeSet(int iset) const;
   //! \brief Defines a node set by parsing a list of node numbers.
   virtual int parseNodeSet(const std::string& setName, const char* cset);
 

--- a/src/ASM/ASMu1DLag.C
+++ b/src/ASM/ASMu1DLag.C
@@ -104,45 +104,45 @@ bool ASMu1DLag::generateOrientedFEModel (const Vec3& Zaxis)
 
 int ASMu1DLag::getElementSetIdx (const std::string& setName) const
 {
-  int idx = 1;
+  int iset = 1;
   for (const ASM::NodeSet& es : elemSets)
     if (es.first == setName)
-      return idx;
+      return iset;
     else
-      ++idx;
+      ++iset;
 
   return 0;
 }
 
 
-const IntVec& ASMu1DLag::getElementSet (int idx) const
+const IntVec& ASMu1DLag::getElementSet (int iset) const
 {
-  if (idx > 0 && idx <= static_cast<int>(elemSets.size()))
-    return elemSets[idx-1].second;
+  if (iset > 0 && iset <= static_cast<int>(elemSets.size()))
+    return elemSets[iset-1].second;
 
-  return this->ASMbase::getElementSet(idx);
+  return this->ASMbase::getElementSet(iset);
 }
 
 
-bool ASMu1DLag::isInElementSet (int idx, int iel) const
+bool ASMu1DLag::isInElementSet (int iset, int iel) const
 {
-  if (idx < 1 || idx > static_cast<int>(elemSets.size()))
+  if (iset < 1 || iset > static_cast<int>(elemSets.size()))
     return false;
 
-  return utl::findIndex(elemSets[idx-1].second,iel) >= 0;
+  return utl::findIndex(elemSets[iset-1].second,iel) >= 0;
 }
 
 
 int ASMu1DLag::parseElemSet (const std::string& setName, const char* cset)
 {
-  int idx = this->getElementSetIdx(setName)-1;
-  if (idx < 0)
+  int iset = this->getElementSetIdx(setName)-1;
+  if (iset < 0)
   {
-    idx = elemSets.size();
+    iset = elemSets.size();
     elemSets.emplace_back(setName,IntVec());
   }
 
-  IntVec& mySet = elemSets[idx].second;
+  IntVec& mySet = elemSets[iset].second;
   size_t ifirst = mySet.size();
   utl::parseIntegers(mySet,cset);
 
@@ -154,7 +154,7 @@ int ASMu1DLag::parseElemSet (const std::string& setName, const char* cset)
       IFEM::cout <<"  ** Warning: Non-existing element "<< mySet[i]
                  <<" in element set \""<< setName <<"\""<< std::endl;
 
-  return 1+idx;
+  return 1+iset;
 }
 
 

--- a/src/ASM/ASMu1DLag.h
+++ b/src/ASM/ASMu1DLag.h
@@ -53,9 +53,9 @@ public:
   //! \brief Returns (1-based) index of a predefined element set in the patch.
   virtual int getElementSetIdx(const std::string& setName) const;
   //! \brief Returns an indexed predefined element set.
-  virtual const IntVec& getElementSet(int idx) const;
-  //! \brief Checks if element \e iel is within predefined element set \a idx.
-  virtual bool isInElementSet(int idx, int iel) const;
+  virtual const IntVec& getElementSet(int iset) const;
+  //! \brief Checks if element \a iel is within predefined element set \a iset.
+  virtual bool isInElementSet(int iset, int iel) const;
   //! \brief Defines an element set by parsing a list of element numbers.
   virtual int parseElemSet(const std::string& setName, const char* cset);
 
@@ -74,9 +74,11 @@ public:
   //! \note The number of element nodes must be set in \a grid on input.
   virtual bool tesselate(ElementBlock& grid, const int*) const;
 
-private:
-  char                      fileType; //!< Mesh file format
+protected:
   std::vector<ASM::NodeSet> elemSets; //!< Element sets for properties
+
+private:
+  char fileType; //!< Mesh file format
 };
 
 #endif

--- a/src/ASM/ASMu2DLag.h
+++ b/src/ASM/ASMu2DLag.h
@@ -70,34 +70,45 @@ public:
   //! \brief Returns (1-based) index of a predefined node set in the patch.
   virtual int getNodeSetIdx(const std::string& setName) const;
   //! \brief Returns an indexed predefined node set.
-  virtual const IntVec& getNodeSet(int idx) const;
-  //! \brief Checks if a node is within a predefined node set.
-  virtual bool isInNodeSet(int idx, int iel) const;
+  virtual const IntVec& getNodeSet(int iset) const;
+  //! \brief Checks if node \a inod is within predefined node set \a iset.
+  virtual bool isInNodeSet(int iset, int inod) const;
   //! \brief Defines a node set by parsing a list of node numbers.
   virtual int parseNodeSet(const std::string& setName, const char* cset);
   //! \brief Defines a node set by parsing a 3D bounding box.
   virtual int parseNodeBox(const std::string& setName, const char* bbox);
-  //! \brief Adds nodal index \a inod to the node set named \a setName.
-  void addToNodeSet(const std::string& setName, int inod);
+  //! \brief Adds a node to a named node set.
+  //! \param[in] setName Name of the node set to receive the node
+  //! \param[in] inod Identifier of the node to add to the set
+  //! \param[in] extId If \e true, \a inod is the external node Id,
+  //! otherwise it is a one-based internal node index
+  //! \return Node set index associated with \a setName
+  int addToNodeSet(const std::string& setName, int inod, bool extId = false);
   //! \brief Returns the name of an indexed predefined node set.
-  bool getNodeSet(int idx, std::string& name) const;
+  bool getNodeSet(int iset, std::string& name) const;
 
   //! \brief Returns (1-based) index of a predefined element set in the patch.
   virtual int getElementSetIdx(const std::string& setName) const;
   //! \brief Returns an indexed predefined element set.
-  virtual const IntVec& getElementSet(int idx) const;
-  //! \brief Checks if element \e iel is within predefined element set \a idx.
-  virtual bool isInElementSet(int idx, int iel) const;
+  virtual const IntVec& getElementSet(int iset) const;
+  //! \brief Checks if element \a iel is within predefined element set \a iset.
+  virtual bool isInElementSet(int iset, int iel) const;
   //! \brief Defines an element set by parsing a list of element numbers.
   virtual int parseElemSet(const std::string& setName, const char* cset);
   //! \brief Defines an element set by parsing a 3D bounding box.
   virtual int parseElemBox(const std::string& setName,
                            const std::string& unionSet, const char* bbox);
-  //! \brief Adds an element \a eId to the element set named \a setName.
-  void addToElemSet(const std::string& setName, int eId);
+  //! \brief Adds an element to a named element set.
+  //! \param[in] setName Name of the element set to receive the element
+  //! \param[in] iel Identifier of the element to add to the set
+  //! \param[in] extId If \e true, \a iel is the external element Id,
+  //! otherwise it is a one-based internal element index
+  //! \return Element set index associated with \a setName
+  int addToElemSet(const std::string& setName, int iel, bool extId = false);
   //! \brief Returns the name of an indexed predefined element set.
-  bool getElementSet(int idx, std::string& name) const;
+  bool getElementSet(int iset, std::string& name) const;
 
+public:
   //! \brief Finds the global (or patch-local) node numbers on a patch boundary.
   //! \param[in] lIndex Local index of the boundary node set
   //! \param nodes Array of node numbers
@@ -120,10 +131,11 @@ public:
 protected:
   bool swapNode34; //!< If \e true, element nodes 3 and 4 should be swapped
 
-private:
-  char                      fileType; //!< Mesh file format
   std::vector<ASM::NodeSet> nodeSets; //!< Node sets for Dirichlet BCs
   std::vector<ASM::NodeSet> elemSets; //!< Element sets for properties
+
+private:
+  char fileType; //!< Mesh file format
 };
 
 #endif

--- a/src/ASM/ASMutils.C
+++ b/src/ASM/ASMutils.C
@@ -132,7 +132,7 @@ bool ASM::readMatlab (std::istream& is, IntMat& MNPC, std::vector<Vec3>& nodes,
         std::cout << std::endl;
 #endif
         std::getline(is,cline);
-        nodeSets.push_back(std::make_pair(setname,nodes));
+        nodeSets.emplace_back(setname,nodes);
       }
     }
 
@@ -255,7 +255,7 @@ bool ASM::readXML (std::istream& is, IntMat& MNPC, std::vector<Vec3>& nodes,
         for (int n : nodes) std::cout <<" "<< n;
         std::cout << std::endl;
 #endif
-        nset->push_back(std::make_pair(name,nodes));
+        nset->emplace_back(name,nodes);
       }
     }
 

--- a/src/ASM/IntegrandBase.C
+++ b/src/ASM/IntegrandBase.C
@@ -316,7 +316,9 @@ void IntegrandBase::resetSolution ()
 
 void IntegrandBase::printSolution (std::ostream& os, int pindx)
 {
-  if (primsol.empty()) return;
+  if (std::all_of(primsol.begin(), primsol.end(),
+                  [](const Vector& sol) { return sol.empty(); }))
+    return; // No solution, or all-empty
 
   int isol = 0;
   os <<"\nCurrent solution for Patch "<< pindx;

--- a/src/Utility/Vec3.h
+++ b/src/Utility/Vec3.h
@@ -97,6 +97,9 @@ public:
     return *this;
   }
 
+  //! \brief Negation operator.
+  Vec3 operator-() const { return Vec3(-x,-y,-z); }
+
   //! \brief Return the sum of the vector.
   Real sum() const { return x+y+z; }
 


### PR DESCRIPTION
Of significance is that the `nodeSets` and `elemSets` containers are now protected (instead of private), such that they can be accessed by sub-classes, and the introduction of the bool second argument for `addTo[Node|Elem]` methods. The rest is cosmetics