### PR TITLE
(Compatible|Piola)Operators: remove hardcoded indices 

### DIFF
--- a/Apps/Common/CompatibleOperators.C
+++ b/Apps/Common/CompatibleOperators.C
@@ -89,6 +89,15 @@ void CompatibleOperators::Weak::Gradient (std::vector<Matrix>& EM,
                                true, -scale*fe.detJxW);
 }
 
+void CompatibleOperators::Weak::ItgConstraint (std::vector<Matrix>& EM,
+                                               const FiniteElement& fe,
+                                              const std::array<int,3>& idx)
+{
+  const size_t nsd = fe.grad(1).cols();
+  for (size_t i = 1; i <= nsd; ++i)
+    EqualOrderOperators::Weak::ItgConstraint(EM[idx[i-1]], fe, 1.0, i);
+}
+
 
 void CompatibleOperators::Weak::Laplacian (std::vector<Matrix>& EM,
                                            const FiniteElement& fe,

--- a/Apps/Common/CompatibleOperators.C
+++ b/Apps/Common/CompatibleOperators.C
@@ -16,33 +16,27 @@
 #include "Vec3.h"
 
 
-namespace {
-  //! \brief Block indices for velocity blocks.
-  static constexpr int vidx[3][3] = {{ 1, 10, 11},
-                                     {18,  2, 19},
-                                     {26, 27,  3}};
-}
-
-
 void CompatibleOperators::Weak::Advection(std::vector<Matrix>& EM,
                                           const FiniteElement& fe,
-                                          const Vec3& AC, double scale,
+                                          const Vec3& AC,
+                                          const std::array<std::array<int,3>,3>& idx,
+                                          double scale,
                                           WeakOperators::ConvectionForm cnvForm)
 {
   size_t nsd = fe.grad(1).cols();
   for (size_t n = 1; n <= nsd; ++n)
     for (size_t k = 1; k <= nsd; ++k)
       if (cnvForm == WeakOperators::CONVECTIVE)
-        EM[n].outer_product(fe.basis(n), fe.grad(n).getColumn(k),
-                            true,scale*AC[k-1]*fe.detJxW);
+        EM[idx[n-1][n-1]].outer_product(fe.basis(n), fe.grad(n).getColumn(k),
+                                        true,scale*AC[k-1]*fe.detJxW);
       else if (cnvForm == WeakOperators::CONSERVATIVE)
-        EM[n].outer_product(fe.grad(n).getColumn(k),
-                            fe.basis(n), true, -scale*AC[k-1]*fe.detJxW);
+        EM[idx[n-1][n-1]].outer_product(fe.grad(n).getColumn(k),
+                                        fe.basis(n), true, -scale*AC[k-1]*fe.detJxW);
       else if (cnvForm == WeakOperators::SKEWSYMMETRIC) {
-        EM[n].outer_product(fe.basis(n), fe.grad(n).getColumn(k),
-                            true,0.5*scale*AC[k-1]*fe.detJxW);
-        EM[n].outer_product(fe.grad(n).getColumn(k),
-                            fe.basis(n), true, -0.5*scale*AC[k-1]*fe.detJxW);
+        EM[idx[n-1][n-1]].outer_product(fe.basis(n), fe.grad(n).getColumn(k),
+                                        true,0.5*scale*AC[k-1]*fe.detJxW);
+        EM[idx[n-1][n-1]].outer_product(fe.grad(n).getColumn(k),
+                                        fe.basis(n), true, -0.5*scale*AC[k-1]*fe.detJxW);
       }
 }
 
@@ -51,6 +45,7 @@ void CompatibleOperators::Weak::Convection(std::vector<Matrix>& EM,
                                            const FiniteElement& fe,
                                            const Vec3& U,
                                            const Tensor& dUdX,
+                                           const std::array<std::array<int,3>,3>& idx,
                                            double scale,
                                            WeakOperators::ConvectionForm form)
 {
@@ -59,44 +54,46 @@ void CompatibleOperators::Weak::Convection(std::vector<Matrix>& EM,
     for (size_t l = 1; l <= nsd; ++l) {
       switch (form) {
         case WeakOperators::CONVECTIVE:
-          EM[vidx[k-1][l-1]].outer_product(fe.basis(k), fe.basis(l), true, scale*fe.detJxW*dUdX(k,l));
+          EM[idx[k-1][l-1]].outer_product(fe.basis(k), fe.basis(l), true, scale*fe.detJxW*dUdX(k,l));
           if(k == l)
             for (size_t m = 1; m <= nsd; ++m)
-              EM[vidx[k-1][l-1]].outer_product(fe.basis(k), fe.grad(l).getColumn(m), true, scale*fe.detJxW*U[m-1]);
+              EM[idx[k-1][l-1]].outer_product(fe.basis(k), fe.grad(l).getColumn(m), true, scale*fe.detJxW*U[m-1]);
           break;
         case WeakOperators::CONSERVATIVE:
-          EM[vidx[k-1][l-1]].outer_product(fe.grad(k).getColumn(l), fe.basis(l), true, -U[k-1]*scale*fe.detJxW);
+          EM[idx[k-1][l-1]].outer_product(fe.grad(k).getColumn(l), fe.basis(l), true, -U[k-1]*scale*fe.detJxW);
           if (k == l)
             for (size_t m = 1; m <= nsd; ++m)
-              EM[vidx[k-1][l-1]].outer_product(fe.basis(k), fe.grad(l).getColumn(m), true, -U[m-1]*scale*fe.detJxW);
+              EM[idx[k-1][l-1]].outer_product(fe.basis(k), fe.grad(l).getColumn(m), true, -U[m-1]*scale*fe.detJxW);
           break;
         case WeakOperators::SKEWSYMMETRIC:
-          EM[vidx[k-1][l-1]].outer_product(fe.basis(k), fe.basis(l), true, 0.5*scale*fe.detJxW*dUdX(k,l));
-          EM[vidx[k-1][l-1]].outer_product(fe.grad(k).getColumn(l), fe.basis(l), true, -0.5*U[k-1]*scale*fe.detJxW);
+          EM[idx[k-1][l-1]].outer_product(fe.basis(k), fe.basis(l), true, 0.5*scale*fe.detJxW*dUdX(k,l));
+          EM[idx[k-1][l-1]].outer_product(fe.grad(k).getColumn(l), fe.basis(l), true, -0.5*U[k-1]*scale*fe.detJxW);
           if (k == l)
             for (size_t m = 1; m <= nsd; ++m) {
-              EM[vidx[k-1][l-1]].outer_product(fe.basis(k), fe.grad(l).getColumn(m), true, 0.5*scale*fe.detJxW*U[m-1]);
-              EM[vidx[k-1][l-1]].outer_product(fe.basis(k), fe.grad(l).getColumn(m), true, -0.5*U[m-1]*scale*fe.detJxW);
+              EM[idx[k-1][l-1]].outer_product(fe.basis(k), fe.grad(l).getColumn(m), true, 0.5*scale*fe.detJxW*U[m-1]);
+              EM[idx[k-1][l-1]].outer_product(fe.basis(k), fe.grad(l).getColumn(m), true, -0.5*U[m-1]*scale*fe.detJxW);
             }
       }
     }
 }
 
 
-void CompatibleOperators::Weak::Gradient(std::vector<Matrix>& EM,
-                                        const FiniteElement& fe,
-                                        double scale)
+void CompatibleOperators::Weak::Gradient (std::vector<Matrix>& EM,
+                                          const FiniteElement& fe,
+                                          const std::array<int,3>& idx,
+                                          double scale)
 {
   size_t nsd = fe.grad(1).cols();
   for (size_t n = 1; n <= nsd; ++n)
-    EM[12+8*(n-1)].outer_product(fe.grad(n).getColumn(n), fe.basis(nsd+1),
-                                true, -scale*fe.detJxW);
+    EM[idx[n-1]].outer_product(fe.grad(n).getColumn(n), fe.basis(nsd+1),
+                               true, -scale*fe.detJxW);
 }
 
 
-void CompatibleOperators::Weak::Laplacian(std::vector<Matrix>& EM,
-                                          const FiniteElement& fe,
-                                          double scale, bool stress)
+void CompatibleOperators::Weak::Laplacian (std::vector<Matrix>& EM,
+                                           const FiniteElement& fe,
+                                           const std::array<std::array<int,3>,3>& idx,
+                                           double scale, bool stress)
 {
   size_t nsd = fe.grad(1).cols();
   for (size_t n = 1; n <= nsd; ++n)
@@ -106,42 +103,47 @@ void CompatibleOperators::Weak::Laplacian(std::vector<Matrix>& EM,
     for (size_t n = m; n <= nsd; n++) {
       const Vector mn = fe.grad(m).getColumn(n);
       const Vector nm = fe.grad(n).getColumn(m);
-      EM[vidx[m-1][n-1]].outer_product(mn, nm, true, scale*fe.detJxW);
-      if (m != n && !EM[vidx[n-1][m-1]].empty())
-        EM[vidx[n-1][m-1]].outer_product(nm, mn, true, scale*fe.detJxW);
+      EM[idx[m-1][n-1]].outer_product(mn, nm, true, scale*fe.detJxW);
+      if (m != n && !EM[idx[n-1][m-1]].empty())
+        EM[idx[n-1][m-1]].outer_product(nm, mn, true, scale*fe.detJxW);
     }
 }
 
 
-void CompatibleOperators::Weak::Mass(std::vector<Matrix>& EM,
-                                     const FiniteElement& fe, double scale)
+void CompatibleOperators::Weak::Mass (std::vector<Matrix>& EM,
+                                      const FiniteElement& fe,
+                                      const std::array<std::array<int,3>,3>& idx,
+                                      double scale)
 {
   for (size_t k = 1; k <= fe.grad(1).cols(); ++k)
-    EqualOrderOperators::Weak::Mass(EM[k], fe, scale, k);
+    EqualOrderOperators::Weak::Mass(EM[idx[k-1][k-1]], fe, scale, k);
 }
+
+void CompatibleOperators::Weak::Source (Vectors& EV,
+                                        const FiniteElement& fe,
+                                        const Vec3& f,
+                                        const std::array<int, 3>& idx,
+                                        double scale)
+{
+  for (size_t k = 1; k <= fe.grad(1).cols(); ++k)
+    EqualOrderOperators::Weak::Source(EV[idx[k-1]], fe, scale*f[k-1], 1, k);
+}
+
 
 void CompatibleOperators::Weak::Source(Vectors& EV,
                                        const FiniteElement& fe,
-                                       const Vec3& f, double scale)
-{
-  for (size_t k = 1; k <= fe.grad(1).cols(); ++k)
-    EqualOrderOperators::Weak::Source(EV[k], fe, scale*f[k-1], 1, k);
-}
-
-
-void CompatibleOperators::Weak::Source(Vectors& EV,
-                                       const FiniteElement& fe,
+                                       const std::array<int, 3>& idx,
                                        double scale)
 {
   for (size_t k = 1; k <= fe.grad(1).cols(); ++k)
-    EqualOrderOperators::Weak::Source(EV[k], fe, scale, 1, k);
+    EqualOrderOperators::Weak::Source(EV[idx[k-1]], fe, scale, 1, k);
 }
 
 
-void CompatibleOperators::Residual::Convection(Vectors& EV, const FiniteElement& fe,
-                                               const Vec3& U, const Tensor& dUdX,
-                                               const Vec3& UC, double scale,
-                                               WeakOperators::ConvectionForm form)
+void CompatibleOperators::Residual::Convection (Vectors& EV, const FiniteElement& fe,
+                                                const Vec3& U, const Tensor& dUdX,
+                                                const Vec3& UC, const std::array<int, 3>& idx,
+                                                double scale, WeakOperators::ConvectionForm form)
 {
   size_t nsd = fe.grad(1).cols();
   for (size_t k = 1; k <= nsd; ++k) {
@@ -150,25 +152,25 @@ void CompatibleOperators::Residual::Convection(Vectors& EV, const FiniteElement&
       case WeakOperators::CONVECTIVE:
         for (size_t l = 1; l <= nsd; ++l)
           conv += -UC[l-1]*dUdX(k,l);
-        EV[k].add(fe.basis(k), scale*conv*fe.detJxW);
+        EV[idx[k-1]].add(fe.basis(k), scale*conv*fe.detJxW);
         break;
      case WeakOperators::CONSERVATIVE:
         for (size_t i = 1; i <= fe.basis(k).size(); ++i) {
           conv = 0.0;
           for (size_t l = 1; l <= nsd; ++l)
             conv += U[k-1]*UC[l-1]*fe.grad(k)(i,l);
-          EV[k](i) += conv*scale*fe.detJxW;
+          EV[idx[k-1]](i) += conv*scale*fe.detJxW;
         }
         break;
      case WeakOperators::SKEWSYMMETRIC:
         for (size_t l = 1; l <= nsd; ++l)
           conv += -UC[l-1]*dUdX(k,l);
-        EV[k].add(fe.basis(k), 0.5*scale*conv*fe.detJxW);
+        EV[idx[k-1]].add(fe.basis(k), 0.5*scale*conv*fe.detJxW);
         for (size_t i = 1; i <= fe.basis(k).size(); ++i) {
           conv = 0.0;
           for (size_t l = 1; l <= nsd; ++l)
             conv += U[k-1]*UC[l-1]*fe.grad(k)(i,l);
-          EV[k](i) += 0.5*scale*conv*fe.detJxW;
+          EV[idx[k-1]](i) += 0.5*scale*conv*fe.detJxW;
         }
         break;
     }
@@ -177,16 +179,18 @@ void CompatibleOperators::Residual::Convection(Vectors& EV, const FiniteElement&
 
 
 void CompatibleOperators::Residual::Gradient (Vectors& EV, const FiniteElement& fe,
+                                              const std::array<int, 3>& idx,
                                               double scale)
 {
-  for (size_t n = 1; n <= fe.grad(n).cols(); ++n)
-    EV[n].add(fe.grad(n).getColumn(n), scale*fe.detJxW);
+  for (size_t k = 1; k <= fe.grad(1).cols(); ++k)
+    EV[idx[k-1]].add(fe.grad(k).getColumn(k), scale*fe.detJxW);
 }
 
 
 void CompatibleOperators::Residual::Laplacian(Vectors& EV,
                                               const FiniteElement& fe,
                                               const Tensor& dUdX,
+                                              const std::array<int, 3>& idx,
                                               double scale, bool stress)
 {
   size_t nsd = fe.grad(1).cols();
@@ -197,6 +201,6 @@ void CompatibleOperators::Residual::Laplacian(Vectors& EV,
     fe.grad(k).multiply(Vector(dUdXT[k-1].ptr(), nsd), diff);
     if (stress)
       fe.grad(k).multiply(Vector(dUdX[k-1].ptr(), nsd), diff, false, 1);
-    EV[k].add(diff, -scale*fe.detJxW);
+    EV[idx[k-1]].add(diff, -scale*fe.detJxW);
   }
 }

--- a/Apps/Common/CompatibleOperators.h
+++ b/Apps/Common/CompatibleOperators.h
@@ -20,6 +20,8 @@ class Vec3;
 #include "MatVec.h"
 #include "EqualOrderOperators.h"
 
+#include <array>
+
 /*! \brief Common operators using div-compatible discretizations.
  *  \details The operators use the block ordering used in the BlockElmMats class.
  */
@@ -34,10 +36,13 @@ public:
     //! \param[out] EM The element matrices to add contribution to
     //! \param[in] fe The finite element to evaluate for
     //! \param[in] AC Advecting field
+    //! \param[in] idx Matrix block indices
     //! \param[in] scale Scaling factor for contribution
     //! \param[in] cnvForm Form of advection operator
     static void Advection(std::vector<Matrix>& EM, const FiniteElement& fe,
-                          const Vec3& AC, double scale=1.0,
+                          const Vec3& AC,
+                          const std::array<std::array<int,3>,3>& idx,
+                          double scale = 1.0,
                           WeakOperators::ConvectionForm cnvForm = WeakOperators::CONVECTIVE);
 
     //! \brief Compute a (nonlinear) convection term.
@@ -45,48 +50,63 @@ public:
     //! \param[in] fe The finite element to evaluate for
     //! \param[in] U  Advecting field
     //! \param[in] dUdX Field gradient
+    //! \param[in] idx Matrix block indices
     //! \param[in] scale Scaling factor for contribution
     //! \param[in] form Which form of the convective form to use
     static void Convection(std::vector<Matrix>& EM, const FiniteElement& fe,
-                           const Vec3& U, const Tensor& dUdX, double scale,
+                           const Vec3& U, const Tensor& dUdX,
+                           const std::array<std::array<int,3>,3>& idx,
+                           double scale,
                            WeakOperators::ConvectionForm form = WeakOperators::CONVECTIVE);
 
     //! \brief Compute a gradient term.
     //! \param[out] EM The element matrix to add contribution to
     //! \param[in] fe The finite element to evaluate for
+    //! \param[in] idx Matrix block indices
     //! \param[in] scale Scaling factor for contribution
     static void Gradient(std::vector<Matrix>& EM,
-                         const FiniteElement& fe, double scale=1.0);
+                         const FiniteElement& fe,
+                         const std::array<int,3>& idx,
+                         double scale = 1.0);
 
     //! \brief Compute a laplacian.
     //! \param[out] EM The element matrix to add contribution to
     //! \param[in] fe The finite element to evaluate for
+    //! \param[in] idx Matrix block indices
     //! \param[in] scale Scaling factor for contribution
     //! \param[in] stress Whether to add extra stress formulation terms
     //! \details Only the upper blocks are added with the stress formulation
     static void Laplacian(std::vector<Matrix>& EM, const FiniteElement& fe,
-                          double scale=1.0, bool stress=false);
+                          const std::array<std::array<int,3>,3>& idx,
+                          double scale = 1.0, bool stress = false);
 
     //! \brief Compute a mass term.
     //! \param[out] EM The element matrices to add contribution to
     //! \param[in] fe The finite element to evaluate for
+    //! \param[in] idx Matrix block indices
     //! \param[in] scale Scaling factor for contribution
     static void Mass(std::vector<Matrix>& EM,
-                     const FiniteElement& fe, double scale=1.0);
+                     const FiniteElement& fe,
+                     const std::array<std::array<int,3>,3>& idx,
+                     double scale = 1.0);
 
-    //! \brief Compute a vector-source term.
+    //! \brief Compute a scalar source term.
     //! \param[out] EV The element vectors to add contribution to
     //! \param[in] fe The finite element to evaluate for
+    //! \param idx Vector block indices
     //! \param[in] scale Scaling factor for contribution
-    static void Source(Vectors& EV, const FiniteElement& fe, double scale=1.0);
+    static void Source(Vectors& EV, const FiniteElement& fe,
+                       const std::array<int,3>& idx, double scale = 1.0);
 
     //! \brief Compute a vector-source term.
     //! \param[out] EV The element vectors to add contribution to
     //! \param[in] fe The finite element to evaluate for
     //! \param[in] f Vector with contributions
+    //! \param idx Vector block indices
     //! \param[in] scale Scaling factor for contribution
     static void Source(Vectors& EV, const FiniteElement& fe,
-                       const Vec3& f, double scale=1.0);
+                       const Vec3& f, const std::array<int,3>& idx,
+                       double scale = 1.0);
   };
 
   //! \brief Common weak residual operators using div-compatible discretizations.
@@ -99,28 +119,36 @@ public:
     //! \param[in] U Advected field
     //! \param[in] dUdX Advected field gradient
     //! \param[in] UC Advecting field
+    //! \param idx Vector block indices
     //! \param[in] scale Scaling factor for contribution
     //! \param[in] form Which form of the convective form to use
     static void Convection(Vectors& EV, const FiniteElement& fe,
-                           const Vec3& U, const Tensor& dUdX, const Vec3& UC, double scale,
-                           WeakOperators::ConvectionForm form=WeakOperators::CONVECTIVE);
+                           const Vec3& U, const Tensor& dUdX,
+                           const Vec3& UC,
+                           const std::array<int,3>& idx,
+                           double scale,
+                           WeakOperators::ConvectionForm form = WeakOperators::CONVECTIVE);
 
     //! \brief Compute a gradient term.
     //! \param[out] EV The element vector to add contribution to
     //! \param[in] fe The finite element to evaluate for
