### PR TITLE
VTF output of external element numbers

### DIFF
--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -468,6 +468,40 @@ const IntVec& ASMs1D::getNodeSet (int iset) const
 }
 
 
+bool ASMs1D::isInNodeSet (int iset, int inod) const
+{
+  if (iset < 1 || iset > static_cast<int>(nodeSets.size()))
+    return false;
+
+  return utl::findIndex(nodeSets[iset-1].second,inod) >= 0;
+}
+
+
+int ASMs1D::parseNodeSet (const std::string& setName, const char* cset)
+{
+  int iset = this->getNodeSetIdx(setName)-1;
+  if (iset < 0)
+  {
+    iset = nodeSets.size();
+    nodeSets.emplace_back(setName,IntVec());
+  }
+
+  IntVec& mySet = nodeSets[iset].second;
+  size_t ifirst = mySet.size();
+  utl::parseIntegers(mySet,cset);
+
+  int inod; // Transform to internal node indices
+  for (size_t i = ifirst; i < mySet.size(); i++)
+    if ((inod = this->getNodeIndex(mySet[i])) > 0)
+      mySet[i] = inod;
+    else
+      IFEM::cout <<"  ** Warning: Non-existing node "<< mySet[i]
+                 <<" in node set \""<< setName <<"\""<< std::endl;
+
+  return 1+iset;
+}
+
+
 bool ASMs1D::connectPatch (int vertex, ASM1D& neighbor, int nvertex, int thick)
 {
   ASMs1D* neighS = dynamic_cast<ASMs1D*>(&neighbor);

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -20,7 +20,7 @@
 #include "ASMutils.h"
 #include "Tensor.h"
 
-typedef std::vector<Tensor> TensorVec; //!< An array of non-symmetric tensors
+using TensorVec = std::vector<Tensor>; //!< An array of non-symmetric tensors
 
 namespace Go {
   class SplineCurve;
@@ -129,6 +129,10 @@ public:
   virtual int getNodeSetIdx(const std::string& setName) const;
   //! \brief Returns an indexed pre-defined node set.
   virtual const IntVec& getNodeSet(int iset) const;
+  //! \brief Checks if node \a inod is within predefined node set \a iset.
+  virtual bool isInNodeSet(int iset, int inod) const;
+  //! \brief Defines a node set by parsing a list of node numbers.
+  virtual int parseNodeSet(const std::string& setName, const char* cset);
 
   //! \brief Finds the node that is closest to the given point.
   //! \param[in] X Global coordinates of point to search for

--- a/src/ASM/ASMs2DTri.C
+++ b/src/ASM/ASMs2DTri.C
@@ -505,16 +505,19 @@ bool ASMs2DTri::integrate (Integrand& integrand, int lIndex,
 bool ASMs2DTri::tesselate (ElementBlock& grid, const int*) const
 {
   // Establish the block grid coordinates
-  size_t i, j, ip;
+  size_t i, k;
   grid.setNoElmNodes(3);
   grid.resize(nx,ny);
   for (i = 0; i < grid.getNoNodes(); i++)
     grid.setCoor(i,this->getCoord(1+i));
 
   // Establish the block grid topology
-  for (i = ip = 0; i < MNPC.size(); i++)
-    for (j = 0; j < 3; j++, ip++)
-      grid.setNode(ip,MNPC[i][j]);
+  for (i = k = 0; i < MNPC.size(); i++)
+  {
+    for (int j : MNPC[i])
+      grid.setNode(k++,j);
+    grid.setElmId(1+i,MLGE[i]);
+  }
 
   return true;
 }

--- a/src/ASM/ASMu1DLag.C
+++ b/src/ASM/ASMu1DLag.C
@@ -187,8 +187,11 @@ bool ASMu1DLag::tesselate (ElementBlock& grid, const int*) const
     grid.setCoor(i,this->getCoord(1+i));
 
   for (i = k = 0; i < nel; i++)
+  {
     for (int j : MNPC[i])
       grid.setNode(k++,j);
+    grid.setElmId(1+i,MLGE[i]);
+  }
 
   return true;
 }

--- a/src/ASM/ASMu2DLag.C
+++ b/src/ASM/ASMu2DLag.C
@@ -415,11 +415,11 @@ bool ASMu2DLag::tesselate (ElementBlock& grid, const int*) const
       --nelms;
   grid.unStructResize(nelms,nnod,nmnpc);
 
-  size_t i, j, k;
+  size_t i, j, k, e;
   for (i = 0; i < nnod; i++)
     grid.setCoor(i,this->getCoord(1+i));
 
-  for (i = k = 0; i < nel; i++)
+  for (i = k = e = 0; i < nel; i++)
     if (MNPC[i].size() > 1) // ignore 1-noded elements
     {
       for (j = 0; j < MNPC[i].size(); j++)
@@ -428,6 +428,7 @@ bool ASMu2DLag::tesselate (ElementBlock& grid, const int*) const
         else
           grid.setNode(k++,MNPC[i][j]);
       grid.endOfElm(k);
+      grid.setElmId(++e,MLGE[i]);
     }
 
   return true;

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -672,13 +672,13 @@ void SIMbase::setQuadratureRule (size_t ng, bool redimBuffers, bool printQP)
 }
 
 
-void SIMbase::printProblem () const
+bool SIMbase::printProblem () const
 {
-  if (myProblem)
-  {
-    IFEM::cout <<"\nProblem definition:"<< std::endl;
-    myProblem->printLog();
-  }
+  if (!myProblem)
+    return false;
+
+  IFEM::cout <<"\nProblem definition:"<< std::endl;
+  myProblem->printLog();
 
 #if SP_DEBUG > 1
   std::cout <<"\nProperty mapping:\n";
@@ -726,6 +726,7 @@ void SIMbase::printProblem () const
               <<" "<< (int)p.ldim <<"D"<< std::endl;
   }
 #endif
+  return true;
 }
 
 

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -149,7 +149,7 @@ public:
                          bool printQP = false);
 
   //! \brief Prints out problem-specific data to the log stream.
-  virtual void printProblem() const;
+  virtual bool printProblem() const;
 
   //! \brief Returns a pointer to the problem-specific data object.
   const IntegrandBase* getProblem() const { return myProblem; }


### PR DESCRIPTION
The first commit is unrelated - an extension of the `Parametric` function class defining element activation histories.
The second commit assigns external element numbers to `ElementBlock` objects, for unstructured Lagrange patches (this was erroneously left out initially).

Then, in the third commit the `SIMoutput::writeGlvNo()` method is extended to also output the original external element numbers as a scalar field to `VTF`. This is needed when the external numbers do not consist of a monotonic sequence 1...nel, but contains "holes". The elements are then renumbered such that they can be used as indices in global element arrays. Therefore we need to do this in order to visualize the original numbers.

The last two commits are also unrelated: Signature change for virtual method `SIMbase::printProblem()` with downstreams implications, and some new node set methods in class `ASMs1D`.