### PR TITLE
State dependency for additional functions

### DIFF
--- a/src/ASM/IBGeometries.C
+++ b/src/ASM/IBGeometries.C
@@ -170,12 +170,6 @@ GeoFunc2D::GeoFunc2D (RealFunc* f, double p, double eps)
 }
 
 
-GeoFunc2D::~GeoFunc2D ()
-{
-  delete myAlpha;
-}
-
-
 double GeoFunc2D::Alpha (const Vec3& X) const
 {
   double value = myAlpha ? pow((*myAlpha)(X),myExponent) : 0.0;

--- a/src/ASM/IBGeometries.h
+++ b/src/ASM/IBGeometries.h
@@ -39,8 +39,6 @@ class Hole2D : public Immersed::Geometry
 public:
   //! \brief Default constructor initializing the radius and center of the hole.
   Hole2D(double r = 1.0, double x = 0.0, double y = 0.0) : R(r), Xc(x), Yc(y) {}
-  //! \brief Empty destructor.
-  virtual ~Hole2D() {}
 
   //! \brief Performs the inside-outside test for the perforated plate object.
   //! \details Alpha is used as an indicator here:
@@ -68,8 +66,6 @@ class Oval2D : public Hole2D
 public:
   //! \brief Default constructor initializing the radius and center of the hole.
   Oval2D(double r, double x0, double y0, double x1, double y1);
-  //! \brief Empty destructor.
-  virtual ~Oval2D() {}
 
   //! \brief Performs the inside-outside test for the perforated plate object.
   virtual double Alpha(double X, double Y, double) const;
@@ -124,15 +120,13 @@ class GeoFunc2D : public Immersed::Geometry
 public:
   //! \brief Default constructor.
   explicit GeoFunc2D(RealFunc* f = nullptr, double p = 1.0, double eps = 0.5);
-  //! \brief The destructor deletes the function.
-  virtual ~GeoFunc2D();
 
   //! \brief Performs the inside-outside test for the geometric object.
   virtual double Alpha(const Vec3& X) const;
 
 private:
   RealFunc* myAlpha; //!< Function describing the inside-outside state
-  double myExponent; //!< The exponent to apply on the \a myAlpha function
+  double myExponent; //!< The exponent to apply on the \ref myAlpha function
   double  threshold; //!< Inside/outside threshold
 };
 

--- a/src/SIM/MultiStepSIM.h
+++ b/src/SIM/MultiStepSIM.h
@@ -39,9 +39,6 @@ protected:
   explicit MultiStepSIM(SIMbase& sim);
 
 public:
-  //! \brief Empty destructor.
-  virtual ~MultiStepSIM() {}
-
   //! \brief Prints out problem-specific data to the log stream.
   //! \param[in] stopInputTimer If \e true, stop file input timer before print
   virtual void printProblem(bool stopInputTimer = false) const;
@@ -51,8 +48,9 @@ public:
 
   //! \brief Initializes time integration parameters for the integrand.
   virtual void initPrm();
+
   //! \brief Initializes the primary solution vectors.
-  //! \param[in] nSol Number of consequtive solutions stored in core
+  //! \param[in] nSol Number of consecutive solutions stored in core
   //! \param[in] nDof Number of degrees of freedom (solution vector length)
   virtual void initSol(size_t nSol = 1, size_t nDof = 0);
 
@@ -169,6 +167,8 @@ public:
 
   //! \brief Returns whether this solution driver is linear or not.
   virtual bool isLinear() const { return true; }
+  //! \brief Returns whether this is a dynamic solution driver or not.
+  virtual bool isDynamic() const { return false; }
 
   //! \brief Returns a const reference to the FE model.
   const SIMoutput& getModel() const { return model; }

--- a/src/SIM/NewmarkSIM.h
+++ b/src/SIM/NewmarkSIM.h
@@ -26,8 +26,6 @@ class NewmarkSIM : public MultiStepSIM
 public:
   //! \brief The constructor initializes default solution parameters.
   explicit NewmarkSIM(SIMbase& sim);
-  //! \brief Empty destructor.
-  virtual ~NewmarkSIM() {}
 
   using MultiStepSIM::parse;
   //! \brief Parses a data section from an XML document.
