### PR TITLE
Grid output of selected solution components only

### DIFF
--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -317,6 +317,8 @@ public:
   void printNodes(std::ostream& os) const;
   //! \brief Prints out element connections of this patch to the given stream.
   void printElements(std::ostream& os) const;
+  //! \brief Prints out additional app-dependent element information.
+  virtual void printElmInfo(int, const IntegrandBase*) const {}
 
   //! \brief Increase all global node numbers by \a nshift.
   virtual void shiftGlobalNodeNums(int nshift);

--- a/src/ASM/ASMs2DLag.C
+++ b/src/ASM/ASMs2DLag.C
@@ -718,7 +718,8 @@ bool ASMs2DLag::tesselate (ElementBlock& grid, const int*) const
 }
 
 
-void ASMs2DLag::constrainEdge (int dir, bool open, int dof, int code, char basis)
+void ASMs2DLag::constrainEdge (int dir, bool open, int dof, int code,
+                               char basis)
 {
   this->ASMs2D::constrainEdge(dir, open, dof, code > 0 ? -code : code, basis);
 }
@@ -741,38 +742,61 @@ bool ASMs2DLag::evalSolution (Matrix& sField, const Vector& locSol,
   size_t nCmp = locSol.size() / this->getNoProjectionNodes();
   size_t ni   = gpar ? gpar[0].size() : nel;
   size_t nj   = gpar ? gpar[1].size() : 1;
-  size_t nen  = p1*p2;
 
   sField.resize(nCmp,ni*nj);
-  Matrix elmSol(nCmp,nen);
-  RealArray N(nen), val;
+  RealArray N, val;
 
   double xi = 0.0, eta = 0.0;
   if (!gpar && !Lagrange::computeBasis(N,p1,xi,p2,eta))
     return false;
 
-  size_t ip = 1;
+  size_t ip = 0;
   int iel = 0;
   for (size_t j = 0; j < nj; j++)
-    for (size_t i = 0; i < ni; i++, ip++)
+    for (size_t i = 0; i < ni; i++)
     {
       if (gpar)
-      {
         iel = this->findElement(gpar[0][i], gpar[1][j], &xi, &eta);
-        if (iel < 1 || iel > static_cast<int>(nel))
-          return false;
-        if (!Lagrange::computeBasis(N,p1,xi,p2,eta))
-          return false;
-      }
-      else
-        iel++;
+      else // evaluate at element centers
+        --iel;
 
-      for (size_t a = 1; a <= nen; a++)
-        elmSol.fillColumn(a, locSol.ptr() + nCmp*MNPC[iel-1][a-1]);
-
-      elmSol.multiply(N,val);
-      sField.fillColumn(ip,val);
+      if (!this->evalSolPt(iel,xi,eta,nCmp,locSol,val,N))
+        return false;
+      else if (!val.empty()) // skip elements with no results
+        sField.fillColumn(++ip,val);
     }
+
+  sField.resize(nCmp,ip);
+  return true;
+}
+
+
+/*!
+  If \a iel is negative, it is assumed that the basis function values aready
+  have been evaluated in \a N, and the &xi; and &eta; parameters are not used.
+  If \a iel is positive, the basis functions are evaluated at point &xi;,&eta;.
+*/
+
+bool ASMs2DLag::evalSolPt (int iel, double xi, double eta, size_t nCmp,
+                           const Vector& pchSol, RealArray& ptSol,
+                           RealArray& N) const
+{
+  if (iel < 0 && -iel <= static_cast<int>(nel)) // assume N is already evaluated
+    iel = -iel-1;
+  else if (iel < 1 || iel > static_cast<int>(nel))
+    return false;
+  else if (!Lagrange::computeBasis(N,p1,xi,p2,eta))
+    return false;
+  else
+    --iel;
+
+  ptSol.assign(nCmp,0.0);
+  for (size_t a = 0; a < N.size(); a++)
+  {
+    size_t ip = nCmp*MNPC[iel][a];
+    for (size_t i = 0; i < nCmp; i++)
+      ptSol[i] += N[a]*pchSol[ip++];
+  }
 
   return true;
 }
