### PR TITLE
added: callback for changing number of threads

### DIFF
--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -485,6 +485,8 @@ public:
   //! \brief Generate element-groups for multi-threading based on a partition.
   virtual void generateThreadGroupsFromElms(const IntVec&) {}
 
+  //! \brief Hook for changing number of threads.
+  virtual void changeNumThreads() {}
 
   // Methods for integration of finite element quantities.
   // These are the main computational methods of the ASM class hierarchy.

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -3098,6 +3098,13 @@ void ASMs2D::generateThreadGroups (size_t strip1, size_t strip2,
 }
 
 
+void ASMs2D::changeNumThreads ()
+{
+  for (std::unique_ptr<BasisFunctionCache>& c : myCache)
+    c->resizeThreadBuffers();
+}
+
+
 bool ASMs2D::getNoStructElms (int& n1, int& n2, int& n3) const
 {
   n1 = surf->numCoefs_u() - surf->order_u() + 1;

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -688,6 +688,9 @@ protected:
   virtual void generateThreadGroups(const Integrand& integrand, bool silence,
                                     bool ignoreGlobalLM);
 
+  //! \brief Hook for changing number of threads.
+  virtual void changeNumThreads();
+
   //! \brief Generates element groups for multi-threading of interior integrals.
   //! \param[in] strip1 Strip width in first direction
   //! \param[in] strip2 Strip width in second direction

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -3531,6 +3531,13 @@ void ASMs3D::generateThreadGroups (size_t strip1, size_t strip2, size_t strip3,
 }
 
 
+void ASMs3D::changeNumThreads ()
+{
+  for (std::unique_ptr<BasisFunctionCache>& c : myCache)
+    c->resizeThreadBuffers();
+}
+
+
 void ASMs3D::generateThreadGroups (char lIndex, bool silence, bool)
 {
   std::map<char,ThreadGroups>::iterator tit = threadGroupsFace.find(lIndex);

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -768,6 +768,9 @@ protected:
   void generateThreadGroups(size_t strip1, size_t strip2, size_t strip3,
                             bool silence, bool ignoreGlobalLM);
 
+  //! \brief Hook for changing number of threads.
+  virtual void changeNumThreads();
+
   //! \brief Returns 0-based index of first node on integration basis.
   virtual int getFirstItgElmNode() const { return 0; }
   //! \brief Returns 0-based index of last node on integration basis.

--- a/src/ASM/BasisFunctionCache.C
+++ b/src/ASM/BasisFunctionCache.C
@@ -46,16 +46,10 @@ bool BasisFunctionCache<Dim>::init (int nd)
     return false;
 
   if (ASM::cachePolicy == ASM::NO_CACHE) {
-#ifdef USE_OPENMP
-    size_t size = omp_get_max_threads();
-#else
-    size_t size = 1;
-#endif
-    values.resize(size);
-    if (this->hasReduced())
-      valuesRed.resize(size);
+    this->resizeThreadBuffers();
     return true;
   }
+
   values.resize(nTotal);
   if (this->hasReduced())
     valuesRed.resize(nTotalRed);
@@ -132,6 +126,22 @@ BasisFunctionCache<Dim>::gpIndex (size_t gp, bool reduced) const
     return { gp % q.ng[0], gp / q.ng[0] };
   else if constexpr (Dim == 3)
     return { gp % q.ng[0], (gp / q.ng[0]) % q.ng[1],  gp / (q.ng[0]*q.ng[1]) };
+}
+
+
+template<size_t Dim>
+void BasisFunctionCache<Dim>::resizeThreadBuffers ()
+{
+  if (ASM::cachePolicy == ASM::NO_CACHE) {
+#ifdef USE_OPENMP
+    size_t size = omp_get_max_threads();
+#else
+    size_t size = 1;
+#endif
+    values.resize(size);
+    if (this->hasReduced())
+      valuesRed.resize(size);
+  }
 }
 
 

--- a/src/ASM/BasisFunctionCache.h
+++ b/src/ASM/BasisFunctionCache.h
@@ -84,6 +84,9 @@ public:
 
   int basis = 1; //!< Basis to use
 
+  //! \brief Called if application changes number of threads.
+  void resizeThreadBuffers();
+
 protected:
   //! \brief Template struct holding information about a quadrature.
   struct Quadrature {

--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -2643,6 +2643,13 @@ void ASMu2D::generateThreadGroups (const Integrand& integrand, bool silence,
 }
 
 
+void ASMu2D::changeNumThreads ()
+{
+  for (std::unique_ptr<BasisFunctionCache>& c : myCache)
+    c->resizeThreadBuffers();
+}
+
+
 void ASMu2D::remapErrors (RealArray& errors,
                           const RealArray& origErr, bool elemErrors) const
 {

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -674,6 +674,9 @@ protected:
   //! \brief Generate element groups from a partition.
   virtual void generateThreadGroupsFromElms(const std::vector<int>& elms);
 
+  //! \brief Hook for changing number of threads.
+  virtual void changeNumThreads();
+
   //! \brief Remap element wise errors to basis functions.
   //! \param     errors The remapped errors
   //! \param[in] origErr The element wise errors on the geometry mesh

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -1916,6 +1916,13 @@ void ASMu3D::generateThreadGroups (const Integrand& integrand, bool silence,
 }
 
 
+void ASMu3D::changeNumThreads ()
+{
+  for (std::unique_ptr<BasisFunctionCache>& c : myCache)
+    c->resizeThreadBuffers();
+}
+
+
 bool ASMu3D::updateDirichlet (const std::map<int,RealFunc*>& func,
                               const std::map<int,VecFunc*>& vfunc, double time,
                               const std::map<int,int>* g2l)

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -680,6 +680,9 @@ protected:
   //! \brief Generate element groups from a partition.
   virtual void generateThreadGroupsFromElms(const std::vector<int>& elms);
 
+  //! \brief Hook for changing number of threads.
+  virtual void changeNumThreads();
+
   //! \brief Remap element wise errors to basis functions.
   //! \param     errors The remapped errors
   //! \param[in] origErr The element wise errors on the geometry mesh

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -491,6 +491,14 @@ void SIMbase::generateThreadGroups (const Property& p, bool silence)
 }
 
 
+void SIMbase::changeNumThreads ()
+{
+  for (ASMbase* pch : myModel)
+    if (!pch->empty())
+      pch->changeNumThreads();
+}
+
+
 VecFunc* SIMbase::getVecFunc (size_t patch, Property::Type ptype) const
 {
   for (PropertyVec::const_iterator p = myProps.begin(); p != myProps.end(); ++p)

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -758,6 +758,9 @@ protected:
   //! \param[in] silence If \e true, suppress threading group outprint
   void generateThreadGroups(const Property& p, bool silence = false);
 
+  //! \brief Called if number of threads changes.
+  void changeNumThreads();
+
   //! \brief Adds a MADOF with an extraordinary number of DOFs on a given basis.
   //! \param[in] basis The basis to specify number of DOFs for
   //! \param[in] nndof Number of nodal DOFs on the given basis


### PR DESCRIPTION
application may have to change this and this would create problems in basis function cache since it is sized according to number of max threads. this adds a callback so application can signal and have the buffers resize accordingly