### PR TITLE
Reorder solution vectors in Newmark drivers

### DIFF
--- a/src/ASM/IntegrandBase.h
+++ b/src/ASM/IntegrandBase.h
@@ -296,7 +296,7 @@ public:
   virtual bool suppressOutput(size_t, ASM::ResultClass) const { return false; }
 
   //! \brief Returns the number of solution vectors.
-  size_t getNoSolutions() const { return primsol.size(); }
+  virtual size_t getNoSolutions(bool = true) const { return primsol.size(); }
 
   //! \brief Returns the patch-wise extraction function field, if any.
   virtual Vector* getExtractionField(size_t = 1) { return nullptr; }

--- a/src/ASM/NewmarkMats.h
+++ b/src/ASM/NewmarkMats.h
@@ -48,6 +48,13 @@ public:
   //! \brief Returns the element-level right-hand-side vector.
   virtual const Vector& getRHSVector() const;
 
+  //! \brief Returns a const reference to current/previous displacement vector.
+  const Vector& dis(bool prev = false) const { return vec[prev ? 3 : 0]; }
+  //! \brief Returns a const reference to current/previous velocity vector.
+  const Vector& vel(bool prev = false) const { return vec[prev ? 4 : 1]; }
+  //! \brief Returns a const reference to current/previous velocity vector.
+  const Vector& acc(bool prev = false) const { return vec[prev ? 5 : 2]; }
+
 protected:
   bool  isPredictor; //!< If \e true, we are in the predictor step
   double h;          //!< Time step size

--- a/src/SIM/EigenModeSIM.C
+++ b/src/SIM/EigenModeSIM.C
@@ -83,22 +83,22 @@ void EigenModeSIM::printProblem () const
 }
 
 
-bool EigenModeSIM::initSol (size_t nSol)
+void EigenModeSIM::initSol (size_t nSol, size_t nDof)
 {
-  if (!this->MultiStepSIM::initSol(nSol))
-    return false;
-  else if (nSol > 0)
-    return true;
+  this->MultiStepSIM::initSol(nSol,nDof);
+  if (nSol > 0) return;
 
   // Solve the eigenvalue problem giving the natural eigenfrequencies
   model.setMode(SIM::VIBRATION);
   model.initSystem(opt.solver,2,0);
   model.setQuadratureRule(opt.nGauss[0],true);
-  if (!model.assembleSystem())
-    return false;
-
-  if (!model.systemModes(modes))
-    return false;
+  if (!model.assembleSystem() || !model.systemModes(modes))
+  {
+    solution.clear();
+    std::cerr <<" *** EigenModeSIM::initSol: No eigenvalue solution."
+              << std::endl;
+    return;
+  }
 
   // Scale all eigenvectors to have max amplitude equal to one,
   // and convert the eigenvalues back to angular frequency
@@ -113,8 +113,6 @@ bool EigenModeSIM::initSol (size_t nSol)
     std::cout <<"\nEigenvector #"<< i+1 <<":"<< modes[i].eigVec;
 #endif
   }
-
-  return true;
 }
 
 

--- a/src/SIM/EigenModeSIM.h
+++ b/src/SIM/EigenModeSIM.h
@@ -38,7 +38,7 @@ public:
   virtual void printProblem() const;
 
   //! \brief Initializes primary solution vectors.
-  virtual bool initSol(size_t nSol);
+  virtual void initSol(size_t nSol, size_t nDof);
 
   //! \brief Advances the time step one step forward.
   virtual bool advanceStep(TimeStep& param, bool updateTime = true);

--- a/src/SIM/GenAlphaSIM.h
+++ b/src/SIM/GenAlphaSIM.h
@@ -36,8 +36,7 @@ public:
   //! \brief Initializes time integration parameters for the integrand.
   virtual void initPrm();
   //! \brief Initializes primary solution vectors.
-  //! \param[in] nSol Number of consequtive solutions stored
-  virtual bool initSol(size_t nSol = 3);
+  virtual void initSol(size_t nSol, size_t nDof = 0);
 
   //! \brief Advances the time step one step forward.
   //! \param param Time stepping parameters

--- a/src/SIM/HHTSIM.h
+++ b/src/SIM/HHTSIM.h
@@ -194,10 +194,7 @@ public:
   //! \brief Initializes time integration parameters for the integrand.
   virtual void initPrm();
   //! \brief Initializes the primary solution vectors.
-  virtual bool initSol(size_t nSol = 3);
-
-  //! \brief Advances the time step one step forward.
-  virtual bool advanceStep(TimeStep& param, bool updateTime = true);
+  virtual void initSol(size_t nSol, size_t nDof = 0);
 
   //! \brief Modifies the current solution vector (used by sub-iterations only).
   virtual void setSolution(const RealArray& newSol, int idx);
