### PR TITLE
L2 projection: Add interface for assembling

### DIFF
--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -37,8 +37,8 @@ class IntegrandBase;
 class Integrand;
 class L2Integrand;
 class ASMbase;
-class SparseMatrix;
-class StdVector;
+class SystemMatrix;
+class SystemVector;
 class FunctionBase;
 class RealFunc;
 class VecFunc;
@@ -925,7 +925,7 @@ protected:
   //! \param[out] B Right-hand-side vectors
   //! \param[in] obj Wrapper object for integrand/function
   //! \param[in] continuous If \e false, a discrete L2-projection is used
-  virtual bool assembleL2matrices(SparseMatrix& A, StdVector& B,
+  virtual bool assembleL2matrices(SystemMatrix& A, SystemVector& B,
                                   const L2Integrand& obj,
                                   bool continuous) const { return false; }
 

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -1845,7 +1845,7 @@ bool ASMs1D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
 }
 
 
-bool ASMs1D::assembleL2matrices (SparseMatrix& A, StdVector& B,
+bool ASMs1D::assembleL2matrices (SystemMatrix& A, SystemVector& B,
                                  const L2Integrand& integrand,
                                  bool continuous) const
 {
@@ -1926,17 +1926,8 @@ bool ASMs1D::assembleL2matrices (SparseMatrix& A, StdVector& B,
       for (size_t r = 1; r <= sField.rows(); r++)
         eB[r-1].add(phi,sField(r,ip+1)*dJw);
 
-      for (size_t ii = 0; ii < phi.size(); ii++)
-      {
-        int inod = mnpc[iel][ii]+1;
-        for (size_t jj = 0; jj < phi.size(); jj++)
-        {
-          int jnod = mnpc[iel][jj]+1;
-          A(inod,jnod) += eA(ii+1,jj+1);
-        }
-        for (size_t r = 1; r <= sField.rows(); r++)
-          B(inod+(r-1)*nnod) += eB[r-1](ii+1);
-      }
+      A.assemble(eA, mnpc[iel]);
+      B.assemble(eB, mnpc[iel], nnod);
     }
   }
 

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -1918,17 +1918,24 @@ bool ASMs1D::assembleL2matrices (SparseMatrix& A, StdVector& B,
         if (dJw == 0.0) continue; // skip singular points
       }
 
-      // Integrate the linear system A*x=B
+      Matrix eA;
+      eA.outer_product(phi, phi, false, dJw);
+
+      // Integrate the rhs vector B
+      Vectors eB(sField.rows(), Vector(phi.size()));
+      for (size_t r = 1; r <= sField.rows(); r++)
+        eB[r-1].add(phi,sField(r,ip+1)*dJw);
+
       for (size_t ii = 0; ii < phi.size(); ii++)
       {
         int inod = mnpc[iel][ii]+1;
         for (size_t jj = 0; jj < phi.size(); jj++)
         {
           int jnod = mnpc[iel][jj]+1;
-          A(inod,jnod) += phi[ii]*phi[jj]*dJw;
+          A(inod,jnod) += eA(ii+1,jj+1);
         }
         for (size_t r = 1; r <= sField.rows(); r++)
-          B(inod+(r-1)*nnod) += phi[ii]*sField(r,ip+1)*dJw;
+          B(inod+(r-1)*nnod) += eB[r-1](ii+1);
       }
     }
   }

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -373,7 +373,7 @@ protected:
   //! \param[out] B Right-hand-side vectors
   //! \param[in] integrand Object with problem-specific data and methods
   //! \param[in] continuous If \e false, a discrete L2-projection is used
