### PR TITLE
getElmConnectivities: add flag for using local element numbers

### DIFF
--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -393,7 +393,7 @@ public:
                                   IntVec* corners = nullptr) const = 0;
 
   //! \brief Obtain element neighbours.
-  virtual void getElmConnectivities(IntMat& neighs) const = 0;
+  virtual void getElmConnectivities(IntMat& neighs, bool local = false) const = 0;
 
   // Various preprocessing methods
   // =============================

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -1998,12 +1998,15 @@ Fields* ASMs1D::getProjectedFields (const Vector& coefs, size_t) const
 }
 
 
-void ASMs1D::getElmConnectivities (IntMat& neigh) const
+void ASMs1D::getElmConnectivities (IntMat& neigh, bool local) const
 {
-  neigh[MLGE[    0]-1] = { -1, MLGE[1]-1 };
-  neigh[MLGE[nel-1]-1] = { MLGE[nel-2]-1, -1 };
+  auto&& index = [&mlge = MLGE, local](int idx)
+                 { return local ? idx : mlge[idx]-1; };
+
+  neigh[index(0)] = {-1, index(1)};
+  neigh[index(nel-1)] = {index(nel-2), -1};
   for (size_t i = 1; i+1 < nel; i++)
-    neigh[MLGE[i]-1] = { MLGE[i-1]-1, MLGE[i+1]-1 };
+    neigh[index(i)] = {index(i-1), index(i+1)};
 }
 
 

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -452,7 +452,7 @@ public:
   virtual bool getParameterDomain(Real2DMat& u, IntVec* corners) const;
 
   //! \brief Obtain element neighbours.
-  virtual void getElmConnectivities(IntMat& neighs) const;
+  virtual void getElmConnectivities(IntMat& neigh, bool local = false) const;
 
 protected:
   std::shared_ptr<Go::SplineCurve> curv; //!< The actual spline curve object

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -3229,7 +3229,7 @@ size_t ASMs2D::getNoProjectionNodes () const
 }
 
 
-void ASMs2D::getElmConnectivities (IntMat& neigh) const
+void ASMs2D::getElmConnectivities (IntMat& neigh, bool local) const
 {
   const int n1 = surf->numCoefs_u();
   const int n2 = surf->numCoefs_v();
@@ -3237,21 +3237,24 @@ void ASMs2D::getElmConnectivities (IntMat& neigh) const
   const int p2 = surf->order_v();
   const int N1 = n1 - p1 + 1;
 
+  auto&& index = [&mlge = MLGE, local](int idx)
+                 { return local ? idx : mlge[idx]-1; };
+
   size_t iel = 0;
   for (int i2 = p2; i2 <= n2; i2++)
     for (int i1 = p1; i1 <= n1; i1++, iel++)
-      if (MLGE[iel] > 0)
+      if (local || MLGE[iel] > 0)
       {
-        int idx = MLGE[iel]-1;
+        const int idx = index(iel);
         neigh[idx].resize(4,-1);
         if (i1 > p1)
-          neigh[idx][0] = MLGE[iel-1]-1;
+          neigh[idx][0] = index(iel-1);
         if (i1 < n1)
-          neigh[idx][1] = MLGE[iel+1]-1;
+          neigh[idx][1] = index(iel+1);
         if (i2 > p2)
-          neigh[idx][2] = MLGE[iel-N1]-1;
+          neigh[idx][2] = index(iel-N1);
         if (i2 < n2)
-          neigh[idx][3] = MLGE[iel+N1]-1;
+          neigh[idx][3] = index(iel+N1);
       }
 }
 

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -739,7 +739,7 @@ public:
   virtual bool getNoStructElms(int& n1, int& n2, int& n3) const;
 
   //! \brief Obtain element neighbours.
-  virtual void getElmConnectivities(IntMat& neigh) const;
+  virtual void getElmConnectivities(IntMat& neigh, bool local = false) const;
 
   //! \brief Returns the number of elements on a boundary.
   virtual size_t getNoBoundaryElms(char lIndex, char ldim) const;

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -3758,7 +3758,7 @@ size_t ASMs3D::getNoProjectionNodes () const
 }
 
 
