### PR TITLE
Fixed: Remove BeamGeometry stuff before building ShellEx app

### DIFF
--- a/Apps/CMakeLists.txt
+++ b/Apps/CMakeLists.txt
@@ -1,3 +1,9 @@
+# This is a top-level CMakeLists.txt which will build all IFEM apps
+# which exist as a local clone in sub-directories.
+#
+# NOTE: This file is _not_ used by the Jenkins build system on github.
+# Therefore, make sure to test any changes locally before merging.
+
 cmake_minimum_required(VERSION 3.5)
 
 project(IFEM_Apps)


### PR DESCRIPTION
Without this, the dependencies for ShellEx will be incorrect.