### PR TITLE
Refactor MNPC generation for reuse

### DIFF
--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -392,8 +392,15 @@ public:
   virtual bool getParameterDomain(Real2DMat& u,
                                   IntVec* corners = nullptr) const = 0;
 
-  //! \brief Obtain element neighbours.
-  virtual void getElmConnectivities(IntMat& neighs, bool local = false) const = 0;
+  //! \brief Calculates the matrix of element neighbour connectivities.
+  //! \param[out] neighs List of element neighbors for each element
+  //! \param[in] local If \e true, return the local (patch-wise) element indices
+  virtual void getElmConnectivities(IntMat& neighs,
+                                    bool local = false) const = 0;
+
+  //! \brief Returns the matrix of nodal point correspondance for given basis.
+  virtual IntMat getElmNodes(int) const { return MNPC; }
+
 
   // Various preprocessing methods
   // =============================

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -451,8 +451,17 @@ public:
   //! \param[out] corners 1-based indices of the corner nodes (optional)
   virtual bool getParameterDomain(Real2DMat& u, IntVec* corners) const;
 
-  //! \brief Obtain element neighbours.
+  //! \brief Calculates the matrix of element neighbour connectivities.
+  //! \param[out] neigh List of element neighbors for each element
+  //! \param[in] local If \e true, return the local (patch-wise) element indices
   virtual void getElmConnectivities(IntMat& neigh, bool local = false) const;
+
+  //! \brief Returns the matrix of nodal point correspondance for given basis.
+  virtual IntMat getElmNodes(int basis) const;
+
+private:
+  //! \brief Creates matrix of nodal point correspondance for a spline curve.
+  static void createMNPC(const Go::SplineCurve* crv, IntMat& MNPC);
 
 protected:
   std::shared_ptr<Go::SplineCurve> curv; //!< The actual spline curve object

--- a/src/ASM/ASMs1DLag.h
+++ b/src/ASM/ASMs1DLag.h
@@ -146,6 +146,13 @@ public:
   //! \brief Returns the number of nodal points in the patch.
   virtual int getSize(int = 0) const { return nx; }
 
+  //! \brief Returns the matrix of nodal point correspondance.
+  virtual IntMat getElmNodes(int) const;
+
+private:
+  //! \brief Creates matrix of nodal point correspondance for a structured grid.
+  static void createMNPC(size_t nel, int p1, IntMat& MNPC);
+
 protected:
   size_t nx; //!< Number of nodes
   int    p1; //!< Polynomial order of the basis

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -20,8 +20,6 @@
 #include "Interface.h"
 #include "ThreadGroups.h"
 
-#include <memory>
-
 namespace utl {
   class Point;
 }
@@ -235,7 +233,8 @@ public:
   //! \param[in] iel 1-based element index local to current patch
   //! \param[in] forceItg If \e true, return the integration basis coordinates
   //! otherwise the geometry basis coordinates are returned
-  virtual bool getElementCoordinates(Matrix& X, int iel, bool forceItg = false) const;
+  virtual bool getElementCoordinates(Matrix& X, int iel,
+                                     bool forceItg = false) const;
 
   //! \brief Returns a matrix with all nodal coordinates within the patch.
   //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes
@@ -738,8 +737,13 @@ public:
   //! \param[out] n3 Number of nodes in third (w) direction
   virtual bool getNoStructElms(int& n1, int& n2, int& n3) const;
 
-  //! \brief Obtain element neighbours.
+  //! \brief Calculates the matrix of element neighbour connectivities.
+  //! \param[out] neigh List of element neighbors for each element
+  //! \param[in] local If \e true, return the local (patch-wise) element indices
   virtual void getElmConnectivities(IntMat& neigh, bool local = false) const;
+
+  //! \brief Returns the matrix of nodal point correspondance for given basis.
+  virtual IntMat getElmNodes(int basis) const;
 
   //! \brief Returns the number of elements on a boundary.
   virtual size_t getNoBoundaryElms(char lIndex, char ldim) const;