-void ASMs3D::getElmConnectivities (IntMat& neigh) const
+void ASMs3D::getElmConnectivities (IntMat& neigh, bool local) const
 {
   const int n1 = svol->numCoefs(0);
   const int n2 = svol->numCoefs(1);
@@ -3769,26 +3769,29 @@ void ASMs3D::getElmConnectivities (IntMat& neigh) const
   const int N1 = n1 - p1 + 1;
   const int N2 = n2 - p2 + 1;
 
+  auto&& index = [&mlge = MLGE, local](int idx)
+                 { return local ? idx : mlge[idx]-1; };
+
   size_t iel = 0;
   for (int i3 = p3; i3 <= n3; i3++)
     for (int i2 = p2; i2 <= n2; i2++)
       for (int i1 = p1; i1 <= n1; i1++, iel++)
         if (MLGE[iel] > 0)
         {
-          int idx = MLGE[iel]-1;
+          const int idx = index(iel);
           neigh[idx].resize(6,-1);
           if (i1 > p1)
-            neigh[idx][0] = MLGE[iel-1]-1;
+            neigh[idx][0] = index(iel-1);
           if (i1 < n1)
-            neigh[idx][1] = MLGE[iel+1]-1;
+            neigh[idx][1] = index(iel+1);
           if (i2 > p2)
-            neigh[idx][2] = MLGE[iel-N1]-1;
+            neigh[idx][2] = index(iel-N1);
           if (i2 < n2)
-            neigh[idx][3] = MLGE[iel+N1]-1;
+            neigh[idx][3] = index(iel+N1);
           if (i3 > p3)
-            neigh[idx][4] = MLGE[iel-N1*N2]-1;
+            neigh[idx][4] = index(iel-N1*N2);
           if (i3 < n3)
-            neigh[idx][5] = MLGE[iel+N1*N2]-1;
+            neigh[idx][5] = index(iel+N1*N2);
         }
 }
 

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -810,7 +810,7 @@ public:
   virtual bool getNoStructElms(int& n1, int& n2, int& n3) const;
 
   //! \brief Obtain element neighbours.
-  virtual void getElmConnectivities(IntMat& neigh) const;
+  virtual void getElmConnectivities(IntMat& neigh, bool local = false) const;
 
   //! \brief Returns the number of elements on a boundary.
   virtual size_t getNoBoundaryElms(char lIndex, char ldim) const;

--- a/src/ASM/ASMsupel.h
+++ b/src/ASM/ASMsupel.h
@@ -80,7 +80,7 @@ public:
   //! \brief Dummy method doing nothing.
   virtual bool getParameterDomain(Real2DMat&, IntVec*) const { return false; }
   //! \brief Dummy method doing nothing.
-  virtual void getElmConnectivities(IntMat&) const {}
+  virtual void getElmConnectivities(IntMat&, bool = false) const {}
   //! \brief Dummy method doing nothing.
   virtual bool updateCoords(const Vector&) { return false; }
   //! \brief Dummy method doing nothing.

--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -2920,10 +2920,10 @@ void ASMu2D::computeBasis (double u, double v, Go::BasisDerivsSf3& bas,
 }
 
 
-void ASMu2D::getElmConnectivities (IntMat& neigh) const
+void ASMu2D::getElmConnectivities (IntMat& neigh, bool local) const
 {
   const double epsilon = 1.0e-6;
-  const LR::LRSplineSurface* lr = this->getBasis(1);
+  const LR::LRSplineSurface* lr = this->getBasis(ASM::INTEGRATION_BASIS);
 
   for (LR::Meshline* m : lr->getAllMeshlines()) {
     RealArray isectpts(1,0.0);
@@ -2953,8 +2953,8 @@ void ASMu2D::getElmConnectivities (IntMat& neigh) const
       int el1 = lr->getElementContaining(parval_left);
       int el2 = lr->getElementContaining(parval_right);
       if (el1 > -1 && el2 > -1) {
-        neigh[MLGE[el1]-1].push_back(MLGE[el2]-1);
-        neigh[MLGE[el2]-1].push_back(MLGE[el1]-1);
+        neigh[local ? el1 : MLGE[el1]-1].push_back(local ? el2 : MLGE[el2]-1);
+        neigh[local ? el2 : MLGE[el2]-1].push_back(local ? el1 : MLGE[el1]-1);
       }
     }
   }

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -158,7 +158,7 @@ public:
   virtual bool getElementCoordinates(Matrix& X, int iel, bool forceItg = false) const;
 
   //! \brief Obtain element neighbours.
