### PR TITLE
Fixed: Write displacement blocks for the additional geometries only...

### DIFF
--- a/src/SIM/SIMoptions.C
+++ b/src/SIM/SIMoptions.C
@@ -195,7 +195,7 @@ bool SIMoptions::parseOutputTag (const tinyxml2::XMLElement* elem)
       hdf5 = "(default)";
   }
 
-  else if (!strcasecmp(elem->Value(),"primarySolOnly"))
+  else if (!strncasecmp(elem->Value(),"primarySolOnly",10))
     pSolOnly = true;
 
   else if (!strncasecmp(elem->Value(),"saveTrac",8))


### PR DESCRIPTION
..when writing deformations (and not velocities and accelerations).
Swap variables idBlock and jBlk in `SIMoutput::writeGlvS()` for convenience.