### PR TITLE
Changed: Use std::string as type on the first argument for the virtual setParam() method

### DIFF
--- a/src/ASM/Integrand.h
+++ b/src/ASM/Integrand.h
@@ -16,7 +16,7 @@
 
 #include "SIMenums.h"
 #include <vector>
-#include <cstddef>
+#include <string>
 
 struct TimeDomain;
 class LocalIntegral;
@@ -379,9 +379,9 @@ protected:
 
 public:
   //! \brief Assigns a parameter value to property functions of the integrand.
-  virtual void setParam(const char*, double) {}
+  virtual void setParam(const std::string&, double) {}
   //! \brief Assigns parameter values to property functions of the integrand.
-  virtual void setParam(const char*, const Vec3&) {}
+  virtual void setParam(const std::string&, const Vec3&) {}
 };
 
 #endif

--- a/src/ASM/IntegrandBase.h
+++ b/src/ASM/IntegrandBase.h
@@ -465,14 +465,14 @@ public:
   //! \brief Assigns a parameter value to property functions of the integrand.
   //! \param[in] name Parameter name
   //! \param[in] value Parameter value
-  void setParam(const char* name, double value) override
+  void setParam(const std::string& name, double value) override
   {
     myProblem.setParam(name,value);
   }
   //! \brief Assigns parameter values to property functions of the integrand.
   //! \param[in] name Parameter name
   //! \param[in] value Parameter value
-  void setParam(const char* name, const Vec3& value) override
+  void setParam(const std::string& name, const Vec3& value) override
   {
     myProblem.setParam(name,value);
   }
@@ -571,14 +571,14 @@ public:
   //! \brief Assigns a parameter value to property functions of the integrand.
   //! \param[in] name Parameter name
   //! \param[in] value Parameter value
-  void setParam(const char* name, double value) override
+  void setParam(const std::string& name, double value) override
   {
     myProblem.setParam(name,value);
   }
   //! \brief Assigns parameter values to property functions of the integrand.
   //! \param[in] name Parameter name
   //! \param[in] value Parameter value
-  void setParam(const char* name, const Vec3& value) override
+  void setParam(const std::string& name, const Vec3& value) override
   {
     myProblem.setParam(name,value);
   }

--- a/src/Utility/ExprFunctions.h
+++ b/src/Utility/ExprFunctions.h
@@ -163,11 +163,8 @@ public:
   //! \brief Returns second-derivative of the function.
   Real dderiv(const Vec3& X, int dir1, int dir2) const override;
 
-  //! \brief Set an additional parameter in the function.
-  void setParam(const std::string& name, double value);
-
   //! \brief Sets an additional parameter in the function.
-  void setParameter(const char* n, double v) override { this->setParam(n,v); }
+  void setParam(const std::string& name, double value) override;
 
   //! \brief Evaluates first derivatives of the function.
   Vec3 gradient(const Vec3& X) const override
@@ -209,13 +206,6 @@ public:
   //! \brief Adds an expression function for a first or second derivative.
   void addDerivative(const std::string& functions,
                      const std::string& variables, int d1, int d2 = 0);
-
-  //! \brief Set an additional parameter in the function.
-  void setParam(const std::string& name, double value)
-  {
-    for (std::unique_ptr<FuncType>& func : this->p)
-      func->setParam(name, value);
-  }
 
   //! \brief Returns number of spatial dimension.
   size_t getNoSpaceDim() const { return nsd; }
@@ -268,7 +258,11 @@ public:
   Ret dderiv(const Vec3& X, int dir1, int dir2) const override;
 
   //! \brief Sets an additional parameter in the function.
-  void setParameter(const char* n, double v) override { this->setParam(n,v); }
+  void setParam(const std::string& name, double value) override
+  {
+    for (std::unique_ptr<FuncType>& func : this->p)
+      func->setParam(name,value);
+  }
 
 protected:
   //! \brief Sets the number of spatial dimensions (default implementation).

--- a/src/Utility/Function.h
+++ b/src/Utility/Function.h
@@ -169,14 +169,13 @@ public:
   virtual bool inDomain(const Vec3&) const { return true; }
 
   //! \brief Sets an additional parameter in the function.
-  virtual void setParameter(const char*, double) {}
+  virtual void setParam(const std::string&, double) {}
   //! \brief Sets additional parameter values in the function.
-  void setParameter(const char* name, const Vec3& value)
+  void setParam(const std::string& name, const Vec3& value)
   {
-    std::string v(name);
-    this->setParameter((v + "x").c_str(), value.x);
-    this->setParameter((v + "y").c_str(), value.y);
-    this->setParameter((v + "z").c_str(), value.z);
+    this->setParam(name + "x", value.x);
+    this->setParam(name + "y", value.y);
+    this->setParam(name + "z", value.z);
   }
 
 protected:


### PR DESCRIPTION
 Then we don't need the setParameter() wrapper in the Function class but can override directly.