@@ -995,7 +1019,7 @@ int ASMs2DLag::findElement (double u, double v, double* xi, double* eta) const
   if (!surf)
   {
     std::cerr <<" *** ASMs2DLag::findElement: No spline geometry"<< std::endl;
-    return -1;
+    return 0;
   }
 
   int ku, kv;

--- a/src/ASM/ASMs2DLag.h
+++ b/src/ASM/ASMs2DLag.h
@@ -290,6 +290,18 @@ private:
   static void createMNPC(size_t nx, size_t ny, int p1, int p2, IntMat& MNPC);
 
 protected:
+  //! \brief Evaluates a nodal solution field at specified point in an element.
+  //! \param[in] iel 1-based element index local to current patch
+  //! \param[in] xi First parametric coordinate, &xi; &isin; [-1,1]
+  //! \param[in] eta Second parametric coordinate, &eta; &isin; [-1,1]
+  //! \param[in] nCmp Number of solution components
+  //! \param[in] pchSol Nodal values of the field to evaluate
+  //! \param[out] ptSol Solution field values at the specified point
+  //! \param[out] N Basis function values at the sepcified point
+  virtual bool evalSolPt(int iel, double xi, double eta,
+                         size_t nCmp, const Vector& pchSol,
+                         RealArray& ptSol, RealArray& N) const;
+
   size_t nx; //!< Number of nodes in first parameter direction
   size_t ny; //!< Number of nodes in second parameter direction
   int    p1; //!< Polynomial order in first parameter direction

--- a/src/ASM/ASMs3DLag.h
+++ b/src/ASM/ASMs3DLag.h
@@ -313,6 +313,19 @@ private:
                          int p1, int p2, int p3, IntMat& MNPC);
 
 protected:
+  //! \brief Evaluates a nodal solution field at specified point in an element.
+  //! \param[in] iel 1-based element index local to current patch
+  //! \param[in] xi First parametric coordinate in range [-1,1]
+  //! \param[in] eta Second parametric coordinate in range [-1,1]
+  //! \param[in] zeta Second parametric coordinate in range [-1,1]
+  //! \param[in] nCmp Number of solution components
+  //! \param[in] pchSol Nodal values of the field to evaluate
+  //! \param[out] ptSol Solution field values at the specified point
+  //! \param[out] N Basis function values at the sepcified point
+  virtual bool evalSolPt(int iel, double xi, double eta, double zeta,
+                         size_t nCmp, const Vector& pchSol,
+                         RealArray& ptSol, RealArray& N) const;
+
   size_t nx; //!< Number of nodes in first parameter direction
   size_t ny; //!< Number of nodes in second parameter direction
   size_t nz; //!< Number of nodes in third parameter direction

--- a/src/ASM/ASMu2DLag.C
+++ b/src/ASM/ASMu2DLag.C
@@ -21,6 +21,7 @@
 #include "IFEM.h"
 #include <numeric>
 #include <sstream>
+#include <fstream>
 
 #ifdef USE_OPENMP
 #include <omp.h>
@@ -586,4 +587,35 @@ bool ASMu2DLag::integrate (Integrand& integrand,
     cache.clear();
 
   return ok;
+}
+
+
+bool ASMu2DLag::writeXML (const char* fname) const
+{
+  std::ofstream os(fname);
+  if (!os) return false;
+
+  os <<"<patch>\n  <nodes>";
+  for (const Vec3& X : coord)
+    os <<"\n    "<< X;
+  os <<"\n  </nodes>";
+  for (size_t nen = 1; nen <= 4; nen++)
+  {
+    bool haveElms = false;
+    for (const IntVec& mnpc : MNPC)
+      if (mnpc.size() == nen)
+      {
+        if (!haveElms)
+          os <<"\n  <elements nenod=\""<< nen <<"\">";
+        os <<"\n   ";
+        for (int inod : mnpc)
+          os <<" "<< inod;
+        haveElms = true;
+      }
+    if (haveElms)
+      os <<"\n  </elements>";
+  }
+  os <<"\n</patch>\n";
+
+  return true;
 }

