### PR TITLE
Added: Pass global 0-based element index to the integrand

### DIFF
--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -66,7 +66,7 @@ ASMbase::ASMbase (unsigned char n_p, unsigned char n_s, unsigned char n_f)
   nGauss = 0;
   nel = nnod = 0;
   idx = 0;
-  firstIp = 0;
+  firstEl = firstIp = 0;
   myElActive = nullptr;
 }
 
@@ -84,6 +84,7 @@ ASMbase::ASMbase (const ASMbase& patch, unsigned char n_f)
   nel = patch.nel;
   nnod = patch.nnod;
   idx = patch.idx;
+  firstEl = patch.firstEl;
   firstIp = patch.firstIp;
   // Note: Properties are _not_ copied
   myElActive = nullptr; // Element activation function is not copied
@@ -101,6 +102,7 @@ ASMbase::ASMbase (const ASMbase& patch)
   nel = patch.nel;
   nnod = patch.nnod;
   idx = patch.idx;
+  firstEl = patch.firstEl;
   firstIp = patch.firstIp;
 
   // Only copy the regular part of the FE data, leave out any extraordinaries
@@ -1831,6 +1833,5 @@ bool ASMbase::isElementActive (int elmId, double time) const
 
 bool ASMbase::isElementInPartition (int iel) const
 {
-  return myElms.empty() ||
-         std::find(myElms.begin(), myElms.end(), iel) != myElms.end();
+  return myElms.empty() || utl::findIndex(myElms,iel) >= 0;
 }

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -337,7 +337,7 @@ public:
   //! \brief Returns \e true if element with global id \a elmId is active.
   bool isElementActive(int elmId, double time = -1.0) const;
   //! \brief Returns \e true if element is in process partition.
-  //! \param iel Element id (0 based)
+  //! \param[in] iel 0-based element index local to current patch
   bool isElementInPartition(int iel) const;
 
   //! \brief Returns the nodal point correspondance array for an element.
@@ -509,9 +509,9 @@ public:
   virtual void generateThreadGroups(const Integrand&, bool, bool) {}
   //! \brief Generates element groups for multi-threading of boundary integrals.
   virtual void generateThreadGroups(char, bool, bool) {}
-  //! \brief Generate element-groups for multi-threading based on a partition.
+  //! \brief Generates element groups for multi-threading based on a partition.
   virtual void generateThreadGroupsFromElms(const IntVec&) {}
-  //! \brief Generate element-groups for multi-threading based on a partition.
+  //! \brief Generates element groups for multi-threading based on a partition.
   virtual void generateProjThreadGroupsFromElms(const IntVec&) {}
 
   //! \brief Hook for changing number of threads.
@@ -1041,6 +1041,7 @@ protected:
   //! in each parameter direction is set to \a p+nGauss%10.
   int nGauss; //!< \sa getNoGaussPt
 
+  size_t firstEl; //!< Global index to first element within this patch
   size_t firstIp; //!< Global index to first interior integration point
 
   //! Global indices to first integration point for the Neumann boundaries

--- a/src/ASM/ASMs1DLag.C
+++ b/src/ASM/ASMs1DLag.C
@@ -78,6 +78,8 @@ bool ASMs1DLag::generateOrientedFEModel (const Vec3& Zaxis)
   if (!coord.empty())
     return coord.size() == nnod;
 
+  firstEl = gEl;
+
   // Number of elements in the patch
   nel = (nx-1)/(p1-1);
 
