### PR TITLE
Fix VTF output for Lagrange models with extra-ordinary nodes

### DIFF
--- a/src/ASM/ASMs1DLag.C
+++ b/src/ASM/ASMs1DLag.C
@@ -478,7 +478,7 @@ bool ASMs1DLag::evalSolution (Matrix& sField, const Vector& locSol,
                               const RealArray*, bool, int, int) const
 {
   // Direct nodal evaluation
-  return this->nodalField(sField,locSol,coord.size());
+  return this->nodalField(sField,locSol,nnod);
 }
 
 

--- a/src/ASM/ASMs2DLag.C
+++ b/src/ASM/ASMs2DLag.C
@@ -343,6 +343,8 @@ bool ASMs2DLag::integrate (Integrand& integrand,
         int iel = group[e];
         if (iel < 0 || iel >= static_cast<int>(nel))
         {
+          std::cerr <<" *** ASMs2DLag::integrate: Element index "<< iel
+                    <<" out of range [0,"<< nel <<">."<< std::endl;
           ok = false;
           break;
         }
@@ -369,6 +371,8 @@ bool ASMs2DLag::integrate (Integrand& integrand,
         const int nRed = fe.Xn.cols() < 4 ? 0 : cache.nGauss(true).front();
         if (!integrand.initElement(MNPC[iel],fe,X,nRed*nRed,*A))
         {
+          std::cerr <<" *** ASMs2DLag::integrate: Failed to initialize element "
+                    << iel <<" "<< fe.iel << std::endl;
           A->destruct();
           ok = false;
           break;
@@ -888,7 +892,11 @@ bool ASMs2DLag::evalSolution (Matrix& sField, const IntegrandBase& integrand,
 
 void ASMs2DLag::generateThreadGroups (const Integrand&, bool, bool)
 {
-  threadGroups.calcGroups((nx-1)/(p1-1),(ny-1)/(p2-1),1);
+  if (threadGroups.stripDir == ThreadGroups::NONE)
+    threadGroups.oneGroup(nel);
+  else
+    threadGroups.calcGroups((nx-1)/(p1-1),(ny-1)/(p2-1),1);
+
   projThreadGroups = threadGroups;
 }
 

--- a/src/ASM/ASMs2DLag.C
+++ b/src/ASM/ASMs2DLag.C
@@ -727,7 +727,7 @@ bool ASMs2DLag::evalSolution (Matrix& sField, const Vector& locSol,
                               int, int) const
 {
   if (!gpar && !regular) // Direct nodal evaluation
-    return this->nodalField(sField,locSol,this->getNoNodes(-1));
+    return this->nodalField(sField,locSol,nnod);
 
   size_t nCmp = locSol.size() / this->getNoProjectionNodes();
   size_t ni   = gpar ? gpar[0].size() : nel;

--- a/src/ASM/ASMs2DTri.C
+++ b/src/ASM/ASMs2DTri.C
@@ -577,7 +577,11 @@ bool ASMs2DTri::evalSolution (Matrix&, const IntegrandBase&,
 
 void ASMs2DTri::generateThreadGroups (const Integrand&, bool, bool)
 {
-  threadGroups.calcGroups(nx-1,ny-1,1);
+  if (threadGroups.stripDir == ThreadGroups::NONE)
+    threadGroups.oneGroup(nel);
+  else
+    threadGroups.calcGroups(nx-1,ny-1,1);
+
 #if defined(USE_OPENMP) && SP_DEBUG > 1
   std::cout <<"\nThreading groups after triangularization:"<< std::endl;
 #endif

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -1281,6 +1281,12 @@ bool ASMs2Dmx::evalSolution (Matrix& sField, const IntegrandBase& integrand,
 void ASMs2Dmx::generateThreadGroups (const Integrand& integrand, bool silence,
                                      bool ignoreGlobalLM)
 {
+  if (threadGroups.stripDir == ThreadGroups::NONE)
+  {
+    threadGroups.oneGroup(nel);
+    return;
+  }
+
   int p1 = 0, p2 = 0;
   for (const auto& it : m_basis) {
     if (it->order_u() > p1)

--- a/src/ASM/ASMs3DLag.C
+++ b/src/ASM/ASMs3DLag.C
@@ -987,7 +987,7 @@ bool ASMs3DLag::evalSolution (Matrix& sField, const Vector& locSol,
                               int, int) const
 {
   if (!gpar && !regular) // Direct nodal evaluation
-    return this->nodalField(sField,locSol,this->getNoNodes(-1));
+    return this->nodalField(sField,locSol,nnod);
 
   size_t nCmp = locSol.size() / this->getNoProjectionNodes();
   size_t ni   = gpar ? gpar[0].size() : nel;

--- a/src/ASM/ASMs3Dmx.C
+++ b/src/ASM/ASMs3Dmx.C
@@ -1271,17 +1271,31 @@ std::array<int,3> ASMs3Dmx::getMaxSplineOrder () const
 void ASMs3Dmx::generateThreadGroups (const Integrand& integrand, bool silence,
                                      bool ignoreGlobalLM)
 {
-  const std::array<int,3> p = getMaxSplineOrder();
-  this->ASMs3D::generateThreadGroups(p[0]-1, p[1]-1, p[2]-1,
-                                     silence, ignoreGlobalLM);
+  if (threadGroupsVol.stripDir == ThreadGroups::NONE)
+    threadGroupsVol.oneGroup(nel);
+  else
+  {
+    const std::array<int,3> p = this->getMaxSplineOrder();
+    this->ASMs3D::generateThreadGroups(p[0]-1, p[1]-1, p[2]-1,
+                                       silence, ignoreGlobalLM);
+  }
 }
 
 
 void ASMs3Dmx::generateThreadGroups (char lIndex, bool silence, bool)
 {
-  const std::array<int,3> p = getMaxSplineOrder();
-  this->ASMs3D::generateThreadGroups(p[0]-1, p[1]-1, p[2]-1,
-                                     lIndex,silence,false);
+  std::map<char,ThreadGroups>::iterator tit = threadGroupsFace.find(lIndex);
+  if (tit != threadGroupsFace.end())
+  {
+    if (tit->second.stripDir == ThreadGroups::NONE)
+      tit->second.oneGroup(nel);
+  }
+  else
+  {
+    const std::array<int,3> p = this->getMaxSplineOrder();
+    this->ASMs3D::generateThreadGroups(p[0]-1, p[1]-1, p[2]-1,
+                                       lIndex,silence,false);
+  }
 }
 
 

--- a/src/ASM/LR/ASMLRSpline.C
+++ b/src/ASM/LR/ASMLRSpline.C
@@ -98,7 +98,7 @@ void LR::generateThreadGroups (ThreadGroups& threadGroups,
 {
   int nElement = lr->nElements();
 #ifdef USE_OPENMP
-  if (omp_get_max_threads() > 1)
+  if (omp_get_max_threads() > 1 && threadGroups.stripDir != ThreadGroups::NONE)
   {
     threadGroups[0].clear();
     threadGroups[1].clear();

--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -725,6 +725,7 @@ bool SIMoutput::writeGlvBC (int& nBlock, int iStep) const
 
   Matrix field;
   std::array<IntVec,6> dID;
+  std::array<int,6> flag{};
 
   size_t j, n;
   int geomID = myGeomID;
@@ -735,14 +736,12 @@ bool SIMoutput::writeGlvBC (int& nBlock, int iStep) const
 
     ++geomID;
     size_t nbc = pch->getNoFields(1);
-    size_t nNodes = pch->getNoNodes(-1);
-    for (n = 2; n <= pch->getNoBasis(); n++)
-      nNodes -= pch->getNoNodes(n);
-    Vector bc(nbc*nNodes);
-    std::array<int,6> flag{0,0,0,0,0,0};
+    size_t nNod = pch->getNoNodes(1);
+    Vector bc(nbc*nNod);
+    flag.fill(0);
     ASMbase::BCVec::const_iterator bit;
     for (bit = pch->begin_BC(); bit != pch->end_BC(); ++bit)
-      if ((n = pch->getNodeIndex(bit->node,true)) && n <= nNodes)
+      if ((n = pch->getNodeIndex(bit->node,true)) && n <= nNod)
       {
         size_t offs = nbc*(n-1);
         if (!bit->CX && nbc > 0) bc[offs]   = flag[0] = 1;


### PR DESCRIPTION
This fixes #783. We now always consider basis 1 only when writing BC codes to VTF-file, such that the extraordinary nodes (either from rigid elements or contact analysis) are excluded. If not, the export would fail for Lagrange meshes where a one-to-one correspondence between the FE nodes and the visualization nodes are assumed. For spline meshes it worked since the fields are interpolated anyway.

Also deactivating multi-threading for Lagrange and mixed models when requested. It was only done for single-basis spline models so far.