### PR TITLE
Some utl::vector extensions

### DIFF
--- a/Apps/Common/PiolaOperators.C
+++ b/Apps/Common/PiolaOperators.C
@@ -204,7 +204,7 @@ void PiolaOperators::Copy (Matrices& EM,
 {
   const size_t nsd = fe.dNdX.cols();
   if (nsd < 1 || nsd > 3)
-      return;
+    return;
   size_t ofs = 1;
   for (size_t b = 1; b <= nsd; ++b) {
     size_t ofs2 = ofs;
@@ -221,7 +221,7 @@ void PiolaOperators::Copy (Matrices& EM,
 void PiolaOperators::Copy (Vectors& EV,
                            const FiniteElement& fe,
                            const std::array<int,3>& idx,
-                           const Vector& V)
+                           const RealArray& V)
 {
   size_t ofs = 0;
   const size_t nsd = fe.dNdX.cols();

--- a/Apps/Common/PiolaOperators.h
+++ b/Apps/Common/PiolaOperators.h
@@ -13,18 +13,20 @@
 #ifndef PIOLA_OPERATORS_H_
 #define PIOLA_OPERATORS_H_
 
-class FiniteElement;
-class Tensor;
-class Vec3;
-
 #include "MatVec.h"
 #include "EqualOrderOperators.h"
 
 #include <array>
 
-/*! \brief Common operators using Piola mapped discretizations.
- *  \details The operators use the block ordering used in the BlockElmMats class.
- */
+class FiniteElement;
+class Tensor;
+class Vec3;
+
+
+/*!
+  \brief Common operators using Piola mapped discretizations.
+  \details The operators use the block ordering used in the BlockElmMats class.
+*/
 
 class PiolaOperators
 {
@@ -169,7 +171,7 @@ public:
   static void Copy(Vectors& EV,
                    const FiniteElement& fe,
                    const std::array<int,3>& idx,
-                   const Vector& V);
+                   const RealArray& V);
 };
 
 #endif

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -1001,10 +1001,10 @@ bool ASMs1D::getParameterDomain (Real2DMat& u, IntVec* corners) const
 }
 
 
-const Vector& ASMs1D::getGaussPointParameters (Matrix& uGP, int nGauss,
-                                               const double* xi,
-                                               const Go::SplineCurve* crv,
-                                               bool skipNullSpans) const
+const RealArray& ASMs1D::getGaussPointParameters (Matrix& uGP, int nGauss,
+                                                  const double* xi,
+                                                  const Go::SplineCurve* crv,
+                                                  bool skipNullSpans) const
 {
   if (!crv) crv = curv.get();
 
@@ -1697,9 +1697,8 @@ bool ASMs1D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
 	if (c)
 	{
 	  // Evaluate the projected field at the result sampling points
-	  const Vector& svec = sField; // using utl::matrix cast operator
 	  sField.resize(c->dimension(),gpar.size());
-	  c->gridEvaluator(const_cast<Vector&>(svec),gpar);
+	  c->gridEvaluator(sField,gpar);
 	  delete c;
 	  return true;
 	}
@@ -1756,12 +1755,9 @@ Go::SplineCurve* ASMs1D::projectSolution (const IntegrandBase& integrand) const
   if (curv->rational())
     curv->getWeights(weights);
 
-  const Vector& vec = sValues;
   return Go::CurveInterpolator::regularInterpolation(curv->basis(), gpar,
-						     const_cast<Vector&>(vec),
-						     sValues.rows(),
-						     curv->rational(),
-						     weights);
+                                                     sValues, sValues.rows(),
+                                                     curv->rational(), weights);
 }
 
 

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -392,10 +392,10 @@ protected:
   //! \param[in] crv Spline curve with element structure
   //! \param[in] skipNullSpans If \e true, consider non-zero knot spans only
   //! \return The parameter value matrix casted into a one-dimensional vector
-  const Vector& getGaussPointParameters(Matrix& uGP, int nGauss,
-                                        const double* xi,
-                                        const Go::SplineCurve* crv = nullptr,
-                                        bool skipNullSpans = false) const;
+  const RealArray& getGaussPointParameters(Matrix& uGP, int nGauss,
+                                           const double* xi,
+                                           const Go::SplineCurve* crv = nullptr,
+                                           bool skipNullSpans = false) const;
 
   //! \brief Calculates parameter values for the Greville points.
   //! \param[out] prm Parameter values for all points

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -1602,9 +1602,10 @@ bool ASMs2D::getParameterDomain (Real2DMat& u, IntVec* corners) const
 }
 
 