@@ -233,6 +235,7 @@ bool ASMs1DLag::integrate (Integrand& integrand,
   bool ok = true;
   for (size_t iel = 0; iel < nel && ok; iel++)
   {
+    fe.idx = firstEl + iel;
     fe.iel = MLGE[iel];
     if (!this->isElementActive(fe.iel)) continue; // zero-length element
 
@@ -340,9 +343,6 @@ bool ASMs1DLag::integrate (Integrand& integrand, int lIndex,
 {
   if (this->empty()) return true; // silently ignore empty patches
 
-  // Extract the Neumann order flag (1 or higher) for the integrand
-  integrand.setNeumannOrder(1 + lIndex/10);
-
   // Integration of boundary point
 
   FiniteElement fe;
@@ -364,8 +364,12 @@ bool ASMs1DLag::integrate (Integrand& integrand, int lIndex,
       return false;
     }
 
+  fe.idx = firstEl + iel;
   fe.iel = MLGE[iel];
   if (!this->isElementActive(fe.iel)) return true; // zero-length element
+
+  // Extract the Neumann order flag (1 or higher) for the integrand
+  integrand.setNeumannOrder(1 + lIndex/10);
 
   // Set up nodal point coordinates for current element
   this->getElementCoordinates(fe.Xn,1+iel);
@@ -508,6 +512,7 @@ bool ASMs1DLag::evalSolution (Matrix& sField, const IntegrandBase& integrand,
   // Evaluate the secondary solution field at each element node or center
   for (size_t iel = 0; iel < nel; iel++)
   {
+    fe.idx = firstEl + iel;
     fe.iel = MLGE[iel];
     if (fe.iel < 1) continue; // zero-length element
 

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -539,6 +539,7 @@ bool ASMs2D::generateFEMTopology ()
   myMLGN.resize(n1*n2);
   myNodeInd.resize(myMLGN.size());
 
+  firstEl = gEl;
   nnod = nel = 0;
   for (int i2 = 1; i2 <= n2; i2++)
     for (int i1 = 1; i1 <= n1; i1++)
@@ -1727,9 +1728,9 @@ bool ASMs2D::integrate (Integrand& integrand,
   const int nel1 = n1 - p1 + 1;
 
   ThreadGroups oneGroup;
-  if (glInt.threadSafe())
-    oneGroup.oneStripe(nel, myElms);
+  if (glInt.threadSafe()) oneGroup.oneStripe(nel,myElms);
   const ThreadGroups& groups = glInt.threadSafe() ? oneGroup : threadGroups;
+
 
   // === Assembly loop over all elements in the patch ==========================
 
@@ -1749,14 +1750,18 @@ bool ASMs2D::integrate (Integrand& integrand,
       for (size_t e = 0; e < groups[g][t].size() && ok; e++)
       {
         int iel = groups[g][t][e];
-        fe.iel = MLGE[iel];
-        if (!this->isElementActive(fe.iel,time.t))
-          continue; // zero-area or inactive element
-
 #ifdef SP_DEBUG
         if (dbgElm < 0 && 1+iel != -dbgElm)
           continue; // Skipping all elements, except for -dbgElm
 #endif
+
+        if (!this->isElementInPartition(iel))
+          continue; // this element is in the partition of another process
+
+        fe.idx = firstEl + iel;
+        fe.iel = MLGE[iel];
+        if (!this->isElementActive(fe.iel,time.t))
+          continue; // zero-area or inactive element
 
         int i1 = p1 + iel % nel1;
         int i2 = p2 + iel / nel1;
@@ -2036,19 +2041,20 @@ bool ASMs2D::integrate (Integrand& integrand,
       for (size_t e = 0; e < groups[g][t].size() && ok; e++)
       {
         int iel = groups[g][t][e];
+#ifdef SP_DEBUG
+        if (dbgElm < 0 && 1+iel != -dbgElm)
+          continue; // skipping all elements, except for -dbgElm
+#endif
+
         if (itgPts[iel].empty())
           continue; // no points in this element
+        if (!this->isElementInPartition(iel))
+          continue; // this element is in the partition of another process
 
+        fe.iel = firstEl + iel;
         fe.iel = MLGE[iel];
         if (!this->isElementActive(fe.iel,time.t))
           continue; // zero-area or inactive element
-        if (!this->isElementInPartition(iel))
-          continue;
-
-#ifdef SP_DEBUG
-        if (dbgElm < 0 && 1+iel != -dbgElm)
-          continue; // Skipping all elements, except for -dbgElm
-#endif
 
         int i1 = p1 + iel % nel1;
         int i2 = p2 + iel / nel1;
@@ -2218,6 +2224,7 @@ bool ASMs2D::integrate (Integrand& integrand,
     {
       if (!hasInterfaceElms) jel = iel;
 
+      fe.idx = firstEl + iel;
       fe.iel = abs(MLGE[jel]);
       if (!this->isElementActive(fe.iel,time.t))
         continue; // zero-area element
@@ -2419,21 +2426,23 @@ bool ASMs2D::integrate (Integrand& integrand, int lIndex,
 
   // === Assembly loop over all elements on the patch edge =====================
 
-  int iel = 1;
+  int iel = 0;
   for (int i2 = p2; i2 <= n2; i2++)
     for (int i1 = p1; i1 <= n1; i1++, iel++)
     {
-      fe.iel = abs(MLGE[doXelms+iel-1]);
+ #ifdef SP_DEBUG
+      int ielm = 1+iel;
+      if (dbgElm < 0 && ielm != -dbgElm)
+        continue; // skipping all elements, except for -dbgElm
+#endif
+
+      if (!this->isElementInPartition(iel))
+        continue; // this element is in the partition of another process
+
+      fe.idx = firstEl + iel;
+      fe.iel = abs(MLGE[doXelms+iel]);
       if (!this->isElementActive(fe.iel,time.t))
         continue; // zero-area element
-
-      if (!this->isElementInPartition(iel-1))
-        continue;
-
-#ifdef SP_DEBUG
-      if (dbgElm < 0 && iel != -dbgElm)
-        continue; // Skipping all elements, except for -dbgElm
-#endif
 
       // Skip elements that are not on current boundary edge
       bool skipMe = false;
@@ -2447,11 +2456,11 @@ bool ASMs2D::integrate (Integrand& integrand, int lIndex,
       if (skipMe) continue;
 
       // Get element edge length in the parameter space
-      double dS = 0.5*this->getParametricLength(iel,t2);
+      double dS = 0.5*this->getParametricLength(1+iel,t2);
       if (dS < 0.0) return false; // topology error (probably logic error)
 
       // Set up control point coordinates for current element
-      if (!this->getElementCoordinates(Xnod,iel)) return false;
+      if (!this->getElementCoordinates(Xnod,1+iel)) return false;
 
       if (integrand.getIntegrandType() & Integrand::ELEMENT_CORNERS)
         fe.h = this->getElementCorners(i1-1,i2-1,fe.XC);
@@ -2465,7 +2474,7 @@ bool ASMs2D::integrate (Integrand& integrand, int lIndex,
 
       // Initialize element quantities
       LocalIntegral* A = integrand.getLocalIntegral(fe.N.size(),fe.iel,true);
-      bool ok = integrand.initElementBou(MNPC[doXelms+iel-1],*A);
+      bool ok = integrand.initElementBou(MNPC[doXelms+iel],*A);
 
 
       // --- Integration loop over all Gauss points along the edge -------------
@@ -2504,7 +2513,7 @@ bool ASMs2D::integrate (Integrand& integrand, int lIndex,
           fe.G = Jac; // Store tangent vectors in fe.G for shells
 
 #if SP_DEBUG > 4
-        if (iel == dbgElm || iel == -dbgElm || dbgElm == 0)
+        if (ielm == dbgElm || ielm == -dbgElm || dbgElm == 0)
           std::cout <<"\n"<< fe;
 #endif
 
@@ -2529,7 +2538,7 @@ bool ASMs2D::integrate (Integrand& integrand, int lIndex,
       if (!ok) return false;
 
 #ifdef SP_DEBUG
-      if (dbgElm < 0 && iel == -dbgElm)
+      if (dbgElm < 0 && ielm == -dbgElm)
         break; // Skipping all elements, except for -dbgElm
 #endif
     }

--- a/src/ASM/ASMs2DLag.C
+++ b/src/ASM/ASMs2DLag.C
@@ -156,6 +156,8 @@ bool ASMs2DLag::generateFEMTopology ()
   if (!coord.empty())
     return coord.size() == nnod;
 
+  firstEl = gEl;
+
   // Number of elements in each direction
   const int nelx = (nx-1)/(p1-1);
   const int nely = (ny-1)/(p2-1);
@@ -323,9 +325,9 @@ bool ASMs2DLag::integrate (Integrand& integrand,
   const int nelx = (nx-1)/(p1-1);
 
   ThreadGroups oneGroup;
-  if (glInt.threadSafe())
-    oneGroup.oneStripe(nel, myElms);
+  if (glInt.threadSafe()) oneGroup.oneStripe(nel, myElms);
   const ThreadGroups& groups = glInt.threadSafe() ? oneGroup : threadGroups;
+
 
   // === Assembly loop over all elements in the patch ==========================
 
@@ -349,8 +351,13 @@ bool ASMs2DLag::integrate (Integrand& integrand,
           break;
         }
 
+        if (!this->isElementInPartition(iel))
+          continue; // this element is in the partition of another process
+
+        fe.idx = firstEl + iel;
         fe.iel = MLGE[iel];
-        if (!this->isElementActive(fe.iel)) continue; // zero-area element
+        if (!this->isElementActive(fe.iel))
+          continue; // zero-area element
 
         // Set up nodal point coordinates for current element
         this->getElementCoordinates(fe.Xn,1+iel);
@@ -562,15 +569,17 @@ bool ASMs2DLag::integrate (Integrand& integrand, int lIndex,
 
   // === Assembly loop over all elements on the patch edge =====================
 
-  int iel = 1;
+  int iel = 0;
   for (int i2 = 0; i2 < nely; i2++)
     for (int i1 = 0; i1 < nelx; i1++, iel++)
     {
-      fe.iel = abs(MLGE[doXelms+iel-1]);
-      if (!this->isElementActive(fe.iel)) continue; // zero-area element
+      if (!this->isElementInPartition(iel))
+        continue; // this element is in the partition of another process
 
-      if (!this->isElementInPartition(iel-1))
-        continue;
+      fe.idx = firstEl + iel;
+      fe.iel = abs(MLGE[doXelms+iel]);
+      if (!this->isElementActive(fe.iel))
+	continue; // zero-area element
 
       // Skip elements that are not on current boundary edge
       bool skipMe = false;
@@ -584,11 +593,11 @@ bool ASMs2DLag::integrate (Integrand& integrand, int lIndex,
       if (skipMe) continue;
 
       // Set up nodal point coordinates for current element
-      this->getElementCoordinates(fe.Xn,iel);
+      this->getElementCoordinates(fe.Xn,1+iel);
 
       // Initialize element quantities
       LocalIntegral* A = integrand.getLocalIntegral(fe.Xn.cols(),fe.iel,true);
-      bool ok = integrand.initElementBou(MNPC[doXelms+iel-1],*A);
+      bool ok = integrand.initElementBou(MNPC[doXelms+iel],*A);
 
       if (integrand.getIntegrandType() & Integrand::POINT_DEFORMATION)
         if (!time.first || time.it > 0)
@@ -788,6 +797,7 @@ bool ASMs2DLag::evalSolution (Matrix& sField, const IntegrandBase& integrand,
   // Evaluate the secondary solution field at each point
   for (size_t iel = 0; iel < nel; iel++)
   {
+    fe.idx = firstEl + iel;
     fe.iel = MLGE[iel];
     if (fe.iel < 1) continue; // zero-area element
 
@@ -861,6 +871,7 @@ bool ASMs2DLag::evalSolution (Matrix& sField, const IntegrandBase& integrand,
         return false;
     }
 
+    fe.idx = firstEl + iel-1;
     fe.iel = MLGE[iel-1];
     if (fe.iel < 1) continue; // zero-area element
 
@@ -994,10 +1005,8 @@ int ASMs2DLag::findElement (double u, double v, double* xi, double* eta) const
 
   int ku, kv;
 #pragma omp critical
-  {
-    ku = surf->basis(0).knotInterval(u);
-    kv = surf->basis(1).knotInterval(v);
-  }
+  std::tie(ku,kv) = std::make_pair(surf->basis(0).knotInterval(u),
+                                   surf->basis(1).knotInterval(v));
 
   const int elmx = ku - (p1 - 1);
   const int elmy = kv - (p2 - 1);

--- a/src/ASM/ASMs2DTri.C
+++ b/src/ASM/ASMs2DTri.C
@@ -43,6 +43,8 @@ bool ASMs2DTri::generateFEMTopology ()
     return false;
   }
 
+  firstEl = gEl;
+
   // Double the number of elements in the patch
   IntMat qMNPC(myMNPC);
   size_t nquad = nel;
@@ -221,6 +223,7 @@ bool ASMs2DTri::integrate (Integrand& integrand,
         }
 
         // Initialize element quantities
+        fe.idx = firstEl + iel;
         fe.iel = MLGE[iel];
         LocalIntegral* A = integrand.getLocalIntegral(nen,fe.iel);
         if (!integrand.initElement(MNPC[iel],fe,X,nRed*nRed,*A))
@@ -404,6 +407,7 @@ bool ASMs2DTri::integrate (Integrand& integrand, int lIndex,
       if (!this->getElementCoordinates(Xnod,1+jel)) return false;
 
       // Initialize element quantities
+      fe.idx = firstEl + jel;
       fe.iel = abs(MLGE[doXelms+jel]);
       LocalIntegral* A = integrand.getLocalIntegral(fe.N.size(),fe.iel,true);
       bool ok = integrand.initElementBou(MNPC[doXelms+jel],*A);

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -475,6 +475,7 @@ bool ASMs3D::generateFEMTopology ()
   myMLGN.resize(n1*n2*n3);
   myNodeInd.resize(myMLGN.size());
 
+  firstEl = gEl;
   nnod = nel = 0;
   for (int i3 = 1; i3 <= n3; i3++)
     for (int i2 = 1; i2 <= n2; i2++)
@@ -2083,9 +2084,9 @@ bool ASMs3D::integrate (Integrand& integrand,
   const int nel2 = n2 - p2 + 1;
 
   ThreadGroups oneGroup;
-  if (glInt.threadSafe())
-    oneGroup.oneStripe(nel, myElms);
+  if (glInt.threadSafe()) oneGroup.oneStripe(nel,myElms);
   const ThreadGroups& groups = glInt.threadSafe() ? oneGroup : threadGroupsVol;
+
 
   // === Assembly loop over all elements in the patch ==========================
 
@@ -2103,14 +2104,18 @@ bool ASMs3D::integrate (Integrand& integrand,
       for (size_t l = 0; l < groups[g][t].size() && ok; l++)
       {
         int iel = groups[g][t][l];
+ #ifdef SP_DEBUG
+        if (dbgElm < 0 && 1+iel != -dbgElm)
+          continue; // skipping all elements, except for -dbgElm
+#endif
+
+        if (!this->isElementInPartition(iel))
+          continue; // this element is in the partition of another process
+
+        fe.idx = firstEl + iel;
         fe.iel = MLGE[iel];
         if (!this->isElementActive(fe.iel,time.t))
           continue; // zero-volume or inactive element
-
-#ifdef SP_DEBUG
-        if (dbgElm < 0 && 1+iel != -dbgElm)
-          continue; // Skipping all elements, except for -dbgElm
-#endif
 
         int i1 = p1 + iel % nel1;
         int i2 = p2 + (iel / nel1) % nel2;
@@ -2379,20 +2384,20 @@ bool ASMs3D::integrate (Integrand& integrand,
       for (size_t e = 0; e < groups[g][t].size() && ok; e++)
       {
         int iel = groups[g][t][e];
+#ifdef SP_DEBUG
+        if (dbgElm < 0 && 1+iel != -dbgElm)
+          continue; // skipping all elements, except for -dbgElm
+#endif
+
         if (itgPts[iel].empty())
           continue; // no integration points in this element
+        if (!this->isElementInPartition(iel))
+          continue; // this element is in the partition of another process
 
+        fe.idx = firstEl + iel;
         fe.iel = MLGE[iel];
         if (!this->isElementActive(fe.iel,time.t))
           continue; // zero-volume or inactive element
-
-        if (!this->isElementInPartition(iel))
-          continue;
-
-#ifdef SP_DEBUG
-        if (dbgElm < 0 && 1+iel != -dbgElm)
-          continue; // Skipping all elements, except for -dbgElm
-#endif
 
         int i1 = p1 + iel % nel1;
         int i2 = p2 + (iel / nel1) % nel2;
@@ -2643,17 +2648,18 @@ bool ASMs3D::integrate (Integrand& integrand, int lIndex,
       for (size_t l = 0; l < threadGrp[g][t].size() && ok; l++)
       {
         int iel = threadGrp[g][t][l];
+#ifdef SP_DEBUG
+        if (dbgElm < 0 && 1+iel != -dbgElm)
+          continue; // skipping all elements, except for -dbgElm
+#endif
+
+        if (!this->isElementInPartition(iel))
+          continue; // this element is in the partition of another process
+
+        fe.idx = firstEl + iel;
         fe.iel = abs(MLGE[doXelms+iel]);
         if (!this->isElementActive(fe.iel,time.t))
           continue; // zero-volume or inactive element
-
-        if (!this->isElementInPartition(iel))
-          continue;
-
-#ifdef SP_DEBUG
-        if (dbgElm < 0 && 1+iel != -dbgElm)
-          continue; // Skipping all elements, except for -dbgElm
-#endif
 
         int i1 = p1 + iel % nel1;
         int i2 = p2 + (iel / nel1) % nel2;
@@ -2876,17 +2882,18 @@ bool ASMs3D::integrateEdge (Integrand& integrand, int lEdge,
 
   // === Assembly loop over all elements on the patch edge =====================
 
-  int iel = 1;
+  int iel = 0;
   for (int i3 = p3; i3 <= n3; i3++)
     for (int i2 = p2; i2 <= n2; i2++)
       for (int i1 = p1; i1 <= n1; i1++, iel++)
       {
-        fe.iel = MLGE[iel-1];
+        if (!this->isElementInPartition(iel))
+          continue; // this element is in the partition of another process
+
+        fe.iel = firstEl + iel;
+        fe.iel = MLGE[iel];
         if (!this->isElementActive(fe.iel,time.t))
           continue; // zero-volume or inactive element
-
-        if (!this->isElementInPartition(iel-1))
-          continue;
 
 	// Skip elements that are not on current boundary edge
 	bool skipMe = false;
@@ -2909,7 +2916,7 @@ bool ASMs3D::integrateEdge (Integrand& integrand, int lEdge,
 
 	// Get element edge length in the parameter space
 	double dS = 0.0;
-	int ip = MNPC[iel-1][svol->order(0)*svol->order(1)*svol->order(2)-1];
+	int ip = MNPC[iel][svol->order(0)*svol->order(1)*svol->order(2)-1];
 #ifdef INDEX_CHECK
         if (ip < 0 || static_cast<size_t>(ip) >= nnod)
           return false;
@@ -2931,11 +2938,11 @@ bool ASMs3D::integrateEdge (Integrand& integrand, int lEdge,
 	}
 
 	// Set up control point coordinates for current element
-	if (!this->getElementCoordinates(Xnod,iel)) return false;
+	if (!this->getElementCoordinates(Xnod,1+iel)) return false;
 
 	// Initialize element quantities
         LocalIntegral* A = integrand.getLocalIntegral(fe.N.size(),fe.iel,true);
-        bool ok = integrand.initElementBou(MNPC[iel-1],*A);
+        bool ok = integrand.initElementBou(MNPC[iel],*A);
 
 
 	// --- Integration loop over all Gauss points along the edge -----------

--- a/src/ASM/ASMs3DLag.C
+++ b/src/ASM/ASMs3DLag.C
@@ -170,6 +170,8 @@ bool ASMs3DLag::generateFEMTopology ()
   if (!coord.empty())
     return coord.size() == nnod;
 
+  firstEl = gEl;
+
   // Number of elements in each direction
   const int nelx = (nx-1)/(p1-1);
   const int nely = (ny-1)/(p2-1);
@@ -350,9 +352,9 @@ bool ASMs3DLag::integrate (Integrand& integrand,
   const int nel2 = cache.noElms()[1];
 
   ThreadGroups oneGroup;
-  if (glInt.threadSafe())
-    oneGroup.oneStripe(nel, myElms);
+  if (glInt.threadSafe()) oneGroup.oneStripe(nel, myElms);
   const ThreadGroups& groups = glInt.threadSafe() ? oneGroup : threadGroupsVol;
+
 
   // === Assembly loop over all elements in the patch ==========================
 
@@ -376,8 +378,13 @@ bool ASMs3DLag::integrate (Integrand& integrand,
           break;
         }
 
+        if (!this->isElementInPartition(iel))
+          continue; // this element is in the partition of another process
+
+        fe.idx = firstEl + iel;
         fe.iel = MLGE[iel];
-        if (!this->isElementActive(fe.iel)) continue; // zero-volume element
+        if (!this->isElementActive(fe.iel))
+          continue; // zero-volume element
 
         // Set up nodal point coordinates for current element
         this->getElementCoordinates(fe.Xn,1+iel);
@@ -631,15 +638,19 @@ bool ASMs3DLag::integrate (Integrand& integrand, int lIndex,
         int iel = group[e];
         if (iel < 0 || iel >= static_cast<int>(nel))
         {
+          std::cerr <<" *** ASMs3DLag::integrate: Element index "<< iel
+                    <<" out of range [0,"<< nel <<">."<< std::endl;
           ok = false;
           break;
         }
 
-        fe.iel = abs(MLGE[doXelms+iel]);
-        if (!this->isElementActive(fe.iel)) continue; // zero-volume element
-
         if (!this->isElementInPartition(iel))
-          continue;
+          continue; // this element is in the partition of another process
+
+        fe.idx = firstEl + iel;
+        fe.iel = abs(MLGE[doXelms+iel]);
+        if (!this->isElementActive(fe.iel))
+          continue; // zero-volume element
 
         // Set up nodal point coordinates for current element
         this->getElementCoordinates(fe.Xn,1+iel);
@@ -786,15 +797,18 @@ bool ASMs3DLag::integrateEdge (Integrand& integrand, int lEdge,
 
   // === Assembly loop over all elements on the patch edge =====================
 
-  int ip, iel = 1;
+  int ip, iel = 0;
   for (int i3 = 0; i3 < nelz; i3++)
     for (int i2 = 0; i2 < nely; i2++)
       for (int i1 = 0; i1 < nelx; i1++, iel++)
       {
-        fe.iel = MLGE[iel-1];
-        if (!this->isElementActive(fe.iel)) continue; // zero-volume element
-        if (!this->isElementInPartition(iel-1))
-          continue;
+        if (!this->isElementInPartition(iel))
+          continue; // this element is in the partition of another process
+
+        fe.idx = firstEl + iel;
+        fe.iel = MLGE[iel];
+        if (!this->isElementActive(fe.iel))
+           continue; // zero-volume element
 
         // Skip elements that are not on current boundary edge
         bool skipMe = false;
@@ -823,11 +837,11 @@ bool ASMs3DLag::integrateEdge (Integrand& integrand, int lEdge,
           ip = i3*ng;
 
         // Set up nodal point coordinates for current element
-        this->getElementCoordinates(fe.Xn,iel);
+        this->getElementCoordinates(fe.Xn,1+iel);
 
         // Initialize element quantities
         LocalIntegral* A = integrand.getLocalIntegral(fe.Xn.cols(),fe.iel,true);
-        bool ok = integrand.initElementBou(MNPC[iel-1],*A);
+        bool ok = integrand.initElementBou(MNPC[iel],*A);
 
 
         // --- Integration loop over all Gauss points along the edge -----------
@@ -1054,6 +1068,7 @@ bool ASMs3DLag::evalSolution (Matrix& sField, const IntegrandBase& integrand,
   // Evaluate the secondary solution field at each point
   for (size_t iel = 0; iel < nel; iel++)
   {
+    fe.idx = firstEl + iel;
     fe.iel = MLGE[iel];
     if (fe.iel < 1) continue; // zero-volume element
 
@@ -1130,6 +1145,7 @@ bool ASMs3DLag::evalSolution (Matrix& sField, const IntegrandBase& integrand,
         return false;
     }
 
+    fe.idx = firstEl + iel;
     fe.iel = MLGE[iel-1];
     if (fe.iel < 1) continue; // zero-volume element
 

--- a/src/ASM/ASMstruct.C
+++ b/src/ASM/ASMstruct.C
@@ -91,7 +91,7 @@ bool ASMstruct::addXNodes (unsigned short int dim, size_t nXn, IntVec& nodes)
 bool ASMstruct::checkThreadGroups (const std::vector<std::set<int>>& nodes,
                                    int group, bool ignoreGlobalLM)
 {
-  if (group < 0 || group >= (int)nodes.size())
+  if (group < 0 || group >= static_cast<int>(nodes.size()))
     return false;
 
 #if SP_DEBUG > 1
@@ -105,7 +105,8 @@ bool ASMstruct::checkThreadGroups (const std::vector<std::set<int>>& nodes,
   for (int k = 0; k < group; k++)
     for (int node : nodes[group])
       if ((this->getLMType(node+1) != 'G' || !ignoreGlobalLM) &&
-          nodes[k].find(node) != nodes[k].end()) {
+          nodes[k].find(node) != nodes[k].end())
+      {
         std::cout <<"\n  ** Warning: Node "<< node <<" is present on both"
                   <<" thread "<< k+1 <<" and thread "<< group+1;
         ok = false;
@@ -120,7 +121,7 @@ bool ASMstruct::diracPoint (Integrand& integr, GlobalIntegral& glInt,
                             const double* u, const Vec3& pval)
 {
   int iel = this->findElementContaining(u);
-  if (iel < 1 || iel > (int)nel)
+  if (iel < 1 || iel > static_cast<int>(nel))
   {
     std::cerr <<" *** ASMstruct::diracPoint: The point";
     for (unsigned char i = 0; i < ndim; i++) std::cerr <<" "<< u[i];
@@ -159,13 +160,14 @@ bool ASMstruct::diracPoint (Integrand& integr, GlobalIntegral& glInt,
 #endif
 
   FiniteElement fe;
-  fe.iel = MLGE[iel-1];
+  fe.idx = firstEl + (--iel);
+  fe.iel = MLGE[iel];
   if (ndim > 0) fe.u = u[0];
   if (ndim > 1) fe.v = u[1];
   if (ndim > 2) fe.w = u[2];
   this->evaluateBasis(fe.u,fe.v,fe.w,fe.N);
 
-  LocalIntegral* A = integr.getLocalIntegral(MNPC[iel-1].size(),fe.iel,true);
+  LocalIntegral* A = integr.getLocalIntegral(MNPC[iel].size(),fe.iel,true);
   bool ok = (integr.evalPoint(*A,fe,pval) &&
              integr.finalizeElement(*A,fe,TimeDomain(),0) &&
              glInt.assemble(A,fe.iel));

--- a/src/ASM/ASMu1DLag.C
+++ b/src/ASM/ASMu1DLag.C
@@ -57,6 +57,8 @@ bool ASMu1DLag::generateOrientedFEModel (const Vec3& Zaxis)
 {
   p1 = 2; // So far only linear elements supported
 
+  firstEl = gEl;
+
   nnod = myCoord.size();
   nel  = myMNPC.size();
 

--- a/src/ASM/ASMu2DLag.C
+++ b/src/ASM/ASMu2DLag.C
@@ -65,6 +65,8 @@ bool ASMu2DLag::generateFEMTopology ()
 {
   p1 = p2 = 2; // So far only linear elements supported
 
+  firstEl = gEl;
+
   nnod = myCoord.size();
   nel  = myMNPC.size();
 

--- a/src/ASM/ItgPoint.h
+++ b/src/ASM/ItgPoint.h
@@ -29,6 +29,7 @@ public:
   {
     iGP = i;
     iel = -1;
+    idx = 0;
     u = v = w = xi = eta = zeta = 0.0;
   }
 
@@ -40,6 +41,7 @@ public:
     w = c;
 
     iGP = i;
+    idx = 0;
     iel = -1;
     xi = eta = zeta = 0.0;
   }
@@ -52,6 +54,7 @@ public:
     w = par[2];
 
     iGP = i;
+    idx = 0;
     iel = -1;
     xi = eta = zeta = 0.0;
   }
@@ -66,6 +69,7 @@ public:
   double w; //!< Third spline parameter of the point
 
   int    iel;  //!< Identifier of the element containing this point
+  size_t idx;  //!< Global index (0-based) of the element containing this point
   double xi;   //!< First local coordinate within current element
   double eta;  //!< Second local coordinate within current element
   double zeta; //!< Third local coordinate within current element

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -2449,8 +2449,10 @@ bool SIMbase::project (RealArray& values, const FunctionBase* f,
 bool SIMbase::extractPatchSolution (IntegrandBase* problem,
                                     const Vectors& sol, size_t pindx) const
 {
+  if (!problem || !mySam) return false;
+
   ASMbase* pch = this->getPatch(pindx+1);
-  if (!pch || !mySam) return false;
+  if (!pch) return false;
 
   problem->initNodeMap(pch->getGlobalNodeNums());
   for (size_t i = 0; i < problem->getNoSolutions(); i++)


### PR DESCRIPTION
Used for allocating global element matrix cache for integrands.

Also adding some (missing?) isElementInPartition() calls in integrate() methods.