+    //! \param idx Vector block indices
     //! \param[in] scale Scaling factor for contribution
     static void Gradient(Vectors& EV, const FiniteElement& fe,
-                         double scale=1.0);
+                         const std::array<int,3>& idx, double scale = 1.0);
 
     //! \brief Compute a laplacian term in a residual vector.
     //! \param[out] EV The element vector to add contribution to
     //! \param[in] fe The finite element to evaluate for
     //! \param[in] dUdX Current solution gradient
+    //! \param idx Vector block indices
     //! \param[in] scale Scaling factor for contribution
     //! \param[in] stress Whether to add extra stress formulation terms
     static void Laplacian(Vectors& EV, const FiniteElement& fe,
-                          const Tensor& dUdX, double scale=1.0,
-                          bool stress=false);
+                          const Tensor& dUdX,
+                          const std::array<int,3>& idx,
+                          double scale = 1.0,
+                          bool stress = false);
   };
 };
 

--- a/Apps/Common/CompatibleOperators.h
+++ b/Apps/Common/CompatibleOperators.h
@@ -69,6 +69,14 @@ public:
                          const std::array<int,3>& idx,
                          double scale = 1.0);
 
+    //! \brief Compute an integration constraint.
+    //! \param[out] EM The element matrix to add contribution to
+    //! \param[in] idx Matrix block indices
+    //! \param[in] fe The finite element to evaluate for
+    static void ItgConstraint(std::vector<Matrix>& EM,
+                              const FiniteElement& fe,
+                              const std::array<int,3>& idx);
+
     //! \brief Compute a laplacian.
     //! \param[out] EM The element matrix to add contribution to
     //! \param[in] fe The finite element to evaluate for