--- a/src/ASM/ASMu2DLag.h
+++ b/src/ASM/ASMu2DLag.h
@@ -140,6 +140,18 @@ public:
   bool writeXML(const char* fname) const;
 
 protected:
+  //! \brief Evaluates a nodal solution field at specified point in an element.
+  //! \param[in] iel 1-based element index local to current patch
+  //! \param[in] xi First parametric coordinate in range [-1,1]
+  //! \param[in] eta Second parametric coordinate in range [-1,1]
+  //! \param[in] nCmp Number of solution components
+  //! \param[in] pchSol Nodal values of the field to evaluate
+  //! \param[out] ptSol Solution field values at the specified point
+  //! \param[out] N Basis function values at the sepcified point
+  virtual bool evalSolPt(int iel, double xi, double eta,
+                         size_t nCmp, const Vector& pchSol,
+                         RealArray& ptSol, RealArray& N) const;
+
   //! \brief Generate thread groups using multi-coloring.
   void generateThreadGroupsMultiColored(bool silence, bool separateGroup1Noded);
 

--- a/src/ASM/ASMu2DLag.h
+++ b/src/ASM/ASMu2DLag.h
@@ -136,6 +136,9 @@ public:
   //! \note The number of element nodes must be set in \a grid on input.
   virtual bool tesselate(ElementBlock& grid, const int*) const;
 
+  //! \brief Dumps the mesh to the specified XML-file.
+  bool writeXML(const char* fname) const;
+
 protected:
   //! \brief Generate thread groups using multi-coloring.
   void generateThreadGroupsMultiColored(bool silence, bool separateGroup1Noded);

--- a/src/SIM/SIM1D.C
+++ b/src/SIM/SIM1D.C
@@ -148,7 +148,7 @@ bool SIM1D::parseGeometryTag (const tinyxml2::XMLElement* elem)
     utl::getAttribute(elem,"offset",offset);
 
     const tinyxml2::XMLElement* child = elem->FirstChildElement("connection");
