### PR TITLE
add parseVecFuncExpr to allow autodiff

### DIFF
--- a/src/Utility/ExprFunctions.C
+++ b/src/Utility/ExprFunctions.C
@@ -728,6 +728,15 @@ RealFunc* utl::parseExprRealFunc (const std::string& function, bool autodiff)
 }
 
 
+VecFunc* utl::parseExprVecFunc (const std::string& function, bool autodiff)
+{
+  if (autodiff)
+    return new EvalMultiFunction<VecFunc,Vec3,autodiff::var>(function, "");
+  else
+    return new EvalMultiFunction<VecFunc,Vec3,Real>(function, "");
+}
+
+
 template class EvalFuncScalar<Real>;
 template class EvalFuncScalar<autodiff::var>;
 template class EvalFuncSpatial<Real>;

--- a/src/Utility/Functions.h
+++ b/src/Utility/Functions.h
@@ -646,6 +646,14 @@ namespace utl
   //! for encapsulation of the autodiff package.
   RealFunc* parseExprRealFunc(const std::string& function, bool autodiff);
 
+  //! \brief Creates a scalar-valued function by parsing a character string.
+  //! \param[in] function %Function expression
+  //! \param[in] autodiff if \e true, auto-differentiation is enabled
+  //!
+  //! \details The implementation of this method is in the file ExprFunctions.C
+  //! for encapsulation of the autodiff package.
+  VecFunc* parseExprVecFunc(const std::string& functions, bool autodiff);
+
   //! \brief Creates a scalar-valued int function by parsing a character string.
   //! \param[in] func Character string to parse function definition from
   //! \param[in] type %Function definition type flag


### PR DESCRIPTION
Maybe just merge this? It's general functionality not only related to the Darcy transport correction app.
Needs a rebase though, as master has one more commit.