--- a/Apps/Common/PiolaOperators.C
+++ b/Apps/Common/PiolaOperators.C
@@ -99,6 +99,15 @@ void PiolaOperators::Weak::Gradient (Matrices& EM,
 }
 
 
+void PiolaOperators::Weak::ItgConstraint (std::vector<Matrix>&,
+                                          const FiniteElement&,
+                                          const std::array<int,3>&)
+{
+  std::cerr << "Integration constraint operator not implemented with piola" << std::endl;
+  exit(1);
+}
+
+
 void PiolaOperators::Weak::Laplacian (Matrices& EM,
                                       const FiniteElement& fe,
                                       const std::array<std::array<int,3>,3>& idx,

--- a/Apps/Common/PiolaOperators.h
+++ b/Apps/Common/PiolaOperators.h
@@ -20,6 +20,8 @@ class Vec3;
 #include "MatVec.h"
 #include "EqualOrderOperators.h"
 
+#include <array>
+
 /*! \brief Common operators using Piola mapped discretizations.
  *  \details The operators use the block ordering used in the BlockElmMats class.
  */
@@ -35,10 +37,13 @@ public:
     //! \param[out] EM The element matrices to add contribution to
     //! \param[in] fe The finite element to evaluate for
     //! \param[in] AC Advecting field
+    //! \param[in] idx Matrix block indices
     //! \param[in] scale Scaling factor for contribution
     //! \param[in] cnvForm Form of advection operator
     static void Advection(Matrices& EM, const FiniteElement& fe,
-                          const Vec3& AC, double scale = 1.0,
+                          const Vec3& AC,
+                          const std::array<std::array<int, 3>, 3>& idx,
+                          double scale = 1.0,
                           WeakOperators::ConvectionForm cnvForm = WeakOperators::CONVECTIVE);
 
     //! \brief Compute a (nonlinear) convection term.
@@ -46,43 +51,56 @@ public:
     //! \param[in] fe The finite element to evaluate for
     //! \param[in] U  Advecting field
     //! \param[in] dUdX Field gradient
+    //! \param[in] idx Matrix block indices
     //! \param[in] scale Scaling factor for contribution
     //! \param[in] form Which form of the convective form to use
     static void Convection(Matrices& EM, const FiniteElement& fe,
-                           const Vec3& U, const Tensor& dUdX, double scale,
+                           const Vec3& U, const Tensor& dUdX,
+                           const std::array<std::array<int, 3>, 3>& idx,
+                           double scale,
                            WeakOperators::ConvectionForm form = WeakOperators::CONVECTIVE);
 
     //! \brief Compute a gradient term.
     //! \param[out] EM The element matrix to add contribution to
     //! \param[in] fe The finite element to evaluate for
+    //! \param[in] idx Matrix block indices
     //! \param[in] scale Scaling factor for contribution
     static void Gradient(Matrices& EM,
-                         const FiniteElement& fe, double scale = 1.0);
+                         const FiniteElement& fe,
+                         std::array<int,3>& idx,
+                         double scale = 1.0);
 
     //! \brief Compute a laplacian.
     //! \param[out] EM The element matrix to add contribution to
     //! \param[in] fe The finite element to evaluate for
