### PR TITLE
Changed: allocated=false as default in SIMbase::getNoSolutions()

### DIFF
--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -196,7 +196,7 @@ public:
   //! including zero-volume elements due to multiple knots, etc.
   size_t getNoElms(bool includeXelms = false, bool includeZelms = false) const;
   //! \brief Returns the number of solution vectors.
-  size_t getNoSolutions(bool allocated = true) const;
+  size_t getNoSolutions(bool allocated = false) const;
   //! \brief Returns the total number of patches in the model.
   int getNoPatches() const { return nGlPatches; }
   //! \brief Returns the number of unknowns in the linear equation system.


### PR DESCRIPTION
Required for sintefmath/IFEM-Stokes#327 and sintefmath/IFEM-NavierStokes#259 when this method is used during initializations before the solution vectors are allocated (by invoking setMode).