@@ -800,6 +804,9 @@ private:
   //! \brief Returns an index into the internal coefficient array for a node.
   //! \param[in] inod 0-based node index local to current patch
   int coeffInd(size_t inod) const;
+
+  //! \brief Creates matrix of nodal point correspondance for a spline surface.
+  static void createMNPC(const Go::SplineSurface* srf, IntMat& MNPC);
 
 protected:
   std::shared_ptr<Go::SplineSurface> surf; //!< The actual spline surface object

--- a/src/ASM/ASMs2DLag.h
+++ b/src/ASM/ASMs2DLag.h
@@ -270,8 +270,15 @@ public:
   //! \brief Generates element groups for multi-threading of interior integrals.
   virtual void generateThreadGroups(const Integrand&, bool, bool);
 
+  //! \brief Returns the matrix of nodal point correspondance for given basis.
+  virtual IntMat getElmNodes(int basis) const;
+
   //! \brief Returns the number of elements on a boundary.
   virtual size_t getNoBoundaryElms(char lIndex, char ldim) const;
+
+private:
+  //! \brief Returns matrix of nodal point correspondance for a structured grid.
+  static void createMNPC(size_t nx, size_t ny, int p1, int p2, IntMat& MNPC);
 
 protected:
   size_t nx; //!< Number of nodes in first parameter direction

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -20,8 +20,6 @@
 #include "Interface.h"
 #include "ThreadGroups.h"
 
-#include <memory>
-
 namespace utl {
   class Point;
 }
@@ -251,7 +249,8 @@ public:
   //! \param[in] iel 1-based element index local to current patch
   //! \param[in] forceItg If \e true, return the integration basis coordinates
   //! otherwise the geometry basis coordinates are returned
-  virtual bool getElementCoordinates(Matrix& X, int iel, bool forceItg = false) const;
+  virtual bool getElementCoordinates(Matrix& X, int iel,
+                                     bool forceItg = false) const;
 
   //! \brief Returns a matrix with all nodal coordinates within the patch.
   //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes
@@ -809,8 +808,13 @@ public:
   //! \param[out] n3 Number of nodes in third (w) direction
   virtual bool getNoStructElms(int& n1, int& n2, int& n3) const;
 
-  //! \brief Obtain element neighbours.
+  //! \brief Calculates the matrix of element neighbour connectivities.
+  //! \param[out] neigh List of element neighbors for each element
+  //! \param[in] local If \e true, return the local (patch-wise) element indices
   virtual void getElmConnectivities(IntMat& neigh, bool local = false) const;
+
+  //! \brief Returns the matrix of nodal point correspondance for given basis.
+  virtual IntMat getElmNodes(int basis) const;
 
   //! \brief Returns the number of elements on a boundary.
   virtual size_t getNoBoundaryElms(char lIndex, char ldim) const;
@@ -890,6 +894,9 @@ private:
   //! \param[in] basis Basis to obtain sizes for
   //! \param[in] face Face to obtain sizes for
   bool getFaceSize(int& n1, int& n2, int basis, int face) const;
+
+  //! \brief Creates matrix of nodal point correspondance for a spline surface.
+  static void createMNPC(const Go::SplineVolume* svol, IntMat& MNPC);
 
 protected:
   std::shared_ptr<Go::SplineVolume> svol;  //!< The actual spline volume object

--- a/src/ASM/ASMs3DLag.h
+++ b/src/ASM/ASMs3DLag.h
@@ -289,6 +289,9 @@ public:
   //! \param[in] lIndex Local index [1,6] of the boundary face
   virtual void generateThreadGroups(char lIndex, bool, bool);
 
+  //! \brief Returns the matrix of nodal point correspondance for given basis.
+  virtual IntMat getElmNodes(int basis) const;
+
   //! \brief Returns the number of elements on a boundary.
   virtual size_t getNoBoundaryElms(char lIndex, char ldim) const;
 