-const Vector& ASMs2D::getGaussPointParameters (Matrix& uGP, int dir, int nGauss,
-                                               const double* xi,
-                                               const Go::SplineSurface* spline) const
+const RealArray& ASMs2D::getGaussPointParameters (Matrix& uGP,
+                                                  int dir, int nGauss,
+                                                  const double* xi,
+                                                  const Go::SplineSurface* spline) const
 {
   if (!spline)
     spline = surf.get();
@@ -2876,9 +2877,8 @@ bool ASMs2D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
       else if (s)
       {
         // Evaluate the projected field at the result sampling points
-        const Vector& svec = sField; // using utl::matrix cast operator
         sField.resize(s->dimension(),gpar[0].size()*gpar[1].size());
-        s->gridEvaluator(const_cast<Vector&>(svec),gpar[0],gpar[1]);
+        s->gridEvaluator(sField,gpar[0],gpar[1]);
         delete s;
         return true;
       }

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -624,11 +624,11 @@ protected:
   //! \param[in] dir Parameter direction (0,1)
   //! \param[in] nGauss Number of Gauss points along a knot-span
   //! \param[in] xi Dimensionless Gauss point coordinates [-1,1]
-  //! \param[in] spline If given get gauss points for this spline instead of integration basis
+  //! \param[in] spline Spline surface with element structure
   //! \return The parameter value matrix casted into a one-dimensional vector
-  const Vector& getGaussPointParameters(Matrix& uGP, int dir, int nGauss,
-                                        const double* xi,
-                                        const Go::SplineSurface* spline = nullptr) const;
+  const RealArray& getGaussPointParameters(Matrix& uGP, int dir,
+                                           int nGauss, const double* xi,
+                                           const Go::SplineSurface* spline = nullptr) const;
 
   //! \brief Calculates parameter values for the Greville points.
   //! \param[out] prm Parameter values in given direction for all points

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -1040,7 +1040,7 @@ bool ASMs2Dmx::evalSolution (Matrix& sField, const Vector& locSol,
         Xtmp.multiply(splinex[b][i].basisValues,Ytmp);
       else {
         Xtmp.multiply(splinex[b][i].basisValues,Ztmp);
-        Ytmp.insert(Ytmp.end(),Ztmp.begin(),Ztmp.end());
+        Ytmp.push_back(Ztmp.begin(),Ztmp.end());
       }
       comp += nc[b]*nb[b];
     }
@@ -1134,8 +1134,8 @@ bool ASMs2Dmx::evalSolutionPiola (Matrix& sField, const Vector& locSol,
     fe.basis(1) = splinex[0][i].basisValues;
     fe.basis(2) = splinex[1][i].basisValues;
     fe.piolaBasis(detJ, J);
-    coefs[0].insert(coefs[0].end(), coefs[1].begin(), coefs[1].end());
-    fe.P.multiply(coefs[0], Ytmp);
+    coefs.front().push_back(coefs[1].begin(), coefs[1].end());
+    fe.P.multiply(coefs.front(), Ytmp);
     if (withPressure)
       for (size_t b = 2; b < nfx.size(); ++b)
         for (size_t i = 0; i < nfx[b]; ++i)

--- a/src/ASM/ASMs2Drecovery.C
+++ b/src/ASM/ASMs2Drecovery.C
@@ -95,15 +95,12 @@ bool ASMs2D::evaluate (const ASMbase* basis, const Vector& locVec,
   if (surf->rational())
     surf->getWeights(weights);
 
-  const Vector& vec2 = sValues;
   Go::SplineSurface* surf_new =
     Go::SurfaceInterpolator::regularInterpolation(surf->basis(0),
 						  surf->basis(1),
 						  gpar[0], gpar[1],
-						  const_cast<Vector&>(vec2),
-						  sValues.rows(),
-						  surf->rational(),
-						  weights);
+						  sValues, sValues.rows(),
+						  surf->rational(), weights);
 
   vec.assign(surf_new->coefs_begin(),surf_new->coefs_end());
   delete surf_new;
@@ -142,12 +139,10 @@ Go::SplineSurface* ASMs2D::projectSolution (const IntegrandBase& integrnd) const
   if (psurf->rational())
     psurf->getWeights(weights);
 
-  const Vector& vec = sValues;
   return Go::SurfaceInterpolator::regularInterpolation(psurf->basis(0),
                                                        psurf->basis(1),
                                                        gpar[0], gpar[1],
-                                                       const_cast<Vector&>(vec),
-                                                       sValues.rows(),
+                                                       sValues, sValues.rows(),
                                                        psurf->rational(),
                                                        weights);
 }
@@ -467,12 +462,11 @@ Go::SplineSurface* ASMs2D::scRecovery (const IntegrandBase& integrand) const
   if (surf->rational())
     surf->getWeights(weights);
 
-  const Vector& vec = sValues;
   return Go::SurfaceInterpolator::regularInterpolation(surf->basis(0),
 						       surf->basis(1),
 						       gpar[0], gpar[1],
-						       const_cast<Vector&>(vec),
-						       nCmp, surf->rational(),
+						       sValues, nCmp,
+						       surf->rational(),
 						       weights);
 }
 

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -1960,9 +1960,9 @@ bool ASMs3D::getParameterDomain (Real2DMat& u, IntVec* corners) const
 }
 
 
