### PR TITLE
Fixed: utl::parseTracFunc() for type="linear"

### DIFF
--- a/src/SIM/AdaptiveSIM.C
+++ b/src/SIM/AdaptiveSIM.C
@@ -38,9 +38,9 @@ bool AdaptiveSIM::parse (char* keyWord, std::istream& is)
 }
 
 
-bool AdaptiveSIM::preprocess (const std::vector<int>& ignored, bool fixDup)
+bool AdaptiveSIM::preprocessC (const IntVec& ignored, bool fixDup, double time0)
 {
-  return model.preprocess(ignored,fixDup);
+  return model.preprocessC(ignored,fixDup,time0);
 }
 
 

--- a/src/SIM/AdaptiveSIM.h
+++ b/src/SIM/AdaptiveSIM.h
@@ -80,9 +80,9 @@ public:
   virtual bool parse(const tinyxml2::XMLElement* elem);
 
   //! \brief Performs some pre-processing tasks on the FE model.
-  //! \param[in] ignored Indices of patches to ignore in the analysis
+  //! \param[in] ignored Indices of patches to be ignored in the analysis
   //! \param[in] fixDup Merge duplicated FE nodes on patch interfaces?
-  virtual bool preprocess(const std::vector<int>& ignored, bool fixDup);
+  virtual bool preprocessC(const IntVec& ignored, bool fixDup, double time0);
 
 protected:
   //! \brief Assembles and solves the linear FE equation system.