@@ -303,6 +306,11 @@ public:
   virtual bool assembleL2matrices(SparseMatrix& A, StdVector& B,
                                   const L2Integrand& integrand,
                                   bool continuous) const;
+
+private:
+  //! \brief Creates matrix of nodal point correspondance for a structured grid.
+  static void createMNPC(size_t nx, size_t ny, size_t nz,
+                         int p1, int p2, int p3, IntMat& MNPC);
 
 protected:
   size_t nx; //!< Number of nodes in first parameter direction

--- a/src/ASM/LR/ASMLRSpline.C
+++ b/src/ASM/LR/ASMLRSpline.C
@@ -184,6 +184,21 @@ void LR::generateThreadGroups (ThreadGroups& threadGroups,
 }
 
 
+void LR::createMNPC (const LR::LRSpline* basis, IntMat& result)
+{
+  result.resize(basis->nElements());
+  size_t iel = 0;
+  for (const LR::Element* elm : basis->getAllElements())
+  {
+    result[iel].resize(elm->nBasisFunctions());
+    std::transform(elm->support().begin(), elm->support().end(),
+                   result[iel].begin(),
+                   [](const LR::Basisfunction* b) { return b->getId(); });
+    ++iel;
+  }
+}
+
+
 ASMLRSpline::ASMLRSpline (unsigned char n_p, unsigned char n_s,
                           unsigned char n_f)
   : ASMbase(n_p,n_s,n_f)

--- a/src/ASM/LR/ASMLRSpline.h
+++ b/src/ASM/LR/ASMLRSpline.h
@@ -59,6 +59,11 @@ namespace LR //! Utilities for LR-splines.
   void generateThreadGroups(ThreadGroups& threadGroups,
                             const LRSpline* lr,
                             const std::vector<LRSpline*>& addConstraints = {});
+
+  //! \brief Createss the matrix of nodal point correspondance for a LR-spline.
+  //! \param[in] basis LR-spline to get nodal point correspondance for
+  //! \param[out] result Matrix of nodal point correspondance for the elements
+  void createMNPC(const LR::LRSpline* basis, IntMat& result);
 }
 
 

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -155,10 +155,16 @@ public:
   //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes
   //! in one element
   //! \param[in] forceItg If true return integration basis element coordinates
-  virtual bool getElementCoordinates(Matrix& X, int iel, bool forceItg = false) const;
+  virtual bool getElementCoordinates(Matrix& X, int iel,
+                                     bool forceItg = false) const;
 
-  //! \brief Obtain element neighbours.
+  //! \brief Calculates the matrix of element neighbour connectivities.
+  //! \param[out] neighs List of element neighbors for each element
+  //! \param[in] local If \e true, return the local (patch-wise) element indices
   virtual void getElmConnectivities(IntMat& neighs, bool local = false) const;
+
+  //! \brief Returns the matrix of nodal point correspondance for given basis.
+  virtual IntMat getElmNodes(int basis) const;
 
   //! \brief Returns a matrix with all nodal coordinates within the patch.
   //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -140,10 +140,16 @@ public:
   //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes
   //! in one element
   //! \param[in] forceItg If true return integration basis element coordinates
-  virtual bool getElementCoordinates(Matrix& X, int iel, bool forceItg = false) const;
+  virtual bool getElementCoordinates(Matrix& X, int iel,
+                                     bool forceItg = false) const;
 
-  //! \brief Obtain element neighbours.
+  //! \brief Calculates the matrix of element neighbour connectivities.
+  //! \param[out] neighs List of element neighbors for each element
+  //! \param[in] local If \e true, return the local (patch-wise) element indices
   virtual void getElmConnectivities(IntMat& neighs, bool local = false) const;
+
+  //! \brief Returns the matrix of nodal point correspondance for given basis.
+  virtual IntMat getElmNodes(int basis) const;
 
   //! \brief Returns a matrix with all nodal coordinates within the patch.
   //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes

--- a/src/ASM/LR/Test/TestASMu2D.C
+++ b/src/ASM/LR/Test/TestASMu2D.C
@@ -344,3 +344,48 @@ TEST(TestASMu2D, Write)
   EXPECT_TRUE(pch1.write(str, ASM::INTEGRATION_BASIS));
   EXPECT_EQ(str.str(), ASMuSquare::square);
 }
+
+
+TEST(TestASMu2D, ElmNodes)
+{
+  ASMbase::resetNumbering();
+
+  ASMuSquare pch1;
+  pch1.createProjectionBasis(true);
+  pch1.raiseOrder(1,1);
+  pch1.uniformRefine(0,1);
+  pch1.uniformRefine(1,1);
+  pch1.createProjectionBasis(false);
+  ASSERT_TRUE(pch1.uniformRefine(0,1));
+  ASSERT_TRUE(pch1.uniformRefine(1,1));
+  ASSERT_TRUE(pch1.generateFEMTopology());
+
+  const IntMat mnpc = pch1.getElmNodes(1);
+
+  const auto ref = std::array{
+      std::array{0,2,6,8},
+      std::array{1,2,7,8},
+      std::array{3,5,6,8},
+      std::array{4,5,7,8},
+  };
+  ASSERT_EQ(mnpc.size(), ref.size());
+  for (size_t i = 0; i < mnpc.size(); ++i) {
+    EXPECT_EQ(mnpc[i].size(), ref[i].size());
+    for (size_t j = 0; j < mnpc[i].size(); ++j)
+      EXPECT_EQ(mnpc[i][j], ref[i][j]);
+  }
+
+  const auto ref_proj = std::array{
+      std::array{0,2,3,8,10,11,12,14,15},
+      std::array{1,2,3,9,10,11,13,14,15},
+      std::array{4,6,7,8,10,11,12,14,15},
+      std::array{5,6,7,9,10,11,13,14,15},
+  };
+  const IntMat mnpc_proj = pch1.getElmNodes(ASM::PROJECTION_BASIS);
+  ASSERT_EQ(mnpc_proj.size(), ref_proj.size());
+  for (size_t i = 0; i < mnpc_proj.size(); ++i) {
+    EXPECT_EQ(mnpc_proj[i].size(), ref_proj[i].size());
+    for (size_t j = 0; j < mnpc_proj[i].size(); ++j)
+      EXPECT_EQ(mnpc_proj[i][j], ref_proj[i][j]);
+  }
+}

--- a/src/ASM/LR/Test/TestASMu3D.C
+++ b/src/ASM/LR/Test/TestASMu3D.C
@@ -258,3 +258,58 @@ TEST(TestASMu3D, Write)
   EXPECT_TRUE(pch1.write(str, ASM::INTEGRATION_BASIS));
   EXPECT_EQ(str.str(), ASMuCube::cube);
 }
