### PR TITLE
fixed: parallel L2 assembly for ASMsxDLag

### DIFF
--- a/src/ASM/ASMs2DLag.C
+++ b/src/ASM/ASMs2DLag.C
@@ -992,8 +992,12 @@ int ASMs2DLag::findElement (double u, double v, double* xi, double* eta) const
     return -1;
   }
 
-  const int ku = surf->basis(0).knotInterval(u);
-  const int kv = surf->basis(1).knotInterval(v);
+  int ku, kv;
+#pragma omp critical
+  {
+    ku = surf->basis(0).knotInterval(u);
+    kv = surf->basis(1).knotInterval(v);
+  }
 
   const int elmx = ku - (p1 - 1);
   const int elmy = kv - (p2 - 1);

--- a/src/ASM/ASMs3DLag.C
+++ b/src/ASM/ASMs3DLag.C
@@ -947,11 +947,13 @@ int ASMs3DLag::findElement (double u, double v, double w,
     return -1;
   }
 
-  const std::array<std::pair<double,int>,3> knot {{
-    {u, svol->basis(0).knotInterval(u)},
-    {v, svol->basis(1).knotInterval(v)},
-    {w, svol->basis(2).knotInterval(w)}
-  }};
+  std::array<std::pair<double,int>,3> knot;
+#pragma omp critical
+  {
+    knot[0] = {u, svol->basis(0).knotInterval(u)};
+    knot[1] = {v, svol->basis(1).knotInterval(v)};
+    knot[2] = {w, svol->basis(2).knotInterval(w)};
+  }
 
   const std::array<int,3> elm {
     knot[0].second - (p1 - 1),


### PR DESCRIPTION
as BsplineBasis::knotInterval() is not thread safe. this is called when evaluating the integrand solution inside the omp loop.