### PR TITLE
PETSc: implement ::add() and fix reuse of matrices

### DIFF
--- a/src/LinAlg/PETScMatrix.C
+++ b/src/LinAlg/PETScMatrix.C
@@ -711,6 +711,20 @@ void PETScMatrix::mult (Real alpha)
 }
 
 
+bool PETScMatrix::add (Real sigma, int ieq)
+{
+  if (ieq > static_cast<int>(nrow))
+    return false;
+  else if (ieq > 0) {
+    const int eq = adm.dd.getGlobalEq(ieq) - 1;
+    MatSetValue(pA, eq, eq, sigma, ADD_VALUES);
+  } else
+    MatShift(pA, sigma);
+
+  return true;
+}
+
+
 bool PETScMatrix::multiply (const SystemVector& B, SystemVector& C) const
 {
   const PETScVector* Bptr = dynamic_cast<const PETScVector*>(&B);

--- a/src/LinAlg/PETScMatrix.C
+++ b/src/LinAlg/PETScMatrix.C
@@ -702,6 +702,7 @@ void PETScMatrix::init ()
     MatZeroEntries(m);
 
   assembled = false;
+  factored = false;
 }
 
 
@@ -787,17 +788,19 @@ bool PETScMatrix::solve (const Vec& b, Vec& x, bool knoll)
     }
   }
 
-  if (setParams) {
 #if PETSC_VERSION_MINOR < 5
     KSPSetOperators(ksp,pA,pA, factored ? SAME_PRECONDITIONER : SAME_NONZERO_PATTERN);
 #else
     KSPSetOperators(ksp,pA,pA);
     KSPSetReusePreconditioner(ksp, factored ? PETSC_TRUE : PETSC_FALSE);
 #endif
+
+  if (setParams) {
     if (!setParameters(true))
       return false;
     setParams = false;
   }
+
   if (knoll)
     KSPSetInitialGuessKnoll(ksp,PETSC_TRUE);
   else

--- a/src/LinAlg/PETScMatrix.h
+++ b/src/LinAlg/PETScMatrix.h
@@ -307,6 +307,9 @@ public:
   //! \brief Returns a const-ref to domain decompositioning.
   const DomainDecomposition& getDD() const;
 
+  //! \brief Adds the constant &sigma; to the diagonal of this matrix.
+  bool add(Real sigma, int ieq) override;
+
 protected:
   //! \brief Solve a linear system.
   bool solve(const Vec& b, Vec& x, bool knoll);


### PR DESCRIPTION
For allowing MLC shell simulator to use PETSc