### PR TITLE
utl::vector refactoring without inheritance of std::vector

### DIFF
--- a/Apps/Common/MeshUtils.C
+++ b/Apps/Common/MeshUtils.C
@@ -22,10 +22,10 @@ typedef double(*CellFunction)(const ASMbase& patch, int iel);
 
 
 //! \brief Function running over mesh cells calling the cellfunction for each element
-static bool compute(Vector& result, const SIMbase& model,
+static bool compute(std::vector<double>& result, const SIMbase& model,
                     const Vector& displacement, CellFunction func)
 {
-  result.resize(model.getNoElms());
+  result.resize(model.getNoElms(),0.0);
 
   for (int idx = 1; idx <= model.getNoPatches(); idx++) {
     ASMbase* pch = model.getPatch(idx,true);
@@ -40,8 +40,8 @@ static bool compute(Vector& result, const SIMbase& model,
     size_t nel = pch->getNoElms(true);
     for (size_t e = 1; e <= nel; e++) {
       int iel = pch->getElmID(e);
-      if (iel  > 0)
-        result(iel) = func(*pch,e);
+      if (iel > 0)
+        result[iel-1] = func(*pch,e);
     }
 
     if (!displacement.empty()) {
@@ -111,14 +111,14 @@ static double skewness(const ASMbase& patch, int iel)
 
 namespace MeshUtils
 {
-  bool computeAspectRatios(Vector& elmAspects, const SIMbase& model,
-                           const Vector& displacement)
+  bool computeAspectRatios(std::vector<double>& elmAspects,
+                           const SIMbase& model, const Vector& displacement)
   {
     return compute(elmAspects, model, displacement, aspectRatio);
   }
 
-  bool computeMeshSkewness(Vector& elmSkewness, const SIMbase& model,
-                           const Vector& displacement)
+  bool computeMeshSkewness(std::vector<double>& elmSkewness,
+                           const SIMbase& model, const Vector& displacement)
   {
     return compute(elmSkewness, model, displacement, skewness);
   }

--- a/Apps/Common/MeshUtils.h
+++ b/Apps/Common/MeshUtils.h
@@ -23,14 +23,15 @@ namespace MeshUtils
   //! \param[out] elmAspects The element aspect ratios
   //! \param[in] model The model holding the mesh
   //! \param[in] displacement A displacement to apply to mesh coordinates
-  bool computeAspectRatios(Vector& elmAspects, const SIMbase& model,
+  bool computeAspectRatios(std::vector<double>& elmAspects,
+                           const SIMbase& model,
                            const Vector& displacement=Vector());
 
   //! \brief Compute element skewness for a mesh
   //! \param[out] elmSkewness The element skewness values
   //! \param[in] model The model holding the mesh
   //! \param[in] displacement A displacement to apply to mesh coordinates
-  bool computeMeshSkewness(Vector& elmSkewness,
+  bool computeMeshSkewness(std::vector<double>& elmSkewness,
                            const SIMbase& model,
                            const Vector& displacement=Vector());
 }

--- a/Apps/Common/PiolaOperators.C
+++ b/Apps/Common/PiolaOperators.C
@@ -22,10 +22,10 @@ void AdvectionConvInt (Matrix& C,
                        const Vec3& U, double scale)
 {
   Matrix G1(2, fe.dPdX.cols()), G2(2, fe.dPdX.cols());
-  G1.fillRow(1, fe.dPdX.getRow(1).data());
-  G1.fillRow(2, fe.dPdX.getRow(3).data());
-  G2.fillRow(1, fe.dPdX.getRow(2).data());
-  G2.fillRow(2, fe.dPdX.getRow(4).data());
+  G1.fillRow(1, fe.dPdX.getRow(1).ptr());
+  G1.fillRow(2, fe.dPdX.getRow(3).ptr());
+  G2.fillRow(1, fe.dPdX.getRow(2).ptr());
+  G2.fillRow(2, fe.dPdX.getRow(4).ptr());
   C.multiply(fe.P, G1, true, false, false, U[0] * scale * fe.detJxW);
   C.multiply(fe.P, G2, true, false, true,  U[1] * scale * fe.detJxW);
 }

--- a/Apps/Common/Test/TestMeshUtils.C
+++ b/Apps/Common/Test/TestMeshUtils.C
@@ -22,7 +22,7 @@ TEST(TestMeshUtils, Aspect2D)
   ASSERT_TRUE(model.createDefaultModel());
   ASSERT_TRUE(model.createFEMmodel());
 
-  Vector aspect;
+  std::vector<double> aspect;
   MeshUtils::computeAspectRatios(aspect, model);
   ASSERT_FLOAT_EQ(aspect.front(), 1.0);
 
@@ -39,7 +39,7 @@ TEST(TestMeshUtils, Skewness2D)
   ASSERT_TRUE(model.createDefaultModel());
   ASSERT_TRUE(model.createFEMmodel());
 
-  Vector skewness;
+  std::vector<double> skewness;
   MeshUtils::computeMeshSkewness(skewness, model);
   ASSERT_FLOAT_EQ(skewness.front(), 0.0);
 

--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -1573,7 +1573,7 @@ bool ASMbase::getSolution (Matrix& sField, const Vector& locSol,
       sField.fillColumn(i+1,RealArray(nf,0.0));
     }
     else
-      sField.fillColumn(i+1,locSol.data()+nf*nodes[i]-nf);
+      sField.fillColumn(i+1,locSol.ptr()+nf*nodes[i]-nf);
 
   return true;
 }

--- a/src/ASM/ASMs2DLag.C
+++ b/src/ASM/ASMs2DLag.C
@@ -752,7 +752,7 @@ bool ASMs2DLag::evalSolution (Matrix& sField, const Vector& locSol,
         iel++;
 
       for (size_t a = 1; a <= nen; a++)
-        elmSol.fillColumn(a, locSol.data() + nCmp*MNPC[iel-1][a-1]);
+        elmSol.fillColumn(a, locSol.ptr() + nCmp*MNPC[iel-1][a-1]);
 
       elmSol.multiply(N,val);
       sField.fillColumn(ip,val);

--- a/src/ASM/ASMs2DTri.C
+++ b/src/ASM/ASMs2DTri.C
@@ -23,6 +23,7 @@
 #include "TriangleQuadrature.h"
 #include "GaussQuadrature.h"
 #include "ElementBlock.h"
+#include "Vec3Oper.h"
 #include <numeric>
 
 
@@ -356,6 +357,12 @@ bool ASMs2DTri::integrate (Integrand& integrand, int lIndex,
   Vec4   X(nullptr,time.t);
   Vec3   normal, v1, v2;
 
+  // Lambda function extracting an edge vector from element coordinates.
+  auto&& getEdge = [&Xnod](int i, int j)
+  {
+    return Vec3(Xnod.getColumn(j)) - Vec3(Xnod.getColumn(i));
+  };
+
 
   // === Assembly loop over all elements on the patch edge =====================
 
@@ -452,18 +459,18 @@ bool ASMs2DTri::integrate (Integrand& integrand, int lIndex,
         // This calculation is valid for linear triangles only.
         if (t1 == 2)
         {
-          v1 = Xnod.getColumn(2) - Xnod.getColumn(1);
-          normal = Xnod.getColumn(3) - Xnod.getColumn(1);
+          v1     = getEdge(1,2);
+          normal = getEdge(1,3);
         }
         else if (flipDiag)
         {
-          v1 = Xnod.getColumn(1) - Xnod.getColumn(3);
-          normal = Xnod.getColumn(2) - Xnod.getColumn(3);
+          v1     = getEdge(3,1);
+          normal = getEdge(3,2);
         }
         else
         {
-          v1 = Xnod.getColumn(3) - Xnod.getColumn(2);
-          normal = Xnod.getColumn(1) - Xnod.getColumn(2);
+          v1     = getEdge(2,3);
+          normal = getEdge(2,1);
         }
         v2.cross(v1,normal).normalize();
         fe.detJxW = 0.5*v1.normalize();

--- a/src/ASM/ASMs3DLag.C
+++ b/src/ASM/ASMs3DLag.C
@@ -1050,7 +1050,7 @@ bool ASMs3DLag::evalSolution (Matrix& sField, const Vector& locSol,
           iel++;
 
         for (size_t a = 1; a <= nen; a++)
-          elmSol.fillColumn(a, locSol.data() + nCmp*MNPC[iel-1][a-1]);
+          elmSol.fillColumn(a, locSol.ptr() + nCmp*MNPC[iel-1][a-1]);
 
         elmSol.multiply(N,val);
         sField.fillColumn(ip,val);

--- a/src/ASM/AlgEqSystem.C
+++ b/src/ASM/AlgEqSystem.C
@@ -514,7 +514,8 @@ bool AlgEqSystem::readRecoveryMatrix (Matrix& Rmat, const char* recmatFile)
 bool AlgEqSystem::recoverInternals (const Matrix& Rmat, const IntVec& extNodes,
                                     const Vector& xe, Vector& xFull) const
 {
-  Vector x1, x2(xe);
+  Vector x1;
+  RealArray x2(xe);
   x2.insert(x2.begin(),1,1.0); // Assume first column of Rmat is load vector
   if (!Rmat.multiply(x2,x1))
     return false;

--- a/src/ASM/GlbL2projector.C
+++ b/src/ASM/GlbL2projector.C
@@ -595,8 +595,8 @@ bool ASMbase::globalL2projection (Matrix& sField,
   {
 #if SP_DEBUG > 1
     std::cout <<"Replacing end/corner-point values of projected field at node "
-              << corners[i] <<"\nfrom"<< sField.getColumn(corners[i])
-              <<"to"<< sCorner.getColumn(1+i);
+              << corners[i] <<"\nfrom"<< Vector(sField.getColumn(corners[i]))
+              <<"to"<< Vector(sCorner.getColumn(1+i));
 #endif
     sField.fillColumn(corners[i],sCorner.getColumn(1+i));
   }

--- a/src/ASM/HHTMats.C
+++ b/src/ASM/HHTMats.C
@@ -110,7 +110,7 @@ const Vector& HHTMats::getRHSVector () const
   if (b.size() > 3)
     std::cout <<"S_dmp"<< b[3];
   if (haveMass && ia >= 0)
-    std::cout <<"S_inert = M*a"<< A[1]*vec[ia];
+    std::cout <<"S_inert = M*a"<< Vector(A[1]*vec[ia]);
 #endif
 
   // Calculate the right-hand-side force vector of the dynamic problem

--- a/src/ASM/LR/ASMu2Dmx.C
+++ b/src/ASM/LR/ASMu2Dmx.C
@@ -878,7 +878,7 @@ bool ASMu2Dmx::evalSolution (Matrix& sField, const Vector& locSol,
     std::vector<int> els;
     this->getElementsAt({gpar[0][i],gpar[1][i]},els);
     RealArray Ztmp;
-    const double* locPtr = locSol.data();
+    const double* locPtr = locSol.ptr();
     for (size_t j = 0; j < m_basis.size(); ++j) {
       if (nc[j] == 0)
         continue;
@@ -946,7 +946,7 @@ bool ASMu2Dmx::evalSolutionPiola (Matrix& sField, const Vector& locSol,
     std::vector<int>    els;
     std::vector<size_t> elem_size;
     this->getElementsAt({gpar[0][i],gpar[1][i]},els,&elem_size);
-    const double* locPtr = locSol.data();
+    const double* locPtr = locSol.ptr();
     Vectors coefs(nfx.size());
     MxFiniteElement fe(elem_size);
     for (size_t j = 0; j < nBasis; ++j)

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -2595,10 +2595,12 @@ calculatePrm (FiniteElement& fe,
       C.fill(extrMat.data(),extrMat.size());
       Matrix B(b.N.rows(), 4);
       B.fillColumn(1, b.N.getColumn(gp+1));
-      B.fillColumn(2, b.dNdu.getColumn(gp+1) / du[0]);
-      B.fillColumn(3, b.dNdv.getColumn(gp+1) / du[1]);
-      B.fillColumn(4, b.dNdw.getColumn(gp+1) / du[2]);
-
+      B.fillColumn(2, b.dNdu.getColumn(gp+1));
+      B.fillColumn(3, b.dNdv.getColumn(gp+1));
+      B.fillColumn(4, b.dNdw.getColumn(gp+1));
+      for (size_t col = 2; col <= 4; col++)
+        for (size_t r = 1; r <= B.rows(); r++)
+          B(r,col) /= du[col-2];
       patch.evaluateBasis(result.N, result.dNdu, C, B);
     } else
       patch.evaluateBasis(el, fe.u, fe.v, fe.w, result.N, result.dNdu, basis);

--- a/src/ASM/LR/ASMu3Dmx.C
+++ b/src/ASM/LR/ASMu3Dmx.C
@@ -720,7 +720,7 @@ bool ASMu3Dmx::evalSolution (Matrix& sField, const Vector& locSol,
     std::vector<int> els;
     this->getElementsAt({gpar[0][i],gpar[1][i],gpar[2][i]},els);
     RealArray Ztmp;
-    const double* locPtr = locSol.data();
+    const double* locPtr = locSol.ptr();
     for (size_t j = 0; j < m_basis.size(); ++j) {
       if (nc[j] == 0)
         continue;

--- a/src/ASM/LR/ASMu3Drecovery.C
+++ b/src/ASM/LR/ASMu3Drecovery.C
@@ -560,9 +560,9 @@ bool ASMu3D::faceL2projection (const DirichletFace& face,
     // Set up control point coordinates for current element
     if (!this->getElementCoordinates(Xnod,iel)) return false;
 
-    double u = param[0] = gpar[0].front();
-    double v = param[1] = gpar[1].front();
-    double w = param[2] = gpar[2].front();
+    double u = param[0] = gpar[0][0];
+    double v = param[1] = gpar[1][0];
+    double w = param[2] = gpar[2][0];
 
     // --- Integration loop over all Gauss points over the face ----------------
 
@@ -578,9 +578,9 @@ bool ASMu3D::faceL2projection (const DirichletFace& face,
           case 3: k1 = i; k2 = j; k3 = 0; break;
           default: k1 = k2 = k3 = 0;
         }
-        if (gpar[0].size() > 1) u = param[0] = gpar[0](k1+1);
-        if (gpar[1].size() > 1) v = param[1] = gpar[1](k2+1);
-        if (gpar[2].size() > 1) w = param[2] = gpar[2](k3+1);
+        if (gpar[0].size() > 1) u = param[0] = gpar[0][k1];
+        if (gpar[1].size() > 1) v = param[1] = gpar[1][k2];
+        if (gpar[2].size() > 1) w = param[2] = gpar[2][k3];
 
         // Evaluate basis function derivatives at integration points
         this->evaluateBasis(ielG-1, u, v, w, N, dNdu, ASM::GEOMETRY_BASIS);

--- a/src/ASM/LR/LRSplineFields2Dmx.C
+++ b/src/ASM/LR/LRSplineFields2Dmx.C
@@ -28,18 +28,23 @@ LRSplineFields2Dmx::LRSplineFields2Dmx (const ASMu2Dmx* patch,
   : Fields(name), surf(patch), bases(utl::getDigits(basis))
 {
   nf = 2;
-  auto vit = v.begin();
-  size_t ofs = 0;
-  for (int i = 1; i < *bases.begin(); ++i)
-    ofs += patch->getNoNodes(i)*patch->getNoFields(i);
-  vit += ofs;
-  for (int b : bases) {
-    size_t nno = patch->getNoNodes(b)*patch->getNoFields(b);
-    RealArray::const_iterator end = v.size() > nno+ofs ? vit+nno : v.end();
-    std::copy(vit,end,std::back_inserter(values));
+
+  size_t ofs = 0, nno = 0;
+  for (int b = 1; b < *bases.begin(); b++)
+    ofs += patch->getNoNodes(b)*patch->getNoFields(b);
+  for (int b : bases)
+    nno += patch->getNoNodes(b)*patch->getNoFields(b);
+  values.resize(nno);
+
+  RealArray::const_iterator vit = v.begin() + ofs;
+  RealArray::iterator voit = values.begin();
+  for (int b : bases)
+  {
+    nno = patch->getNoNodes(b)*patch->getNoFields(b);
+    std::copy(vit, ofs+nno < v.size() ? vit+nno : v.end(), voit);
     vit += nno;
     ofs += nno;
-    values.resize(ofs);
+    voit += nno;
   }
 }
 

--- a/src/ASM/LR/LRSplineFields3Dmx.C
+++ b/src/ASM/LR/LRSplineFields3Dmx.C
@@ -29,18 +29,23 @@ LRSplineFields3Dmx::LRSplineFields3Dmx (const ASMu3Dmx* patch,
   : Fields(name), vol(patch), bases(utl::getDigits(basis))
 {
   nf = 3;
-  auto vit = v.begin();
-  size_t ofs = 0;
-  for (int i = 1; i < *bases.begin(); ++i)
-    ofs += patch->getNoNodes(i)*patch->getNoFields(i);
-  vit += ofs;
-  for (int b : bases) {
-    size_t nno = patch->getNoNodes(b)*patch->getNoFields(b);
-    RealArray::const_iterator end = v.size() > nno+ofs ? vit+nno : v.end();
-    std::copy(vit,end,std::back_inserter(values));
+
+  size_t ofs = 0, nno = 0;
+  for (int b = 1; b < *bases.begin(); b++)
+    ofs += patch->getNoNodes(b)*patch->getNoFields(b);
+  for (int b : bases)
+    nno += patch->getNoNodes(b)*patch->getNoFields(b);
+  values.resize(nno);
+
+  RealArray::const_iterator vit = v.begin() + ofs;
+  RealArray::iterator voit = values.begin();
+  for (int b : bases)
+  {
+    nno = patch->getNoNodes(b)*patch->getNoFields(b);
+    std::copy(vit, ofs+nno < v.size() ? vit+nno : v.end(), voit);
     vit += nno;
     ofs += nno;
-    values.resize(ofs);
+    voit += nno;
   }
 }
 

--- a/src/ASM/NewmarkMats.C
+++ b/src/ASM/NewmarkMats.C
@@ -90,15 +90,17 @@ const Vector& NewmarkMats::getRHSVector () const
   if (ia >= 0) std::cout <<"a:"<< vec[ia];
   std::cout <<"\nf_ext - f_s"<< dF;
   if (haveMass && ia >= 0)
-    std::cout <<"f_i = M*a"<< A[1]*vec[ia];
+    std::cout <<"f_i = M*a"<< Vector(A[1]*vec[ia]);
   if (b.size() > 1)
     std::cout <<"f_d"<< b[1];
   else if (haveDamp && iv >= 0)
-    std::cout <<"f_d = C*v"<< A[3]*vec[iv];
+    std::cout <<"f_d = C*v"<< Vector(A[3]*vec[iv]);
   if (alpha1 > 0.0 && haveMass && iv >= 0)
-    std::cout <<"f_d1/alpha1 = M*v (alpha1="<< alpha1 <<")"<< A[1]*vec[iv];
+    std::cout <<"f_d1/alpha1 = M*v (alpha1="<< alpha1 <<")"
+              << Vector(A[1]*vec[iv]);
   if (alpha2 > 0.0 && haveStif && iv >= 0)
-    std::cout <<"f_d2/alpha2 = K*v (alpha2="<< alpha2 <<")"<< A[2]*vec[iv];
+    std::cout <<"f_d2/alpha2 = K*v (alpha2="<< alpha2 <<")"
+              << Vector(A[2]*vec[iv]);
 #endif
 
   if (haveMass && ia >= 0)

--- a/src/ASM/SplineFields1D.C
+++ b/src/ASM/SplineFields1D.C
@@ -41,7 +41,7 @@ bool SplineFields1D::valueFE (const ItgPoint& x, Vector& vals) const
   {
     // We are at an interpolatory point (with C^0 continuity)
     vals.resize(nf);
-    vals.fill(values.data()+nf*first,nf);
+    vals.fill(values.ptr()+nf*first,nf);
     return true;
   }
 

--- a/src/ASM/SplineFields2Dmx.C
+++ b/src/ASM/SplineFields2Dmx.C
@@ -29,18 +29,23 @@ SplineFields2Dmx::SplineFields2Dmx (const ASMs2Dmx* patch,
   : Fields(name), surf(patch), bases(utl::getDigits(basis))
 {
   nf = 2;
-  auto vit = v.begin();
-  size_t ofs = 0;
-  for (int i = 1; i < *bases.begin(); ++i)
-    ofs += patch->getNoNodes(i)*patch->getNoFields(i);
-  vit += ofs;
-  for (int b : bases) {
-    size_t nno = patch->getNoNodes(b)*patch->getNoFields(b);
-    RealArray::const_iterator end = v.size() > nno+ofs ? vit+nno : v.end();
-    std::copy(vit,end,std::back_inserter(values));
+
+  size_t ofs = 0, nno = 0;
+  for (int b = 1; b < *bases.begin(); b++)
+    ofs += patch->getNoNodes(b)*patch->getNoFields(b);
+  for (int b : bases)
+    nno += patch->getNoNodes(b)*patch->getNoFields(b);
+  values.resize(nno);
+
+  RealArray::const_iterator vit = v.begin() + ofs;
+  RealArray::iterator voit = values.begin();
+  for (int b : bases)
+  {
+    nno = patch->getNoNodes(b)*patch->getNoFields(b);
+    std::copy(vit, ofs+nno < v.size() ? vit+nno : v.end(), voit);
     vit += nno;
     ofs += nno;
-    values.resize(ofs);
+    voit += nno;
   }
 }
 

--- a/src/ASM/SplineFields2Dmx.C
+++ b/src/ASM/SplineFields2Dmx.C
@@ -100,7 +100,7 @@ bool SplineFields2Dmx::valueFE (const ItgPoint& x, Vector& vals) const
 
     Matrix Vnod;
     utl::gather(ip,1,Vector(&*vit,surf->getNoNodes(b)),Vnod);
-    Vector val2;
+    RealArray val2;
     Vnod.multiply(spline.basisValues,val2); // vals = Vnod * basisValues
     *rit++ = val2.front();
     vit += surf->getNoNodes(b);

--- a/src/ASM/SplineFields3Dmx.C
+++ b/src/ASM/SplineFields3Dmx.C
@@ -29,18 +29,23 @@ SplineFields3Dmx::SplineFields3Dmx (const ASMs3Dmx* patch,
   : Fields(name), svol(patch), bases(utl::getDigits(basis))
 {
   nf = 3;
-  auto vit = v.begin();
-  size_t ofs = 0;
-  for (int i = 1; i < *bases.begin(); ++i)
-    ofs += patch->getNoNodes(i)*patch->getNoFields(i);
-  vit += ofs;
-  for (int b : bases) {
-    size_t nno = patch->getNoFields(b)*patch->getNoNodes(b);
-    RealArray::const_iterator end = v.size() > nno+ofs ? vit+nno : v.end();
-    std::copy(vit,end,std::back_inserter(values));
+
+  size_t ofs = 0, nno = 0;
+  for (int b = 1; b < *bases.begin(); b++)
+    ofs += patch->getNoNodes(b)*patch->getNoFields(b);
+  for (int b : bases)
+    nno += patch->getNoNodes(b)*patch->getNoFields(b);
+  values.resize(nno);
+
+  RealArray::const_iterator vit = v.begin() + ofs;
+  RealArray::iterator voit = values.begin();
+  for (int b : bases)
+  {
+    nno = patch->getNoNodes(b)*patch->getNoFields(b);
+    std::copy(vit, ofs+nno < v.size() ? vit+nno : v.end(), voit);
     vit += nno;
     ofs += nno;
-    values.resize(ofs);
+    voit += nno;
   }
 }
 

--- a/src/ASM/SplineFields3Dmx.C
+++ b/src/ASM/SplineFields3Dmx.C
@@ -93,7 +93,7 @@ bool SplineFields3Dmx::valueFE (const ItgPoint& x, Vector& vals) const
 
     Matrix Vnod;
     utl::gather(ip,1,Vector(&*vit,svol->getNoNodes(b)),Vnod);
-    Vector val2;
+    RealArray val2;
     Vnod.multiply(spline.basisValues,val2); // vals = Vnod * basisValues
     *rit++ = val2.front();
     vit += svol->getNoNodes(b);

--- a/src/Eig/EigSolver.C
+++ b/src/Eig/EigSolver.C
@@ -192,7 +192,7 @@ static void _eig_ax(const SystemMatrix* A, const double* x, double* y)
 
   StdVector Y;
   A->multiply(StdVector(x,A->dim()),Y);
-  memcpy(y,Y.data(),Y.dim()*sizeof(double));
+  memcpy(y,Y.ptr(),Y.dim()*sizeof(double));
 }
 
 
@@ -213,5 +213,5 @@ extern "C" void eig_sol_(const double* x, double* y, int& ierr)
 
   StdVector RHS(x,AM->dim());
   ierr = AM->solve(RHS) ? 0 : -1;
-  memcpy(y,RHS.data(),RHS.dim()*sizeof(double));
+  memcpy(y,RHS.ptr(),RHS.dim()*sizeof(double));
 }

--- a/src/LinAlg/DiagMatrix.C
+++ b/src/LinAlg/DiagMatrix.C
@@ -20,7 +20,7 @@ DiagMatrix::DiagMatrix (const RealArray& data, size_t nrows)
   if (nrows == 0) nrows = data.size();
 
   myMat.resize(nrows);
-  memcpy(myMat.data(),data.data(),nrows*sizeof(Real));
+  memcpy(myMat.ptr(),data.data(),nrows*sizeof(Real));
 }
 
 

--- a/src/LinAlg/DiagMatrix.C
+++ b/src/LinAlg/DiagMatrix.C
@@ -97,16 +97,6 @@ bool DiagMatrix::assemble (const Matrix& eM, const SAM& sam,
 }
 
 
-bool DiagMatrix::redim (size_t r)
-{
-  if (r == myMat.size())
-    return false;
-
-  myMat.std::vector<Real>::resize(r);
-  return true;
-}
-
-
 bool DiagMatrix::add (const SystemMatrix& B, Real alpha)
 {
   const DiagMatrix* Bptr = dynamic_cast<const DiagMatrix*>(&B);

--- a/src/LinAlg/DiagMatrix.h
+++ b/src/LinAlg/DiagMatrix.h
@@ -41,7 +41,7 @@ public:
 
   //! \brief Resizes the matrix to dimension \f$r \times r\f$.
   //! \details Will preserve existing matrix content within the new dimension.
-  bool redim(size_t r);
+  bool redim(size_t r) { return myMat.resize(r,utl::RETAIN); }
 
   //! \brief Returns the dimension of the system matrix.
   virtual size_t dim(int) const { return myMat.size(); }

--- a/src/LinAlg/MatVec.C
+++ b/src/LinAlg/MatVec.C
@@ -54,17 +54,17 @@ Matrix utl::operator* (const Matrix& A, Real c)
 }
 
 
-Vector utl::operator* (const Matrix& A, const Vector& X)
+RealArray utl::operator* (const Matrix& A, const Vector& X)
 {
-  Vector Y;
+  RealArray Y;
   A.multiply(X,Y);
   return Y;
 }
 
 
-Vector utl::operator* (const Vector& X, const Matrix& A)
+RealArray utl::operator* (const Vector& X, const Matrix& A)
 {
-  Vector Y;
+  RealArray Y;
   A.multiply(X,Y,true);
   return Y;
 }

--- a/src/LinAlg/MatVec.h
+++ b/src/LinAlg/MatVec.h
@@ -71,10 +71,10 @@ namespace utl
 
   //! \brief Multiplication of a matrix and a vector.
   //! \return \f$ {\bf Y} = {\bf A} {\bf X} \f$
-  Vector operator*(const Matrix& A, const Vector& X);
+  RealArray operator*(const Matrix& A, const Vector& X);
   //! \brief Multiplication of a vector and a matrix.
   //! \return \f$ {\bf Y} = {\bf A}^T {\bf X} \f$
-  Vector operator*(const Vector& X, const Matrix& A);
+  RealArray operator*(const Vector& X, const Matrix& A);
 
   //! \brief Multiplication of two matrices.
   //! \return \f$ {\bf C} = {\bf A} {\bf B} \f$

--- a/src/LinAlg/MatVec.h
+++ b/src/LinAlg/MatVec.h
@@ -95,4 +95,22 @@ namespace utl
   bool invert(Matrix& A);
 }
 
+#if HAS_CEREAL
+namespace cereal
+{
+  //! \brief Specialization for utl::vector.
+  template<class Archive, class T>
+  void load(Archive& archive, utl::vector<T>& vec)
+  {
+    archive(static_cast<std::vector<T>&>(vec));
+  }
+
+  //! \brief Specialization for utl::vector.
+  template<class Archive, class T>
+  void save(Archive& archive, const utl::vector<T>& vec)
+  {
+    archive(static_cast<const std::vector<T>&>(vec));
+  }
+}
+#endif
 #endif

--- a/src/LinAlg/SparseMatrix.C
+++ b/src/LinAlg/SparseMatrix.C
@@ -379,7 +379,7 @@ void SparseMatrix::dump (std::ostream& os, LinAlg::StorageFormat format,
   else if (solver == SUPERLU || solver == UMFPACK)
   {
     // Column-oriented format with 0-based indices
-    os << JA.front()+1 <<" 1 "<< A.front();
+    os << JA.front()+1 <<" 1 "<< A[0];
     for (size_t j = 1; j <= ncol; j++)
       for (int i = IA[j-1]; i < IA[j]; i++)
         if (j > 1 || i != IA.front())
@@ -388,7 +388,7 @@ void SparseMatrix::dump (std::ostream& os, LinAlg::StorageFormat format,
   else
   {
     // Row-oriented format with 1-based indices
-    os <<"1 "<< JA.front() <<' '<< A.front();
+    os <<"1 "<< JA.front() <<' '<< A[0];
     for (size_t i = 1; i <= nrow; i++)
       for (int j = IA[i-1]; j < IA[i]; j++)
         if (i > 1 || j != IA.front())

--- a/src/LinAlg/SparseMatrix.C
+++ b/src/LinAlg/SparseMatrix.C
@@ -1045,7 +1045,7 @@ bool SparseMatrix::solveSLU (Vector& B)
     // Create a new SuperLU matrix
     slu = new SuperLUdata(nrow,ncol);
     dCreate_CompCol_Matrix(&slu->A, nrow, ncol, this->size(),
-                           A.data(), JA.data(), IA.data(),
+                           A.ptr(), JA.data(), IA.data(),
                            SLU_NC, SLU_D, SLU_GE);
   }
   else {
@@ -1053,7 +1053,7 @@ bool SparseMatrix::solveSLU (Vector& B)
     Destroy_SuperNode_Matrix(&slu->L);
     Destroy_CompCol_Matrix(&slu->U);
     dCreate_CompCol_Matrix(&slu->A, nrow, ncol, this->size(),
-                           A.data(), JA.data(), IA.data(),
+                           A.ptr(), JA.data(), IA.data(),
                            SLU_NC, SLU_D, SLU_GE);
   }
 
@@ -1068,7 +1068,7 @@ bool SparseMatrix::solveSLU (Vector& B)
   // Create right-hand-side/solution vector(s)
   size_t nrhs = B.size() / nrow;
   SuperMatrix Bmat;
-  dCreate_Dense_Matrix(&Bmat, nrow, nrhs, B.data(), nrow,
+  dCreate_Dense_Matrix(&Bmat, nrow, nrhs, B.ptr(), nrow,
                        SLU_DN, SLU_D, SLU_GE);
 
   // Invoke the simple driver
@@ -1081,7 +1081,7 @@ bool SparseMatrix::solveSLU (Vector& B)
     // Create a new SuperLU matrix
     slu = new SuperLUdata(nrow,ncol,1);
     dCreate_CompCol_Matrix(&slu->A, nrow, ncol, this->size(),
-                           A.data(), JA.data(), IA.data(),
+                           A.ptr(), JA.data(), IA.data(),
                            SLU_NC, SLU_D, SLU_GE);
   }
   else if (factored)
@@ -1091,14 +1091,14 @@ bool SparseMatrix::solveSLU (Vector& B)
     Destroy_SuperNode_Matrix(&slu->L);
     Destroy_CompCol_Matrix(&slu->U);
     dCreate_CompCol_Matrix(&slu->A, nrow, ncol, this->size(),
-                           A.data(), JA.data(), IA.data(),
+                           A.ptr(), JA.data(), IA.data(),
                            SLU_NC, SLU_D, SLU_GE);
   }
 
   // Create right-hand-side/solution vector(s)
   size_t nrhs = B.size() / nrow;
   SuperMatrix Bmat;
-  dCreate_Dense_Matrix(&Bmat, nrow, nrhs, B.data(), nrow,
+  dCreate_Dense_Matrix(&Bmat, nrow, nrhs, B.ptr(), nrow,
                        SLU_DN, SLU_D, SLU_GE);
 
   SuperLUStat_t stat;
@@ -1150,7 +1150,7 @@ bool SparseMatrix::solveSLUx (Vector& B, Real* rcond)
     memset(slu->opts->part_super_h, 0, ncol*sizeof(int));
     memset(slu->opts->etree, 0, ncol*sizeof(int));
     dCreate_CompCol_Matrix(&slu->A, nrow, ncol, this->size(),
-                           A.data(), JA.data(), IA.data(),
+                           A.ptr(), JA.data(), IA.data(),
                            SLU_NC, SLU_D, SLU_GE);
 
     // Get column permutation vector perm_c[], according to permc_spec:
@@ -1170,9 +1170,9 @@ bool SparseMatrix::solveSLUx (Vector& B, Real* rcond)
   Vector      X(B.size());
   SuperMatrix Bmat, Xmat;
   const size_t nrhs = B.size() / nrow;
-  dCreate_Dense_Matrix(&Bmat, nrow, nrhs, B.data(), nrow,
+  dCreate_Dense_Matrix(&Bmat, nrow, nrhs, B.ptr(), nrow,
                        SLU_DN, SLU_D, SLU_GE);
-  dCreate_Dense_Matrix(&Xmat, nrow, nrhs, X.data(), nrow,
+  dCreate_Dense_Matrix(&Xmat, nrow, nrhs, X.ptr(), nrow,
                        SLU_DN, SLU_D, SLU_GE);
 
   Real ferr[nrhs], berr[nrhs];
@@ -1196,7 +1196,7 @@ bool SparseMatrix::solveSLUx (Vector& B, Real* rcond)
     slu->C = new Real[ncol];
     slu->R = new Real[nrow];
     dCreate_CompCol_Matrix(&slu->A, nrow, ncol, this->size(),
-                           A.data(), JA.data(), IA.data(),
+                           A.ptr(), JA.data(), IA.data(),
                            SLU_NC, SLU_D, SLU_GE);
   }
   else if (factored)
@@ -1206,7 +1206,7 @@ bool SparseMatrix::solveSLUx (Vector& B, Real* rcond)
     Destroy_SuperNode_Matrix(&slu->L);
     Destroy_CompCol_Matrix(&slu->U);
     dCreate_CompCol_Matrix(&slu->A, nrow, ncol, this->size(),
-                           A.data(), JA.data(), IA.data(),
+                           A.ptr(), JA.data(), IA.data(),
                            SLU_NC, SLU_D, SLU_GE);
     slu->opts->Fact = SamePattern;
   }
@@ -1215,9 +1215,9 @@ bool SparseMatrix::solveSLUx (Vector& B, Real* rcond)
   Vector      X(B.size());
   SuperMatrix Bmat, Xmat;
   const  size_t nrhs = B.size() / nrow;
-  dCreate_Dense_Matrix(&Bmat, nrow, nrhs, B.data(), nrow,
+  dCreate_Dense_Matrix(&Bmat, nrow, nrhs, B.ptr(), nrow,
                        SLU_DN, SLU_D, SLU_GE);
-  dCreate_Dense_Matrix(&Xmat, nrow, nrhs, X.data(), nrow,
+  dCreate_Dense_Matrix(&Xmat, nrow, nrhs, X.ptr(), nrow,
                        SLU_DN, SLU_D, SLU_GE);
 
   slu->opts->ConditionNumber = printSLUstat || rcond ? YES : NO;
@@ -1298,13 +1298,13 @@ bool SparseMatrix::solveUMF (Vector& B, Real* rcond)
   double info[UMFPACK_INFO];
   if (!umfSymbolic) {
     umfpack_di_symbolic(nrow, ncol, IA.data(), JA.data(),
-                        A.data(), &umfSymbolic, nullptr, info);
+                        A.ptr(), &umfSymbolic, nullptr, info);
     if (info[UMFPACK_STATUS] != UMFPACK_OK)
       return false;
   }
 
   void* numeric = nullptr;
-  umfpack_di_numeric(IA.data(), JA.data(), A.data(), umfSymbolic,
+  umfpack_di_numeric(IA.data(), JA.data(), A.ptr(), umfSymbolic,
                      &numeric, nullptr, info);
   if (rcond)
     *rcond = info[UMFPACK_RCOND];
@@ -1314,7 +1314,7 @@ bool SparseMatrix::solveUMF (Vector& B, Real* rcond)
   bool okAll = info[UMFPACK_STATUS] == UMFPACK_OK;
   for (size_t i = 0; i < nrhs && okAll; ++i) {
     umfpack_di_solve(UMFPACK_A,
-                     IA.data(), JA.data(), A.data(),
+                     IA.data(), JA.data(), A.ptr(),
                      &X[i*nrow], &B[i*nrow], numeric, nullptr, info);
     okAll = info[UMFPACK_STATUS] == UMFPACK_OK;
   }
@@ -1370,7 +1370,7 @@ bool SparseMatrix::solveSAMG (Vector& B)
   Vector X(B.size());
 
   SAMG(&nnu, &nna, &nsys,
-       IA.data(), JA.data(), A.data(), B.data(), X.data(),
+       IA.data(), JA.data(), A.ptr(), B.ptr(), X.ptr(),
        &iu, &ndiu, &ip, &ndip, &matrix, &iscale,
        &res_in, &res_out, &ncyc_done, &ierr,
        &nsolve, &ifirst, &eps, &ncyc, &iswitch,

--- a/src/LinAlg/SystemMatrix.h
+++ b/src/LinAlg/SystemMatrix.h
@@ -56,7 +56,7 @@ public:
   virtual void resize(size_t n, bool = false) { this->redim(n); }
 
   //! \brief Checks if the vector is empty.
-  virtual bool empty() const { return this->dim() == 0; }
+  bool empty() const { return this->dim() == 0; }
 
   //! \brief Access through pointer.
   virtual Real* getPtr() = 0;
@@ -112,17 +112,12 @@ protected:
 class StdVector : public SystemVector, public utl::vector<Real>
 {
 public:
-  //! \brief Constructor creating an empty vector.
-  StdVector() {}
-  //! \brief Constructor creating a vector of length \a n.
-  explicit StdVector(size_t n) : utl::vector<Real>(n) {}
+  //! \brief Default constructor creating a vector of length \a n.
+  explicit StdVector(size_t n = 0) : utl::vector<Real>(n) {}
   //! \brief Constructor creating a vector from an array.
   StdVector(const Real* values, size_t n) : utl::vector<Real>(values,n) {}
   //! \brief Overloaded copy constructor.
-  explicit StdVector(const std::vector<Real>& vec)
-  {
-    this->insert(this->end(),vec.begin(),vec.end());
-  }
+  explicit StdVector(const std::vector<Real>& vec) : utl::vector<Real>(vec) {}
 
   //! \brief Returns the vector type.
   virtual LinAlg::MatrixType getType() const { return LinAlg::DENSE; }
@@ -130,14 +125,14 @@ public:
   //! \brief Creates a copy of the system vector and returns a pointer to it.
   virtual SystemVector* copy() const { return new StdVector(*this); }
 
-  //! \brief Checks if the vector is empty.
-  virtual bool empty() const { return this->std::vector<Real>::empty(); }
-
   //! \brief Returns the dimension of the system vector.
-  virtual size_t dim() const { return this->std::vector<Real>::size(); }
+  virtual size_t dim() const { return this->size(); }
 
-  //! \brief Sets the dimension of the system vector.
-  virtual void redim(size_t n) { this->std::vector<Real>::resize(n,Real(0)); }
+  //! \brief Sets the dimension of the system vector while retaining content.
+  virtual void redim(size_t n)
+  {
+    this->utl::vector<Real>::resize(n,utl::RETAIN);
+  }
 
   //! \brief Resizes the vector to length \a n.
   //! \details Will erase the previous content, but only if the size changed,

--- a/src/LinAlg/Test/MatrixTests.h
+++ b/src/LinAlg/Test/MatrixTests.h
@@ -129,7 +129,7 @@ void multiplyTest()
   EXPECT_FLOAT_EQ(x.sum(),0.0);
   EXPECT_FLOAT_EQ(y.sum(),0.0);
 
-  u.std::template vector<Scalar>::resize(5);
+  u.resize(5,utl::RETAIN);
   ASSERT_TRUE(A.multiply(u,v));
   v *= 0.5;
 

--- a/src/LinAlg/Test/NoBlas/TestMatrixFallback.C
+++ b/src/LinAlg/Test/NoBlas/TestMatrixFallback.C
@@ -60,7 +60,7 @@ TEST(TestMatrixFallback, Norm)
 }
 
 
-TEST(TestMatrix, OuterProduct)
+TEST(TestMatrixFallback, OuterProduct)
 {
   outerProductTest<double>();
   outerProductTest<float>();

--- a/src/LinAlg/matrixnd.h
+++ b/src/LinAlg/matrixnd.h
@@ -114,7 +114,7 @@ namespace utl
       CHECK_INDEX("matrix3d::getColumn: Third index " ,i3,this->n[2]);
       if (this->n[1] < 2 && this->n[2] < 2) return this->elem;
       vector<T> col(this->n[0]);
-      memcpy(col.data(),this->ptr(i2-1+this->n[1]*(i3-1)),col.size()*sizeof(T));
+      memcpy(col.ptr(),this->ptr(i2-1+this->n[1]*(i3-1)),col.size()*sizeof(T));
       return col;
     }
 
@@ -310,7 +310,7 @@ namespace utl
       CHECK_INDEX("matrix4d::getColumn: Fourth index ",i4,this->n[3]);
       if (this->n[1] < 2 && this->n[2] < 2 && this->n[3] < 2) return this->elem;
       vector<T> col(this->n[0]);
-      memcpy(col.data(),
+      memcpy(col.ptr(),
              this->ptr(i2-1 + this->n[1]*((i3-1) + this->n[2]*(i4-1))),
              col.size()*sizeof(T));
       return col;

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -1808,7 +1808,7 @@ bool SIMbase::solutionNorms (const TimeDomain& time,
 
   if (!adm.dd.isPartitioned())
     for (Vector& glbNorm : gNorm)
-      adm.allReduceAsSum(glbNorm);
+      adm.allReduceAsSum(static_cast<RealArray&>(glbNorm));
 
   return ok && this->postProcessNorms(gNorm,eNorm);
 }
@@ -1845,8 +1845,8 @@ double SIMbase::externalEnergy (const Vectors& psol, const TimeDomain&) const
   RF[i] = \sum_{n=1}^{\rm nnod} f_n^i \quad\forall\quad i=1,\ldots,{\rm nsd}
   \f]
 
-  If \a psol representing the displacement field \a u is empty,
-  the first norm is omitted and the size of the output array \RF will be \a nsd.
+  If \a psol representing the displacement field \a u is empty, the first
+  norm is omitted and the size of the output array \a RF will be \a nsd.
 */
 
 bool SIMbase::getCurrentReactions (RealArray& RF,

--- a/src/SIM/SIMgeneric.C
+++ b/src/SIM/SIMgeneric.C
@@ -192,7 +192,7 @@ void SIMgeneric::printNorms (const Vectors& norms, size_t w) const
   if (norms.size() > 1+opt.project.size())
   {
     if (norms.back().size() == 1)
-      IFEM::cout <<"\nVol(D) : "<<  norms.back().front();
+      IFEM::cout <<"\nVol(D) : "<<  norms.back()[0];
     else for (i = 0; i < norms.back().size(); i++)
       IFEM::cout <<"\nVol(D"<< i+1 <<") : "<<  norms.back()[i];
   }

--- a/src/SIM/Test/TestNewmark.C
+++ b/src/SIM/Test/TestNewmark.C
@@ -206,7 +206,7 @@ public:
       ok = this->assembleMass(M,2);
     else {
       NewmarkMats* elm;
-      double v = prevSol[prevSol.size()-2].front();
+      double v = prevSol[prevSol.size()-2][0];
       const double* intPrm = static_cast<Problem*>(myProblem)->getIntPrm();
       bool nlDyn = intPrm[3] <= 0.0;
       if (nlDyn)
@@ -261,7 +261,7 @@ public:
     elm.A[1].diag(M); // Mass matrix
     elm.A[2].diag(K); // Stiffness matrix
     elm.A[2](2,1) = elm.A[2](1,2) = -K;
-    elm.b[0] = elm.A[2]*prevSol.front(); // Elastic forces
+    elm.b[0] = elm.A[2]*prevSol[0]; // Elastic forces
     elm.b[0] *= -1.0;
     elm.vec = prevSol;
 
@@ -316,7 +316,7 @@ void runSingleDof (NewmarkSIM& solver, double rtol = 0.5e-11)
 
   ASSERT_TRUE(solver.initEqSystem());
   ASSERT_TRUE(solver.initAcc());
-  EXPECT_FLOAT_EQ(solver.getAcceleration().front(),0.1);
+  EXPECT_FLOAT_EQ(solver.getAcceleration()[0],0.1);
 
   //               at t=0.1           at t=0.25         at t=0.5
   double u[3] = { 0.000457484252515, 0.00178698471292, 0.000732016593476 };
@@ -326,9 +326,9 @@ void runSingleDof (NewmarkSIM& solver, double rtol = 0.5e-11)
   while (solver.advanceStep(tp))
   {
     ASSERT_TRUE(solver.solveStep(tp) == SIM::CONVERGED);
-    double dis = solver.getSolution().front();
-    double vel = solver.getVelocity().front();
-    double acc = solver.getAcceleration().front();
+    double dis = solver.getSolution()[0];
+    double vel = solver.getVelocity()[0];
+    double acc = solver.getAcceleration()[0];
 
     // Check the response at three randomly selected time steps
     if (tp.step == 10) {
@@ -370,7 +370,7 @@ void runTwoDof (NewmarkSIM& solver, double refAcc, double rtol = 0.5e-11)
   solver.opt.solver = LinAlg::DENSE;
   ASSERT_TRUE(solver.initEqSystem());
   ASSERT_TRUE(solver.initAcc());
-  EXPECT_FLOAT_EQ(solver.getAcceleration().front(),refAcc);
+  EXPECT_FLOAT_EQ(solver.getAcceleration()[0],refAcc);
 
   while (solver.advanceStep(tp))
   {
@@ -398,9 +398,9 @@ void runPrescribed (NewmarkSIM& solver, double rtol = 0.5e-11)
   while (solver.advanceStep(tp))
   {
     ASSERT_TRUE(solver.solveStep(tp) == SIM::CONVERGED);
-    double dis = solver.getSolution().front();
-    double vel = solver.getVelocity().front();
-    double acc = solver.getAcceleration().front();
+    double dis = solver.getSolution()[0];
+    double vel = solver.getVelocity()[0];
+    double acc = solver.getAcceleration()[0];
 
     // Check the response at three randomly selected time steps
     if (tp.step == 10) {

--- a/src/SIM/Test/TestNonLinSIM.C
+++ b/src/SIM/Test/TestNonLinSIM.C
@@ -55,7 +55,7 @@ public:
     const double K = 26925.824035673; // Axial stiffness
     const double F = -200.0;          // External load (constant)
 
-    double u   = prevSol.front().front(); // Current deflection
+    double u   = prevSol.front()[0]; // Current deflection
     double L   = hypot(x,y+u); // Current length of the bar
     double L0  = hypot(x,y);   // Initial length of the bar
     double eps = L/L0 - 1.0;   // Axial strain
@@ -105,7 +105,7 @@ static void runSingleDof (NonLinSIM& solver, int& n, double& s)
   ASSERT_TRUE(solver.initSol());
   ASSERT_TRUE(solver.advanceStep(tp));
   ASSERT_EQ(solver.solveStep(tp),SIM::CONVERGED);
-  s = solver.getSolution().front(); n = tp.iter;
+  s = solver.getSolution()[0]; n = tp.iter;
   std::cout <<"  Solution "<< s <<" obtained in "<< n <<" iterations.\n";
 }
 

--- a/src/Utility/CoordinateMapping.C
+++ b/src/Utility/CoordinateMapping.C
@@ -34,7 +34,8 @@ Real utl::Jacobian (matrix<Real>& J, matrix<Real>& dNdX,
     // Special treatment for one-parametric elements in multi-dimension space
     dNdX = dNdu;
     // Compute the length of the tangent vector {X},u
-    detJ = J.getColumn(1).norm2(); // |J| = sqrt(X,u*X,u + Y,u*Y,u + Z,u*Z,u)
+    Vec3 dXdu(J.getColumn(1));
+    detJ = dXdu.length(); // |J| = sqrt(X,u*X,u + Y,u*Y,u + Z,u*Z,u)
   }
   else if (J.cols() == 2 && J.rows() > 2)
   {

--- a/src/Utility/FieldFunctions.C
+++ b/src/Utility/FieldFunctions.C
@@ -334,7 +334,8 @@ Vec3 FieldFunction::gradient (const Vec3& X) const
 
   Vector res;
   field[pidx]->gradFE(ItgPoint(x4->u, x4->idx), res);
-  return res;
+
+  return Vec3(res.ptr(), res.size());
 }
 
 

--- a/src/Utility/HDF5Writer.C
+++ b/src/Utility/HDF5Writer.C
@@ -210,7 +210,7 @@ void HDF5Writer::writeVector(int level, const DataEntry& entry)
   if (entry.second.field == DataExporter::VECTOR) {
     Vector* dvec = (Vector*)entry.second.data;
     int len = !redundant || rank == 0 ? dvec->size() : 0;
-    this->writeArray(level,entry.first,1,len,dvec->data(),H5T_NATIVE_DOUBLE);
+    this->writeArray(level,entry.first,1,len,dvec->ptr(),H5T_NATIVE_DOUBLE);
   }
   else if (entry.second.field == DataExporter::INTVECTOR) {
     std::vector<int>* ivec = (std::vector<int>*)entry.second.data;
@@ -783,8 +783,8 @@ void HDF5Writer::writeNodalForces (int level, const DataEntry& entry)
         values[i*3+j] = val[j];
       }
     }
-    writeArray(group2,"values",-1,values.size(),values.data(),H5T_NATIVE_DOUBLE);
-    writeArray(group2,"coords",-1,coords.size(),coords.data(),H5T_NATIVE_DOUBLE);
+    writeArray(group2,"values",-1,values.size(),values.ptr(),H5T_NATIVE_DOUBLE);
+    writeArray(group2,"coords",-1,coords.size(),coords.ptr(),H5T_NATIVE_DOUBLE);
   } else {
     double dummy=0.0;
     writeArray(group2,"values",-1,0,&dummy,H5T_NATIVE_DOUBLE);


### PR DESCRIPTION
Changing the `std::vector` relationship from "is-a" to "has-a" since `std::vector` is not supposed to be inherited. A bit more changes than initially planned, but this is basically what it takes. The commits are quite fragmented to better see how things are related. The first 9 commits are actually independent of the `utl::vector` refactor in the 10th commit and could be implemented first without changing the vector class. But they are necessary to make things work after the changes in commit 10. The last commit is side effects of the changes made in commit 10, but is kept separately for clarity.

Quite some downstream affections of course, which will be added subsequently.