-  virtual void getElmConnectivities(IntMat& neighs) const;
+  virtual void getElmConnectivities(IntMat& neighs, bool local = false) const;
 
   //! \brief Returns a matrix with all nodal coordinates within the patch.
   //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -2349,16 +2349,16 @@ bool ASMu3D::refine (const LR::RefineData& prm, Vectors& sol)
 }
 
 
-void ASMu3D::getElmConnectivities (IntMat& neigh) const
+void ASMu3D::getElmConnectivities (IntMat& neigh, bool local) const
 {
-  const LR::LRSplineVolume* lr = this->getBasis(1);
+  const LR::LRSplineVolume* lr = this->getBasis(ASM::INTEGRATION_BASIS);
   for (const LR::Element* m : lr->getAllElements()) {
     int iel = m->getId();
-    IntVec& neighbor = neigh[MLGE[iel]-1];
+    IntVec& neighbor = local ? neigh[iel] : neigh[MLGE[iel]-1];
     for (int face = 1; face <= 6; face++) {
       std::set<int> elms = lr->getElementNeighbours(iel,getFaceEnum(face));
       for (int elm : elms)
-        neighbor.push_back(MLGE[elm]-1);
+        neighbor.push_back(local ? elm : MLGE[elm]-1);
     }
   }
 }

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -143,7 +143,7 @@ public:
   virtual bool getElementCoordinates(Matrix& X, int iel, bool forceItg = false) const;
 
   //! \brief Obtain element neighbours.
-  virtual void getElmConnectivities(IntMat& neighs) const;
+  virtual void getElmConnectivities(IntMat& neighs, bool local = false) const;
 
   //! \brief Returns a matrix with all nodal coordinates within the patch.
   //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes

--- a/src/ASM/LR/Test/ASMuCube.h
+++ b/src/ASM/LR/Test/ASMuCube.h
@@ -69,6 +69,13 @@ public:
                           addLine(xshift + 1.0, yshift + 1.0, zshift + 1.0));
     this->read(geo);
   }
+
+  void shiftElemNumbers(int shift)
+  {
+    for (int& e : myMLGE)
+      e += (e == -1 ? 0 : shift);
+  }
+
   virtual ~ASMuCube() {}
 };
 

--- a/src/ASM/LR/Test/ASMuSquare.h
+++ b/src/ASM/LR/Test/ASMuSquare.h
@@ -51,6 +51,13 @@ public:
                           addLine(xshift+1.0, yshift+1.0));
     this->read(geo);
   }
+
+  void shiftElemNumbers(int shift)
+  {
+    for (int& e : myMLGE)
+      e += (e == -1 ? 0 : shift);
+  }
+
   virtual ~ASMuSquare() {}
 };
 

--- a/src/ASM/LR/Test/TestASMu2D.C
+++ b/src/ASM/LR/Test/TestASMu2D.C
@@ -270,17 +270,24 @@ TEST(TestASMu2D, ElementConnectivities)
   ASSERT_TRUE(pch1.uniformRefine(1,1));
   ASSERT_TRUE(pch1.generateFEMTopology());
   pch1.getBasis(1)->generateIDs();
-  IntMat neigh(4);
-  pch1.getElmConnectivities(neigh);
+  const int nel = pch1.getNoElms();
+  pch1.shiftElemNumbers(nel);
+  IntMat neighGlb(2*nel), neighLoc(nel);
+  pch1.getElmConnectivities(neighGlb);
+  pch1.getElmConnectivities(neighLoc, true);
   const std::array<std::vector<int>,4> ref = {{{1, 2},
                                                {0, 3},
                                                {3, 0},
                                                {2, 1}}};
