### PR TITLE
Fixed: BLAS version of utl::vector::add with stride larger than 1

### DIFF
--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -939,12 +939,12 @@ protected:
   //! \brief Returns \e true if \a dirs constains all local DOFs in the patch.
   bool allDofs(int dirs) const;
 
-  //! \brief Calculated the deformed configuration for current element.
-  //! \param[in] Xnod Array of nodal point coordinates for current element
+  //! \brief Calculates the deformed configuration for current element.
+  //! \param[in] Xnod Matrix of nodal point coordinates for current element
   //! \param eVec Current element solution vectors
   //! \param[in] force2nd If \e true, put updated coordinates as the 2nd vector
-  bool deformedConfig(const RealArray& Xnod, Vectors& eVec,
-                      bool force2nd = false) const;
+  static bool deformedConfig(const Matrix& Xnod, Vectors& eVec,
+                             bool force2nd = false);
 
   //! \brief Collapses the given two nodes into one.
   //! \details The global node number of the node with the highest number

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -1863,7 +1863,7 @@ bool ASMs2D::integrate (Integrand& integrand,
 
         if (integrand.getIntegrandType() & Integrand::UPDATED_NODES)
           if (!time.first || time.it > 0)
-            if (!this->deformedConfig(Xnod,A->vec))
+            if (!deformedConfig(Xnod,A->vec))
             {
               A->destruct();
               ok = false;
@@ -2111,7 +2111,7 @@ bool ASMs2D::integrate (Integrand& integrand,
 
         if (integrand.getIntegrandType() & Integrand::UPDATED_NODES)
           if (!time.first || time.it > 0)
-            if (!this->deformedConfig(Xnod,A->vec))
+            if (!deformedConfig(Xnod,A->vec))
             {
               A->destruct();
               ok = false;
@@ -2950,7 +2950,7 @@ bool ASMs2D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
   if (integrand.getIntegrandType() & Integrand::UPDATED_NODES)
   {
     Vectors& eV = const_cast<IntegrandBase&>(integrand).getSolutions();
-    if (!this->deformedConfig(Xnod,eV,true))
+    if (!deformedConfig(Xnod,eV,true))
       return false;
   }
 

--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -1231,7 +1231,7 @@ bool ASMu2D::integrate (Integrand& integrand,
 
       if (integrand.getIntegrandType() & Integrand::UPDATED_NODES)
         if (!time.first || time.it > 0)
-          if (!this->deformedConfig(Xnod,A->vec))
+          if (!deformedConfig(Xnod,A->vec))
           {
             A->destruct();
             ok = false;
@@ -1478,7 +1478,7 @@ bool ASMu2D::integrate (Integrand& integrand,
 
       if (integrand.getIntegrandType() & Integrand::UPDATED_NODES)
         if (!time.first || time.it > 0)
-          if (!this->deformedConfig(Xnod,A->vec))
+          if (!deformedConfig(Xnod,A->vec))
           {
             A->destruct();
             ok = false;
@@ -2261,7 +2261,7 @@ bool ASMu2D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
     // while the first vector being the current total displacement vector
     this->getNodalCoordinates(Xnod);
     Vectors& eV = const_cast<IntegrandBase&>(integrand).getSolutions();
-    if (!this->deformedConfig(Xnod,eV,true))
+    if (!deformedConfig(Xnod,eV,true))
       return false;
   }
 

--- a/src/LinAlg/Test/MatrixTests.h
+++ b/src/LinAlg/Test/MatrixTests.h
@@ -10,46 +10,54 @@
 //!
 //==============================================================================
 
-#include "MatVec.h"
+#include "matrixnd.h"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <limits>
 #include <numeric>
+
 
 namespace {
 
 template<class Scalar>
 void vectorAddTest()
 {
-  constexpr size_t size = 10;
-
-  utl::vector<Scalar> d(size);
-  std::iota(d.begin(), d.end(), 0.0);
+  utl::vector<Scalar> d(12);
+  std::iota(d.begin(), d.end(), 1.0);
 
   utl::vector<Scalar> d2(d);
   d2.add(d, 1.5);
+  std::cout <<"d2:"<< d2 << std::endl;
 
-  utl::vector<Scalar> d3(size / 2);
+  utl::vector<Scalar> d3(d.size() / 2);
   d3.add(d, 0.5, 1, 2);
+  std::cout <<"d3:"<< d3 << std::endl;
 
-  utl::vector<Scalar> d4(size);
+  utl::vector<Scalar> d4(d.size());
   d4.add(d3, 1.0, 0, 1, 0, 2);
   d4.add(d3, 1.0, 0, 1, 1, 2);
-  std::cout << d4 << std::endl;
+  std::cout <<"d4:"<< d4 << std::endl;
 
-  for (size_t i = 0; i < size; ++i) {
-    EXPECT_FLOAT_EQ(d2[i], 2.5*i);
+  for (size_t i = 0; i < d2.size(); ++i) {
+    EXPECT_FLOAT_EQ(d2[i], 2.5*(i+1));
     EXPECT_FLOAT_EQ(d4[i], d3[i/2]);
   }
-  for (size_t i = 0; i < size / 2; ++i)
-    EXPECT_FLOAT_EQ(d3[i], i + 0.5);
 
-  if constexpr (std::is_same_v<Scalar,Real>) {
-    utl::vector<Scalar> v = d + d;
-    for (size_t i = 0; i < size; ++i)
-      EXPECT_FLOAT_EQ(v[i], 2.0*i);
-  }
+  for (size_t i = 0; i < d3.size(); ++i)
+    EXPECT_FLOAT_EQ(d3[i], i+1);
+
+  d2.fill(0.0);
+  d2.add(d, 1.0, 0, 3, 0, 3);
+  d2.add(d, 1.0, 1, 3, 1, 3);
+  d2.add(d, 1.0, 2, 3, 2, 3);
+  std::cout <<"d5:"<< d2 << std::endl;
+  for (size_t i = 0; i < d.size(); ++i)
+    EXPECT_FLOAT_EQ(d[i], d2[i]);
+  d2.add(d, 1.0, 0, 1, 7, 3);
+  std::cout <<"d6:"<< d2 << std::endl;
+  for (size_t i = 7; i < d.size(); i += 3)
+    EXPECT_FLOAT_EQ(d2[i], d[i]+(i-4)/3);
 }
 
 
@@ -57,7 +65,7 @@ template<class Scalar>
 void vectorDotTest()
 {
   constexpr size_t size = 10;
-  constexpr Scalar max = Scalar(size-1) * Scalar(size) / 2.0;
+  constexpr Scalar max = Scalar((size-1)*size/2);
 
   utl::vector<Scalar> d(size);
   for (size_t i = 0; i < size; ++i)
@@ -149,18 +157,18 @@ void multiplyTest()
       EXPECT_FLOAT_EQ(B3(j,i), A(i,j));
     }
 
-  if constexpr (std::is_same_v<Scalar,Real>) {
-    utl::vector<Scalar> v2 = A * u;
-    EXPECT_FLOAT_EQ(v2(1),135.0);
-    EXPECT_FLOAT_EQ(v2(2),150.0);
-    EXPECT_FLOAT_EQ(v2(3),165.0);
-  }
+  ASSERT_TRUE(A.multiply(u,v));
+  EXPECT_FLOAT_EQ(v(1),135.0);
+  EXPECT_FLOAT_EQ(v(2),150.0);
+  EXPECT_FLOAT_EQ(v(3),165.0);
 }
 
 
 template<class Scalar>
 void normTest()
 {
+  constexpr Scalar eps = std::numeric_limits<Scalar>::epsilon()*10;
+
   utl::matrix<Scalar> a(4,5);
   std::iota(a.begin(),a.end(),1.0);
   std::cout <<"A:"<< a;
@@ -169,7 +177,7 @@ void normTest()
   EXPECT_FLOAT_EQ(a.sum(5),34.0);
   EXPECT_FLOAT_EQ(a.asum(5),34.0);
   EXPECT_FLOAT_EQ(a.trace(),34.0);
-  EXPECT_NEAR(a.norm2(5),sqrt(414.0),std::numeric_limits<Scalar>::epsilon()*10.0);
+  EXPECT_NEAR(a.norm2(5),sqrt(414.0),eps);
   EXPECT_FLOAT_EQ(a.normInf(),60.0);
 }
 

--- a/src/LinAlg/Test/TestMatVec.C
+++ b/src/LinAlg/Test/TestMatVec.C
@@ -14,6 +14,34 @@
 
 #include <gtest/gtest.h>
 
+#include <numeric>
+
+
+TEST(TestMatVec, add)
+{
+  Vector d(10);
+  std::iota(d.begin(),d.end(),Real(0));
+
+  Vector v = d + d;
+  for (size_t i = 0; i < v.size(); i++)
+    EXPECT_FLOAT_EQ(v[i], 2*Real(i));
+}
+
+
+TEST(TestMatVec, multiply)
+{
+  Matrix A(3,5);
+  Vector u(5);
+
+  std::iota(A.begin(),A.end(),Real(1));
+  std::iota(u.begin(),u.end(),Real(1));
+
+  Vector v = A * u;
+  EXPECT_FLOAT_EQ(v(1),Real(135));
+  EXPECT_FLOAT_EQ(v(2),Real(150));
+  EXPECT_FLOAT_EQ(v(3),Real(165));
+}
+
 
 TEST(TestMatVec, transform)
 {
@@ -30,7 +58,7 @@ TEST(TestMatVec, transform)
 
   Matrix T(3,3), B(A);
   Vector w(v);
-  T(1,1) =  1.0;
+  T(1,1) =  Real(1);
   T(2,2) =  T(3,3) = cos(alpha);
   T(2,3) =  sin(alpha);
   T(3,2) = -T(2,3);

--- a/src/LinAlg/Test/TestMatrix.C
+++ b/src/LinAlg/Test/TestMatrix.C
@@ -160,6 +160,23 @@ TEST(TestMatrix, SumCols)
 }
 
 
+TEST(TestMatrix, Fill)
+{
+  utl::matrix<int> a;
+  std::vector<int> v(16);
+  std::iota(v.begin(),v.end(),1);
+  a.fill(v,3,4);
+  std::cout <<"a:"<< a;
+  EXPECT_EQ(a(3,1),3);
+  a.fill(v,4,4);
+  std::cout <<"a:"<< a;
+  EXPECT_EQ(a(4,1),4);
+  a.fill(v,5,4);
+  std::cout <<"a:"<< a;
+  EXPECT_EQ(a(5,1),0);
+}
+
+
 TEST(TestMatrix, Multiply)
 {
   multiplyTest<double>();

--- a/src/LinAlg/matrix.h
+++ b/src/LinAlg/matrix.h
@@ -612,6 +612,24 @@ namespace utl //! General utility classes and functions.
       return col;
     }
 
+    using matrixBase<T>::fill;
+    //! \brief Fill the matrix with vector data.
+    void fill(const std::vector<T>& v, size_t n, size_t m = 0)
+    {
+      if (n == 0 || v.size() < n) return;
+      if (m == 0) m = v.size()/n;
+      this->resize(n,m,true);
+      if (n*m == v.size())
+        this->elem.fill(v.data());
+      else if ((n = v.size()/m) > nrow)
+        for (size_t c = 0; c < ncol; c++)
+          this->fillColumn(c+1,v.data()+c*n);
+      else // n < nrow
+        for (size_t c = 0; c < ncol; c++)
+          for (size_t r = 0; r < n; r++)
+            this->elem[r+c*nrow] = v[r+c*n];
+    }
+
     //! \brief Fill a column of the matrix.
     void fillColumn(size_t c, const std::vector<T>& data)
     {


### PR DESCRIPTION
The `n` argument to the `[sd]axpy` calls was too large resulting in invalid memory access.
Also adding some sanity checking on the stride arguments, they can be negative (at least for BLAS version), but not zero.
Also adding an overloaded `utl::matrix::fill()` method.