### PR TITLE
ThreadGroups: add oneStripe(list)

### DIFF
--- a/src/Utility/Test/TestThreadGroups.C
+++ b/src/Utility/Test/TestThreadGroups.C
@@ -467,3 +467,33 @@ TEST(TestThreadGroups, Groups3D)
     EXPECT_EQ(groups2[0][0][i], i);
 #endif
 }
+
+
+TEST(TestThreadGroups, OneStripe)
+{
+  ThreadGroups all_elms;
+  ThreadGroups selected_elms;
+
+  constexpr size_t nel = 13;
+
+  all_elms.oneStripe(nel);
+  std::vector<int> elms;
+  for (size_t i = 0; i < nel; i += 2)
+    elms.push_back(i);
+
+  selected_elms.oneStripe(elms);
+
+  ASSERT_EQ(all_elms.size(), 1);
+  ASSERT_EQ(all_elms[0].size(), nel);
+  for (size_t i = 0; i < nel; ++i) {
+    ASSERT_EQ(all_elms[0][i].size(), 1);
+    EXPECT_EQ(all_elms[0][i][0], i);
+  }
+
+  ASSERT_EQ(selected_elms.size(), 1);
+  ASSERT_EQ(selected_elms[0].size(), elms.size());
+  for (size_t i = 0; i < elms.size(); ++i) {
+    ASSERT_EQ(selected_elms[0][i].size(), 1);
+    EXPECT_EQ(selected_elms[0][i][0], 2*i);
+  }
+}

--- a/src/Utility/ThreadGroups.C
+++ b/src/Utility/ThreadGroups.C
@@ -38,6 +38,15 @@ void ThreadGroups::oneStripe (size_t nel)
 }
 
 
+void ThreadGroups::oneStripe (const std::vector<int>& elms)
+{
+  tg[0].resize(elms.size());
+  tg[1].resize(0);
+  for (size_t iel = 0; iel < elms.size(); ++iel)
+    tg[0][iel].resize(1,elms[iel]);
+}
+
+
 void ThreadGroups::calcGroups (const BoolVec& el1, const BoolVec& el2,
                                int p1, int p2)
 {

--- a/src/Utility/ThreadGroups.h
+++ b/src/Utility/ThreadGroups.h
@@ -69,6 +69,9 @@ public:
   //! \brief Initializes the threading groups in case of a single stripe.
   //! \param[in] nel Total number of elements
   void oneStripe(size_t nel);
+  //! \brief Initializes the threading groups in case of a single stripe.
+  //! \param[in] elms Elements to include in stripe
+  void oneStripe(const std::vector<int>& elms);
 
   //! \brief Maps a partitioning through a map.
   //! \details The original entry \a n in the group is mapped onto \a map[n].


### PR DESCRIPTION
this adds the specified elements in one stripe,
so they can all be safely assembled in parallel
in structured asms.

to be used for threadsafe integrand handling