+
+
+TEST(TestASMu3D, ElmNodes)
+{
+  ASMbase::resetNumbering();
+
+  ASMuCube pch1;
+  pch1.createProjectionBasis(true);
+  pch1.raiseOrder(1,1,1,false);
+  pch1.uniformRefine(0,1);
+  pch1.uniformRefine(1,1);
+  pch1.uniformRefine(2,1);
+  pch1.createProjectionBasis(false);
+  ASSERT_TRUE(pch1.uniformRefine(0,1));
+  ASSERT_TRUE(pch1.uniformRefine(1,1));
+  ASSERT_TRUE(pch1.uniformRefine(2,1));
+  ASSERT_TRUE(pch1.generateFEMTopology());
+
+  const IntMat mnpc = pch1.getElmNodes(1);
+
+  const auto ref = std::array{
+      std::array{0,2,6,8,18,20,24,26},
+      std::array{1,2,7,8,19,20,25,26},
+      std::array{3,5,6,8,21,23,24,26},
+      std::array{4,5,7,8,22,23,25,26},
+      std::array{9,11,15,17,18,20,24,26},
+      std::array{10,11,16,17,19,20,25,26},
+      std::array{12,14,15,17,21,23,24,26},
+      std::array{13,14,16,17,22,23,25,26},
+  };
+  ASSERT_EQ(mnpc.size(), ref.size());
+  for (size_t i = 0; i < mnpc.size(); ++i) {
+    EXPECT_EQ(mnpc[i].size(), ref[i].size());
+    for (size_t j = 0; j < mnpc[i].size(); ++j)
+      EXPECT_EQ(mnpc[i][j], ref[i][j]);
+  }
+
+  const auto ref_proj = std::array{
+      std::array{0,1,2,4,5,6,8,9,10,16,17,18,20,21,22,24,25,26,32,33,34,36,37,38,40,41,42},
+      std::array{1,2,3,5,6,7,9,10,11,17,18,19,21,22,23,25,26,27,33,34,35,37,38,39,41,42,43},
+      std::array{4,5,6,8,9,10,12,13,14,20,21,22,24,25,26,28,29,30,36,37,38,40,41,42,44,45,46},
+      std::array{5,6,7,9,10,11,13,14,15,21,22,23,25,26,27,29,30,31,37,38,39,41,42,43,45,46,47},
+      std::array{16,17,18,20,21,22,24,25,26,32,33,34,36,37,38,40,41,42,48,49,50,52,53,54,56,57,58},
+      std::array{17,18,19,21,22,23,25,26,27,33,34,35,37,38,39,41,42,43,49,50,51,53,54,55,57,58,59},
+      std::array{20,21,22,24,25,26,28,29,30,36,37,38,40,41,42,44,45,46,52,53,54,56,57,58,60,61,62},
+      std::array{21,22,23,25,26,27,29,30,31,37,38,39,41,42,43,45,46,47,53,54,55,57,58,59,61,62,63},
+  };
+  const IntMat mnpc_proj = pch1.getElmNodes(ASM::PROJECTION_BASIS);
+  ASSERT_EQ(mnpc_proj.size(), ref_proj.size());
+  for (size_t i = 0; i < mnpc_proj.size(); ++i) {
+    EXPECT_EQ(mnpc_proj[i].size(), ref_proj[i].size());
+    for (size_t j = 0; j < mnpc_proj[i].size(); ++j)
+      EXPECT_EQ(mnpc_proj[i][j], ref_proj[i][j]);
+  }
+}

--- a/src/ASM/Test/TestASMs1D.C
+++ b/src/ASM/Test/TestASMs1D.C
@@ -21,13 +21,15 @@
 class ASMLine : public ASMs1D
 {
 public:
-  explicit ASMLine(int extraKnots = 0, int extraOrder = 0)
+  explicit ASMLine(int extraKnots = 0, int extraOrder = 0, bool init = true)
   {
     std::stringstream geo("100 1 0 0\n2 0\n2 2\n0 0 1 1\n0 0\n1 0\n");
     EXPECT_TRUE(this->read(geo));
     EXPECT_TRUE(this->raiseOrder(extraOrder));
-    EXPECT_TRUE(this->uniformRefine(extraKnots));
-    EXPECT_TRUE(this->generateFEMTopology());
+    if (extraKnots > 0)
+      EXPECT_TRUE(this->uniformRefine(extraKnots));
+    if (init)
+      EXPECT_TRUE(this->generateFEMTopology());
   }
 
   void shiftElmNumbers(int shift)
@@ -176,5 +178,45 @@ TEST(TestASMs1D, BoundaryElements)
     pch1.getBoundaryElms(i, nodes);
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes.front(), i == 1 ? 0 : 2);
+  }
+}
+
+
+TEST(TestASMs1D, ElmNodes)
+{
+  ASMbase::resetNumbering();
+
+  ASMLine pch1(0, 0, false);
+  pch1.createProjectionBasis(true);
+  pch1.raiseOrder(1);
+  pch1.uniformRefine(2);
+  pch1.createProjectionBasis(false);
+  pch1.uniformRefine(2);
+  EXPECT_TRUE(pch1.generateFEMTopology());
+  const IntMat mnpc = pch1.getElmNodes(1);
+
+  const auto ref = std::array{
+      std::array{0,1},
+      std::array{1,2},
+      std::array{2,3},
+  };
+  ASSERT_EQ(mnpc.size(), ref.size());
+  for (size_t i = 0; i < mnpc.size(); ++i) {
+    EXPECT_EQ(mnpc[i].size(), ref[i].size());
+    for (size_t j = 0; j < mnpc[i].size(); ++j)
+      EXPECT_EQ(mnpc[i][j], ref[i][j]);
+  }
+
+  const auto ref_proj = std::array{
+      std::array{0,1,2},
+      std::array{1,2,3},
+      std::array{2,3,4},
+  };
+  const IntMat mnpc_proj = pch1.getElmNodes(ASM::PROJECTION_BASIS);
+  ASSERT_EQ(mnpc_proj.size(), ref_proj.size());
+  for (size_t i = 0; i < mnpc_proj.size(); ++i) {
+    EXPECT_EQ(mnpc_proj[i].size(), ref_proj[i].size());
+    for (size_t j = 0; j < mnpc_proj[i].size(); ++j)
+      EXPECT_EQ(mnpc_proj[i][j], ref_proj[i][j]);
   }
 }