@@ -223,9 +220,6 @@ protected:
 private:
   unsigned short int pA; //!< Index to predicted acceleration vector
   unsigned short int pV; //!< Index to predicted velocity vector
-  unsigned short int iA; //!< Index to corrected acceleration vector
-  unsigned short int iV; //!< Index to corrected velocity vector
-  unsigned short int iD; //!< Index to corrected displacement vector
 
   Vector incDis;  //!< Incremental displacement vector
 

--- a/src/SIM/MultiStepSIM.C
+++ b/src/SIM/MultiStepSIM.C
@@ -61,8 +61,8 @@ void MultiStepSIM::initSol (size_t nSol, size_t nDof)
 {
   if (!solution.empty())
     nSol = solution.size();
-  else if (nSol > 0 && nSol < model.getNoSolutions())
-    nSol = model.getNoSolutions();
+  else if (nSol > 0 && nSol < model.getNoSolutions(false))
+    nSol = model.getNoSolutions(false);
 
   if (nDof == 0)
     nDof = model.getNoDOFs();

--- a/src/SIM/MultiStepSIM.C
+++ b/src/SIM/MultiStepSIM.C
@@ -57,14 +57,17 @@ bool MultiStepSIM::preprocess (const std::vector<int>& ignored, bool fixDup)
 }
 
 
-bool MultiStepSIM::initSol (size_t nSol)
+void MultiStepSIM::initSol (size_t nSol, size_t nDof)
 {
   if (!solution.empty())
     nSol = solution.size();
   else if (nSol > 0 && nSol < model.getNoSolutions())
     nSol = model.getNoSolutions();
 
-  return this->initSolution(model.getNoDOFs(),nSol);
+  if (nDof == 0)
+    nDof = model.getNoDOFs();
+
+  this->initSolution(nDof,nSol);
 }
 
 

--- a/src/SIM/MultiStepSIM.h
+++ b/src/SIM/MultiStepSIM.h
@@ -52,7 +52,8 @@ public:
   virtual void initPrm() {}
   //! \brief Initializes the primary solution vectors.
   //! \param[in] nSol Number of consequtive solutions stored in core
-  virtual bool initSol(size_t nSol = 1);
+  //! \param[in] nDof Number of degrees of freedom (solution vector length)
+  virtual void initSol(size_t nSol = 1, size_t nDof = 0);
 
   //! \brief Allocates the FE system matrices.
   //! \param[in] withRF Whether nodal reaction forces should be computed or not

--- a/src/SIM/NewmarkNLSIM.h
+++ b/src/SIM/NewmarkNLSIM.h
@@ -188,10 +188,7 @@ public:
   //! \brief Initializes time integration parameters for the integrand.
   virtual void initPrm();
   //! \brief Initializes the primary solution vectors.
-  virtual bool initSol(size_t nSol = 3);
-
-  //! \brief Advances the time step one step forward.
-  virtual bool advanceStep(TimeStep& param, bool updateTime = true);
+  virtual void initSol(size_t nSol, size_t nDof = 0);
 
   //! \brief Modifies the current solution vector (used by sub-iterations only).
   virtual void setSolution(const RealArray& newSol, int idx);
@@ -215,10 +212,6 @@ protected:
   virtual void finalizeRHSvector(bool);
 
 private:
-  unsigned short int iA; //!< Index to corrected acceleration vector
-  unsigned short int iV; //!< Index to corrected velocity vector
-  unsigned short int iD; //!< Index to corrected displacement vector
-
   Vector incDis;  //!< Incremental displacement vector
   Vector predVel; //!< Predicted velocity vector
   Vector predAcc; //!< Predicted acceleration vector

--- a/src/SIM/NewmarkSIM.h
+++ b/src/SIM/NewmarkSIM.h
@@ -42,6 +42,9 @@ public:
   //! \brief Calculates initial accelerations.
   bool initAcc(double zero_tolerance = 1.0e-8, std::streamsize outPrec = 0);
 
+  //! \brief Advances the time step one step forward.
+  virtual bool advanceStep(TimeStep& param, bool updateTime = true);
+
   //! \brief Solves the dynamic equations by a predictor/multi-corrector method.
   //! \param param Time stepping parameters
   //! \param[in] zero_tolerance Truncate norm values smaller than this to zero
@@ -76,9 +79,9 @@ protected:
 
 public:
   //! \brief Returns a const reference to current velocity vector.
