### PR TITLE
fixed: use getNoProjectionNodes() instead of getNodes()

### DIFF
--- a/src/ASM/ASMs2DLag.C
+++ b/src/ASM/ASMs2DLag.C
@@ -722,7 +722,7 @@ bool ASMs2DLag::evalSolution (Matrix& sField, const Vector& locSol,
   if (!gpar && !regular) // Direct nodal evaluation
     return this->nodalField(sField,locSol,this->getNoNodes(-1));
 
-  size_t nCmp = locSol.size() / this->getNoNodes();
+  size_t nCmp = locSol.size() / this->getNoProjectionNodes();
   size_t ni   = gpar ? gpar[0].size() : nel;
   size_t nj   = gpar ? gpar[1].size() : 1;
   size_t nen  = p1*p2;

--- a/src/ASM/ASMs3DLag.C
+++ b/src/ASM/ASMs3DLag.C
@@ -1017,7 +1017,7 @@ bool ASMs3DLag::evalSolution (Matrix& sField, const Vector& locSol,
   if (!gpar && !regular) // Direct nodal evaluation
     return this->nodalField(sField,locSol,this->getNoNodes(-1));
 
-  size_t nCmp = locSol.size() / this->getNoNodes();
+  size_t nCmp = locSol.size() / this->getNoProjectionNodes();
   size_t ni   = gpar ? gpar[0].size() : nel;
   size_t nj   = gpar ? gpar[1].size() : 1;
   size_t nk   = gpar ? gpar[2].size() : 1;


### PR DESCRIPTION
the latter includes GLMs. causes missing output in VTF files