@@ -61,6 +59,9 @@ public:
 
   //! \brief Returns the maximum number of iterations.
   int getMaxit() const { return maxit; }
+
+  //! \brief Returns whether this is a dynamic solution driver or not.
+  virtual bool isDynamic() const { return true; }
 
 protected:
   //! \brief Computes and prints some solution norm quantities.

--- a/src/SIM/SIM2D.h
+++ b/src/SIM/SIM2D.h
@@ -133,12 +133,6 @@ protected:
   virtual bool connectPatches(const ASM::Interface& ifc,
                               bool coordCheck = true);
 
-  //! \brief Writes out the additional functions to VTF-file.
-  virtual bool writeAddFuncs(int iStep, int& nBlock, int idBlock, double time);
-
-private:
-  std::map<std::string,RealFunc*> myAddScalars; //!< Scalar functions to output
-
 protected:
   CharVec nf;         //!< Number of scalar fields
   bool    checkRHSys; //!< Check if all patches are in a right-hand system

--- a/src/SIM/SIMoutput.h
+++ b/src/SIM/SIMoutput.h
@@ -166,9 +166,9 @@ public:
   //! \param[in] time Load/time step parameter
   //! \param[in] idBlock Starting value of result block numbering
   //! \param[in] psolComps Optional number of primary solution components
-  virtual bool writeGlvS2(const Vector& psol, int iStep, int& nBlock,
-                          double time = 0.0, int idBlock = 20,
-                          int psolComps = 0);
+  virtual int writeGlvS2(const Vector& psol, int iStep, int& nBlock,
+                         double time = 0.0, int idBlock = 20,
+                         int psolComps = 0);
 
   //! \brief Evaluates the secondary solution for a given load/time step.
   //! \param[in] psol Primary solution vector
@@ -229,10 +229,14 @@ public:
   //! \param[in] fname Name of the function
   //! \param[in] iStep Load/time step identifier
   //! \param nBlock Running result block counter
+  //! \param[in] state Optional state vector (for state-dependent functions)
   //! \param[in] idBlock Starting value of result block numbering
   //! \param[in] time Load/time step parameter
-  bool writeGlvF(const RealFunc& f, const char* fname,
-                 int iStep, int& nBlock, int idBlock = 50, double time = 0.0);
+  //! \param[in] patch If specified, only evalulate for this patch
+  bool writeGlvF(const RealFunc& f, const char* fname, int iStep, int& nBlock,
+                 const Vector* state = nullptr,
+                 int idBlock = 50, double time = 0.0,
+                 const ASMbase* patch = nullptr);
 
   //! \brief Writes load/time step info to the VTF-file.
   //! \param[in] iStep Load/time step identifier
@@ -331,12 +335,20 @@ public:
   //! \brief Prints out the nodal reaction forces to the log stream.
   virtual int printNRforces(const std::vector<int>& glbNodes = {}) const;
 
-  //! \brief Writes out the additional functions to VTF-file.
-  virtual bool writeAddFuncs(int iStep, int& nBlock, int idBlock, double time);
-
 protected:
-  //! \brief Adds an additional function for VTF-file output.
-  void addAddFunc(const std::string& name, RealFunc* f);
+  //! \brief Adds a function for additional VTF-file output.
+  //! \param[in] fn Function name (appears as the scalar name in the VTF-file)
+  //! \param[in] f Pointer to a scalar-valued spatial function.
+  void addAddFunc(const std::string& fn, RealFunc* f) { myAddScalars[fn] = f; }
+
+  //! \brief Writes out the additional functions to VTF-file.
+  //! \param nBlock Running result block counter
+  //! \param idBlock Running scalar identification block numbering
+  //! \param[in] psol Primary solution vector (for state-dependent functions)
+  //! \param[in] iStep Load/time step identifier
+  //! \param[in] time Load/time step parameter
+  virtual bool writeAddFuncs(int& nBlock, int& idBlock, const Vector& psol,
+                             int iStep, double time);
 
 private:
   //! \brief Private helper to initialize patch for solution evaluation.