+    //! \param[in] idx Matrix block indices
     //! \param[in] scale Scaling factor for contribution
     //! \param[in] stress Whether to add extra stress formulation terms
     //! \details Only the upper blocks are added with the stress formulation
     static void Laplacian(Matrices& EM,
                           const FiniteElement& fe,
+                          const std::array<std::array<int,3>,3>& idx,
                           double scale, bool stress);
 
     //! \brief Compute a mass term.
     //! \param[out] EM The element matrices to add contribution to
     //! \param[in] fe The finite element to evaluate for
+    //! \param[in] idx Matrix block indices
     //! \param[in] scale Scaling factor for contribution
     static void Mass(Matrices& EM,
-                     const FiniteElement& fe, double scale);
+                     const FiniteElement& fe,
+                     const std::array<std::array<int,3>,3>& idx,
+                     double scale);
 
-      //! \brief Compute a vector-source term.
-      //! \param[out] EV The element vectors to add contribution to
-      //! \param[in] fe The finite element to evaluate for
-      //! \param[in] f Vector with contributions
-      //! \param[in] scale Scaling factor for contribution
+    //! \brief Compute a vector-source term.
+    //! \param[out] EV The element vectors to add contribution to
+    //! \param[in] fe The finite element to evaluate for
+    //! \param[in] f Vector with contributions
+    //! \param idx Vector block indices
+    //! \param[in] scale Scaling factor for contribution
     static void Source(Vectors& EV, const FiniteElement& fe,
-                       const Vec3& f, double scale);
+                       const Vec3& f, const std::array<int,3>& idx,
+                       double scale);
   };
 
   //! \brief Common weak residual operators using div-compatible discretizations.