--- a/src/SIM/SIMadmin.h
+++ b/src/SIM/SIMadmin.h
@@ -31,6 +31,8 @@
 class SIMadmin : public XMLInputBase
 {
 protected:
+  using IntVec = std::vector<int>; //!< Convenience alias
+
   //! \brief The default constructor initializes the process administrator.
   explicit SIMadmin(const char* heading = nullptr);
   //! \brief Copy constructor.
@@ -49,7 +51,13 @@ public:
   virtual bool parse(const tinyxml2::XMLElement* elem);
 
   //! \brief Performs some pre-processing tasks on the FE model.
-  virtual bool preprocess(const std::vector<int>&, bool) { return false; }
+  virtual bool preprocess(const IntVec& ignored = {}, bool fixDup = false)
+  {
+    return this->preprocessC(ignored,fixDup);
+  }
+
+  //! \brief Performs some pre-processing tasks on the FE model.
+  virtual bool preprocessC(const IntVec&, bool, double = 0.0) { return false; }
 
   //! \brief Returns the parallel process administrator.
   const ProcessAdm& getProcessAdm() const { return adm; }

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -192,7 +192,7 @@ void printNodalConnectivity (const ASMVec& model, std::ostream& os)
 #endif
 
 
-bool SIMbase::preprocess (const IntVec& ignored, bool fixDup)
+bool SIMbase::preprocessC (const IntVec& ignored, bool fixDup, double time0)
 {
   if (myModel.empty())
     return true; // Empty simulator, nothing to preprocess
@@ -359,7 +359,7 @@ bool SIMbase::preprocess (const IntVec& ignored, bool fixDup)
     ASMbase::resolveMPCchains(allMPCs,myModel,timeDependent);
 
   // Set initial values for the inhomogeneous dirichlet conditions, if any
-  if (timeDependent && !this->initDirichlet())
+  if (timeDependent && !this->initDirichlet(time0))
     return false;
 
   // Generate element groups for multi-threading

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -101,9 +101,8 @@ public:
   //! \brief Performs some pre-processing tasks on the FE model.
   //! \param[in] ignored Indices of patches to ignore in the analysis
   //! \param[in] fixDup Merge duplicated FE nodes on patch interfaces?
-  //! \return Total number of unique FE nodes in the model
-  virtual bool preprocess(const std::vector<int>& ignored = std::vector<int>(),
-                          bool fixDup = false);
+  //! \param[in] time0 Initial time for time-dependent dirichlet conditions
+  virtual bool preprocessC(const IntVec& ignored, bool fixDup, double time0);
 
   //! \brief Merges the global equation system of \a that simulator with this.
   //! \param that The simulator whose equation system is to be merged
@@ -219,22 +218,22 @@ public:
   //! \brief Returns the process-local node number from a global node number.
   int getLocalNode(int node) const;
   //! \brief Finds the Matrix of Nodal Point Correspondance for element \a iel.
-  bool getElmNodes(std::vector<int>& mnpc, int iel) const;
+  bool getElmNodes(IntVec& mnpc, int iel) const;
   //! \brief Obtain element-element connectivities
-  virtual std::vector<std::vector<int>> getElmConnectivities() const = 0;
+  virtual std::vector<IntVec> getElmConnectivities() const = 0;
 
   //! \brief Finds the list of global nodes associated with a boundary.
   //! \param[in] pcode Property code identifying the boundary
   //! \param[out] glbNodes Global node numbers on the boundary
   //! \param[out] XYZ Spatial coordinates of the boundary nodes (optional)
-  void getBoundaryNodes(int pcode, std::vector<int>& glbNodes,
+  void getBoundaryNodes(int pcode, IntVec& glbNodes,
                         std::vector<Vec3>* XYZ = nullptr) const;
 
   //! \brief Finds the node that is closest to the given point \b X.
   int findClosestNode(const Vec3&) const;
 
   //! \brief Returns a predefined node set.
-  std::vector<int> getNodeSet(const std::string& setName) const;
+  IntVec getNodeSet(const std::string& setName) const;
 
   //! \brief Initializes time-dependent in-homogeneous Dirichlet coefficients.
   //! \param[in] time Current time
@@ -727,7 +726,7 @@ public:
   void dumpSolVec(const Vector& x,bool isExpanded = true, bool expOnly = false);
 
   //! \brief Prints out nodal reaction forces to the log stream.
-  virtual int printNRforces(const std::vector<int>& = {}) const { return 0; }
+  virtual int printNRforces(const IntVec& = {}) const { return 0; }
 
 protected:
   //! \brief Returns the multi-dimension simulator sequence flag.
@@ -775,8 +774,7 @@ private:
   //! \brief Returns an extraordinary MADOF array.
   //! \param[in] basis The basis to specify number of DOFs for
   //! \param[in] nndof Number of nodal DOFs on the given basis
-  const std::vector<int>& getMADOF(unsigned char basis,
-                                   unsigned char nndof) const;
+  const IntVec& getMADOF(unsigned char basis, unsigned char nndof) const;
 
 public:
   static bool ignoreDirichlet; //!< Set to \e true for free vibration analysis
@@ -840,8 +838,8 @@ protected:
 
   // Parallel computing attributes
   int               nGlPatches; //!< Number of global patches
-  std::vector<int>  myPatches;  //!< Global patch numbers for current processor
-  std::vector<int>  myLoc2Glb;  //!< Local-to-global node number mapping
+  IntVec            myPatches;  //!< Global patch numbers for current processor
+  IntVec            myLoc2Glb;  //!< Local-to-global node number mapping
   std::map<int,int> myGlb2Loc;  //!< Global-to-local node number mapping
   const std::map<int,int>* g2l; //!< Pointer to global-to-local node mapping
   std::map<int,int> myDegenElm; //!< Degenerated elements mapping
@@ -859,7 +857,7 @@ private:
   char   mdFlag; //!< Sequence flag for multi-dimensional simulators
 
   //! Additional MADOF arrays with varying DOF counts per node
-  mutable std::map<int,std::vector<int>> extraMADOFs;
+  mutable std::map<int,IntVec> extraMADOFs;
 
   mutable double extEnergy;  //!< Path integral of external forces
   mutable Vector prevForces; //!< Reaction forces of previous time step

--- a/src/SIM/SIMmultiCpl.C
+++ b/src/SIM/SIMmultiCpl.C
@@ -86,14 +86,14 @@ bool SIMmultiCpl::parseConnection (const tinyxml2::XMLElement* elem)
 }
 
 
-bool SIMmultiCpl::preprocess (const std::vector<int>& ignored, bool fixDup)
+bool SIMmultiCpl::preprocessC (const IntVec& ignored, bool fixDup, double time0)
 {
   // Preprocess the FE model of each sub-simulator
-  std::vector<int> empty;
+  IntVec empty;
   int nOffset = 0, pOffset = 0;
   std::map<SIMinput*,int> nSubNodes, nSubPatch;
   for (SIMoutput* sim : mySims)
-    if (sim->preprocess(nOffset == 0 ? ignored : empty, fixDup))
+    if (sim->preprocessC(nOffset == 0 ? ignored : empty, fixDup, time0))
     {
       nSubNodes[sim] = nOffset;
       nSubPatch[sim] = pOffset;
@@ -111,7 +111,7 @@ bool SIMmultiCpl::preprocess (const std::vector<int>& ignored, bool fixDup)
   std::map<int,int> cplNodes;
   for (const SIMcoupling& cpl : myCpl)
   {
-    std::vector<int> mNodes, sNodes;
+    IntVec mNodes, sNodes;
     cpl.mstSim->getTopItemNodes(*cpl.master,mNodes);
     cpl.slvSim->getTopItemNodes(*cpl.slave,sNodes);
     for (int& n : mNodes) n += nSubNodes[cpl.mstSim];

--- a/src/SIM/SIMmultiCpl.h
+++ b/src/SIM/SIMmultiCpl.h
@@ -38,9 +38,10 @@ public:
   virtual bool parse(const tinyxml2::XMLElement* elem);
 
   //! \brief Performs some pre-processing tasks on the FE model.
-  //! \param[in] ignored Indices of patches to ignore in the analysis
+  //! \param[in] ignored Indices of patches to be ignored in the analysis
   //! \param[in] fixDup Merge duplicated FE nodes on patch interfaces?
-  virtual bool preprocess(const std::vector<int>& ignored, bool fixDup);
+  //! \param[in] time0 Initial time for time-dependent dirichlet conditions
+  virtual bool preprocessC(const IntVec& ignored, bool fixDup, double time0);
 
 private:
   //! \brief Parses a connection definition from an XML element.

--- a/src/Utility/Functions.C
+++ b/src/Utility/Functions.C
@@ -1107,7 +1107,10 @@ TractionFunc* utl::parseTracFunc (const std::string& func,
   RealFunc* f = nullptr;
   if (!func.empty())
   {
-    if (type == "constant" || func.find_first_of("\t ") == std::string::npos)
+    if (type == "linear")
+      f = parseRealFunc(func,type);
+    else if (type == "constant" ||
+             func.find_first_of("\t ") == std::string::npos)
       IFEM::cout <<": "<< (p = atof(func.c_str()));
     else
       f = parseRealFunc(func,type);


### PR DESCRIPTION
Bug introduced in commit d7780614f43dad0cee714838a6933b2ee1cf677e.

type="linear" should result in a function linear in time and constant in space, but ended up with constant in time also.