### PR TITLE
Profiler: output to IFEM::cout

### DIFF
--- a/src/Utility/Profiler.C
+++ b/src/Utility/Profiler.C
@@ -48,7 +48,7 @@ Profiler::~Profiler ()
 {
   this->stop("Total");
   if (autoReport)
-    this->report(std::cout);
+    this->report(IFEM::cout);
 
   LinAlgInit::decrefs();
   IFEM::Close();
@@ -163,7 +163,8 @@ std::ostream& operator<< (std::ostream& os, const Profiler::Profile& p)
 }
 
 
-void Profiler::report (std::ostream& os) const
+template<class Stream>
+void Profiler::report (Stream& os) const
 {
   if (myTimers.empty()) return;
 

--- a/src/Utility/Profiler.h
+++ b/src/Utility/Profiler.h
@@ -57,7 +57,7 @@ public:
   void stop(const std::string& funcName);
 
   //! \brief Prints a profiling report for all tasks that have been measured.
-  void report(std::ostream& os) const;
+  template<class Stream> void report(Stream& os) const;
   //! \brief Clears the profiler.
   void clear() { myTimers.clear(); allCPU = allWall = 0.0; nRunners = 0; }
 


### PR DESCRIPTION
Output to the per-process output instead of std::cout.

In particular this fixes unstable regression tests in parallel, where the profiler output from all processes has the potential to end up interleaved with output we are actually checking for (e.g. recently introduced eigenvalue regression tests).