@@ -95,45 +113,54 @@ public:
     //! \param[in] U Advected field
     //! \param[in] dUdX Advected field gradient
     //! \param[in] UC Advecting field
+    //! \param idx Vector block indices
     //! \param[in] scale Scaling factor for contribution
     //! \param[in] form Which form of the convective form to use
     static void Convection(Vectors& EV, const FiniteElement& fe,
                            const Vec3& U, const Tensor& dUdX,
-                           const Vec3& UC, double scale,
+                           const Vec3& UC,
+                           const std::array<int,3>& idx, double scale,
                            WeakOperators::ConvectionForm form = WeakOperators::CONVECTIVE);
 
     //! \brief Compute a gradient term.
     //! \param[out] EV The element vector to add contribution to
     //! \param[in] fe The finite element to evaluate for
+    //! \param idx Vector block indices
     //! \param[in] scale Scaling factor for contribution
     static void Gradient(Vectors& EV, const FiniteElement& fe,
-                         double scale = 1.0);
+                         const std::array<int,3>& idx, double scale = 1.0);
 
     //! \brief Compute a laplacian term in a residual vector.
     //! \param[out] EV The element vector to add contribution to
     //! \param[in] fe The finite element to evaluate for
     //! \param[in] dUdX Current solution gradient
+    //! \param idx Vector block indices
     //! \param[in] scale Scaling factor for contribution
     //! \param[in] stress Whether to add extra stress formulation terms
     static void Laplacian(Vectors& EV, const FiniteElement& fe,
-                          const Tensor& dUdX, double scale = 1.0,
+                          const Tensor& dUdX,
+                          const std::array<int, 3>& idx, double scale = 1.0,
                           bool stress = false);
   };
 
   //! \brief Add the full Piola operator to the blocks.
   //! \param EM Vector of block matrices
   //! \param fe Finite element information
