### PR TITLE
IFEM-test: suppress listing on non-root processes

### DIFF
--- a/src/IFEM-test.C
+++ b/src/IFEM-test.C
@@ -15,6 +15,11 @@
 #include "IFEM.h"
 #include "Profiler.h"
 
+#ifdef HAVE_MPI
+#include <algorithm>
+#include <mpi.h>
+#endif
+
 
 /*!
   \brief Main program for the IFEM unit tests.
@@ -22,9 +27,24 @@
 
 int main (int argc, char** argv)
 {
+#ifdef HAVE_MPI
+  const bool list_tests =
+        std::any_of(argv+1, argv + argc,
+                    [](const char* arg)
+                    { return !strcmp(arg, "--gtest_list_tests"); });
+#endif
   testing::InitGoogleTest(&argc, argv);
   IFEM::Init(argc, argv);
   Profiler prof(argv[0], false);
+
+#ifdef HAVE_MPI
+  if (list_tests) {
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    if (rank != 0)
+      return 0;
+  }
+#endif
 
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Parallel unit tests were registered once per rank they run on in ctest, as all processes output the list when run with --gtest_list_tests. This is the mechanism used to register the tests in ctest. By suppressing listing on non-root ranks, we now only get a single register as intended.

I've been waiting for cmake to fix this, but it does not seem to happen, so let's workaround it.