--- a/src/Utility/Test/TestTensor.C
+++ b/src/Utility/Test/TestTensor.C
@@ -193,7 +193,7 @@ TEST_CASE("TestTensor.Principal")
   REQUIRE_THAT(dir[1].y, WithinRel(Trans3(2,2), 1.0e-15));
   REQUIRE_THAT(dir[1].z, WithinRel(Trans3(3,2), 1.0e-15));
   REQUIRE_THAT(dir[2].x, WithinRel(Trans3(1,1), 1.0e-15));
-  REQUIRE_THAT(dir[2].y, WithinRel(Trans3(2,1), 1.0e-15));
+  REQUIRE_THAT(dir[2].y, WithinRel(Trans3(2,1), 1.0e-14));
   REQUIRE_THAT(dir[2].z, WithinRel(Trans3(3,1), 1.0e-15));
   T3.principal(p,dir.data(),2);
   REQUIRE_THAT(p.x, WithinRel(3.0));
@@ -203,7 +203,7 @@ TEST_CASE("TestTensor.Principal")
   REQUIRE_THAT(dir[0].y, WithinRel(Trans3(2,3), 1.0e-15));
   REQUIRE_THAT(dir[0].z, WithinRel(Trans3(3,3), 1.0e-15));
   REQUIRE_THAT(dir[1].x, WithinRel(Trans3(1,1), 1.0e-15));
-  REQUIRE_THAT(dir[1].y, WithinRel(Trans3(2,1), 1.0e-15));
+  REQUIRE_THAT(dir[1].y, WithinRel(Trans3(2,1), 1.0e-14));
   REQUIRE_THAT(dir[1].z, WithinRel(Trans3(3,1), 1.0e-15));
 
   REQUIRE(T1.vonMises() == sqrt(3.0));

--- a/src/Utility/VTF.C
+++ b/src/Utility/VTF.C
@@ -467,7 +467,8 @@ bool VTF::writeNres (const std::vector<Real>& nodalResult,
 }
 
 
-bool VTF::writeNfunc (const RealFunc& f, Real time, int idBlock, int geomID)
+bool VTF::writeNfunc (const RealFunc& f, const Real* u,
+                      Real time, int idBlock, int geomID)
 {
   if (!myFile) return true;
 
@@ -479,8 +480,13 @@ bool VTF::writeNfunc (const RealFunc& f, Real time, int idBlock, int geomID)
 
   // Evaluate the function at the grid points
   std::vector<float> resVec(nres);
-  for (size_t i = 0; i < nres; i++)
+  size_t i, ip;
+  for (i = ip = 0; i < nres; i++, ip += 3)
+  {
+    if (u) // Update solution state parameters
+      const_cast<RealFunc*>(&f)->setParam("u",Vec3(u+ip));
     resVec[i] = f(Vec4(grid->getCoord(i),time,grid->getParam(i)));
+  }
 
 #if HAS_VTFAPI == 1
   VTFAResultBlock dBlock(idBlock,VTFA_DIM_SCALAR,VTFA_RESMAP_NODE,0);

--- a/src/Utility/VTF.h
+++ b/src/Utility/VTF.h
@@ -105,11 +105,12 @@ public:
                  int idBlock = 1, int geomID = 1, size_t nvc = 0);
   //! \brief Writes a block of scalar nodal function values to the VTF-file.
   //! \param[in] f The scalar function to evaluate at the grid points
+  //! \param[in] u Pointer to array of solution state values
   //! \param[in] time Current time
   //! \param[in] idBlock Result block identifier
   //! \param[in] gID Geometry block identifier
-  bool writeNfunc(const RealFunc& f, Real time = Real(0),
-                  int idBlock = 1, int gID = 1);
+  bool writeNfunc(const RealFunc& f, const Real* u = nullptr,
+                  Real time = Real(0), int idBlock = 1, int gID = 1);
   //! \brief Writes a block of point vector results to the VTF-file.
   //! \param[in] pntResult A set of result vectors with associated attack points
   //! \param gID Running geometry block identifier


### PR DESCRIPTION
If an expression function is registered for additional VTF output, this will ensure that state dependency is accounted for,
such that "ux", "uy", and "uz" is evaluated correctly as solution variables.