+  //! \param idx Vector block indices
   //! \param A Piola operator to add
   static void Copy(Matrices& EM,
                    const FiniteElement& fe,
+                   const std::array<std::array<int,3>,3>& idx,
                    const Matrix& A);
 
   //! \brief Add the full Piola vector to the blocks.
   //! \param EV Vector of block vectors
   //! \param fe Finite element information
+  //! \param idx Vector block indices
   //! \param V Piola vector to add
   static void Copy(Vectors& EV,
                    const FiniteElement& fe,
+                   const std::array<int,3>& idx,
                    const Vector& V);
 };
 

--- a/Apps/Common/PiolaOperators.h
+++ b/Apps/Common/PiolaOperators.h
@@ -70,6 +70,14 @@ public:
                          std::array<int,3>& idx,
                          double scale = 1.0);
 
+    //! \brief Compute an integration constraint.
+    //! \param[out] EM The element matrix to add contribution to
+    //! \param[in] idx Matrix block indices
+    //! \param[in] fe The finite element to evaluate for
+    static void ItgConstraint(std::vector<Matrix>& EM,
+                              const FiniteElement& fe,
+                              const std::array<int,3>& idx);
+
     //! \brief Compute a laplacian.
     //! \param[out] EM The element matrix to add contribution to
     //! \param[in] fe The finite element to evaluate for