-const Vector& ASMs3D::getGaussPointParameters (Matrix& uGP, int dir, int nGauss,
-                                               const double* xi,
-                                               const Go::SplineVolume* spline) const
+const RealArray& ASMs3D::getGaussPointParameters (Matrix& uGP, int dir,
+                                                  int nGauss, const double* xi,
+                                                  const Go::SplineVolume* spline) const
 {
   if (!spline)
     spline = svol.get();
@@ -3330,10 +3330,9 @@ bool ASMs3D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
       else if (v)
       {
         // Evaluate the projected field at the result sampling points
-        const Vector& svec = sField; // using utl::matrix cast operator
         sField.resize(v->dimension(),
                       gpar[0].size()*gpar[1].size()*gpar[2].size());
-        v->gridEvaluator(gpar[0],gpar[1],gpar[2],const_cast<Vector&>(svec));
+        v->gridEvaluator(gpar[0],gpar[1],gpar[2],sField);
         delete v;
         return true;
       }

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -695,11 +695,11 @@ protected:
   //! \param[in] dir Parameter direction (0,1,2)
   //! \param[in] nGauss Number of Gauss points along a knot-span
   //! \param[in] xi Dimensionless Gauss point coordinates [-1,1]
-  //! \param[in] spline If given get gauss points for this spline
+  //! \param[in] spline Spline volume with element structure
   //! \return The parameter value matrix casted into a one-dimensional vector
-  const Vector& getGaussPointParameters(Matrix& uGP, int dir, int nGauss,
-                                        const double* xi,
-                                        const Go::SplineVolume* spline = nullptr) const;
+  const RealArray& getGaussPointParameters(Matrix& uGP, int dir,
+                                           int nGauss, const double* xi,
+                                           const Go::SplineVolume* spline = nullptr) const;
 
   //! \brief Calculates parameter values for the Greville points.
   //! \param[out] prm Parameter values in given direction for all points

--- a/src/ASM/ASMs3Dmx.C
+++ b/src/ASM/ASMs3Dmx.C
@@ -1139,7 +1139,7 @@ bool ASMs3Dmx::evalSolution (Matrix& sField, const Vector& locSol,
         Xtmp.multiply(splinex[b][i].basisValues,Ytmp);
       else {
         Xtmp.multiply(splinex[b][i].basisValues,Ztmp);
-        Ytmp.insert(Ytmp.end(),Ztmp.begin(),Ztmp.end());
+        Ytmp.push_back(Ztmp.begin(),Ztmp.end());
       }
       comp += nc[b]*nb[b];
     }

--- a/src/ASM/ASMs3Drecovery.C
+++ b/src/ASM/ASMs3Drecovery.C
@@ -22,7 +22,6 @@
 #include "GlbL2projector.h"
 #include "SparseMatrix.h"
 #include "SplineUtils.h"
-#include "Utilities.h"
 #include "Profiler.h"
 #include <array>
 
@@ -94,16 +93,13 @@ bool ASMs3D::evaluate (const ASMbase* basis, const Vector& locVec,
   if (svol->rational())
     svol->getWeights(weights);
 
-  const Vector& vec2 = sValues;
   Go::SplineVolume* vol_new =
     Go::VolumeInterpolator::regularInterpolation(svol->basis(0),
                                                  svol->basis(1),
                                                  svol->basis(2),
                                                  gpar[0], gpar[1], gpar[2],
-                                                 const_cast<Vector&>(vec2),
-                                                 sValues.rows(),
-                                                 svol->rational(),
-                                                 weights);
+                                                 sValues, sValues.rows(),
+                                                 svol->rational(), weights);
 
   vec.assign(vol_new->coefs_begin(),vol_new->coefs_end());
   delete vol_new;
@@ -142,13 +138,11 @@ Go::SplineVolume* ASMs3D::projectSolution (const IntegrandBase& integrand) const
   if (pvol->rational())
     pvol->getWeights(weights);
 
-  const Vector& vec = sValues;
   return Go::VolumeInterpolator::regularInterpolation(pvol->basis(0),
                                                       pvol->basis(1),
                                                       pvol->basis(2),
                                                       gpar[0], gpar[1], gpar[2],
-                                                      const_cast<Vector&>(vec),
-                                                      sValues.rows(),
+                                                      sValues, sValues.rows(),
                                                       pvol->rational(),
                                                       weights);
 }