-  ASSERT_EQ(neigh.size(), 4U);
-  for (size_t n = 0; n < neigh.size(); ++n) {
-    ASSERT_EQ(neigh[n].size(), ref[n].size());
-    for (size_t i = 0; i < neigh[n].size(); ++i)
-      EXPECT_EQ(neigh[n][i], ref[n][i]);
+  ASSERT_EQ(neighLoc.size(), nel);
+  ASSERT_EQ(neighGlb.size(), 2*nel);
+  for (size_t n = 0; n < neighLoc.size(); ++n) {
+    ASSERT_EQ(neighLoc[n].size(), ref[n].size());
+    ASSERT_EQ(neighGlb[n+nel].size(), ref[n].size());
+    for (size_t i = 0; i < neighLoc[n].size(); ++i) {
+      EXPECT_EQ(neighLoc[n][i], ref[n][i]);
+      EXPECT_EQ(neighGlb[n+nel][i], ref[n][i] > -1 ? ref[n][i] + nel : -1);
+    }
   }
 }
 

--- a/src/ASM/LR/Test/TestASMu3D.C
+++ b/src/ASM/LR/Test/TestASMu3D.C
@@ -165,8 +165,11 @@ TEST(TestASMu3D, ElementConnectivities)
   ASSERT_TRUE(pch1.uniformRefine(1,1));
   ASSERT_TRUE(pch1.uniformRefine(2,1));
   ASSERT_TRUE(pch1.generateFEMTopology());
-  IntMat neigh(8);
-  pch1.getElmConnectivities(neigh);
+  const size_t nel = pch1.getNoElms();
+  IntMat neighGlb(2*nel), neighLoc(nel);
+  pch1.shiftElemNumbers(nel);
+  pch1.getElmConnectivities(neighGlb);
+  pch1.getElmConnectivities(neighLoc, true);
   const std::array<std::vector<int>,8> ref = {{{1, 2, 4},
                                                {0, 3, 5},
                                                {3, 0, 6},
@@ -175,11 +178,15 @@ TEST(TestASMu3D, ElementConnectivities)
                                                {4, 7, 1},
                                                {7, 4, 2},
                                                {6, 5, 3}}};
-  ASSERT_EQ(neigh.size(), 8U);
-  for (size_t n = 0; n < neigh.size(); ++n) {
-    ASSERT_EQ(neigh[n].size(), ref[n].size());
-    for (size_t i = 0; i < neigh[n].size(); ++i)
-      EXPECT_EQ(neigh[n][i], ref[n][i]);
+  ASSERT_EQ(neighLoc.size(), nel);
+  ASSERT_EQ(neighGlb.size(), 2*nel);
+  for (size_t n = 0; n < neighLoc.size(); ++n) {
+    ASSERT_EQ(neighLoc[n].size(), ref[n].size());
+    ASSERT_EQ(neighGlb[n+nel].size(), ref[n].size());
+    for (size_t i = 0; i < neighLoc[n].size(); ++i) {
+      EXPECT_EQ(neighLoc[n][i], ref[n][i]);
+      EXPECT_EQ(neighGlb[n+nel][i], ref[n][i] > -1 ? ref[n][i] + nel : -1);
+    }
   }
 }
 

--- a/src/ASM/Test/ASMCube.h
+++ b/src/ASM/Test/ASMCube.h
@@ -42,6 +42,13 @@ public:
     std::stringstream geo(cube);
     this->read(geo);
   }
+
+  void shiftElemNumbers(int shift)
+  {
+    for (int& e : myMLGE)
+      e += (e == -1 ? 0 : shift);
+  }
+
   virtual ~ASMCube() {}
 };
 

--- a/src/ASM/Test/ASMSquare.h
+++ b/src/ASM/Test/ASMSquare.h
@@ -37,6 +37,12 @@ public:
     this->read(geo);
   }
   virtual ~ASMSquare() {}
+
+  void shiftElemNumbers(int shift)
+  {
+    for (int& e : myMLGE)
+      e += (e == -1 ? 0 : shift);
+  }
 };
 
 
@@ -48,6 +54,8 @@ public:
     std::stringstream geo(ASMSquare::square);
     this->read(geo);
   }
+
+
   virtual ~ASMmxSquare() {}
 };
 

--- a/src/ASM/Test/TestASMs2D.C
+++ b/src/ASM/Test/TestASMs2D.C
@@ -23,17 +23,24 @@ TEST(TestASMs2D, ElementConnectivities)
   ASSERT_TRUE(pch1.uniformRefine(0,1));
   ASSERT_TRUE(pch1.uniformRefine(1,1));
   ASSERT_TRUE(pch1.generateFEMTopology());