--- a/src/ASM/Test/TestASMs2D.C
+++ b/src/ASM/Test/TestASMs2D.C
@@ -161,3 +161,48 @@ TEST(TestASMs2D, Collapse)
     EXPECT_TRUE(pch.collapseEdge(iedge));
   }
 }
+
+
+TEST(TestASMs2D, ElmNodes)
+{
+  ASMbase::resetNumbering();
+
+  ASMSquare pch1;
+  pch1.createProjectionBasis(true);
+  pch1.raiseOrder(1,1);
+  pch1.uniformRefine(0,1);
+  pch1.uniformRefine(1,1);
+  pch1.createProjectionBasis(false);
+  ASSERT_TRUE(pch1.uniformRefine(0,1));
+  ASSERT_TRUE(pch1.uniformRefine(1,1));
+  ASSERT_TRUE(pch1.generateFEMTopology());
+
+  const IntMat mnpc = pch1.getElmNodes(1);
+
+  const auto ref = std::array{
+      std::array{0,1,3,4},
+      std::array{1,2,4,5},
+      std::array{3,4,6,7},
+      std::array{4,5,7,8},
+  };
+  ASSERT_EQ(mnpc.size(), ref.size());
+  for (size_t i = 0; i < mnpc.size(); ++i) {
+    EXPECT_EQ(mnpc[i].size(), ref[i].size());
+    for (size_t j = 0; j < mnpc[i].size(); ++j)
+      EXPECT_EQ(mnpc[i][j], ref[i][j]);
+  }
+
+  const auto ref_proj = std::array{
+      std::array{0,1,2,4,5,6,8,9,10},
+      std::array{1,2,3,5,6,7,9,10,11},
+      std::array{4,5,6,8,9,10,12,13,14},
+      std::array{5,6,7,9,10,11,13,14,15},
+  };
+  const IntMat mnpc_proj = pch1.getElmNodes(ASM::PROJECTION_BASIS);
+  ASSERT_EQ(mnpc_proj.size(), ref_proj.size());
+  for (size_t i = 0; i < mnpc_proj.size(); ++i) {
+    EXPECT_EQ(mnpc_proj[i].size(), ref_proj[i].size());
+    for (size_t j = 0; j < mnpc_proj[i].size(); ++j)
+      EXPECT_EQ(mnpc_proj[i][j], ref_proj[i][j]);
+  }
+}

--- a/src/ASM/Test/TestASMs3D.C
+++ b/src/ASM/Test/TestASMs3D.C
@@ -404,3 +404,58 @@ TEST(TestASMs3D, FaceIntegrate)
     ASSERT_TRUE(patch.integrate(prb,lIndex,dummy,TimeDomain()));
   }
 }