-  virtual bool assembleL2matrices(SparseMatrix& A, StdVector& B,
+  virtual bool assembleL2matrices(SystemMatrix& A, SystemVector& B,
                                   const L2Integrand& integrand,
                                   bool continuous) const;
 

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -597,7 +597,7 @@ protected:
   //! \param[out] B Right-hand-side vectors
   //! \param[in] integrand Object with problem-specific data and methods
   //! \param[in] continuous If \e false, a discrete L2-projection is used
-  virtual bool assembleL2matrices(SparseMatrix& A, StdVector& B,
+  virtual bool assembleL2matrices(SystemMatrix& A, SystemVector& B,
                                   const L2Integrand& integrand,
                                   bool continuous) const;
 

--- a/src/ASM/ASMs2DLag.C
+++ b/src/ASM/ASMs2DLag.C
@@ -1027,7 +1027,7 @@ size_t ASMs2DLag::getNoProjectionNodes () const
 }
 
 
-bool ASMs2DLag::assembleL2matrices (SparseMatrix& A, StdVector& B,
+bool ASMs2DLag::assembleL2matrices (SystemMatrix& A, SystemVector& B,
                                     const L2Integrand& integrand,
                                     bool continuous) const
 {
@@ -1082,15 +1082,8 @@ bool ASMs2DLag::assembleL2matrices (SparseMatrix& A, StdVector& B,
         }
 
       const IntVec& mnpc = MNPC[iel];
-
-      for (int i = 0; i < p1*p2; ++i) {
-        for (int j = 0; j < p1*p2; ++j)
-          A(mnpc[i]+1, mnpc[j]+1) += eA(i+1, j+1);
-
-        int jp = mnpc[i]+1;
-        for (size_t r = 0; r < sField.rows(); r++, jp += nnod)
-          B(jp) += eB[r](1+i);
-      }
+      A.assemble(eA, mnpc);
+      B.assemble(eB, mnpc, nnod);
     }
 
   return true;

--- a/src/ASM/ASMs2DLag.h
+++ b/src/ASM/ASMs2DLag.h
@@ -138,7 +138,7 @@ public:
   //! \param[out] B Right-hand-side vectors
   //! \param[in] integrand Object with problem-specific data and methods
   //! \param[in] continuous If \e false, a discrete L2-projection is used
-  virtual bool assembleL2matrices(SparseMatrix& A, StdVector& B,
+  virtual bool assembleL2matrices(SystemMatrix& A, SystemVector& B,
                                   const L2Integrand& integrand,
                                   bool continuous) const;
 

--- a/src/ASM/ASMs2Drecovery.C
+++ b/src/ASM/ASMs2Drecovery.C
@@ -154,7 +154,7 @@ Go::GeomObject* ASMs2D::evalSolution (const IntegrandBase& integrand) const
 }
 
 
-bool ASMs2D::assembleL2matrices (SparseMatrix& A, StdVector& B,
+bool ASMs2D::assembleL2matrices (SystemMatrix& A, SystemVector& B,
                                  const L2Integrand& integrand,
                                  bool continuous) const
 {
@@ -285,14 +285,8 @@ bool ASMs2D::assembleL2matrices (SparseMatrix& A, StdVector& B,
             eB[r-1].add(phi,sField(r,ip+1)*dJw);
         }
 
-      for (int i = 0; i < p1*p2; ++i) {
-        for (int j = 0; j < p1*p2; ++j)
-          A(mnpc[i]+1, mnpc[j]+1) += eA(i+1, j+1);
-
-        int jp = mnpc[i]+1;
-        for (size_t r = 0; r < sField.rows(); r++, jp += nnod)
-          B(jp) += eB[r](1+i);
-      }
+      A.assemble(eA, mnpc);
+      B.assemble(eB, mnpc, nnod);
     }
 
   return true;

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -668,7 +668,7 @@ protected:
   //! \param[out] B Right-hand-side vectors
   //! \param[in] integrand Object with problem-specific data and methods
   //! \param[in] continuous If \e false, a discrete L2-projection is used
-  virtual bool assembleL2matrices(SparseMatrix& A, StdVector& B,
+  virtual bool assembleL2matrices(SystemMatrix& A, SystemVector& B,
                                   const L2Integrand& integrand,
                                   bool continuous) const;
 

--- a/src/ASM/ASMs3DLag.C
+++ b/src/ASM/ASMs3DLag.C
@@ -1361,7 +1361,7 @@ size_t ASMs3DLag::getNoProjectionNodes () const
 }
 
 
-bool ASMs3DLag::assembleL2matrices (SparseMatrix& A, StdVector& B,
+bool ASMs3DLag::assembleL2matrices (SystemMatrix& A, SystemVector& B,
                                     const L2Integrand& integrand,
                                     bool continuous) const
 {
@@ -1422,15 +1422,8 @@ bool ASMs3DLag::assembleL2matrices (SparseMatrix& A, StdVector& B,
             }
 
         const IntVec& mnpc = MNPC[iel];
-
-        for (int i = 0; i < p1*p2*p3; ++i) {
-          for (int j = 0; j < p1*p2*p3; ++j)
-            A(mnpc[i]+1, mnpc[j]+1) += eA(i+1, j+1);
-
-          int jp = mnpc[i]+1;
-          for (size_t r = 0; r < sField.rows(); r++, jp += nnod)
-            B(jp) += eB[r](1+i);
-        }
+        A.assemble(eA, mnpc);
+        B.assemble(eB, mnpc, nnod);
       }
 
   return true;

--- a/src/ASM/ASMs3DLag.h
+++ b/src/ASM/ASMs3DLag.h
@@ -303,7 +303,7 @@ public:
   //! \param[out] B Right-hand-side vectors
   //! \param[in] integrand Object with problem-specific data and methods
   //! \param[in] continuous If \e false, a discrete L2-projection is used
-  virtual bool assembleL2matrices(SparseMatrix& A, StdVector& B,
+  virtual bool assembleL2matrices(SystemMatrix& A, SystemVector& B,
                                   const L2Integrand& integrand,
                                   bool continuous) const;
 

--- a/src/ASM/ASMs3Drecovery.C
+++ b/src/ASM/ASMs3Drecovery.C
@@ -154,7 +154,7 @@ Go::GeomObject* ASMs3D::evalSolution (const IntegrandBase& integrand) const
 }
 
 
-bool ASMs3D::assembleL2matrices (SparseMatrix& A, StdVector& B,
+bool ASMs3D::assembleL2matrices (SystemMatrix& A, SystemVector& B,
                                  const L2Integrand& integrand,
                                  bool continuous) const
 {
@@ -301,14 +301,8 @@ bool ASMs3D::assembleL2matrices (SparseMatrix& A, StdVector& B,
                 eB[r-1].add(phi,sField(r,ip+1)*dJw);
             }
 
-        for (int i = 0; i < p1*p2*p3; ++i) {
-          for (int j = 0; j < p1*p2*p3; ++j)
-            A(mnpc[i]+1, mnpc[j]+1) += eA(i+1, j+1);
-
-          int jp = mnpc[i]+1;
-          for (size_t r = 0; r < sField.rows(); r++, jp += nnod)
-            B(jp) += eB[r](1+i);
-        }
+        A.assemble(eA, mnpc);
+        B.assemble(eB, mnpc, nnod);
       }
 
   return true;

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -588,7 +588,7 @@ protected:
   //! \param[out] B Right-hand-side vectors
   //! \param[in] integrand Object with problem-specific data and methods
   //! \param[in] continuous If \e false, a discrete L2-projection is used
-  virtual bool assembleL2matrices(SparseMatrix& A, StdVector& B,
+  virtual bool assembleL2matrices(SystemMatrix& A, SystemVector& B,
                                   const L2Integrand& integrand,
                                   bool continuous) const;
 

--- a/src/ASM/LR/ASMu2Drecovery.C
+++ b/src/ASM/LR/ASMu2Drecovery.C
@@ -102,7 +102,7 @@ LR::LRSpline* ASMu2D::evalSolution (const IntegrandBase& integrand) const
 }
 
 
-bool ASMu2D::assembleL2matrices (SparseMatrix& A, StdVector& B,
+bool ASMu2D::assembleL2matrices (SystemMatrix& A, SystemVector& B,
                                  const L2Integrand& integrand,
                                  bool continuous) const
 {
@@ -220,14 +220,8 @@ bool ASMu2D::assembleL2matrices (SparseMatrix& A, StdVector& B,
             eB[r-1].add(phi,sField(r,ip+1)*dJw);
         }
 
-      for (size_t i = 0; i < eA.rows(); ++i) {
-        for (size_t j = 0; j < eA.cols(); ++j)
-          A(mnpc[i]+1, mnpc[j]+1) += eA(i+1,j+1);
-
-        int jp = mnpc[i]+1;
-        for (size_t r = 0; r < sField.rows(); r++, jp += nnod)
-          B(jp) += eB[r](1+i);
-      }
+      A.assemble(eA, mnpc);
+      B.assemble(eB, mnpc, nnod);
     }
 
   return ok;

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -596,7 +596,7 @@ protected:
   //! \param[out] B Right-hand-side vectors
   //! \param[in] integrand Object with problem-specific data and methods
   //! \param[in] continuous If \e false, a discrete L2-projection is used
-  virtual bool assembleL2matrices(SparseMatrix& A, StdVector& B,
+  virtual bool assembleL2matrices(SystemMatrix& A, SystemVector& B,
                                   const L2Integrand& integrand,
                                   bool continuous) const;
 

--- a/src/ASM/LR/ASMu3Drecovery.C
+++ b/src/ASM/LR/ASMu3Drecovery.C
@@ -104,7 +104,7 @@ LR::LRSpline* ASMu3D::evalSolution (const IntegrandBase& integrand) const
 }
 
 
-bool ASMu3D::assembleL2matrices (SparseMatrix& A, StdVector& B,
+bool ASMu3D::assembleL2matrices (SystemMatrix& A, SystemVector& B,
                                  const L2Integrand& integrand,
                                  bool continuous) const
 {
@@ -227,14 +227,8 @@ bool ASMu3D::assembleL2matrices (SparseMatrix& A, StdVector& B,
               eB[r-1].add(phi,sField(r,ip+1)*dJw);
           }
 
-      for (size_t i = 0; i < eA.rows(); ++i) {
-        for (size_t j = 0; j < eA.cols(); ++j)
-          A(mnpc[i]+1, mnpc[j]+1) += eA(i+1,j+1);
-
-        int jp = mnpc[i]+1;
-        for (size_t r = 0; r < sField.rows(); r++, jp += nnod)
-          B(jp) += eB[r](1+i);
-      }
+      A.assemble(eA, mnpc);
+      B.assemble(eB, mnpc, nnod);
     }
 
   return ok;

--- a/src/LinAlg/DenseMatrix.C
+++ b/src/LinAlg/DenseMatrix.C
@@ -277,6 +277,16 @@ bool DenseMatrix::assemble (const Matrix& eM, const SAM& sam,
 }
 
 
+bool DenseMatrix::assemble (const Matrix& eM, const IntVec& meq)
+{
+  for (size_t i = 0; i < meq.size(); ++i)
+    for (size_t j = 0; j < meq.size(); ++j)
+      (*this)(meq[i]+1, meq[j]+1) += eM(i+1, j+1);
+
+  return true;
+}
+
+
 bool DenseMatrix::augment (const SystemMatrix& B, size_t r0, size_t c0)
 {
   const SparseMatrix* sB = dynamic_cast<const SparseMatrix*>(&B);

--- a/src/LinAlg/DenseMatrix.h
+++ b/src/LinAlg/DenseMatrix.h
@@ -106,6 +106,14 @@ public:
   virtual bool assemble(const Matrix& eM, const SAM& sam,
                         SystemVector& B, const std::vector<int>& meq);
 
+  //! \brief Adds an element matrix into the associated system matrix.
+  //! \param[in] eM  The element matrix
+  //! \param[in] meq Matrix of element equation numbers (0 based)
+  //! \return \e true on successful assembly, otherwise \e false
+  //!
+  //! \details To be used when there is no underlying SAM
+  virtual bool assemble(const Matrix& eM, const IntVec& meq);
+
   //! \brief Augments a similar matrix symmetrically to the current matrix.
   //! \param[in] B  The matrix to be augmented
   //! \param[in] r0 Row offset for the augmented matrix

--- a/src/LinAlg/DiagMatrix.C
+++ b/src/LinAlg/DiagMatrix.C
@@ -62,13 +62,13 @@ bool DiagMatrix::assemble (const Matrix& eM, const SAM& sam, int e)
     return false;
 
   StdVector B;
-  std::vector<int> meen;
+  IntVec meen;
   return sam.getElmEqns(meen,e,eM.rows()) && this->assemble(eM,sam,B,meen);
 }
 
 
 bool DiagMatrix::assemble (const Matrix& eM, const SAM& sam,
-                           SystemVector&, const std::vector<int>& meq)
+                           SystemVector&, const IntVec& meq)
 {
   if (meq.size() != 1 || eM.size() != 1)
   {
@@ -95,6 +95,15 @@ bool DiagMatrix::assemble (const Matrix& eM, const SAM& sam,
                            SystemVector&, int e)
 {
   return this->assemble(eM,sam,e);
+}
+
+
+bool DiagMatrix::assemble (const Matrix& eM, const IntVec& meq)
+{
+  for (size_t i = 0; i < meq.size(); ++i)
+    (*this)(meq[i]+1) += eM(i+1, i+1);
+
+  return true;
 }
 
 

--- a/src/LinAlg/DiagMatrix.h
+++ b/src/LinAlg/DiagMatrix.h
@@ -91,7 +91,15 @@ public:
   //! \details When multi-point constraints are present, contributions from
   //! these are also added into the system right-hand-side vector, \a B.
   virtual bool assemble(const Matrix& eM, const SAM& sam,
-                        SystemVector& B, const std::vector<int>& meq);
+                        SystemVector& B, const IntVec& meq);
+
+  //! \brief Adds an element matrix into the associated system matrix.
+  //! \param[in] eM  The element matrix
+  //! \param[in] meq Matrix of element equation numbers (0 based)
+  //! \return \e true on successful assembly, otherwise \e false
+  //!
+  //! \details To be used when there is no underlying SAM
+  virtual bool assemble(const Matrix& eM, const IntVec& meq);
 
   //! \brief Multiplication with a scalar.
   virtual void mult(Real alpha) { myMat *= alpha; }

--- a/src/LinAlg/SPRMatrix.C
+++ b/src/LinAlg/SPRMatrix.C
@@ -436,10 +436,17 @@ bool SPRMatrix::assemble (const Matrix& eM, const SAM& sam,
 
 
 bool SPRMatrix::assemble (const Matrix&, const SAM&,
-                          SystemVector&, const std::vector<int>&)
+                          SystemVector&, const IntVec&)
 {
   std::cerr <<"SPRMatrix::assemble(const Matrix&,const SAM&,"
-            <<"SystemVector&,const std::vector<int>&): Not implemented."
+            <<"SystemVector&,const IntVec&): Not implemented."
+            << std::endl;
+  return false;
+}
+
+bool SPRMatrix::assemble (const Matrix&, const IntVec&)
+{
+  std::cerr <<"SPRMatrix::assemble(const Matrix&,const IntVec&): Not implemented."
             << std::endl;
   return false;
 }

--- a/src/LinAlg/SPRMatrix.h
+++ b/src/LinAlg/SPRMatrix.h
@@ -87,7 +87,15 @@ public:
   //! \details When multi-point constraints are present, contributions from
   //! these are also added into the system right-hand-side vector, \a B.
   virtual bool assemble(const Matrix& eM, const SAM& sam,
-                        SystemVector& B, const std::vector<int>& meq);
+                        SystemVector& B, const IntVec& meq);
+
+  //! \brief Adds an element matrix into the associated system matrix.
+  //! \param[in] eM  The element matrix
+  //! \param[in] meq Matrix of element equation numbers (0 based)
+  //! \return \e true on successful assembly, otherwise \e false
+  //!
+  //! \details To be used when there is no underlying SAM
+  virtual bool assemble(const Matrix& eM, const IntVec& meq);
 
   //! \brief Multiplication with a scalar.
   virtual void mult(Real alpha);

--- a/src/LinAlg/SparseMatrix.C
+++ b/src/LinAlg/SparseMatrix.C
@@ -855,6 +855,16 @@ bool SparseMatrix::assemble (const Matrix& eM, const SAM& sam,
 }
 
 
+bool SparseMatrix::assemble (const Matrix& eM, const IntVec& meq)
+{
+  for (size_t i = 0; i < eM.rows(); ++i)
+    for (size_t j = 0; j < eM.cols(); ++j)
+      (*this)(meq[i]+1, meq[j]+1) += eM(i+1, j+1);
+
+  return true;
+}
+
+
 bool SparseMatrix::assembleCol (const RealArray& V, const SAM& sam,
                                 int n, size_t col)
 {

--- a/src/LinAlg/SparseMatrix.h
+++ b/src/LinAlg/SparseMatrix.h
@@ -154,6 +154,14 @@ public:
   virtual bool assemble(const Matrix& eM, const SAM& sam,
                         SystemVector& B, const IntVec& meq);
 
+  //! \brief Adds an element matrix into the associated system matrix.
+  //! \param[in] eM  The element matrix
+  //! \param[in] meq Matrix of element equation numbers (0 based)
+  //! \return \e true on successful assembly, otherwise \e false
+  //!
+  //! \details To be used when there is no underlying SAM
+  virtual bool assemble(const Matrix& eM, const IntVec& meq);
+
   //! \brief Adds a nodal vector into columns of a non-symmetric sparse matrix.
   //! \param[in] V   The nodal vector
   //! \param[in] sam Auxiliary data for FE assembly management

--- a/src/LinAlg/SystemMatrix.C
+++ b/src/LinAlg/SystemMatrix.C
@@ -60,6 +60,19 @@ SystemVector& SystemVector::copy (const SystemVector& x)
 }
 
 
+void StdVector::assemble (const Vectors& vecs,
+                          const IntVec& meqn,
+                          const int neq)
+{
+  size_t ofs = 0;
+  for (const Vector& v : vecs) {
+    for (size_t i = 0; i < v.size(); ++i)
+      (*this)(ofs+meqn[i]+1) += v[i];
+    ofs += neq;
+  }
+}
+
+
 void StdVector::dump (const utl::vector<Real>& x, const char* label,
                       LinAlg::StorageFormat format, std::ostream& os)
 {

--- a/src/LinAlg/SystemMatrix.h
+++ b/src/LinAlg/SystemMatrix.h
@@ -281,6 +281,14 @@ public:
   virtual bool assemble(const Matrix& eM, const SAM& sam,
                         SystemVector& B, const IntVec& meq) = 0;
 
+  //! \brief Adds an element matrix into the associated system matrix.
+  //! \param[in] eM  The element matrix
+  //! \param[in] meq Matrix of element equation numbers (0 based)
+  //! \return \e true on successful assembly, otherwise \e false
+  //!
+  //! \details To be used when there is no underlying SAM
+  virtual bool assemble(const Matrix& eM, const IntVec& meq) = 0;
+
   //! \brief Augments a similar matrix symmetrically to the current matrix.
   virtual bool augment(const SystemMatrix&, size_t, size_t) { return false; }
 

--- a/src/LinAlg/SystemMatrix.h
+++ b/src/LinAlg/SystemMatrix.h
@@ -71,6 +71,15 @@ public:
   //! \brief Copies entries from input vector \b x into \a *this.
   SystemVector& copy(const SystemVector& x);
 
+  //! \brief Adds element vectors into the system vector.
+  //! \param[in] vecs The element vectors
+  //! \param[in] meqn Matrix of element equation numbers (0 based)
+  //! \param[in] neq Number of equations for (each) load vector
+  //!
+  //! \details This assembles for multiple RHS
+  virtual void assemble(const Vectors& vecs,
+                        const IntVec& meqn, int neq) = 0;
+
   //! \brief Finalizes the system vector assembly.
   virtual bool endAssembly() { return true; }
 
@@ -124,6 +133,16 @@ public:
 
   //! \brief Creates a copy of the system vector and returns a pointer to it.
   virtual SystemVector* copy() const { return new StdVector(*this); }
+
+  //! \brief Adds element vectors into the system vector.
+  //! \param[in] vecs The element vectors
+  //! \param[in] meqn Matrix of element equation numbers (0 based)
+  //! \param[in] neq Number of equations for (each) load vector
+  //!
+  //! \details This assembles for multiple RHS
+  virtual void assemble(const Vectors& vecs,
+                        const IntVec& meqn,
+                        int neq);
 
   //! \brief Returns the dimension of the system vector.
   virtual size_t dim() const { return this->size(); }


### PR DESCRIPTION
So that we can override this for other matrix types (e.g. PETSc) in the future.