### PR TITLE
Use RealArray as type for reaction forces containers

### DIFF
--- a/src/ASM/ReactionsOnly.C
+++ b/src/ASM/ReactionsOnly.C
@@ -19,7 +19,7 @@
 
 
 ReactionsOnly::ReactionsOnly (const SAM* sam, const ProcessAdm& adm,
-                              Vector* rf, Vector* sf)
+                              RealArray* rf, Vector* sf)
   : mySam(sam), myAdm(adm), R(rf), S(sf)
 {
   mySam->initForAssembly(b,R);
@@ -30,7 +30,7 @@ void ReactionsOnly::initialize (bool)
 {
   b.init();
   if (R)
-    R->fill(0.0);
+    std::fill(R->begin(),R->end(),0.0);
 }
 
 
@@ -41,9 +41,9 @@ bool ReactionsOnly::finalize (bool)
     if (myAdm.dd.isPartitioned())
       myAdm.allReduceAsSum(*R);
 
-    (*R) *= -1.0;
+    for (double& r : *R) r *= -1.0;
 #if SP_DEBUG > 2
-    std::cout <<"\nReaction forces:"<< *R;
+    std::cout <<"\nReaction forces:"<< Vector(*R);
 #endif
   }
 

--- a/src/ASM/ReactionsOnly.h
+++ b/src/ASM/ReactionsOnly.h
@@ -38,10 +38,10 @@ public:
   //! \brief The constructor initializes the data members.
   //! \param[in] sam Data for FE assembly management
   //! \param[in] adm Parallell processing administrator
-  //! \param[in] rf Reaction force vector to be assembled
+  //! \param[in] rf Reaction forces to be assembled
   //! \param[in] sf Internal force vector to be assembled
   ReactionsOnly(const SAM* sam, const ProcessAdm& adm,
-                Vector* rf = nullptr, Vector* sf = nullptr);
+                RealArray* rf = nullptr, Vector* sf = nullptr);
   //! \brief Empty destructor.
   virtual ~ReactionsOnly() {}
 
@@ -65,9 +65,9 @@ private:
   const SAM*        mySam; //!< Data for FE assembly management
   const ProcessAdm& myAdm; //!< Parallel processing administrator
 
-  StdVector b; //!< Internal right-hand-side vector used in the assembly process
-  Vector*   R; //!< Nodal reaction forces
-  Vector*   S; //!< Nodal internal forces
+  StdVector  b; //!< Internal right-hand-side vector used in the force assembly
+  RealArray* R; //!< Nodal reaction forces
+  Vector*    S; //!< Nodal internal forces
 };
 
 #endif

--- a/src/LinAlg/SAM.C
+++ b/src/LinAlg/SAM.C
@@ -1032,7 +1032,8 @@ Real SAM::getReaction (int dir, const RealArray& rf, const IntVec* nodes) const
 }
 
 
-bool SAM::getNodalReactions (int inod, const RealArray& rf, Vector& nrf) const
+bool SAM::getNodalReactions (int inod, const RealArray& rf,
+                             RealArray& nrf) const
 {
   if (inod < 1 || inod > nnod)
   {
@@ -1043,13 +1044,15 @@ bool SAM::getNodalReactions (int inod, const RealArray& rf, Vector& nrf) const
 
   bool haveRF = false;
   int ip = madof[inod-1]-1;
-  nrf.resize(madof[inod]-1-ip,true);
+  nrf.resize(madof[inod]-1-ip);
   for (size_t i = 0; i < nrf.size(); i++, ip++)
     if (msc[ip] < 0 && -msc[ip] <= (int)rf.size())
     {
       haveRF = true;
       nrf[i] = rf[-msc[ip]-1];
     }
+    else
+      nrf[i] = 0.0;
 
   return haveRF;
 }

--- a/src/LinAlg/SAM.h
+++ b/src/LinAlg/SAM.h
@@ -305,9 +305,9 @@ public:
   //! \param[in] rf Reaction force container for the entire model
   //! \param[out] nrf Nodal reaction forces
   //! \return \e true if the specified node has reaction forces
-  bool getNodalReactions(int inod, const RealArray& rf, Vector& nrf) const;
+  bool getNodalReactions(int inod, const RealArray& rf, RealArray& nrf) const;
 
-  //! \brief Merges the assembly data from another %SIM with this.
+  //! \brief Merges the assembly data from another %SIM object with this.
   virtual bool merge(const SAM*, const std::map<int,int>*) { return false; }
 
 protected:

--- a/src/LinAlg/matrix.h
+++ b/src/LinAlg/matrix.h
@@ -66,6 +66,8 @@ namespace utl //! General utility classes and functions.
     explicit vector(size_t n) { this->resize(n); }
     //! \brief Constructor creating a vector from an array.
     vector(const T* values, size_t n) { this->fill(values,n); }
+    //! \brief Overloaded copy constructor.
+    vector(const std::vector<T>& X) { *this = X; }
 
     //! \brief Overloaded assignment operator.
     vector<T>& operator=(const std::vector<T>& X)

--- a/src/SIM/HHTSIM.C
+++ b/src/SIM/HHTSIM.C
@@ -33,6 +33,13 @@ HHTSIM::HHTSIM (SIMbase& sim) : NewmarkSIM(sim), Finert(nullptr), Fext(nullptr)
 }
 
 