-    for (; child; child = child->NextSiblingElement())
+    for (; child; child = child->NextSiblingElement("connection"))
     {
       ASM::Interface ifc;
       if (utl::getAttribute(child,"master",ifc.master))

--- a/src/SIM/SIM2D.C
+++ b/src/SIM/SIM2D.C
@@ -187,7 +187,7 @@ bool SIM2D::parseGeometryTag (const tinyxml2::XMLElement* elem)
 
     std::vector<Interface> top;
     const tinyxml2::XMLElement* child = elem->FirstChildElement("connection");
-    for (; child; child = child->NextSiblingElement())
+    for (; child; child = child->NextSiblingElement("connection"))
     {
       ASM::Interface ifc;
       bool rever = false, periodic = false;

--- a/src/SIM/SIM3D.C
+++ b/src/SIM/SIM3D.C
@@ -178,7 +178,7 @@ bool SIM3D::parseGeometryTag (const tinyxml2::XMLElement* elem)
     utl::getAttribute(elem,"offset",offset);
 
     const tinyxml2::XMLElement* child = elem->FirstChildElement("connection");
-    for (; child; child = child->NextSiblingElement())
+    for (; child; child = child->NextSiblingElement("connection"))
     {
       ASM::Interface ifc;
       bool periodic = false;

--- a/src/SIM/SIMinput.C
+++ b/src/SIM/SIMinput.C
@@ -451,7 +451,7 @@ bool SIMinput::parseBCTag (const tinyxml2::XMLElement* elem)
   else if (!strcasecmp(elem->Value(),"propertycodes"))
   {
     const tinyxml2::XMLElement* code = elem->FirstChildElement("code");
-    for (; code; code = code->NextSiblingElement())
+    for (; code; code = code->NextSiblingElement("code"))
     {
       int icode = 0;
       utl::getAttribute(code,"value",icode);

--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -509,6 +509,8 @@ void SIMoutput::preprocessResPtGroup (std::string& ptFile, ResPointVec& points)
         IFEM::cout <<", element centers will be used."<< std::endl;
       else
         IFEM::cout <<", nodal points will be used."<< std::endl;
+      if (pch && pt.iel > 0)
+        pch->printElmInfo(pt.iel,myProblem);
     }
   }
 

--- a/src/SIM/SIMoutput.h
+++ b/src/SIM/SIMoutput.h
@@ -428,6 +428,8 @@ private:
 
   std::map<std::string,RealFunc*> myAddScalars; //!< Scalar functions to output
 
+  std::set<std::string> wantComps; //!< Component names for grid output
+
   int    myPrec;   //!< Output precision for result sampling
   double myPtSize; //!< Size of result point visualization in VTF-file
   int    myGeomID; //!< Geometry block ID for the first patch in the VTF-file

--- a/src/SIM/TimeStep.C
+++ b/src/SIM/TimeStep.C
@@ -118,7 +118,7 @@ bool TimeStep::parse (const tinyxml2::XMLElement* elem)
   if (f2 > 1.0) f2 = 1.0;
 
   const tinyxml2::XMLElement* child = elem->FirstChildElement("step");
-  for (; child; child = child->NextSiblingElement())
+  for (; child; child = child->NextSiblingElement("step"))
   {
     double start = 0.0, end = 0.0;
     utl::getAttribute(child,"start",start);

--- a/src/Utility/Utilities.C
+++ b/src/Utility/Utilities.C
@@ -14,15 +14,16 @@
 #include "Utilities.h"
 #include "Vec3.h"
 #include "tinyxml2.h"
+#include <algorithm>
 #include <cstdlib>
 #include <cstring>
-#include <algorithm>
 
 
-void utl::parseIntegers (std::vector<int>& values, const char* argv)
+bool utl::parseIntegers (std::vector<int>& values, const char* argv)
 {
-  if (!argv) return;
+  if (!argv) return false;
 
+  size_t old = values.size();
   char* endp = const_cast<char*>(argv);
   while (endp && strlen(endp) > 0)
   {
@@ -34,6 +35,23 @@ void utl::parseIntegers (std::vector<int>& values, const char* argv)
         values.push_back(values.back()+1);
     }
   }
+
+  return values.size() > old;
+}
+
+
+bool utl::parseVec (Vec3& value, const char* argv)
+{
+  if (!argv) return false;
+
+  char* endp = const_cast<char*>(argv);
+  for (int i = 0; i < 3; i++)
+    if (endp && strlen(endp) > 0)
+      value[i] = strtod(endp,&endp);
+    else
+      value[i] = Real(0);
+
+  return true;
 }
 
 

--- a/src/Utility/Utilities.h
+++ b/src/Utility/Utilities.h
@@ -15,11 +15,9 @@
 #define _UTILITIES_H
 
 #include "matrix.h"
-#include <string>
-#include <iostream>
-#include <vector>
 #include <map>
 #include <set>
+#include <string>
 
 namespace tinyxml2 {
   class XMLElement;
@@ -38,7 +36,12 @@ namespace utl
   //! \param[in] argv Character string with integer data
   //!
   //! \details An integer range is recognised through the syntax \a i:j.
-  void parseIntegers(std::vector<int>& values, const char* argv);
+  bool parseIntegers(std::vector<int>& values, const char* argv);
+
+  //! \brief Parses a character string into a point vector.
+  //! \param[out] value The parsed point vector
+  //! \param[in] argv Character string with data
+  bool parseVec(Vec3& value, const char* argv);
 
   //! \brief Parses a (possibly graded) sequence of knot values.
   //! \param xi The knot value(s) is/are appended to this vector


### PR DESCRIPTION
This will add `<components>comp1 comp2 ...</components>` within the `<resultpoint>` scope, such that only the named result components (as defined by the virtual `getField1Name()`  and `getField2Name()` methods) will be output.