### PR TITLE
Changed: Use SIM::RHS_ONLY also in NewmarkSIM

### DIFF
--- a/src/ASM/ASMs2DLag.C
+++ b/src/ASM/ASMs2DLag.C
@@ -333,7 +333,7 @@ bool ASMs2DLag::integrate (Integrand& integrand,
   const double* xr = cache.coord(true)[0];
   const double* wr = cache.weight(true)[0];
 
-  const bool dynamics = integrand.getMode() == SIM::DYNAMIC;
+  const bool dynamics = integrand.getMode(true) == SIM::DYNAMIC;
 
   // Number of elements in first parameter direction
   const int nelx = (nx-1)/(p1-1);
@@ -516,7 +516,7 @@ bool ASMs2DLag::integrate (Integrand& integrand, int lIndex,
   const double* wg = GaussQuadrature::getWeight(nGP);
   if (!xg || !wg) return false;
 
-  const bool dynamics = integrand.getMode() == SIM::DYNAMIC;
+  const bool dynamics = integrand.getMode(true) == SIM::DYNAMIC;
 
   // Find the parametric direction of the edge normal {-2,-1, 1, 2}
   const int edgeDir = (lIndex%10+1)/((lIndex%2) ? -2 : 2);

--- a/src/ASM/GlbL2projector.h
+++ b/src/ASM/GlbL2projector.h
@@ -131,7 +131,7 @@ public:
   virtual ~GlbL2();
 
   //! \brief Returns current solution mode.
-  virtual SIM::SolutionMode getMode() const { return SIM::RECOVERY; }
+  virtual SIM::SolutionMode getMode(bool) const { return SIM::RECOVERY; }
   //! \brief Defines which FE quantities are needed by the integrand.
   virtual int getIntegrandType() const;
 

--- a/src/ASM/Integrand.h
+++ b/src/ASM/Integrand.h
@@ -176,7 +176,7 @@ public:
   };
 
   //! \brief Returns current solution mode.
-  virtual SIM::SolutionMode getMode() const = 0;
+  virtual SIM::SolutionMode getMode(bool = false) const = 0;
   //! \brief Defines which FE quantities are needed by the integrand.
   virtual int getIntegrandType() const { return STANDARD; }
   //! \brief Returns the number of reduced-order integration points.

--- a/src/ASM/IntegrandBase.h
+++ b/src/ASM/IntegrandBase.h
@@ -59,7 +59,7 @@ public:
   //! \brief Defines the solution mode before the element assembly is started.
   virtual void setMode(SIM::SolutionMode mode);
   //! \brief Returns current solution mode.
-  SIM::SolutionMode getMode() const override { return m_mode; }
+  SIM::SolutionMode getMode(bool = false) const override { return m_mode; }
   //! \brief Initializes an integration parameter for the integrand.
   virtual void setIntegrationPrm(unsigned short int, double) {}
   //! \brief Returns an integration parameter for the integrand.
@@ -478,7 +478,7 @@ public:
   }
 
   //! \brief Returns current solution mode.
-  SIM::SolutionMode getMode() const override { return myProblem.getMode(); }
+  SIM::SolutionMode getMode(bool) const override { return myProblem.getMode(); }
 
 protected:
   //! \brief Initializes the projected fields for current element.
@@ -584,7 +584,7 @@ public:
   }
 
   //! \brief Returns current solution mode.
-  SIM::SolutionMode getMode() const override { return myProblem.getMode(); }
+  SIM::SolutionMode getMode(bool) const override { return myProblem.getMode(); }
 
 protected:
   //! \brief Clears out internal buffers.

--- a/src/LinAlg/SPRMatrix.C
+++ b/src/LinAlg/SPRMatrix.C
@@ -150,6 +150,18 @@ void closeftnfile_(const int& iunit);
 }
 
 
+/*!
+  \brief Generic function for copying a C-array.
+*/
+
+template<class T> T* copyArr(const T* array, int n)
+{
+  T* newarr = new T[n];
+  memcpy(newarr,array,n*sizeof(T));
+  return newarr;
+}
+
+
 SPRMatrix::SPRMatrix () : rWork(1)
 {
   ierr = 0;
@@ -168,14 +180,6 @@ SPRMatrix::SPRMatrix () : rWork(1)
 
 SPRMatrix::SPRMatrix (const SPRMatrix& A) : SystemMatrix(A), rWork(1)
 {
-  // Lambda function copying an array.
-  auto&& copyArr = []<typename T>(const T* array, int n)
-  {
-    T* newarr = new T[n];
-    memcpy(newarr,array,n*sizeof(T));
-    return newarr;
-  };
-
   ierr   = 0;
   memcpy(mpar,A.mpar,sizeof(A.mpar));
   msica  = copyArr(A.msica,A.mpar[1]);


### PR DESCRIPTION
To avoid that the system Newton matrix is assembled unnecessarily when iterating the RHS vector only.
This will require some downstream updates though (for users of the NewmarkSIM driver).