+
+
+TEST(TestASMs3D, ElmNodes)
+{
+  ASMbase::resetNumbering();
+
+  ASMCube pch1;
+  pch1.createProjectionBasis(true);
+  pch1.raiseOrder(1,1,1);
+  pch1.uniformRefine(0,1);
+  pch1.uniformRefine(1,1);
+  pch1.uniformRefine(2,1);
+  pch1.createProjectionBasis(false);
+  ASSERT_TRUE(pch1.uniformRefine(0,1));
+  ASSERT_TRUE(pch1.uniformRefine(1,1));
+  ASSERT_TRUE(pch1.uniformRefine(2,1));
+  ASSERT_TRUE(pch1.generateFEMTopology());
+
+  const IntMat mnpc = pch1.getElmNodes(1);
+
+  const auto ref = std::array{
+      std::array{0,1,3,4,9,10,12,13},
+      std::array{1,2,4,5,10,11,13,14},
+      std::array{3,4,6,7,12,13,15,16},
+      std::array{4,5,7,8,13,14,16,17},
+      std::array{9,10,12,13,18,19,21,22},
+      std::array{10,11,13,14,19,20,22,23},
+      std::array{12,13,15,16,21,22,24,25},
+      std::array{13,14,16,17,22,23,25,26},
+  };
+  ASSERT_EQ(mnpc.size(), ref.size());
+  for (size_t i = 0; i < mnpc.size(); ++i) {
+    EXPECT_EQ(mnpc[i].size(), ref[i].size());
+    for (size_t j = 0; j < mnpc[i].size(); ++j)
+      EXPECT_EQ(mnpc[i][j], ref[i][j]);
+  }
+
+  const auto ref_proj = std::array{
+      std::array{0,1,2,4,5,6,8,9,10,16,17,18,20,21,22,24,25,26,32,33,34,36,37,38,40,41,42},
+      std::array{1,2,3,5,6,7,9,10,11,17,18,19,21,22,23,25,26,27,33,34,35,37,38,39,41,42,43},
+      std::array{4,5,6,8,9,10,12,13,14,20,21,22,24,25,26,28,29,30,36,37,38,40,41,42,44,45,46},
+      std::array{5,6,7,9,10,11,13,14,15,21,22,23,25,26,27,29,30,31,37,38,39,41,42,43,45,46,47},
+      std::array{16,17,18,20,21,22,24,25,26,32,33,34,36,37,38,40,41,42,48,49,50,52,53,54,56,57,58},
+      std::array{17,18,19,21,22,23,25,26,27,33,34,35,37,38,39,41,42,43,49,50,51,53,54,55,57,58,59},
+      std::array{20,21,22,24,25,26,28,29,30,36,37,38,40,41,42,44,45,46,52,53,54,56,57,58,60,61,62},
+      std::array{21,22,23,25,26,27,29,30,31,37,38,39,41,42,43,45,46,47,53,54,55,57,58,59,61,62,63},
+  };
+  const IntMat mnpc_proj = pch1.getElmNodes(ASM::PROJECTION_BASIS);
+  ASSERT_EQ(mnpc_proj.size(), ref_proj.size());
+  for (size_t i = 0; i < mnpc_proj.size(); ++i) {
+    EXPECT_EQ(mnpc_proj[i].size(), ref_proj[i].size());
+    for (size_t j = 0; j < mnpc_proj[i].size(); ++j)
+      EXPECT_EQ(mnpc_proj[i][j], ref_proj[i][j]);
+  }
+}


### PR DESCRIPTION
This should replace #768.
The main difference is that the class-dependent implementation is now in the static method `createMNPC()` for each class, which then is used by the the virtual `getElmNodes()` methods. The static methods are also used internally instead of going via the virtual method. In addition, the Lagrange implementation of `getElmNodes()` was probably buggy, in that the `nx`, `ny` and `nz` members where used also when calculating for the projection basis. Now they are recalculated using the correct spline object before invoking the static method for generating  the MNPC.