### PR TITLE
Added: virtual method IntegrandBase::suppressOutput()

### DIFF
--- a/src/ASM/ASMenums.h
+++ b/src/ASM/ASMenums.h
@@ -57,6 +57,15 @@ namespace ASM //! Assembly scope
     REFINEMENT_BASIS   = -3, //!< Refinement basis
     INTEGRATION_BASIS  = -4, //!< Integration basis
   };
+
+  //! \brief Enum for cathegorization of result quantities.
+  enum ResultClass {
+    ANY       = 0,
+    PRIMARY   = 1,
+    SECONDARY = 2,
+    PROJECTED = 3,
+    ANALYTIC  = 4
+  };
 }
 
 #endif

--- a/src/ASM/IntegrandBase.h
+++ b/src/ASM/IntegrandBase.h
@@ -114,7 +114,8 @@ public:
   //! integration loop over the Gaussian quadrature points over an element.
   //! It is supposed to perform all the necessary internal initializations
   //! needed before the numerical integration is started for current element.
-  bool initElement(const std::vector<int>& MNPC, LocalIntegral& elmInt) override;
+  bool initElement(const std::vector<int>& MNPC,
+                   LocalIntegral& elmInt) override;
   //! \brief Initializes current element for numerical integration.
   //! \param[in] MNPC Matrix of nodal point correspondance for current element
   //! \param[in] fe Nodal and integration point data for current element
@@ -278,6 +279,8 @@ public:
   //! \param[in] idx Field component index
   //! \param[in] prefix Name prefix for all components
   virtual std::string getField2Name(size_t idx, const char* prefix = 0) const;
+  //! \brief Filters a result components for output.
+  virtual bool suppressOutput(size_t, ASM::ResultClass) const { return false; }
 
   //! \brief Returns the number of solution vectors.
   size_t getNoSolutions() const { return primsol.size(); }

--- a/src/SIM/SIMoutput.h
+++ b/src/SIM/SIMoutput.h
@@ -7,7 +7,7 @@
 //!
 //! \author Knut Morten Okstad / SINTEF
 //!
-//! \brief Sub-class with functionality for result output to VTF and terminal.
+//! \brief Sub-class with functionality for result output to %VTF and terminal.
 //!
 //==============================================================================
 
@@ -24,7 +24,7 @@ class VTF;
 /*!
   \brief Sub-class with additional functionality for result output.
   \details This class extends the SIMbase class with some added functionalities
-  for dumping simulation results to VTF and ASCII files, and terminal printout.
+  for dumping simulation results to %VTF and ASCII files, and terminal printout.
   These items are put in a separate sub-class to hide them from the SIMbase
   class, which contains the main simulation driver.
 */
@@ -332,7 +332,8 @@ private:
   //! \brief Private helper to write out scalar fields to VTF-file.
   bool writeScalarFields(const Matrix& field, int geomID,
                          int& nBlock, std::vector< std::vector<int> >& sID,
-                         size_t* i = nullptr);
+                         size_t* nScl = nullptr,
+                         ASM::ResultClass resClass = ASM::PRIMARY);
 
 protected:
   //! \brief Struct defining a result sampling point.


### PR DESCRIPTION
This can be used to filter out specific result components for output to VTF.
The suppressOutput() method needs to be overridden by a app-specific subclass, default is not filtering.