--- a/src/ASM/GlbL2projector.C
+++ b/src/ASM/GlbL2projector.C
@@ -351,7 +351,7 @@ bool GlbL2::evalInt (LocalIntegral& elmInt,
   else for (FunctionBase* func : functions)
   {
     RealArray funcPt = func->getValue(X);
-    solPt.insert(solPt.end(),funcPt.begin(),funcPt.end());
+    solPt.push_back(funcPt.begin(),funcPt.end());
   }
 
   gl2.A.front().outer_product(fe.N,fe.N,true,fe.detJxW);

--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -503,12 +503,12 @@ bool ASMu2D::evaluateBasis (int iel, FiniteElement& fe, int derivs) const
   dNdu.fillColumn(2,C*Bv);
 
 #ifdef SP_DEBUG
-  if (fabs(dNdu.getColumn(1).sum()) > 1.0e-10) {
+  if (fabs(dNdu.sum(-1)) > 1.0e-10) {
     std::cerr <<"dNdu do not sum to zero at integration point #"
               << fe.iGP << std::endl;
     return false;
   }
-  else if (fabs(dNdu.getColumn(2).sum()) > 1.0e-10) {
+  else if (fabs(dNdu.sum(-2)) > 1.0e-10) {
     std::cerr <<"dNdv do not sums to zero at integration point #"
               << fe.iGP << std::endl;
     return false;

--- a/src/ASM/LR/ASMu2Dmx.C
+++ b/src/ASM/LR/ASMu2Dmx.C
@@ -982,9 +982,9 @@ bool ASMu2Dmx::evalSolutionPiola (Matrix& sField, const Vector& locSol,
     Matrix J;
     J.multiply(Xnod, bf.dNdu);
     fe.piolaBasis(J.det(), J);
-    coefs[0].insert(coefs[0].end(), coefs[1].begin(), coefs[1].end());
+    coefs.front().push_back(coefs[1].begin(), coefs[1].end());
     Vector Ytmp;
-    fe.P.multiply(coefs[0], Ytmp);
+    fe.P.multiply(coefs.front(), Ytmp);
     if (withPressure)
       for (size_t b = 2; b < nfx.size(); ++b)
         for (size_t n = 0; n < nfx[b]; ++n)

--- a/src/ASM/LR/ASMu2Dnurbs.C
+++ b/src/ASM/LR/ASMu2Dnurbs.C
@@ -48,7 +48,7 @@ bool ASMu2D::evaluateBasisNurbs (int iel, FiniteElement& fe,
   if (derivs < 1) {
     Matrix B;
     B.outer_product(Nu,Nv);
-    fe.N = C*static_cast<const Vector&>(B);
+    C.multiply(B,fe.N); // fe.N = C*B;
     double W = fe.N.dot(w);
     for (size_t i = 0; i < fe.N.size(); i++)
       fe.N[i] *= w[i]/W;

--- a/src/ASM/LR/ASMu2Dnurbs.C
+++ b/src/ASM/LR/ASMu2Dnurbs.C
@@ -57,7 +57,7 @@ bool ASMu2D::evaluateBasisNurbs (int iel, FiniteElement& fe,
     if (fabs(fe.N.sum()-1.0) > 1.0e-10)
       std::cerr <<"fe.N do not sum to one at integration point #"
                 << fe.iGP << std::endl;
-    else if (fabs(static_cast<const Vector&>(B).sum()-1.0) > 1.0e-10)
+    else if (fabs(B.sum()-1.0) > 1.0e-10)
       std::cerr <<"Bezier basis do not sum to one at integration point #"
                 << fe.iGP << std::endl;
     else
@@ -107,10 +107,10 @@ bool ASMu2D::evaluateBasisNurbs (int iel, FiniteElement& fe,
     else if (fabs(B.sum()-1.0) > 1.0e-10)
       std::cerr <<"Bezier basis do not sum to one at integration point #"
                 << fe.iGP << std::endl;
-    else if (fabs(dNdu.getColumn(1).sum()) > 1.0e-10)
+    else if (fabs(dNdu.sum(-1)) > 1.0e-10)
       std::cerr <<"dNdu not sums to zero at integration point #"
                 << fe.iGP << std::endl;
-    else if (fabs(dNdu.getColumn(2).sum()) > 1.0e-10)
+    else if (fabs(dNdu.sum(-2)) > 1.0e-10)
       std::cerr <<"dNdv not sums to zero at integration point #"
                 << fe.iGP << std::endl;
     else if (fabs(Bu.sum()) > 1.0e-10 || fabs(Bv.sum()) > 1.0e-10)

--- a/src/LinAlg/Test/TestMatrix.C
+++ b/src/LinAlg/Test/TestMatrix.C
@@ -149,6 +149,17 @@ TEST(TestMatrix, AugmentCols)
 }
 
 
+TEST(TestMatrix, SumCols)
+{
+  utl::matrix<int> a(5,3);
+  std::iota(a.begin(),a.end(),1);
+  std::cout <<"A:"<< a;
+  EXPECT_EQ(a.sum(-1), 15);
+  EXPECT_EQ(a.sum(-2), 40);
+  EXPECT_EQ(a.sum(-3), 65);
+}
+
+
 TEST(TestMatrix, Multiply)
 {
   multiplyTest<double>();

--- a/src/LinAlg/matrix.h
+++ b/src/LinAlg/matrix.h
@@ -105,6 +105,19 @@ namespace utl //! General utility classes and functions.
       memcpy(this->data(),values,this->size()*sizeof(T));
     }
 
+    //! \brief Append a scalar value to the vector, increasing its size by one.
+    using std::vector<T>::push_back;
+
+    //! \brief Append a range of values increasing the size by \a i2-i1.
+    void push_back(typename std::vector<T>::const_iterator i1,
+                   typename std::vector<T>::const_iterator i2)
+    {
+      this->insert(this->end(),i1,i2);
+    }
+
+    //! \brief Append a range of values increasing the size by \a q-p.
+    void push_back(const T* p, const T* q) { this->insert(this->end(),p,q); }
+
     //! \brief Multiplication with a scalar.
     vector<T>& operator*=(T c);
     //! \brief Division by a scalar.

--- a/src/LinAlg/matrix.h
+++ b/src/LinAlg/matrix.h
@@ -329,8 +329,12 @@ namespace utl //! General utility classes and functions.
     //! \brief Check if the matrix is empty.
     bool empty() const { return elem.empty(); }
 
-    //! \brief Type casting to a one-dimensional vector.
-    operator const vector<T>&() const { return elem; }
+    //! \brief Type casting to a one-dimensional utl::vector, for access.
+    const vector<T>& toVec() const { return elem; }
+    //! \brief Type casting to a one-dimensional std::vector, for access.
+    operator const std::vector<T>&() const { return elem; }
+    //! \brief Type casting to a one-dimensional vector, for update.
+    operator std::vector<T>&() { return elem; }
 
     //! \brief Access through pointer.
     T* ptr(size_t c = 0)

--- a/src/LinAlg/matrix.h
+++ b/src/LinAlg/matrix.h
@@ -372,8 +372,21 @@ namespace utl //! General utility classes and functions.
     //! \param[in] inc Increment in the matrix element vector indices
     T asum(int inc = 1) const { return elem.asum(0,inc); }
     //! \brief Return the sum of the matrix elements.
-    //! \param[in] inc Increment in the matrix element vector indices
-    T sum(int inc = 1) const { return elem.sum(0,inc); }
+    //! \param[in] inc Increment in the matrix element vector indices.
+    //! If negative, the sum of matrix column \a -inc will be returned instead.
+    T sum(int inc = 1) const
+    {
+      if (inc > 0)
+        return elem.sum(0,inc);
+      else if (inc == 0 || -inc > static_cast<int>(n[1]))
+        return T(0);
+
+      T colsum = T(0);
+      size_t ofs = n[0]*(-inc-1);
+      for (size_t i = 0; i < n[0]; i++, ofs++)
+        colsum += elem[ofs];
+      return colsum;
+    }
 
   protected:
     size_t     n[4]; //!< Dimension of the matrix

--- a/src/SIM/SIMoutput.h
+++ b/src/SIM/SIMoutput.h
@@ -105,7 +105,7 @@ public:
   //! \param nBlock Running result block counter
   //! \param[in] idBlock Result block ID number
   //! \param[in] ncmp Number of components in vector field
-  bool writeGlvV(const Vector& vec, const char* fieldName,
+  bool writeGlvV(const RealArray& vec, const char* fieldName,
                  int iStep, int& nBlock, int idBlock = 2, int ncmp = 0) const;
 
   //! \brief Writes a scalar field for a given load/time step to the VTF-file.
@@ -173,7 +173,7 @@ public:
   //! \param[in] idBlock Starting value of result block numbering
   //! \param[in] prefix Common prefix for the field components
   //! \param[in] maxVal Optional array of maximum values
-  bool writeGlvP(const Vector& ssol, int iStep, int& nBlock,
+  bool writeGlvP(const RealArray& ssol, int iStep, int& nBlock,
                  int idBlock = 100, const char* prefix = "Global projected",
                  std::vector<PointValues>* maxVal = nullptr);
 
@@ -325,7 +325,7 @@ private:
   bool initPatchForEvaluation(int patchNo) const;
 
   //! \brief Private helper to extract patch-level solution vectors.
-  bool extractNodeVec(const Vector& glbVec, Vector& locVec,
+  bool extractNodeVec(const RealArray& glbVec, Vector& locVec,
                       const ASMbase* patch, int nodalCmps,
                       bool& emptyPatches) const;
 

--- a/src/Utility/Utilities.C
+++ b/src/Utility/Utilities.C
@@ -370,7 +370,7 @@ int utl::gather (const std::vector<int>& index, size_t nr,
 
 
 int utl::gather (const std::vector<int>& index, size_t nr,
-                 const utl::vector<Real>& in, utl::matrix<Real>& out,
+                 const std::vector<Real>& in, utl::matrix<Real>& out,
                  size_t offset_in, size_t nskip)
 {
   int outside = 0;

--- a/src/Utility/Utilities.h
+++ b/src/Utility/Utilities.h
@@ -169,7 +169,7 @@ namespace utl
   //! \param[in] offset_in Optional start offset for the \a in vector
   //! \param[in] nskip If nonzero, skip the last \a nskip entries in \a index
   int gather(const std::vector<int>& index, size_t nr,
-             const utl::vector<Real>& in, utl::matrix<Real>& out,
+             const std::vector<Real>& in, utl::matrix<Real>& out,
              size_t offset_in = 0, size_t nskip = 0);
 
   //! \brief Compresses a row of a 2D array based on given scatter indices.


### PR DESCRIPTION
This used to be part of #729 but is taken out in a separate (and smaller) PR as a prerequisite for that one.

We here extend the `utl::vector` class with some overloaded `push_back()` methods, and add more type-casting operators for the `utl::matrix` class. Also extending the `utl::matrix::sum()` method to optionally return the sum of a specified column when the argument is a negative value (column index).