### PR TITLE
Multi-patch support for time-dependent element activation

### DIFF
--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -593,9 +593,7 @@ void ASMbase::addLocal2GlobalCpl (int iSlave, int master, const Tensor& Tlg)
   // and that only the first nsd DOFs are subjected to transformation.
   int fixDirs = 0;
   for (unsigned char d = 1; d <= nf; d++)
-  {
-    MPC* cons = new MPC(MLGN[iSlave],d);
-    if (this->addMPC(cons) && cons)
+    if (MPC* cons = new MPC(MLGN[iSlave],d); this->addMPC(cons) && cons)
     {
       if (d > nsd)
       {
@@ -621,7 +619,6 @@ void ASMbase::addLocal2GlobalCpl (int iSlave, int master, const Tensor& Tlg)
         std::cout <<"Added constraint: "<< *cons;
 #endif
     }
-  }
 
   if (fixDirs > 0)
     this->fix(iSlave+1,fixDirs);
@@ -955,11 +952,10 @@ void ASMbase::mergeAndGetAllMPCs (const ASMVec& model, MPCSet& allMPCs)
   int ndeleted = 0;
   for (ASMbase* pch : model)
   {
-    std::pair<MPCIter,bool> ret;
     std::vector<MPC*> uniqueMPC;
     uniqueMPC.reserve(pch->getNoMPCs());
     for (MPC* mpc : pch->mpcs)
-      if ((ret = allMPCs.insert(mpc)).second)
+      if (std::pair<MPCIter,bool> ret = allMPCs.insert(mpc); ret.second)
 	uniqueMPC.push_back(mpc);
       else
       {
@@ -1046,8 +1042,7 @@ void ASMbase::resolveMPCchains (const MPCSet& allMPCs,
     for (size_t i = 0; i < mpc->getNoMaster();)
     {
       MPC master(mpc->getMaster(i).node,mpc->getMaster(i).dof);
-      MPCIter cit = allMPCs.find(&master);
-      if (cit != allMPCs.end())
+      if (MPCIter cit = allMPCs.find(&master); cit != allMPCs.end())
       {
         // We have a master DOF which is a slave in another constraint equation.
         // Invoke resolve() recursively to ensure that all master DOFs of that
@@ -1825,19 +1820,36 @@ void ASMbase::getBoundaryElms (int lIndex, IntVec& elms,
 }
 
 
-bool ASMbase::isElementActive (int elmId, double time) const
+bool ASMbase::isElementActive (int iel, double time) const
 {
-  if (elmId < 1)
+  if (iel < 0 || iel >= static_cast<int>(MLGE.size()))
+    return false;
+
+  if (MLGE[iel] < 1)
     return false; // element with zero extension
 
-  if (myElActive && time < (*myElActive)(elmId))
+  if (myElActive && time+1.0e-12 < (*myElActive)(1+iel))
     return false; // element not activated yet
 
   if (!myActiveEls)
     return true; // all elements are active
 
   return std::find(myActiveEls->begin(),
-                   myActiveEls->end(),elmId) != myActiveEls->end();
+                   myActiveEls->end(),MLGE[iel]) != myActiveEls->end();
+}
+
+
+bool ASMbase::inActive (double time) const
+{
+  if (myElActive)
+  {
+    for (size_t iel = 0; iel < nel; iel++)
+      if (MLGE[iel] > 0 && time+1.0e-12 > (*myElActive)(iel))
+        return false;
+    return true;
+  }
+
+  return myActiveEls ? myActiveEls->empty() : false;
 }
 
 

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -337,8 +337,10 @@ public:
 
   //! \brief Sets the list of active elements during assembly.
   void setActiveElements(IntVec* active) { myActiveEls = active; }
-  //! \brief Returns \e true if element with global id \a elmId is active.
-  bool isElementActive(int elmId, double time = -1.0) const;
+  //! \brief Returns \e true if element with 0-based index \a iel is active.
+  bool isElementActive(int iel, double time = -1.0) const;
+  //! \brief Returns \e true if none of the elements in the patch are active.
+  bool inActive(double time) const;
   //! \brief Returns \e true if element is in process partition.
   //! \param[in] iel 0-based element index local to current patch
   bool isElementInPartition(int iel) const;

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -1199,10 +1199,11 @@ bool ASMs1D::integrate (Integrand& integrand,
     if (dbgElm < 0 && ielm != -dbgElm)
       continue; // Skipping all elements, except for -dbgElm
 #endif
+    if (!this->isElementActive(iel,time.t))
+      continue; // zero-length or inactive element
 
     fe.idx = firstEl + iel;
     fe.iel = MLGE[iel];
-    if (fe.iel < 1) continue; // zero-length element
 
     LocalIntegral* A = integrand.getLocalIntegral(fe.N.size(),fe.iel);
     if (!A) continue; // no integrand contributions for this element
@@ -1386,10 +1387,11 @@ bool ASMs1D::integrate (Integrand& integrand, int lIndex,
   if (dbgElm < 0 && ielm != -dbgElm)
     return true; // Skipping all elements, except for -dbgElm
 #endif
+  if (!this->isElementActive(iel,time.t))
+    return true; // zero-length or inactive element
 
   fe.idx = firstEl + iel;
   fe.iel = MLGE[iel];
-  if (fe.iel < 1) return true; // zero-length element
 
   // Extract the Neumann order flag (1 or higher) for the integrand
   integrand.setNeumannOrder(1 + lIndex/10);

--- a/src/ASM/ASMs1DLag.C
+++ b/src/ASM/ASMs1DLag.C
@@ -235,9 +235,11 @@ bool ASMs1DLag::integrate (Integrand& integrand,
   bool ok = true;
   for (size_t iel = 0; iel < nel && ok; iel++)
   {
+    if (!this->isElementActive(iel,time.t))
+      continue; // zero-length or inactive element
+
     fe.idx = firstEl + iel;
     fe.iel = MLGE[iel];
-    if (!this->isElementActive(fe.iel)) continue; // zero-length element
 
     // Set up nodal point coordinates for current element
     this->getElementCoordinates(fe.Xn,1+iel);
@@ -364,9 +366,11 @@ bool ASMs1DLag::integrate (Integrand& integrand, int lIndex,
       return false;
     }
 
+  if (!this->isElementActive(iel,time.t))
+    return true; // zero-length or inactive element
+
   fe.idx = firstEl + iel;
   fe.iel = MLGE[iel];
-  if (!this->isElementActive(fe.iel)) return true; // zero-length element
 
   // Extract the Neumann order flag (1 or higher) for the integrand
   integrand.setNeumannOrder(1 + lIndex/10);

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -1663,7 +1663,7 @@ double ASMs2D::getElementCorners (int i1, int i2, Vec3Vec& XC,
       }
     }
 
-  return this->getElementSize(XC);
+  return ASM2D::getElementSize(XC);
 }
 
 
@@ -1758,12 +1758,11 @@ bool ASMs2D::integrate (Integrand& integrand,
         if (dbgElm < 0 && 1+iel != -dbgElm)
           continue; // Skipping all elements, except for -dbgElm
 #endif
+        if (!this->isElementActive(iel,time.t))
+          continue; // zero-area or inactive element
 
         fe.idx = firstEl + iel;
         fe.iel = MLGE[iel];
-        if (!this->isElementActive(fe.iel,time.t))
-          continue; // zero-area or inactive element
-
         int i1 = p1 + iel % nel1;
         int i2 = p2 + iel / nel1;
 
@@ -2045,12 +2044,11 @@ bool ASMs2D::integrate (Integrand& integrand,
 #endif
         if (itgPts[iel].empty())
           continue; // no integration points in this element
+        if (!this->isElementActive(iel,time.t))
+          continue; // zero-area or inactive element
 
         fe.idx = firstEl + iel;
         fe.iel = MLGE[iel];
-        if (!this->isElementActive(fe.iel,time.t))
-          continue; // zero-area or inactive element
-
         int i1 = p1 + iel % nel1;
         int i2 = p2 + iel / nel1;
 
@@ -2216,12 +2214,13 @@ bool ASMs2D::integrate (Integrand& integrand,
   for (int i2 = p2; i2 <= n2 && jel < nels; i2++)
     for (int i1 = p1; i1 <= n1 && jel < nels; i1++, iel++)
     {
+      if (!this->isElementActive(iel,time.t))
+        continue; // zero-area or inactive element
+
       if (!hasInterfaceElms) jel = iel;
 
       fe.idx = firstEl + jel;
       fe.iel = abs(MLGE[jel]);
-      if (!this->isElementActive(fe.iel,time.t))
-        continue; // zero-area element
 
       short int status = iChk.hasContribution(iel,i1,i2);
       if (!status) continue; // no interface contributions for this element
@@ -2431,11 +2430,8 @@ bool ASMs2D::integrate (Integrand& integrand, int lIndex,
 #endif
       if (!this->isElementInPartition(iel))
         continue; // this element is in the partition of another process
-
-      fe.idx = firstEl + doXelms+iel;
-      fe.iel = abs(MLGE[doXelms+iel]);
-      if (!this->isElementActive(fe.iel,time.t))
-        continue; // zero-area element
+      if (!this->isElementActive(iel,time.t))
+        continue; // zero-area or inactive element
 
       // Skip elements that are not on current boundary edge
       bool skipMe = false;
@@ -2447,6 +2443,9 @@ bool ASMs2D::integrate (Integrand& integrand, int lIndex,
 	case  2: if (i2 < n2) skipMe = true; break;
 	}
       if (skipMe) continue;
+
+      fe.idx = firstEl + doXelms+iel;
+      fe.iel = abs(MLGE[doXelms+iel]);
 
       // Get element edge length in the parameter space
       double dS = 0.5*this->getParametricLength(1+iel,t2);

--- a/src/ASM/ASMs2DLag.C
+++ b/src/ASM/ASMs2DLag.C
@@ -308,8 +308,8 @@ bool ASMs2DLag::integrateElm (Integrand& integrand, GlobalIntegral& glInt,
     return false;
   }
 
-  if (!this->isElementActive(MLGE[iel]))
-    return true; // zero-area or de-activated element, silently ignore
+  if (!this->isElementActive(iel,time.t))
+    return true; // zero-area or inactive element, silently ignore
 
   FiniteElement fe;
   Matrix Def, Vel;
@@ -574,11 +574,8 @@ bool ASMs2DLag::integrate (Integrand& integrand, int lIndex,
     {
       if (!this->isElementInPartition(iel))
         continue; // this element is in the partition of another process
-
-      fe.idx = firstEl + doXelms+iel;
-      fe.iel = abs(MLGE[doXelms+iel]);
-      if (!this->isElementActive(fe.iel))
-        continue; // zero-area element
+      if (!this->isElementActive(iel,time.t))
+        continue; // zero-area or inactive element
 
       // Skip elements that are not on current boundary edge
       bool skipMe = false;
@@ -590,6 +587,9 @@ bool ASMs2DLag::integrate (Integrand& integrand, int lIndex,
         case  2: if (i2 < nely-1) skipMe = true; break;
       }
       if (skipMe) continue;
+
+      fe.idx = firstEl + doXelms+iel;
+      fe.iel = abs(MLGE[doXelms+iel]);
 
       // Set up nodal point coordinates for current element
       this->getElementCoordinates(fe.Xn,1+iel);

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -2027,7 +2027,7 @@ double ASMs3D::getElementCorners (int i1, int i2, int i3, Vec3Vec& XC,
         }
       }
 
-  return this->getElementSize(XC);
+  return ASM3D::getElementSize(XC);
 }
 
 
@@ -2108,12 +2108,11 @@ bool ASMs3D::integrate (Integrand& integrand,
         if (dbgElm < 0 && 1+iel != -dbgElm)
           continue; // Skipping all elements, except for -dbgElm
 #endif
+        if (!this->isElementActive(iel,time.t))
+          continue; // zero-volume or inactive element
 
         fe.idx = firstEl + iel;
         fe.iel = MLGE[iel];
-        if (!this->isElementActive(fe.iel,time.t))
-          continue; // zero-volume or inactive element
-
         int i1 = p1 + iel % nel1;
         int i2 = p2 + (iel / nel1) % nel2;
         int i3 = p3 + iel / (nel1*nel2);
@@ -2384,12 +2383,11 @@ bool ASMs3D::integrate (Integrand& integrand,
 #endif
         if (itgPts[iel].empty())
           continue; // no integration points in this element
+        if (!this->isElementActive(iel,time.t))
+          continue; // zero-volume or inactive element
 
         fe.idx = firstEl + iel;
         fe.iel = MLGE[iel];
-        if (!this->isElementActive(fe.iel,time.t))
-          continue; // zero-volume or inactive element
-
         int i1 = p1 + iel % nel1;
         int i2 = p2 + (iel / nel1) % nel2;
         int i3 = p3 + iel / (nel1*nel2);
@@ -2645,12 +2643,11 @@ bool ASMs3D::integrate (Integrand& integrand, int lIndex,
         if (dbgElm < 0 && 1+iel != -dbgElm)
           continue; // Skipping all elements, except for -dbgElm
 #endif
+        if (!this->isElementActive(iel,time.t))
+          continue; // zero-volume or inactive element
 
         fe.idx = firstEl + doXelms+iel;
         fe.iel = abs(MLGE[doXelms+iel]);
-        if (!this->isElementActive(fe.iel,time.t))
-          continue; // zero-volume or inactive element
-
         int i1 = p1 + iel % nel1;
         int i2 = p2 + (iel / nel1) % nel2;
         int i3 = p3 + iel / (nel1*nel2);
@@ -2879,10 +2876,7 @@ bool ASMs3D::integrateEdge (Integrand& integrand, int lEdge,
       {
         if (!this->isElementInPartition(iel))
           continue; // this element is in the partition of another process
-
-        fe.idx = firstEl + iel;
-        fe.iel = MLGE[iel];
-        if (!this->isElementActive(fe.iel,time.t))
+        if (!this->isElementActive(iel,time.t))
           continue; // zero-volume or inactive element
 
 	// Skip elements that are not on current boundary edge
@@ -2926,6 +2920,9 @@ bool ASMs3D::integrateEdge (Integrand& integrand, int lEdge,
 	  dS = svol->knotSpan(2,nodeInd[ip].K);
 	  ip = (i3-p3)*ng;
 	}
+
+        fe.idx = firstEl + iel;
+        fe.iel = MLGE[iel];
 
 	// Set up control point coordinates for current element
 	if (!this->getElementCoordinates(Xnod,1+iel)) return false;

--- a/src/ASM/ASMs3DLag.C
+++ b/src/ASM/ASMs3DLag.C
@@ -377,11 +377,11 @@ bool ASMs3DLag::integrate (Integrand& integrand,
           ok = false;
           break;
         }
+        if (!this->isElementActive(iel,time.t))
+          continue; // zero-volume or inactive element
 
         fe.idx = firstEl + iel;
         fe.iel = MLGE[iel];
-        if (!this->isElementActive(fe.iel))
-          continue; // zero-volume element
 
         // Set up nodal point coordinates for current element
         this->getElementCoordinates(fe.Xn,1+iel);
@@ -640,11 +640,11 @@ bool ASMs3DLag::integrate (Integrand& integrand, int lIndex,
           ok = false;
           break;
         }
+        if (!this->isElementActive(iel,time.t))
+          continue; // zero-volume or inactive element
 
         fe.idx = firstEl + doXelms+iel;
         fe.iel = abs(MLGE[doXelms+iel]);
-        if (!this->isElementActive(fe.iel))
-          continue; // zero-volume element
 
         // Set up nodal point coordinates for current element
         this->getElementCoordinates(fe.Xn,1+iel);
@@ -798,11 +798,8 @@ bool ASMs3DLag::integrateEdge (Integrand& integrand, int lEdge,
       {
         if (!this->isElementInPartition(iel))
           continue; // this element is in the partition of another process
-
-        fe.idx = firstEl + iel;
-        fe.iel = MLGE[iel];
-        if (!this->isElementActive(fe.iel))
-          continue; // zero-volume element
+        if (!this->isElementActive(iel,time.t))
+          continue; // zero-volume or inactive element
 
         // Skip elements that are not on current boundary edge
         bool skipMe = false;
@@ -829,6 +826,9 @@ bool ASMs3DLag::integrateEdge (Integrand& integrand, int lEdge,
           ip = i2*ng;
         else
           ip = i3*ng;
+
+        fe.idx = firstEl + iel;
+        fe.iel = MLGE[iel];
 
         // Set up nodal point coordinates for current element
         this->getElementCoordinates(fe.Xn,1+iel);

--- a/src/SIM/EigenModeSIM.C
+++ b/src/SIM/EigenModeSIM.C
@@ -29,11 +29,13 @@ EigenModeSIM::EigenModeSIM (SIMbase& sim) : MultiStepSIM(sim)
 
 bool EigenModeSIM::parse (const tinyxml2::XMLElement* elem)
 {
+  this->MultiStepSIM::parse(elem);
+
   if (strcasecmp(elem->Value(),"eigenmodes"))
     return model.parse(elem);
 
-  const tinyxml2::XMLElement* child = elem->FirstChildElement();
-  for (; child; child = child->NextSiblingElement())
+  for (const tinyxml2::XMLElement* child = elem->FirstChildElement();
+       child; child = child->NextSiblingElement())
   {
     size_t imode = 0;
     double freq = 0.0;

--- a/src/SIM/MultiStepSIM.C
+++ b/src/SIM/MultiStepSIM.C
@@ -17,6 +17,7 @@
 #include "TimeStep.h"
 #include "Profiler.h"
 #include "IFEM.h"
+#include "tinyxml2.h"
 
 
 MultiStepSIM::MultiStepSIM (SIMbase& sim)
@@ -34,8 +35,21 @@ MultiStepSIM::MultiStepSIM (SIMbase& sim)
   subiter = NONE;
   nRHSvec = 1;
   rotUpd  = false;
+  saveBCs = true;
 
   geoBlk = nBlock = lastSt = 0;
+}
+
+
+bool MultiStepSIM::parse (const tinyxml2::XMLElement* elem)
+{
+  if (!strcasecmp(elem->Value(),"postprocessing"))
+    for (const tinyxml2::XMLElement* child = elem->FirstChildElement();
+         child && saveBCs; child = child->NextSiblingElement())
+      if (!strncasecmp(child->Value(),"noBC",4))
+        saveBCs = false;
+
+  return true;
 }
 
 
@@ -113,7 +127,7 @@ bool MultiStepSIM::saveModel (int& gBlock, int& rBlock,
     return false;
 
   // Write Dirichlet boundary conditions
-  return model.writeGlvBC(rBlock);
+  return !saveBCs || model.writeGlvBC(rBlock);
 }
 
 
@@ -122,7 +136,7 @@ bool MultiStepSIM::saveModel (int& gBlock, int& rBlock, double time)
   PROFILE1("MultiStepSIM::saveModel");
 
   // Write model geometry and BCs to already opened VTF-file
-  return model.writeGlvG(gBlock,time) && model.writeGlvBC(rBlock);
+  return model.writeGlvG(gBlock,time) && (!saveBCs || model.writeGlvBC(rBlock));
 }
 
 

--- a/src/SIM/MultiStepSIM.h
+++ b/src/SIM/MultiStepSIM.h
@@ -46,6 +46,11 @@ public:
   //! \brief Returns a list of prioritized XML-tags.
   virtual const char** getPrioritizedTags() const;
 
+  using SIMadmin::parse;
+  //! \brief Parses a data section from an XML document.
+  //! \param[in] elem The XML element to parse
+  virtual bool parse(const tinyxml2::XMLElement* elem);
+
   //! \brief Initializes time integration parameters for the integrand.
   virtual void initPrm();
 
@@ -198,7 +203,7 @@ public:
 
   //! \brief Returns a pointer to the reference norm variable.
   double* theRefNorm() { return &refNorm; }
-  //! \brief Returns const a pointer to the reference norm variable.
+  //! \brief Returns a const pointer to the reference norm variable.
   const double* getRefNorm() const { return &refNorm; }
 
 protected:
@@ -218,7 +223,8 @@ protected:
   int nBlock; //!< Running VTF result block counter
 
 private:
-  int lastSt; //!< The last step that was saved to VTF
+  bool saveBCs; //!< If \e true, Dirchlet boundary conditions are saved to VTF
+  int  lastSt;  //!< The last time/load step that was saved to VTF
 };
 
 #endif

--- a/src/SIM/NewmarkSIM.C
+++ b/src/SIM/NewmarkSIM.C
@@ -84,6 +84,8 @@ bool NewmarkSIM::parse (const tinyxml2::XMLElement* elem)
       nRHSvec = 3;
   }
 
+  this->MultiStepSIM::parse(elem);
+
   if (strcasecmp(elem->Value(),inputContext))
     return model.parse(elem);
 
@@ -96,11 +98,9 @@ bool NewmarkSIM::parse (const tinyxml2::XMLElement* elem)
   utl::getAttribute(elem,"beta",beta);
   utl::getAttribute(elem,"gamma",gamma);
 
-  const tinyxml2::XMLElement* child = elem->FirstChildElement();
-  for (; child; child = child->NextSiblingElement())
-  {
-    const char* value = utl::getValue(child,"maxits");
-    if (value)
+  for (const tinyxml2::XMLElement* child = elem->FirstChildElement();
+       child; child = child->NextSiblingElement())
+    if (const char* value = utl::getValue(child,"maxits"); value)
       maxit = atoi(value);
     else if ((value = utl::getValue(child,"maxIncr")))
       maxIncr = atoi(value);
@@ -145,7 +145,6 @@ bool NewmarkSIM::parse (const tinyxml2::XMLElement* elem)
       solveDisp = true; // no need for value here
     else if (!strcasecmp(child->Value(),"printCond"))
       rCond = 0.0;
-  }
 
   return true;
 }

--- a/src/SIM/NonLinSIM.C
+++ b/src/SIM/NonLinSIM.C
@@ -99,23 +99,22 @@ bool NonLinSIM::parse (char* keyWord, std::istream& is)
 bool NonLinSIM::parse (const tinyxml2::XMLElement* elem)
 {
   if (!strcasecmp(elem->Value(),"postprocessing"))
-  {
-    const tinyxml2::XMLElement* child = elem->FirstChildElement();
-    for (; child && !saveExL; child = child->NextSiblingElement())
+    for (const tinyxml2::XMLElement* child = elem->FirstChildElement();
+         child && !saveExL; child = child->NextSiblingElement())
       saveExL = !strcasecmp(child->Value(),"saveExtForce");
-  }
+
+  this->MultiStepSIM::parse(elem);
 
   if (strcasecmp(elem->Value(),inputContext))
     return model.parse(elem);
 
-  std::string rotUpdate;
-  if (utl::getAttribute(elem,"rotation",rotUpdate,true) && !rotUpdate.empty())
-    rotUpd = rotUpdate.front();
+  if (std::string rotUpdate; utl::getAttribute(elem,"rotation",rotUpdate,true))
+    if (!rotUpdate.empty())
+      rotUpd = rotUpdate.front();
 
-  const tinyxml2::XMLElement* child = elem->FirstChildElement();
-  for (; child; child = child->NextSiblingElement()) {
-    const char* value;
-    if ((value = utl::getValue(child,"maxits")))
+  for (const tinyxml2::XMLElement* child = elem->FirstChildElement();
+       child; child = child->NextSiblingElement())
+    if (const char* value = utl::getValue(child,"maxits"); value)
       maxit = atoi(value);
     else if ((value = utl::getValue(child,"maxIncr")))
       maxIncr = atoi(value);
@@ -158,7 +157,6 @@ bool NonLinSIM::parse (const tinyxml2::XMLElement* elem)
       updNewN = true;
     else if (!strcasecmp(child->Value(),"printCond"))
       rCond = 0.0; // Compute and report condition number in the iteration log
-  }
 
   if (iteNorm == NONE && nupdat < 0)
     iteNorm = NONE_UPTAN; // Recalculate tangent in each step in linear analysis
@@ -169,6 +167,8 @@ bool NonLinSIM::parse (const tinyxml2::XMLElement* elem)
 
 void NonLinSIM::initPrm ()
 {
+  if (iteNorm == NONE && updNewN && model.hasElementActivator())
+    iteNorm = NONE_UPTAN; // Need to (re)calculate tangent matrix at each step
   if (iteNorm <= NONE) // Flag to integrand that a linear solver is used
     model.setIntegrationPrm(3,1.0);
   if (iteNorm <= NONE && nupdat < maxit)

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -990,7 +990,7 @@ void SIMbase::updateForNewElements (Vector& solution,
   for (ASMbase* pch : myModel)
     if (pch->getElementActivator())
       for (size_t iel = 1; iel <= pch->getNoElms(true); iel++)
-        if (pch->isElementActive(pch->getElmID(iel),time.t-time.dt))
+        if (pch->isElementActive(iel-1,time.t-time.dt))
         {
           oldElms.insert(pch->getElmID(iel));
           for (int inod : pch->getElementNodes(iel))
@@ -1006,7 +1006,7 @@ void SIMbase::updateForNewElements (Vector& solution,
       pch->extractNodeVec(solution,pchSol);
       const size_t nf = pch->getNoFields();
       for (size_t iel = 1; iel <= pch->getNoElms(true); iel++)
-        if (pch->isElementActive(pch->getElmID(iel),time.t) &&
+        if (pch->isElementActive(iel-1,time.t) &&
             oldElms.find(pch->getElmID(iel)) == oldElms.end())
         {
           // This element is activated in current time step.
@@ -1480,7 +1480,7 @@ bool SIMbase::solveEqSystem (Vector& solution, size_t idxRHS, double* rCond,
     status = false;
 
 #if SP_DEBUG > 2
-  if (printSol < 1000) printSol = 1000;
+  printSol = 1000*SP_DEBUG;
 #endif
   if (printSol > 0 && status)
     this->printSolutionSummary(solution,printSol,compName);

--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -725,8 +725,8 @@ bool SIMoutput::writeGlvG (int& nBlock, double time)
   for (const ASMbase* pch : myModel)
   {
     ++pidx;
-    if (pch->empty())
-      continue; // skip empty patches
+    if (pch->empty() || pch->inActive(time))
+      continue; // skip empty and inactive patches
 
     if (!(lvb = this->tesselatePatch(pidx-1)))
       return false;
@@ -734,7 +734,7 @@ bool SIMoutput::writeGlvG (int& nBlock, double time)
     if (pch->getElementActivator())
       // Remove the elements not yet activated
       for (int iel = pch->getNoElms(); iel > 0; --iel)
-        if (!pch->isElementActive(iel,time))
+        if (!pch->isElementActive(iel-1,time))
           lvb->removeElement(iel);
 
     if (msgLevel > 1)
@@ -1097,8 +1097,8 @@ int SIMoutput::writeGlvS1 (const Vector& psol, int iStep, int& nBlock,
   {
     if (!this->extractNodeVec(psol,lovec,pch,psolComps%10,empty))
       return -1;
-    else if (pch->empty())
-      continue; // skip empty patches
+    else if (pch->empty() || pch->inActive(time))
+      continue; // skip empty and inactive patches
 
     if (msgLevel > 1)
       IFEM::cout <<"Writing primary solution for patch "
@@ -1291,8 +1291,8 @@ int SIMoutput::writeGlvS2 (const Vector& psol, int iStep, int& nBlock,
     if (!this->extractNodeVec(psol,myProblem->getSolution(),
                               pch,psolComps,empty))
       return -1;
-    else if (pch->empty())
-      continue; // skip empty patches
+    else if (pch->empty() || pch->inActive(time))
+      continue; // skip empty and inactive patches
 
     myProblem->initResultPoints(time,true); // include principal stresses
     if (!this->initPatchForEvaluation(pch->idx+1))
@@ -1422,8 +1422,8 @@ bool SIMoutput::eval2ndSolution (const Vector& psol, double time, int psolComps)
     if (!this->extractNodeVec(psol,myProblem->getSolution(),
                               pch,psolComps,empty))
       return false;
-    else if (pch->empty())
-      continue; // skip empty patches
+    else if (pch->empty() || pch->inActive(time))
+      continue; // skip empty and inactive patches
     else if (!this->initPatchForEvaluation(pch->idx+1))
       return false;
     else if (!pch->evalSolution(field,*myProblem,opt.nViz))

--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -37,14 +37,14 @@ SIMoutput::SIMoutput (IntegrandBase* itg) : SIMinput(itg)
   myPtSize = 0.0;
   myGeomID = myGeofs1 = myGeofs2 = 0;
   myVtf = nullptr;
-  logRpMap = false;
+  mergeVtf = logRpMap = false;
   idxGrid = -1;
 }
 
 
 SIMoutput::~SIMoutput ()
 {
-  if (myVtf) delete myVtf;
+  delete myVtf;
 
   for (std::pair<const std::string,RealFunc*>& func : myAddScalars)
     delete func.second;
@@ -106,6 +106,7 @@ bool SIMoutput::parseOutputTag (const tinyxml2::XMLElement* elem)
 {
   IFEM::cout <<"  Parsing <"<< elem->Value() <<">"<< std::endl;
 
+  bool newGroup = false;
   if (const char* funcval = utl::getValue(elem,"function"); funcval)
   {
     std::string name;
@@ -122,10 +123,14 @@ bool SIMoutput::parseOutputTag (const tinyxml2::XMLElement* elem)
     myAddScalars[name] = f;
     return true;
   }
-  else if (strcasecmp(elem->Value(),"resultpoints"))
+  else if (!strcasecmp(elem->Value(),"resultpoints"))
+    newGroup = true; // we are parsing result points, below
+  else if (!strcasecmp(elem->Value(),"vtfformat"))
+    utl::getAttribute(elem,"merge",mergeVtf);
+
+  if (!newGroup)
     return this->SIMinput::parseOutputTag(elem);
 
-  bool newGroup = true;
   // Lambda function for adding a new result point to the myPoints container.
   auto&& addPoint = [&newGroup,&points=myPoints](const ResultPoint& newPoint)
   {
@@ -711,12 +716,18 @@ bool SIMoutput::writeGlvG (int& nBlock, double time)
   // Get the ID list of current node blocks, if any
   IntVec nodeBlocks;
   int i, nodeBlock;
+  size_t nNodeLast = 0;
   if (time > 0.0)
+  {
     for (i = 1; (nodeBlock = myVtf->getNodeBlock(i)); i++)
       nodeBlocks.push_back(nodeBlock);
+    if (mergeVtf) // Get the size of the last node block written
+      nNodeLast = myVtf->getBlock(i-1)->getNoNodes();
+  }
   if (time >= 0.0)
     myVtf->clearGeometryBlocks();
 
+  ElementBlock* singlePart = nullptr;
   ElementBlock* lvb;
   char pname[64];
 
@@ -737,14 +748,40 @@ bool SIMoutput::writeGlvG (int& nBlock, double time)
         if (!pch->isElementActive(iel-1,time))
           lvb->removeElement(iel);
 
-    if (msgLevel > 1)
-      IFEM::cout <<"Writing geometry for patch "
-                 << pch->idx+1 <<" ("<< lvb->getNoNodes() <<")"<< std::endl;
+    if (mergeVtf && myModel.size() > 1)
+    {
+      // Merge all element blocks into a single part
+      if (!singlePart)
+        singlePart = lvb;
+      else
+      {
+        singlePart->merge(*lvb,false);
+        delete lvb;
+      }
+    }
+    else
+    {
+      if (msgLevel > 1)
+        IFEM::cout <<"Writing geometry for patch "
+                   << pch->idx+1 <<" ("<< lvb->getNoNodes() <<")"<< std::endl;
 
-    sprintf(pname,"Patch %zu",pch->idx+1);
-    // Reuse the existing node block when time > 0.0
-    nodeBlock = i < static_cast<int>(nodeBlocks.size()) ? nodeBlocks[i++] : 0;
-    if (!myVtf->writeGrid(lvb,pname,++nBlock,nodeBlock))
+      sprintf(pname,"Patch %zu",pch->idx+1);
+      // Reuse the existing node block when time > 0.0
+      nodeBlock = i < static_cast<int>(nodeBlocks.size()) ? nodeBlocks[i++] : 0;
+      if (!myVtf->writeGrid(lvb,pname,++nBlock,nodeBlock))
+        return false;
+    }
+  }
+
+  if (singlePart)
+  {
+    if (msgLevel > 1)
+      IFEM::cout <<"Writing new geometry ("
+                 << singlePart->getNoNodes() <<")"<< std::endl;
+
+    // Reuse the last node block when time > 0.0 unless increased size
+    nodeBlock = singlePart->getNoNodes() > nNodeLast ? 0 : nodeBlocks.back();
+    if (!myVtf->writeGrid(singlePart,"FE model",++nBlock,nodeBlock))
       return false;
   }
 
@@ -795,6 +832,8 @@ bool SIMoutput::writeGlvBC (int& nBlock, int iStep) const
 {
   if (!myVtf)
     return true;
+  if (mergeVtf && myModel.size() > 1)
+    return true; // not implemented for merged patches, ignore
 
   Matrix field;
   std::array<IntVec,6> dID;
@@ -933,6 +972,8 @@ bool SIMoutput::writeGlvV (const RealArray& vec, const char* fieldName,
 {
   if (vec.empty() || !myVtf)
     return true;
+  if (mergeVtf && myModel.size() > 1)
+    return true; // not implemented for merged patches, ignore
 
   Matrix field;
   Vector lovec;
@@ -973,6 +1014,8 @@ bool SIMoutput::writeGlvS (const Vector& scl, const char* fieldName,
 {
   if (scl.empty() || !myVtf)
     return true;
+  if (mergeVtf && myModel.size() > 1)
+    return false; // not implemented for merged patches, abort..
 
   const bool piolaMapping = myProblem ?
     myProblem->getIntegrandType() & Integrand::PIOLA_MAPPING : false;
@@ -1086,6 +1129,14 @@ int SIMoutput::writeGlvS1 (const Vector& psol, int iStep, int& nBlock,
       if (myVtf->getBlock(geo))
         vID[0].push_back(dis);
 
+  // Find the last active patch at current time
+  size_t lastActive = 0;
+  if (mergeVtf)
+    for (const ASMbase* pch : myModel)
+      if (!pch->empty() && !pch->inActive(time))
+        lastActive = pch->idx;
+
+  Matrix singleField;
   Matrix field;
   Vector lovec;
 
@@ -1108,6 +1159,19 @@ int SIMoutput::writeGlvS1 (const Vector& psol, int iStep, int& nBlock,
 
     if (!pch->evalSolution(field,lovec,opt.nViz,0,piolaMapping))
       return -1;
+
+    if (lastActive > 0)
+    {
+      // We need to merge the results for all patches before writing them
+      if (singleField.empty())
+        std::swap(singleField,field);
+      else
+        singleField.augmentCols(field);
+      if (lastActive == pch->idx)
+        std::swap(field,singleField);
+      else
+        continue;
+    }
 
     const ElementBlock* grid = myVtf->getBlock(++geomID);
     pch->filterResults(field,grid);
@@ -1280,6 +1344,14 @@ int SIMoutput::writeGlvS2 (const Vector& psol, int iStep, int& nBlock,
   std::vector<IntVec> sID;
   sID.reserve((haveAsol ? 2*nf : nf) + nProj);
 
+  // Find the last active patch at current time
+  size_t lastActive = 0;
+  if (mergeVtf)
+    for (const ASMbase* pch : myModel)
+      if (!pch->empty() && !pch->inActive(time))
+        lastActive = pch->idx;
+
+  Matrix singleField, projField;
   Matrix field, pdir;
   Vector lovec;
 
@@ -1294,7 +1366,7 @@ int SIMoutput::writeGlvS2 (const Vector& psol, int iStep, int& nBlock,
     else if (pch->empty() || pch->inActive(time))
       continue; // skip empty and inactive patches
 
-    myProblem->initResultPoints(time,true); // include principal stresses
+    myProblem->initResultPoints(time,!lastActive); // include principal stresses
     if (!this->initPatchForEvaluation(pch->idx+1))
       return -2;
 
@@ -1307,12 +1379,29 @@ int SIMoutput::writeGlvS2 (const Vector& psol, int iStep, int& nBlock,
     if (!pch->evalSolution(field,*myProblem,opt.nViz))
       return -1;
 
-    const ElementBlock* grid = myVtf->getBlock(++geomID);
-    pch->filterResults(field,grid);
-
     size_t k = 0;
-    if (!this->writeScalarFields(field,geomID,nBlock,sID,&k,ASM::SECONDARY))
-      return -4;
+    bool writeNow = true;
+    if (lastActive > 0)
+    {
+      // We need to merge the results for all patches before writing them
+      if (singleField.empty())
+        std::swap(singleField,field);
+      else
+        singleField.augmentCols(field);
+      if (lastActive == pch->idx)
+        std::swap(field,singleField);
+      else
+        writeNow = false;
+    }
+
+    const ElementBlock* grid = writeNow ? myVtf->getBlock(++geomID) : nullptr;
+
+    if (writeNow)
+    {
+      pch->filterResults(field,grid);
+      if (!this->writeScalarFields(field,geomID,nBlock,sID,&k,ASM::SECONDARY))
+        return -4;
+    }
 
     // Write principal directions, if any, as vector fields
 
@@ -1334,9 +1423,23 @@ int SIMoutput::writeGlvS2 (const Vector& psol, int iStep, int& nBlock,
       if (!pch->evalSolution(field,*myProblem,opt.nViz,'D'))
         return -1;
 
-      pch->filterResults(field,grid);
-      if (!this->writeScalarFields(field,geomID,nBlock,sID,&k,ASM::PROJECTED))
-        return -4;
+      if (lastActive > 0)
+      {
+        // We need to merge the results for all patches before writing them
+        if (projField.empty())
+          std::swap(projField,field);
+        else
+          projField.augmentCols(field);
+        if (lastActive == pch->idx)
+          std::swap(field,projField);
+      }
+
+      if (writeNow)
+      {
+        pch->filterResults(field,grid);
+        if (!this->writeScalarFields(field,geomID,nBlock,sID,&k,ASM::PROJECTED))
+          return -4;
+      }
     }
 
     if (haveAsol && grid)
@@ -1445,6 +1548,8 @@ bool SIMoutput::writeGlvP (const RealArray& ssol, int iStep, int& nBlock,
 {
   if (ssol.empty() || !myVtf)
     return true; // no projected solution
+  if (mergeVtf && myModel.size() > 1)
+    return true; // not implemented for merged patches, ignore
 
   // Lambda function for updating (patch-wise) maximum result values.
   auto&& updateMaxVal = [](PointValues& maxVal, double res,
@@ -1547,6 +1652,8 @@ bool SIMoutput::writeGlvF (const RealFunc& f, const char* fname,
 {
   if (!myVtf)
     return true;
+  if (mergeVtf && myModel.size() > 1)
+    return true; // not implemented for merged patches, ignore
 
   const bool piolaMapping = state && myProblem ?
     myProblem->getIntegrandType() & Integrand::PIOLA_MAPPING : false;
@@ -1607,6 +1714,8 @@ bool SIMoutput::writeGlvM (const Mode& mode, bool freq, int& nBlock)
 {
   if (mode.eigVec.empty() || !myVtf)
     return true; // no eigen modes
+  if (mergeVtf && myModel.size() > 1)
+    return true; // not implemented for merged patches, ignore
 
   if (msgLevel > 1)
     IFEM::cout <<"Writing eigenvector for Mode "<< mode.eigNo << std::endl;
@@ -1683,6 +1792,8 @@ bool SIMoutput::writeGlvN (const Matrix& norms, int iStep, int& nBlock,
 {
   if (norms.empty() || !myVtf)
     return true; // no element norms
+  if (mergeVtf && myModel.size() > 1)
+    return true; // not implemented for merged patches, ignore
 
   NormBase* norm = myProblem->getNormIntegrand(mySol);
 
@@ -1781,6 +1892,8 @@ bool SIMoutput::writeGlvE (const Vector& field, int iStep, int& nBlock,
 {
   if (!myVtf)
     return true;
+  if (mergeVtf && myModel.size() > 1)
+    return true; // not implemented for merged patches, ignore
 
   Vector lVec;
   IntVec sID;

--- a/src/SIM/SIMoutput.h
+++ b/src/SIM/SIMoutput.h
@@ -433,9 +433,10 @@ private:
   int    myPrec;   //!< Output precision for result sampling
   double myPtSize; //!< Size of result point visualization in VTF-file
   int    myGeomID; //!< Geometry block ID for the first patch in the VTF-file
-  int    myGeofs1; //!< Geometry block ID offset for immersed geometry in the VTF-file
-  int    myGeofs2; //!< Geometry block ID offset for extra geometry in the VTF-file
+  int    myGeofs1; //!< ID offset for immersed geometry block in the VTF-file
+  int    myGeofs2; //!< ID offset for extra geometry block in the VTF-file
   VTF*   myVtf;    //!< VTF-file for result visualization
+  bool   mergeVtf; //!< If \e true, merge multi-patches into one on the VTF-file
   bool   logRpMap; //!< If \e true, print out the result point mapping
   int    idxGrid;  //!< Index into \ref myPoints for grid result output
 };

--- a/src/Utility/ElementBlock.C
+++ b/src/Utility/ElementBlock.C
@@ -20,8 +20,12 @@
 
 double ElementBlock::eps = 0.0;
 
-//! \brief List of supported number of element nodes.
-static const std::array<size_t,7> legalNENs = { 2, 3, 4, 6, 8, 9, 27 };
+
+namespace
+{
+  //! \brief List of supported number of element nodes.
+  const std::array<size_t,7> legalNENs = { 2, 3, 4, 6, 8, 9, 27 };
+}
 
 
 ElementBlock::ElementBlock (size_t nenod)
@@ -299,29 +303,32 @@ utl::Point ElementBlock::getCenter (size_t i) const
 }
 
 
-void ElementBlock::removeElement (size_t i)
+void ElementBlock::removeElement (int iel)
 {
-  if (i < 1 || i > MINEX.size())
-    return;
+  for (size_t i = 0; i < MINEX.size();)
+    if (MINEX[i] == iel)
+    {
+      std::vector<int>::iterator it1 = MMNPC.end(), it2 = MMNPC.end();
+      if (nen > 0)
+      {
+        it1 = MMNPC.begin()+nen*i;
+        it2 = it1 + nen;
+      }
+      else
+      {
+        size_t elm = 0;
+        for (size_t ip = 0; ip < MMNPC.size() && it2 == MMNPC.end(); ip++)
+          if (MMNPC[ip] < 0 && ++elm == i+1)
+            it2 = MMNPC.begin() + ip+1;
+          else if (elm == i && it1 == MMNPC.end())
+            it1 = MMNPC.begin() + ip;
+      }
 
-  std::vector<int>::iterator it1 = MMNPC.end(), it2 = MMNPC.end();
-  if (nen > 0)
-  {
-    it2 = MMNPC.begin()+nen*i;
-    it1 = it2 - nen;
-  }
-  else
-  {
-    size_t elm = 0;
-    for (size_t ip = 0; ip < MMNPC.size() && it2 == MMNPC.end(); ip++)
-      if (MMNPC[ip] < 0 && ++elm == i)
-        it2 = MMNPC.begin() + ip+1;
-      else if (elm == i-1 && it1 == MMNPC.end())
-        it1 = MMNPC.begin() + ip;
-  }
-
-  MMNPC.erase(it1,it2);
-  MINEX.erase(MINEX.begin()+i-1);
+      MMNPC.erase(it1,it2);
+      MINEX.erase(MINEX.begin()+i);
+    }
+    else
+      ++i;
 }
 
 

--- a/src/Utility/ElementBlock.h
+++ b/src/Utility/ElementBlock.h
@@ -66,9 +66,9 @@ public:
   //! \param[in] elmId External element ID (generate if negative)
   size_t addLine(size_t i1, const Vec3& X2, int elmId = -1);
 
-  //! \brief Assigns an external id to an element.
+  //! \brief Assigns an external ID to an element.
   void setElmId(size_t i, int iel) { MINEX[i-1] = iel; }
-  //! \brief Returns the external id of an element.
+  //! \brief Returns the external ID of an element.
   int getElmId(size_t i) const { return MINEX[i-1]; }
   //! \brief Returns the internal index of an element in case of mixed types.
   size_t getElmIndex(size_t i) const { return i < elmIdx.size() ? elmIdx[i]:i; }
@@ -108,8 +108,8 @@ public:
 
   //! \brief Returns the coordinates of the center of the given element.
   utl::Point getCenter(size_t i) const;
-  //! \brief Removes the given element.
-  void removeElement(size_t i);
+  //! \brief Removes all elements with the specified external ID.
+  void removeElement(int iel);
 
 protected:
   using Prm3 = std::array<Real,3>; //!< Convenience type
@@ -136,7 +136,7 @@ public:
 class PlaneBlock : public ElementBlock
 {
 public:
-  //! \brief Constructor defining a plane from three points.
+  //! \brief The constructor defines a plane from three points.
   //! \param[in] X0 First corner
   //! \param[in] X1 Second corner
   //! \param[in] X2 Third corner
@@ -153,7 +153,7 @@ public:
 class CubeBlock : public ElementBlock
 {
 public:
-  //! \brief The constructor defines a cube centred at specified point.
+  //! \brief The constructor defines a cube centered at the specified point.
   //! \param[in] X0 Center of the cube
   //! \param[in] dX Length of each cube edge
   CubeBlock(const Vec3& X0, double dX);
@@ -169,7 +169,7 @@ public:
 class SphereBlock : public ElementBlock
 {
 public:
-  //! \brief The constructor defines a sphere centred at specified point.
+  //! \brief The constructor defines a sphere centered at the specified point.
   //! \param[in] X0 Center of the sphere
   //! \param[in] R Sphere diameter
   //! \param[in] nTheta Number of elements around equator
@@ -181,13 +181,13 @@ public:
 /*!
   \brief Class for cylinder geometries.
   \details This class is used to create cylinder shapes in the model,
-  for visualization of rigid contect objects, etc.
+  for visualization of rigid contact objects, etc.
 */
 
 class CylinderBlock : public ElementBlock
 {
 public:
-  //! \brief The constructor defines a sphere centred at specified point.
+  //! \brief The constructor defines a cylinder along an axis through 2 points.
   //! \param[in] X0 First end point
   //! \param[in] X1 Second end point
   //! \param[in] R Cylinder diameter

--- a/src/Utility/Functions.C
+++ b/src/Utility/Functions.C
@@ -872,19 +872,23 @@ IntFunc* utl::parseIntFunc (const std::string& func, const std::string& type)
     int nv; // Number of elements to activate in v-w plane before advancing in u
     int nw; // Number of element divisions per layer in w-direction
     Real s; // Scaling factor
+    Real t; // Time offset
 
   public:
-    Parametric(int u, int v, int w, Real sf) : nu(u), nv(v), nw(w), s(sf) {}
+    explicit Parametric(int u, int v, int w, Real scale)
+      : nu(u), nv(v), nw(w), s(scale), t(Real(0)) {}
+    explicit Parametric(int u, Real offset, Real scale)
+      : nu(u), nv(1), nw(1), s(scale), t(offset) {}
 
   protected:
     Real evaluate(const int& x) const override
     {
       int ix = (x-1)%nu;
       int nx = (x-1)/nu;
-      if (ix < 1 && nx < nv) return Real(0);
+      if (ix < 1 && nx < nv) return t;
 
       Real delta = nw > 1 && nw < nv ? Real(1+nx/(nv/nw))/Real(nw) : Real(0);
-      return s*(Real(ix + nu*(nx/nv)) + delta);
+      return t + s*(Real(ix + nu*(nx/nv)) + delta);
     }
   };
 
@@ -898,6 +902,17 @@ IntFunc* utl::parseIntFunc (const std::string& func, const std::string& type)
     Real sf = (s = strtok(nullptr," ")) ? atof(s) : Real(1);
     free(prms);
     return new Parametric(ne1,ne2,ne3,sf);
+  }
+
+  if (type == "offset" && !func.empty())
+  {
+    char* prms = strdup(func.c_str());
+    char* s = nullptr;
+    int ne1 = atoi(strtok(prms," "));
+    Real ts = (s = strtok(nullptr," ")) ? atof(s) : Real(0);
+    Real sf = (s = strtok(nullptr," ")) ? atof(s) : Real(1);
+    free(prms);
+    return new Parametric(ne1,ts,sf);
   }
 
   Real scaling(1);

--- a/src/Utility/Functions.C
+++ b/src/Utility/Functions.C
@@ -868,6 +868,7 @@ IntFunc* utl::parseIntFunc (const std::string& func, const std::string& type)
   // of nv/nw elements, which then are activated one by one.
   class Parametric : public IntFunc
   {
+    int n0; // Always ignore the first n0 elements
     int nu; // Number of elements in first parameter direction
     int nv; // Number of elements to activate in v-w plane before advancing in u
     int nw; // Number of element divisions per layer in w-direction
@@ -876,13 +877,15 @@ IntFunc* utl::parseIntFunc (const std::string& func, const std::string& type)
 
   public:
     explicit Parametric(int u, int v, int w, Real scale)
-      : nu(u), nv(v), nw(w), s(scale), t(Real(0)) {}
-    explicit Parametric(int u, Real offset, Real scale)
-      : nu(u), nv(1), nw(1), s(scale), t(offset) {}
+      : n0(0), nu(u), nv(v), nw(w), s(scale), t(Real(0)) {}
+    explicit Parametric(int ignore_init, int u, Real offset, Real scale)
+      : n0(ignore_init), nu(u), nv(1), nw(1), s(scale), t(offset) {}
 
   protected:
     Real evaluate(const int& x) const override
     {
+      if (x <= n0) return Real(1.0e99); // always ignore this element
+
       int ix = (x-1)%nu;
       int nx = (x-1)/nu;
       if (ix < 1 && nx < nv) return t;
@@ -911,8 +914,9 @@ IntFunc* utl::parseIntFunc (const std::string& func, const std::string& type)
     int ne1 = atoi(strtok(prms," "));
     Real ts = (s = strtok(nullptr," ")) ? atof(s) : Real(0);
     Real sf = (s = strtok(nullptr," ")) ? atof(s) : Real(1);
+    int ne0 = (s = strtok(nullptr," ")) ? atoi(s) : 0;
     free(prms);
-    return new Parametric(ne1,ts,sf);
+    return new Parametric(ne0,ne1,ts,sf);
   }
 
   Real scaling(1);


### PR DESCRIPTION
Relevant for the SCENE-B simulations.
The activation function now can take a time offset, indicating when the first element in that patch should be active.
Then some changes in SIMoutput, adding the option to merge all patches into one before writing to VTF.
It seems like GLview does not handle multi-patch models where elements appear along the way so well.