+HHTSIM::~HHTSIM()
+{
+  delete Finert;
+  delete Fext;
+}
+
+
 bool HHTSIM::parse (const tinyxml2::XMLElement* elem)
 {
   bool ok = this->NewmarkSIM::parse(elem);
@@ -120,7 +127,7 @@ bool HHTSIM::advanceStep (TimeStep& param, bool updateTime)
 
   This method merges the nodal point loads into the right-hand-side vector of
   the linearized dynamic equilibrium equation, according to the HHT scheme.
-  It also adds the actual inertia force \e *Finert which has been computed
+  It also adds the actual inertia force \ref Finert which has been computed
   from the dynamic equilibrium equation.
 */
 

--- a/src/SIM/HHTSIM.h
+++ b/src/SIM/HHTSIM.h
@@ -181,8 +181,8 @@ class HHTSIM : public NewmarkSIM
 public:
   //! \brief The constructor initializes default solution parameters.
   explicit HHTSIM(SIMbase& sim);
-  //! \brief Empty destructor.
-  virtual ~HHTSIM() {}
+  //! \brief The destructor deletes the \ref Finert and \ref Fext vectors.
+  virtual ~HHTSIM();
 
   using NewmarkSIM::parse;
   //! \brief Parses a data section from an XML document.

--- a/src/SIM/NewmarkNLSIM.h
+++ b/src/SIM/NewmarkNLSIM.h
@@ -175,7 +175,7 @@ class NewmarkNLSIM : public NewmarkSIM
 public:
   //! \brief The constructor initializes default solution parameters.
   explicit NewmarkNLSIM(SIMbase& sim);
-  //! \brief The destructor deletes the \a Finert system vector.
+  //! \brief The destructor deletes the \ref Finert system vector.
   virtual ~NewmarkNLSIM();
 
   using NewmarkSIM::parse;

--- a/src/SIM/SIM1D.C
+++ b/src/SIM/SIM1D.C
@@ -568,8 +568,8 @@ ModelGenerator* SIM1D::getModelGenerator (const tinyxml2::XMLElement* geo) const
 }
 
 
-Vector SIM1D::getSolution (const Vector& psol, double u,
-                           int deriv, int patch) const
+RealArray SIM1D::getSolution (const Vector& psol, double u,
+                              int deriv, int patch) const
 {
   return this->SIMgeneric::getSolution(psol,&u,deriv,patch);
 }

--- a/src/SIM/SIM1D.h
+++ b/src/SIM/SIM1D.h
@@ -49,8 +49,8 @@ public:
   //! \param[in] deriv Derivative order of the solution
   //! \param[in] patch 1-based patch index contining the evaluation point
   //! \return Evaluated solution values
-  Vector getSolution(const Vector& psol, double u,
-                     int deriv = 0, int patch = 1) const;
+  RealArray getSolution(const Vector& psol, double u,
+                        int deriv = 0, int patch = 1) const;
 
 private:
   //! \brief Parses a subelement of the \a geometry XML-tag.

--- a/src/SIM/SIM2D.C
+++ b/src/SIM/SIM2D.C
@@ -873,8 +873,8 @@ ModelGenerator* SIM2D::getModelGenerator (const tinyxml2::XMLElement* geo) const
 }
 
 
-Vector SIM2D::getSolution (const Vector& psol, double u, double v,
-                           int deriv, int patch) const
+RealArray SIM2D::getSolution (const Vector& psol, double u, double v,
+                              int deriv, int patch) const
 {
   double par[2] = { u, v };
   return this->SIMgeneric::getSolution(psol,par,deriv,patch);

--- a/src/SIM/SIM2D.h
+++ b/src/SIM/SIM2D.h
@@ -57,6 +57,7 @@ public:
   virtual void clonePatches(const PatchVec& patches,
                             const std::map<int,int>& g2ln);
 
+  using SIMgeneric::getSolution;
   //! \brief Evaluates the primary solution at the given point.
   //! \param[in] psol Primary solution vector
   //! \param[in] u First parameter of the point to evaluate at
@@ -64,8 +65,8 @@ public:
   //! \param[in] deriv Derivative order of the solution
   //! \param[in] patch 1-based patch index contining the evaluation point
   //! \return Evaluated solution values
-  Vector getSolution(const Vector& psol, double u, double v,
-                     int deriv = 0, int patch = 1) const;
+  RealArray getSolution(const Vector& psol, double u, double v,
+                        int deriv = 0, int patch = 1) const;
 
 private:
   //! \brief Parses a subelement of the \a geometry XML-tag.

--- a/src/SIM/SIM3D.C
+++ b/src/SIM/SIM3D.C
@@ -834,8 +834,8 @@ ModelGenerator* SIM3D::getModelGenerator (const tinyxml2::XMLElement* geo) const
 }
 
 