--- a/Apps/Common/Test/TestCompatibleOperators.C
+++ b/Apps/Common/Test/TestCompatibleOperators.C
@@ -31,9 +31,9 @@ public:
       this->grad(i).resize(6,2);
       this->basis(i).resize(6);
       for (size_t j = 1; j <= 6; ++j) {
-	this->grad(i)(j,1) = 1.0+12*(i-1)+2*(j-1);
-	this->grad(i)(j,2) = 2.0+12*(i-1)+2*(j-1);
-	this->basis(i)(j) = j + 6*(i-1);
+          this->grad(i)(j,1) = 1.0+12*(i-1)+2*(j-1);
+          this->grad(i)(j,2) = 2.0+12*(i-1)+2*(j-1);
+          this->basis(i)(j) = j + 6*(i-1);
       }
     }
 
@@ -121,11 +121,17 @@ TEST(TestCompatibleOperators, Laplacian)
 {
   MyFiniteElement fe;
 
-  std::vector<Matrix> EM(3);
+  std::vector<Matrix> EM(10);
   EM[1].resize(6,6);
   EM[2].resize(6,6);
 
-  CompatibleOperators::Weak::Laplacian(EM, fe);
+  static constexpr auto idx = std::array{
+      std::array{1, 4, 5},
+      std::array{6, 2, 7},
+      std::array{8, 9, 3},
+  };
+
+  CompatibleOperators::Weak::Laplacian(EM, fe, idx);
 
   const DoubleVec EM_1_ref = {{ 5.0, 11.0,  17.0,  23.0,  29.0,  35.0},
                               {11.0, 25.0,  39.0,  53.0,  67.0,  81.0},
@@ -146,14 +152,14 @@ TEST(TestCompatibleOperators, Laplacian)
   check_matrix_equal(EM[2], EM_2_ref);
 
   // stress formulation
-  std::vector<Matrix> EM_stress(36);
+  std::vector<Matrix> EM_stress(10);
 
   EM_stress[1].resize(6,6);
   EM_stress[2].resize(6,6);
-  EM_stress[10].resize(6,6);
-  EM_stress[18].resize(6,6);
+  EM_stress[4].resize(6,6);
+  EM_stress[6].resize(6,6);
 
-  CompatibleOperators::Weak::Laplacian(EM_stress, fe, 1.0, true);
+  CompatibleOperators::Weak::Laplacian(EM_stress, fe, idx, 1.0, true);
   std::cout << EM_stress[1] << std::endl;
   
 /*
@@ -177,11 +183,17 @@ TEST(TestCompatibleOperators, Mass)
 {
   MyFiniteElement fe;
 
-  std::vector<Matrix> EM_vec(3);
+  std::vector<Matrix> EM_vec(10);
   EM_vec[1].resize(6,6);
   EM_vec[2].resize(6,6);
 
-  CompatibleOperators::Weak::Mass(EM_vec, fe);
+  static constexpr auto idx = std::array{
+      std::array{1, 4, 5},
+      std::array{6, 2, 7},
+      std::array{8, 9, 3},
+  };
+
+  CompatibleOperators::Weak::Mass(EM_vec, fe, idx);
 
   const DoubleVec EM_1_ref = {{1.0,  2.0,  3.0,  4.0,  5.0,  6.0},
                               {2.0,  4.0,  6.0,  8.0, 10.0, 12.0},
@@ -207,11 +219,11 @@ TEST(TestCompatibleOperators, Source)
 {
   MyFiniteElement fe;
 
-  Vectors EV_scalar(3);
+  Vectors EV_scalar(4);
   EV_scalar[1].resize(6);
   EV_scalar[2].resize(6);
 
-  CompatibleOperators::Weak::Source(EV_scalar, fe, 2.0);
+  CompatibleOperators::Weak::Source(EV_scalar, fe, {1,2,3}, 2.0);
 
   for (size_t i = 1; i <= 6; ++i) {
     ASSERT_FLOAT_EQ(EV_scalar[1](i), 2.0*fe.basis(1)(i));
@@ -224,7 +236,7 @@ TEST(TestCompatibleOperators, Source)
   f[0] = 1.0;
   f[1] = 2.0;
 
-  CompatibleOperators::Weak::Source(EV_scalar, fe, f, 1.0);
+  CompatibleOperators::Weak::Source(EV_scalar, fe, f, {1,2,3}, 1.0);
   for (size_t i = 1; i <= 6; ++i) {
     ASSERT_FLOAT_EQ(EV_scalar[1](i), fe.basis(1)(i));
     ASSERT_FLOAT_EQ(EV_scalar[2](i), 2.0*fe.basis(2)(i));
@@ -232,7 +244,7 @@ TEST(TestCompatibleOperators, Source)
 
   EV_scalar[1].fill(0.0);
   EV_scalar[2].fill(0.0);
-  CompatibleOperators::Weak::Source(EV_scalar, fe, f, 2.0);
+  CompatibleOperators::Weak::Source(EV_scalar, fe, f, {1,2,3}, 2.0);
   for (size_t i = 1; i <= 6; ++i) {
     ASSERT_FLOAT_EQ(EV_scalar[1](i), 2.0*fe.basis(1)(i));
     ASSERT_FLOAT_EQ(EV_scalar[2](i), 4.0*fe.basis(2)(i));


### PR DESCRIPTION
Instead take arguments passed by application.

This decouples the operators from Stokes logic, improving reusability (and sanity).