-  IntMat neigh(4);
-  pch1.getElmConnectivities(neigh);
+  const size_t nel = pch1.getNoElms();
+  pch1.shiftElemNumbers(nel);
+  IntMat neighGlb(2*nel), neighLoc(nel);
+  pch1.getElmConnectivities(neighGlb);
+  pch1.getElmConnectivities(neighLoc, true);
   const std::array<std::vector<int>,4> ref = {{{-1,  1, -1,  2},
                                                { 0, -1, -1,  3},
                                                {-1,  3,  0, -1},
                                                { 2, -1,  1, -1}}};
-  ASSERT_EQ(neigh.size(), 4U);
-  for (size_t n = 0; n < neigh.size(); ++n) {
-    ASSERT_EQ(neigh[n].size(), ref[n].size());
-    for (size_t i = 0; i < neigh[n].size(); ++i)
-      EXPECT_EQ(neigh[n][i], ref[n][i]);
+  ASSERT_EQ(neighLoc.size(), nel);
+  ASSERT_EQ(neighGlb.size(), 2*nel);
+  for (size_t n = 0; n < neighLoc.size(); ++n) {
+    ASSERT_EQ(neighLoc[n].size(), ref[n].size());
+    ASSERT_EQ(neighGlb[n+nel].size(), ref[n].size());
+    for (size_t i = 0; i < neighLoc[n].size(); ++i) {
+      EXPECT_EQ(neighLoc[n][i], ref[n][i]);
+      EXPECT_EQ(neighGlb[n+nel][i], ref[n][i] > -1 ? ref[n][i] + nel : -1);
+    }
   }
 }
 

--- a/src/ASM/Test/TestASMs3D.C
+++ b/src/ASM/Test/TestASMs3D.C
@@ -27,8 +27,11 @@ TEST(TestASMs3D, ElementConnectivities)
   ASSERT_TRUE(pch1.uniformRefine(1,1));
   ASSERT_TRUE(pch1.uniformRefine(2,1));
   ASSERT_TRUE(pch1.generateFEMTopology());
-  IntMat neigh(8);
-  pch1.getElmConnectivities(neigh);
+  const size_t nel = pch1.getNoElms();
+  pch1.shiftElemNumbers(nel);
+  IntMat neighGlb(2*nel), neighLoc(nel);
+  pch1.getElmConnectivities(neighGlb);
+  pch1.getElmConnectivities(neighLoc, true);
   const std::array<std::vector<int>,8> ref = {{{-1,  1, -1,  2, -1,  4},
                                                { 0, -1, -1,  3, -1,  5},
                                                {-1,  3,  0, -1, -1,  6},
@@ -37,11 +40,15 @@ TEST(TestASMs3D, ElementConnectivities)
                                                { 4, -1, -1,  7,  1, -1},
                                                {-1,  7,  4, -1,  2, -1},
                                                { 6, -1,  5, -1,  3, -1}}};
-  ASSERT_EQ(neigh.size(), 8U);
-  for (size_t n = 0; n < neigh.size(); ++n) {
-    ASSERT_EQ(neigh[n].size(), ref[n].size());
-    for (size_t i = 0; i < neigh[n].size(); ++i)
-      EXPECT_EQ(neigh[n][i], ref[n][i]);
+  ASSERT_EQ(neighGlb.size(), 2*nel);
+  ASSERT_EQ(neighLoc.size(), nel);
+  for (size_t n = 0; n < neighLoc.size(); ++n) {
+    ASSERT_EQ(neighLoc[n].size(), ref[n].size());
+    ASSERT_EQ(neighGlb[n+nel].size(), ref[n].size());
+    for (size_t i = 0; i < neighLoc[n].size(); ++i) {
+      EXPECT_EQ(neighLoc[n][i], ref[n][i]);
+      EXPECT_EQ(neighGlb[n+nel][i], ref[n][i] > -1 ? ref[n][i] + nel : -1);
+    }
   }
 }
 


### PR DESCRIPTION
One small and self-contained piece of the refactor.