-Vector SIM3D::getSolution (const Vector& psol, double u, double v, double w,
-                           int deriv, int patch) const
+RealArray SIM3D::getSolution (const Vector& psol, double u, double v, double w,
+                              int deriv, int patch) const
 {
   double par[3] = { u, v, w };
   return this->SIMgeneric::getSolution(psol,par,deriv,patch);

--- a/src/SIM/SIM3D.h
+++ b/src/SIM/SIM3D.h
@@ -57,6 +57,7 @@ public:
   virtual void clonePatches(const PatchVec& patches,
                             const std::map<int,int>& g2ln);
 
+  using SIMgeneric::getSolution;
   //! \brief Evaluates the primary solution at the given point.
   //! \param[in] psol Primary solution vector
   //! \param[in] u First parameter of the point to evaluate at
@@ -65,8 +66,8 @@ public:
   //! \param[in] deriv Derivative order of the solution
   //! \param[in] patch 1-based patch index contining the evaluation point
   //! \return Evaluated solution values
-  Vector getSolution(const Vector& psol, double u, double v, double w,
-                     int deriv = 0, int patch = 1) const;
+  RealArray getSolution(const Vector& psol, double u, double v, double w,
+                        int deriv = 0, int patch = 1) const;
 
 private:
   //! \brief Parses a subelement of the \a geometry XML-tag.

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -2575,7 +2575,7 @@ void SIMbase::dumpSolVec (const Vector& x, bool isExpanded, bool expOnly)
 
 
 bool SIMbase::assembleForces (const Vector& solution, double t0,
-                              Vector* R, Vector* S)
+                              RealArray* R, Vector* S)
 {
   if (!myProblem) return false;
 

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -464,11 +464,10 @@ public:
   //! \brief Computes the total reaction forces in the model.
   //! \param[out] RF Reaction force in each spatial direction + energy
   //! \param[in] psol Primary solution vector
-  bool getCurrentReactions(RealArray& RF, const Vector& psol) const;
-  //! \brief Computes the total reaction forces associated with a boundary.
-  //! \param[out] RF Reaction force in each spatial direction
-  //! \param[in] pcode Property code identifying the boundary
-  bool getCurrentReactions(RealArray& RF, int pcode) const;
+  //! \param[in] pcode Property code identifying the boundary for which the
+  //! reaction forces are computed (0 means the entire model, or all boundaries)
+  bool getCurrentReactions(RealArray& RF, const Vector& psol,
+                           int pcode = 0) const;
   //! \brief Checks for total reaction forces associated with a boundary.
   //! \param[in] pcode Property code identifying the boundary (0 = all)
   bool haveReactions(int pcode = 0) const;

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -504,7 +504,7 @@ public:
   //! \param[out] R Nodal reaction force container
   //! \param[out] S Nodal interface force container
   bool assembleForces(const Vector& solution, double t0,
-                      Vector* R, Vector* S = nullptr);
+                      RealArray* R, Vector* S = nullptr);
 
 
   // Post-processing methods

--- a/src/SIM/SIMgeneric.h
+++ b/src/SIM/SIMgeneric.h
@@ -44,8 +44,8 @@ public:
   //! \param[in] deriv Derivative order of the solution
   //! \param[in] patch 1-based patch index containing the evaluation point
   //! \return Evaluated solution values
-  Vector getSolution(const Vector& psol, const double* par,
-                     int deriv = 0, int patch = 1) const;
+  RealArray getSolution(const Vector& psol, const double* par,
+                        int deriv = 0, int patch = 1) const;
 
   //! \brief Evaluates the mapping of the geometry at the given point.
   //! \param[in] xi Dimensionless parameters in range [0,1] of the point
@@ -62,8 +62,8 @@ public:
   //! \param[in] weights Nodal weights
   //! \param[in] code Code indentifying the interface to extract forces for
   //! \return The interface force resultant
-  Vector getInterfaceForces(const Vector& sf,
-                            const RealArray& weights, int code) const;
+  RealArray getInterfaceForces(const RealArray& sf,
+                               const RealArray& weights, int code) const;
 
   //! \brief Returns the element that contains a specified spatial point.
   //! \param[in] param The parameters of the point in the knot-span domain
@@ -74,7 +74,7 @@ public:
                             int patch = 1, bool global = false) const;
 
   //! \brief Calculates surface traction resultants.
-  virtual bool calcBouForces(Vectors&, const Vectors&) { return false; }
+  virtual bool calcBouForces(Real2DMat&, const Vectors&) { return false; }
 
   //! \brief Returns the norm index for the a VCP-recovered quantity.
   size_t getVCPindex(size_t idx = 1) const;


### PR DESCRIPTION
These are typically smaller-sized containers which does not require the algebra operations as typical NDOF-length vectors. A `utl::vector` copy constructor is added for easy conversion in the rare event we actually do want to do some algebra stuff. Also fixed a harmless memory leak in `HHTSIM` on destruction.

This used to be part of #729 but is taken out as a prelude for it, as it is a separate issue.