### PR TITLE
Added: virtual method SystemMatrix::compressPattern()

### DIFF
--- a/src/Eig/EigSolver.C
+++ b/src/Eig/EigSolver.C
@@ -137,6 +137,9 @@ bool eig::solve (SystemMatrix* A, SystemMatrix* B,
   int ierr = mode > 10 ? eig::solve(A,B,eigVal,eigVec,nev,mode-10,shift) : 2;
   if (ierr < 2) return ierr == 1;
 
+  A->compressPattern();
+  B->compressPattern();
+
   K = A;
   M = B;
   int n = K->dim();

--- a/src/LinAlg/SparseMatrix.h
+++ b/src/LinAlg/SparseMatrix.h
@@ -122,6 +122,9 @@ public:
   //! \param[in] nel Number of elements to consider (if zero use MMNPC.size())
   virtual void preAssemble(const std::vector<IntVec>& MMNPC, size_t nel = 0);
 
+  //! \brief Compresses the sparsity pattern.
+  virtual void compressPattern();
+
   //! \brief Initializes the matrix to zero assuming it is properly dimensioned.
   virtual void init();
 

--- a/src/LinAlg/SystemMatrix.h
+++ b/src/LinAlg/SystemMatrix.h
@@ -258,6 +258,9 @@ public:
   //! \brief Initializes the element sparsity pattern based on node connections.
   virtual void preAssemble(const std::vector<IntVec>&, size_t = 0) {}
 
+  //! \brief Compresses the sparsity pattern.
+  virtual void compressPattern() {}
+
   //! \brief Initializes the matrix to zero assuming it is properly dimensioned.
   virtual void init() = 0;
 


### PR DESCRIPTION
Implemented for SparseMatrix only.
Use this in eig::solver() to speed up the matrix-vector multiplication in case of single-thread.