### PR TITLE
Additional app-dependent displacement blocks

### DIFF
--- a/src/ASM/AlgEqSystem.C
+++ b/src/ASM/AlgEqSystem.C
@@ -15,6 +15,7 @@
 #include "SparseMatrix.h"
 #include "ElmMats.h"
 #include "SAM.h"
+#include "Profiler.h"
 #include "IFEM.h"
 #include <cstdio>
 #include <cstdlib>
@@ -64,6 +65,7 @@ bool AlgEqSystem::init (LinAlg::MatrixType mtype, const LinSolParams* spar,
       if (!A[i]._A) return false;
     }
 
+    PROFILE("Pre-assembly");
     A[i]._A->initAssembly(sam,preAssemblyFlag);
     A[i]._b = nullptr;
   }

--- a/src/SIM/MultiStepSIM.C
+++ b/src/SIM/MultiStepSIM.C
@@ -158,14 +158,14 @@ bool MultiStepSIM::saveStep (int iStep, double time, const char* vecName)
         return false;
   }
 
+  // Write any problem-specific data (rigid body transformations, etc.)
+  if (!model.writeGlvA(nBlock,iStep,time))
+    return false;
+
   // Write solution fields
   if (this->numSolution())
     if (!model.writeGlvS(this->realSolution(),iStep,nBlock,time,vecName))
       return false;
-
-  // Write any problem-specific data (rigid body transformations, etc.)
-  if (!model.writeGlvA(nBlock,iStep))
-    return false;
 
   // Write time step information
   return model.writeGlvStep(iStep,time);

--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -995,6 +995,11 @@ int SIMoutput::writeGlvS1 (const Vector& psol, int iStep, int& nBlock,
   sID.reserve(nf);
   if (haveXsol) xID.reserve(nf);
 
+  // Any app-dependent vector field (from writeGlvA)?
+  for (const auto& [geo, dis] : addDisBlk)
+    if (myVtf->getBlock(geo))
+      vID[0].push_back(dis);
+
   Matrix field;
   Vector lovec;
 

--- a/src/SIM/SIMoutput.h
+++ b/src/SIM/SIMoutput.h
@@ -89,7 +89,7 @@ public:
   bool writeGlvG(int& nBlock, double time);
 
   //! \brief Writes additional, problem-specific, results to the VTF-file.
-  virtual bool writeGlvA(int&, int, int = 1) const { return true; }
+  virtual bool writeGlvA(int&, int, double, int = 1) const { return true; }
 
   //! \brief Writes boundary conditions as scalar fields to the VTF-file.
   //! \param nBlock Running result block counter
@@ -354,6 +354,8 @@ private:
                          ASM::ResultClass resClass = ASM::PRIMARY);
 
 protected:
+  std::map<int,int> addDisBlk; //!< Additional displacement block mapping
+
   //! \brief Struct defining a result sampling point.
   struct ResultPoint
   {


### PR DESCRIPTION
The protected member `addDisBlk` is added to class `SIMoutput`, through which downstream apps may specify additional displacement field blocks - not belonging to the FE model itself - to be written to the VTF file. handy for visualization of sea surface elevation, etc.

Extended the virtual `writeGlvA()` method with the time argument.

Also (second commit) adding profiling of the `SystemMatrix::initAssembly()` call.