### PR TITLE
More flexible specification of modes for EigenModeSIM

### DIFF
--- a/src/SIM/EigenModeSIM.C
+++ b/src/SIM/EigenModeSIM.C
@@ -152,6 +152,12 @@ SIM::ConvStatus EigenModeSIM::solveStep (TimeStep& param, SIM::SolutionMode,
                                          double zero_tolerance,
                                          std::streamsize outPrec)
 {
+  if (solution.empty())
+    return SIM::FAILURE;
+
+  if (msgLevel >= 0)
+    this->printStep(param);
+
   if (myStart < 0.0)
     myStart = param.time.t - param.time.dt;
 

--- a/src/SIM/MultiStepSIM.C
+++ b/src/SIM/MultiStepSIM.C
@@ -243,6 +243,22 @@ bool MultiStepSIM::savePoints (double time, int step) const
 }
 
 
+void MultiStepSIM::printStep (const TimeStep& param) const
+{
+  double digits = log10(param.time.t) - log10(param.time.dt);
+  if (digits > 6.0)
+  {
+    // Increase precision on physical time for larger time series
+    utl::LogStream& cout = model.getProcessAdm().cout;
+    std::streamsize prec = cout.precision(ceil(digits));
+    model.printStep(param.step,param.time);
+    cout.precision(prec);
+  }
+  else
+    model.printStep(param.step,param.time);
+}
+
+
 bool MultiStepSIM::advanceStep (TimeStep& param, bool updateTime)
 {
   if (param.step > 0 && rotUpd == 't')

--- a/src/SIM/MultiStepSIM.h
+++ b/src/SIM/MultiStepSIM.h
@@ -75,6 +75,10 @@ public:
                                     std::streamsize outPrec = 0) = 0;
 
 protected:
+  //! \brief Prints out time/load step identification.
+  //! \param param[in] Time stepping parameters
+  void printStep(const TimeStep& param) const;
+
   //! \brief Computes and prints some solution norm quantities.
   //! \param[in] zero_tolerance Truncate norm values smaller than this to zero
   //! \param[in] outPrec Number of digits after the decimal point in norm print

--- a/src/SIM/NewmarkSIM.C
+++ b/src/SIM/NewmarkSIM.C
@@ -359,19 +359,11 @@ SIM::ConvStatus NewmarkSIM::solveStep (TimeStep& param, SIM::SolutionMode,
 {
   PROFILE1("NewmarkSIM::solveStep");
 
+  if (solution.empty())
+    return SIM::FAILURE;
+
   if (msgLevel >= 0)
-  {
-    double digits = log10(param.time.t) - log10(param.time.dt);
-    if (digits > 6.0)
-    {
-      utl::LogStream& cout = model.getProcessAdm().cout;
-      std::streamsize oldPrec = cout.precision(ceil(digits));
-      model.printStep(param.step,param.time);
-      cout.precision(oldPrec);
-    }
-    else
-      model.printStep(param.step,param.time);
-  }
+    this->printStep(param);
 
   if (subiter&FIRST && !model.updateDirichlet(param.time.t,&solution.front()))
     return SIM::FAILURE;

--- a/src/SIM/NonLinSIM.C
+++ b/src/SIM/NonLinSIM.C
@@ -209,18 +209,7 @@ ConvStatus NonLinSIM::solveStep (TimeStep& param, SolutionMode mode,
     return FAILURE;
 
   if (msgLevel >= 0)
-  {
-    double digits = log10(param.time.t) - log10(param.time.dt);
-    if (digits > 6.0)
-    {
-      utl::LogStream& cout = model.getProcessAdm().cout;
-      std::streamsize oldPrec = cout.precision(ceil(digits));
-      model.printStep(param.step,param.time);
-      cout.precision(oldPrec);
-    }
-    else
-      model.printStep(param.step,param.time);
-  }
+    this->printStep(param);
 
   param.iter = 0;
   alpha = alphaO = 1.0;


### PR DESCRIPTION
Added the option:

    <eigenmodes>
      <modes scale="1.23">1 2 3 5 7 8</modes>
    </eigenmodes>

which is more compact than specifying mode by mode using `<mode number="1">1.23</mode>`.
The latter syntax is still valid though.