-  const Vector& getVelocity() const { return solution[solution.size()-2]; }
+  const Vector& getVelocity() const { return solution[1]; }
   //! \brief Returns a const reference to current velocity vector.
-  const Vector& getAcceleration() const { return solution[solution.size()-1]; }
+  const Vector& getAcceleration() const { return solution[2]; }
 
   //! \brief Dumps solution variables at user-defined points.
   //! \param[in] time Current time

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -787,9 +787,9 @@ bool SIMbase::getElmNodes (IntVec& mnpc, int iel) const
 }
 
 
-size_t SIMbase::getNoSolutions () const
+size_t SIMbase::getNoSolutions (bool allocated) const
 {
-  return myProblem ? myProblem->getNoSolutions() : 0;
+  return myProblem ? myProblem->getNoSolutions(allocated) : 0;
 }
 
 

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -192,7 +192,7 @@ public:
   //! including zero-volume elements due to multiple knots, etc.
   size_t getNoElms(bool includeXelms = false, bool includeZelms = false) const;
   //! \brief Returns the number of solution vectors.
-  size_t getNoSolutions() const;
+  size_t getNoSolutions(bool allocated = true) const;
   //! \brief Returns the total number of patches in the model.
   int getNoPatches() const { return nGlPatches; }
   //! \brief Returns the number of unknowns in the linear equation system.

--- a/src/SIM/SIMsolution.C
+++ b/src/SIM/SIMsolution.C
@@ -19,25 +19,24 @@
 #endif
 
 
-bool SIMsolution::initSolution (size_t ndof, size_t nsol)
+void SIMsolution::initSolution (size_t ndof, size_t nsol)
 {
   // Note: Always at least one vector at this point, even if nsol is zero
   solution.resize(nsol > 1 ? nsol : 1);
   for (Vector& sol : solution)
     sol.resize(ndof,true);
-  return true;
 }
 
 
-void SIMsolution::pushSolution (size_t nsol)
+void SIMsolution::pushSolution (unsigned short int nVecState)
 {
-  if (solution.empty())
-    return;
-  else if (nsol == 0 || nsol > solution.size())
-    nsol = solution.size();
+  short int nState = solution.size()/nVecState;
+  if (nState < 2) return;
 
-  for (size_t n = nsol-1; n > 0; n--)
-    std::copy(solution[n-1].begin(),solution[n-1].end(),solution[n].begin());
+  for (short int n = (nState-2)*nVecState; n >= 0; n -= nVecState)
+    for (unsigned short int i = 0; i < nVecState; i++)
+      std::copy(solution[n+i].begin(), solution[n+i].end(),
+                solution[n+i+nVecState].begin());
 }
 
 
@@ -51,7 +50,7 @@ bool SIMsolution::saveSolution (SerializeMap& data,
     for (const Vector& sol : this->getSolutions())
       archive(sol);
   }
-  data.insert(std::make_pair(name,str.str()));
+  data.insert({ name, str.str() });
   return true;
 #else
   return false;

--- a/src/SIM/SIMsolution.h
+++ b/src/SIM/SIMsolution.h
@@ -25,23 +25,22 @@
 
 class SIMsolution
 {
-public:
-  //! \brief Default constructor.
-  SIMsolution() {}
-  //! \brief Empty destructor.
-  virtual ~SIMsolution() {}
+protected:
+  //! \brief The default constructor is protected to allow sub-classes only
+  SIMsolution() = default;
+  //! \brief Empty default destructor.
+  virtual ~SIMsolution() = default;
 
   //! \brief Initializes the solution vectors.
   //! \param[in] ndof Number of degrees of freedom
   //! \param[in] nsol Number of solution vectors
-  bool initSolution(size_t ndof, size_t nsol = 1);
+  void initSolution(size_t ndof, size_t nsol = 1);
 
-protected:
   //! \brief Pushes the solution vector stack.
-  //! \param[in] nsol Number of vectors to push (0 = all)
-  void pushSolution(size_t nsol = 0);
+  //! \param[in] nVecState Number of vectors per state
+  void pushSolution(unsigned short int nVecState = 1);
 
-  typedef std::map<std::string,std::string> SerializeMap; //!< Convenience type
+  using SerializeMap = std::map<std::string,std::string>; //!< Convenience type
 
   //! \brief Writes current solution to a serialization container.
   //! \param data Container for serialized data
@@ -71,7 +70,7 @@ public:
   virtual Vectors& theSolutions() { return solution; }
 
   //! \brief Returns a const reference to current solution vector.
-  virtual const Vector& getSolution(int idx = 0) const { return solution[idx]; }
+  virtual const Vector& getSolution(int ix = 0) const { return solution[ix]; }
   //! \brief Modifies the current solution vector (used by sub-iterations only).
   virtual void setSolution(const RealArray& s, int ix = 0) { solution[ix] = s; }
 

--- a/src/SIM/Test/TestNewmark.C
+++ b/src/SIM/Test/TestNewmark.C
@@ -448,7 +448,7 @@ TEST(TestHHT, SingleDOFu)
   SIM1DOF simulator;
   HHTSIM integrator(simulator);
   integrator.initPrm();
-  integrator.initSol();
+  integrator.initSol(3);
   runSingleDof(integrator,0.9);
 }
 
@@ -464,7 +464,7 @@ TEST(TestNewmarkNL, Damped)
   SIM2DOFdmp simulator;
   NewmarkNLSIM integrator(simulator);
   integrator.initPrm();
-  integrator.initSol();
+  integrator.initSol(3);
   runTwoDof(integrator,simulator.getInitAcc());
 }
 
@@ -473,7 +473,7 @@ TEST(TestHHT, Damped)
   SIM2DOFdmp simulator;
   HHTSIM integrator(simulator);
   integrator.initPrm();
-  integrator.initSol();
+  integrator.initSol(3);
   runTwoDof(integrator,simulator.getInitAcc());
 }
 

--- a/src/SIM/Test/TestNonLinSIM.C
+++ b/src/SIM/Test/TestNonLinSIM.C
@@ -102,8 +102,8 @@ public:
 static void runSingleDof (NonLinSIM& solver, int& n, double& s)
 {
   TimeStep tp;
-  ASSERT_TRUE(solver.initSol());
-  ASSERT_TRUE(solver.advanceStep(tp));
+  solver.initSol();
+  solver.advanceStep(tp);
   ASSERT_EQ(solver.solveStep(tp),SIM::CONVERGED);
   s = solver.getSolution()[0]; n = tp.iter;
   std::cout <<"  Solution "<< s <<" obtained in "<< n <<" iterations.\n";

--- a/src/SIM/Test/TestSolution.C
+++ b/src/SIM/Test/TestSolution.C
@@ -1,0 +1,69 @@
+// $Id$
+//==============================================================================
+//!
+//! \file TestSolution.C
+//!
+//! \date Feb 14 2025
+//!
+//! \author Knut Morten Okstad / SINTEF
+//!
+//! \brief Unit tests for the SIMsolution container.
+//!
+//==============================================================================
+
+#include "SIMsolution.h"
+
+#include <gtest/gtest.h>
+
+
+class DummySIM : public SIMsolution
+{
+  int nVecState;
+
+public:
+  DummySIM(int nState, int nvs) : nVecState(nvs)
+  {
+    solution.resize(nState*nVecState,Vector(5));
+    for (size_t i = 1; i <= solution.size(); i++)
+      solution[i-1].fill(i);
+  }
+
+  void push()
+  {
+    this->pushSolution(nVecState);
+    for (int i = 0; i < nVecState; i++)
+      solution[i].fill(0.0);
+  }
+
+  void printMe()
+  {
+    int i = 0;
+    for (const Vector& v : solution) std::cout <<"s"<< ++i <<":"<< v;
+  }
+};
+
+
+TEST(SIMsolution, Push)
+{
+  DummySIM s1(2,1);
+  s1.printMe();
+  s1.push();
+  s1.printMe();
+  EXPECT_EQ(s1.getSolution(0)[0],0);
+  EXPECT_EQ(s1.getSolution(1)[0],1);
+
+  DummySIM s2(4,3);
+  s2.printMe();
+  s2.push();
+  s2.printMe();
+  EXPECT_EQ(s2.getSolution(2)[0],0);
+  EXPECT_EQ(s2.getSolution(5)[0],3);
+  EXPECT_EQ(s2.getSolution(8)[0],6);
+  EXPECT_EQ(s2.getSolution(9)[0],7);
+  s2.push();
+  s2.printMe();
+  EXPECT_EQ(s2.getSolution(2)[0],0);
+  EXPECT_EQ(s2.getSolution(5)[0],0);
+  EXPECT_EQ(s2.getSolution(8)[0],3);
+  EXPECT_EQ(s2.getSolution(9)[0],4);
+}


### PR DESCRIPTION
This is to facilitate accessing the solution state of the previous time step(s) on element/integration point level. The new order is u0,v0,a0, u1,v1,a1, u2,v2,a2, ... while before it was u0,u1,u2,...,v0,a0 and the previous velocity and acceleration states where not available.