### PR TITLE
Support for element age

### DIFF
--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -1822,20 +1822,7 @@ void ASMbase::getBoundaryElms (int lIndex, IntVec& elms,
 
 bool ASMbase::isElementActive (int iel, double time) const
 {
-  if (iel < 0 || iel >= static_cast<int>(MLGE.size()))
-    return false;
-
-  if (MLGE[iel] < 1)
-    return false; // element with zero extension
-
-  if (myElActive && time+1.0e-12 < (*myElActive)(1+iel))
-    return false; // element not activated yet
-
-  if (!myActiveEls)
-    return true; // all elements are active
-
-  return std::find(myActiveEls->begin(),
-                   myActiveEls->end(),MLGE[iel]) != myActiveEls->end();
+  return this->getAge(iel,time) >= 0.0;
 }
 
 
@@ -1845,11 +1832,34 @@ bool ASMbase::inActive (double time) const
   {
     for (size_t iel = 0; iel < nel; iel++)
       if (MLGE[iel] > 0 && time+1.0e-12 > (*myElActive)(iel))
-        return false;
-    return true;
+        return false; // we have at least one active element
+    return true; // no elements activated at this time
   }
 
   return myActiveEls ? myActiveEls->empty() : false;
+}
+
+
+double ASMbase::getAge (int iel, double time) const
+{
+  if (iel < 0 || iel >= static_cast<int>(MLGE.size()))
+    return -1001.0; // element index out of range
+
+  if (MLGE[iel] < 1)
+    return -1002.0; // element with zero extension
+
+  if (myActiveEls && utl::findIndex(*myActiveEls,MLGE[iel]) < 0)
+    return -1003.0; // deactivated element
+
+  // Negative time may occur in snap-through analysis using the
+  // path-following simulation driver, where time is the current load parameter
+  if (time < 0.0) time = 0.0; // reset to zero to avoid element deactivation
+
+  if (!myElActive)
+    return time; // no activation time, age equals current time
+
+  time -= (*myElActive)(1+iel);
+  return time < -1.0e-12 || time > 0.0 ? time : 0.0;
 }
 
 

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -341,6 +341,8 @@ public:
   bool isElementActive(int iel, double time = -1.0) const;
   //! \brief Returns \e true if none of the elements in the patch are active.
   bool inActive(double time) const;
+  //! \brief Returns the age of the element with 0-based index \a iel.
+  double getAge(int iel, double time) const;
   //! \brief Returns \e true if element is in process partition.
   //! \param[in] iel 0-based element index local to current patch
   bool isElementInPartition(int iel) const;

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -1042,7 +1042,7 @@ double ASMs1D::getElementEnds (int i, Vec3Vec& XC) const
   XC.reserve(elmCS.empty() ? 2 : 3);
   const double* pt = &XYZ.front();
   for (int j = 0; j < 2; j++, pt += dim)
-    XC.push_back(Vec3(pt,nsd));
+    XC.emplace_back(pt,nsd);
 
   // Calculate the characteristic element size
   double h = getElementSize(XC);
@@ -1170,7 +1170,7 @@ bool ASMs1D::integrate (Integrand& integrand,
     if (dbgElm < 0 && ielm != -dbgElm)
       continue; // Skipping all elements, except for -dbgElm
 #endif
-    if (!this->isElementActive(iel,time.t))
+    if ((fe.age = this->getAge(iel,time.t)) < 0.0)
       continue; // zero-length or inactive element
 
     fe.idx = firstEl + iel;
@@ -1355,7 +1355,7 @@ bool ASMs1D::integrate (Integrand& integrand, int lIndex,
   if (dbgElm < 0 && ielm != -dbgElm)
     return true; // Skipping all elements, except for -dbgElm
 #endif
-  if (!this->isElementActive(iel,time.t))
+  if ((fe.age = this->getAge(iel,time.t)) < 0.0)
     return true; // zero-length or inactive element
 
   fe.idx = firstEl + iel;
@@ -1412,7 +1412,9 @@ bool ASMs1D::integrate (Integrand& integrand, int lIndex,
 #endif
 
   // Cartesian coordinates of current integration point
-  Vec4 X(fe.Xn*fe.N,time.t);
+  double param[3] = { fe.u, 0.0, 0.0 };
+  Vec4 X(param,time.t);
+  X.assign(fe.Xn*fe.N);
 
   // Evaluate the integrand and accumulate element contributions
   if (ok && !integrand.evalBou(*A,fe,time,X,normal))
@@ -1755,6 +1757,8 @@ bool ASMs1D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
   Matrix   dNdu, Jac, Xtmp;
   Matrix3D d2Ndu2, Hess;
   Matrix4D d3Ndu3;
+  double   param[3] = { 0.0, 0.0, 0.0 };
+  Vec4     X(param,integrand.getTimeLevel());
 
   if (nsd > 1 && (integrand.getIntegrandType() & Integrand::SECOND_DERIVATIVES))
     fe.G.resize(nsd,2); // For storing d{X}/du and d2{X}/du2
@@ -1764,7 +1768,13 @@ bool ASMs1D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
   size_t nPoints = upar.size();
   for (size_t i = 0; i < nPoints; i++, fe.iGP++)
   {
-    fe.u = upar[i];
+    fe.u = param[0] = upar[i];
+    int iel = this->findElementContaining(param) - 1;
+    if ((fe.age = this->getAge(iel,X.t) < 0.0))
+      continue; // skip inactive elements
+
+    fe.idx = firstEl + iel;
+    fe.iel = MLGE[iel];
 
     // Fetch basis function derivatives at current integration point
     if (integrand.getIntegrandType() & Integrand::NO_DERIVATIVES)
@@ -1812,7 +1822,8 @@ bool ASMs1D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
 #endif
 
     // Now evaluate the solution field
-    if (!integrand.evalSol(solPt,fe,Xtmp*fe.N,ip))
+    X.assign(Xtmp * fe.N);
+    if (!integrand.evalSol(solPt,fe,X,ip))
       return false;
     else if (sField.empty())
       sField.resize(solPt.size(),nPoints,true);

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -657,35 +657,6 @@ Tensor ASMs1D::getLocal2Global (double u) const
 }
 
 
-#define DERR -999.99
-
-double ASMs1D::getParametricLength (int iel) const
-{
-#ifdef INDEX_CHECK
-  if (iel < 1 || static_cast<size_t>(iel) > MNPC.size())
-  {
-    std::cerr <<" *** ASMs1D::getParametricLength: Element index "<< iel
-	      <<" out of range [1,"<< MNPC.size() <<"]."<< std::endl;
-    return DERR;
-  }
-#endif
-  if (MNPC[iel-1].empty())
-    return 0.0;
-
-  int inod1 = MNPC[iel-1][curv->order()-1];
-#ifdef INDEX_CHECK
-  if (inod1 < 0 || static_cast<size_t>(inod1) >= MLGN.size())
-  {
-    std::cerr <<" *** ASMs1D::getParametricLength: Node index "<< inod1
-	      <<" out of range [0,"<< MLGN.size() <<">."<< std::endl;
-    return DERR;
-  }
-#endif
-
-  return this->getKnotSpan(inod1);
-}
-
-
 double ASMs1D::getKnotSpan (int i) const
 {
   if (i < 0 || i >= curv->numCoefs() + curv->order() - 1)
@@ -1183,7 +1154,7 @@ bool ASMs1D::integrate (Integrand& integrand,
   Matrix3D d2Ndu2, Hess;
   Matrix4D d3Ndu3;
   double   param[3] = { 0.0, 0.0, 0.0 };
-  Vec4     X(param);
+  Vec4     X(param,time.t);
 
   if (nsd > 1 && (integrand.getIntegrandType() & Integrand::SECOND_DERIVATIVES))
     fe.G.resize(nsd,2); // For storing d{X}/du and d2{X}/du2
@@ -1208,12 +1179,11 @@ bool ASMs1D::integrate (Integrand& integrand,
     LocalIntegral* A = integrand.getLocalIntegral(fe.N.size(),fe.iel);
     if (!A) continue; // no integrand contributions for this element
 
-    // Check that the current element has nonzero length
-    double dL = 0.5*this->getParametricLength(1+iel);
-    if (dL < 0.0) ok = false; // topology error (probably logic error)
+    // Get element length in the parameter space
+    double dL = 0.5*this->getKnotSpan(MNPC[iel][p1-1]);
 
     // Set up control point coordinates for current element
-    ok &= this->getElementCoordinates(fe.Xn,1+iel);
+    ok = this->getElementCoordinates(fe.Xn,1+iel);
 
     if (integrand.getIntegrandType() & Integrand::ELEMENT_CORNERS)
       fe.h = this->getElementEnds(p1+iel,fe.XC);
@@ -1242,8 +1212,8 @@ bool ASMs1D::integrate (Integrand& integrand,
 
       for (int i = 0; i < nRed && ok; i++)
       {
-	// Local element coordinates of current integration point
-	fe.xi = xr[i];
+        // Local element coordinates of current integration point
+        fe.xi = xr[i];
 
         // Parameter values of current integration point
         fe.u = param[0] = redpar[i+nRed*iel];
@@ -1259,12 +1229,11 @@ bool ASMs1D::integrate (Integrand& integrand,
           fe.detJxW = utl::Jacobian(Jac,fe.dNdX,fe.Xn,dNdu)*wr[i];
         }
 
-	// Cartesian coordinates of current integration point
+        // Cartesian coordinates of current integration point
         X.assign(fe.Xn * fe.N);
-	X.t = time.t;
 
-	// Compute the reduced integration terms of the integrand
-	ok = integrand.reducedInt(*A,fe,X);
+        // Compute the reduced integration terms of the integrand
+        ok = integrand.reducedInt(*A,fe,X);
       }
     }
 
@@ -1328,7 +1297,6 @@ bool ASMs1D::integrate (Integrand& integrand,
 
       // Cartesian coordinates of current integration point
       X.assign(fe.Xn * fe.N);
-      X.t = time.t;
 
       // Evaluate the integrand and accumulate element contributions
       if (ok && !integrand.evalInt(*A,fe,time,X))

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -392,10 +392,6 @@ protected:
   //! \param[out] prm Parameter values for all points
   bool getGrevilleParameters(RealArray& prm) const;
 
-  //! \brief Returns the length in the parameter space for an element.
-  //! \param[in] iel 1-based element index local to current patch
-  double getParametricLength(int iel) const;
-
   //! \brief Returns the parametric length on the \a i'th knot-span.
   double getKnotSpan(int i) const;
 

--- a/src/ASM/ASMs1DLag.C
+++ b/src/ASM/ASMs1DLag.C
@@ -235,7 +235,7 @@ bool ASMs1DLag::integrate (Integrand& integrand,
   bool ok = true;
   for (size_t iel = 0; iel < nel && ok; iel++)
   {
-    if (!this->isElementActive(iel,time.t))
+    if ((fe.age = this->getAge(iel,time.t)) < 0.0)
       continue; // zero-length or inactive element
 
     fe.idx = firstEl + iel;
@@ -366,7 +366,7 @@ bool ASMs1DLag::integrate (Integrand& integrand, int lIndex,
       return false;
     }
 
-  if (!this->isElementActive(iel,time.t))
+  if ((fe.age = this->getAge(iel,time.t)) < 0.0)
     return true; // zero-length or inactive element
 
   fe.idx = firstEl + iel;
@@ -512,13 +512,16 @@ bool ASMs1DLag::evalSolution (Matrix& sField, const IntegrandBase& integrand,
   Vector        solPt;
   Vectors       globSolPt(nPoints);
   Matrix        dNdu, Jac;
+  Vec4          X(nullptr,integrand.getTimeLevel());
 
   // Evaluate the secondary solution field at each element node or center
   for (size_t iel = 0; iel < nel; iel++)
   {
+    if ((fe.age = this->getAge(iel,X.t)) < 0.0)
+      continue; // zero-length or inactive element
+
     fe.idx = firstEl + iel;
     fe.iel = MLGE[iel];
-    if (fe.iel < 1) continue; // zero-length element
 
     this->getElementCoordinates(fe.Xn,1+iel);
     const IntVec& mnpc = MNPC[iel];
@@ -541,8 +544,8 @@ bool ASMs1DLag::evalSolution (Matrix& sField, const IntegrandBase& integrand,
       }
 
       // Now evaluate the solution field
-      utl::Point X4(fe.Xn*fe.N,{fe.u});
-      if (!integrand.evalSol(solPt,fe,X4,mnpc))
+      X.assign(fe.Xn * fe.N);
+      if (!integrand.evalSol(solPt,fe,X,mnpc))
         return false;
       else if (sField.empty())
         sField.resize(solPt.size(),nPoints,true);

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -842,7 +842,7 @@ void ASMs2D::constrainEdge (int dir, bool open, int dof, int code, char basis)
 
   int bcode = code;
   if (code > 0) // Dirichlet projection will be performed
-    dirich.push_back(DirichletEdge(this->getBoundary(dir,basis),dof,code));
+    dirich.emplace_back(this->getBoundary(dir,basis),dof,code);
   else if (code < 0)
     bcode = -code;
 
@@ -860,7 +860,7 @@ void ASMs2D::constrainEdge (int dir, bool open, int dof, int code, char basis)
 	// the set of nodes to receive prescribed value from the projection
 	// **unless this node already has a homogeneous constraint**
 	if (this->prescribe(node,dof,-code) == 0 && code > 0)
-	  dirich.back().nodes.push_back(std::make_pair(i2,node));
+	  dirich.back().nodes.emplace_back(i2,node);
       }
       if (!open)
 	this->prescribe(node,dof,bcode);
@@ -878,7 +878,7 @@ void ASMs2D::constrainEdge (int dir, bool open, int dof, int code, char basis)
 	// the set of nodes to receive prescribed value from the projection
 	// **unless this node already has a homogeneous constraint**
 	if (this->prescribe(node,dof,-code) == 0 && code > 0)
-	  dirich.back().nodes.push_back(std::make_pair(i1,node));
+	  dirich.back().nodes.emplace_back(i1,node);
       }
       if (!open)
 	this->prescribe(node,dof,bcode);
@@ -1018,7 +1018,7 @@ size_t ASMs2D::constrainEdgeLocal (int dir, bool open, int dof, int code,
 
   int bcode = code;
   if (code > 0) // Dirichlet projection will be performed
-    dirich.push_back(DirichletEdge(edge,dof,code));
+    dirich.emplace_back(edge,dof,code);
   else if (code < 0)
     bcode = -code;
 
@@ -1070,7 +1070,7 @@ size_t ASMs2D::constrainEdgeLocal (int dir, bool open, int dof, int code,
     {
       this->prescribe(1+iMnod,dof,-code);
       if (code > 0)
-        dirich.back().nodes.push_back(std::make_pair(1+i,1+iMnod));
+        dirich.back().nodes.emplace_back(1+i,1+iMnod);
     }
 
     // Find the local axis directions of the edge at this point
@@ -1655,7 +1655,7 @@ double ASMs2D::getElementCorners (int i1, int i2, Vec3Vec& XC,
   for (int j = 0; j < 2; j++)
     for (int i = 0; i < 2; i++, pt += dim)
     {
-      XC.push_back(Vec3(pt,nsd));
+      XC.emplace_back(pt,nsd);
       if (uC)
       {
         uC->push_back(u[i]);
@@ -1676,7 +1676,7 @@ void ASMs2D::getCornerPoints (int i1, int i2, PointVec& XC) const
   XC.clear();
   XC.reserve(4);
   for (int i = 0; i < 4; i++)
-    XC.push_back(utl::Point(XYZ[i], { uC[2*i], uC[2*i+1] }));
+    XC.emplace_back(XYZ[i], RealArray{ uC[2*i], uC[2*i+1] });
 }
 
 
@@ -1758,7 +1758,7 @@ bool ASMs2D::integrate (Integrand& integrand,
         if (dbgElm < 0 && 1+iel != -dbgElm)
           continue; // Skipping all elements, except for -dbgElm
 #endif
-        if (!this->isElementActive(iel,time.t))
+        if ((fe.age = this->getAge(iel,time.t)) < 0.0)
           continue; // zero-area or inactive element
 
         fe.idx = firstEl + iel;
@@ -2044,7 +2044,7 @@ bool ASMs2D::integrate (Integrand& integrand,
 #endif
         if (itgPts[iel].empty())
           continue; // no integration points in this element
-        if (!this->isElementActive(iel,time.t))
+        if ((fe.age = this->getAge(iel,time.t)) < 0.0)
           continue; // zero-area or inactive element
 
         fe.idx = firstEl + iel;
@@ -2214,7 +2214,7 @@ bool ASMs2D::integrate (Integrand& integrand,
   for (int i2 = p2; i2 <= n2 && jel < nels; i2++)
     for (int i1 = p1; i1 <= n1 && jel < nels; i1++, iel++)
     {
-      if (!this->isElementActive(iel,time.t))
+      if ((fe.age = this->getAge(iel,time.t)) < 0.0)
         continue; // zero-area or inactive element
 
       if (!hasInterfaceElms) jel = iel;
@@ -2430,8 +2430,6 @@ bool ASMs2D::integrate (Integrand& integrand, int lIndex,
 #endif
       if (!this->isElementInPartition(iel))
         continue; // this element is in the partition of another process
-      if (!this->isElementActive(iel,time.t))
-        continue; // zero-area or inactive element
 
       // Skip elements that are not on current boundary edge
       bool skipMe = false;
@@ -2443,6 +2441,9 @@ bool ASMs2D::integrate (Integrand& integrand, int lIndex,
 	case  2: if (i2 < n2) skipMe = true; break;
 	}
       if (skipMe) continue;
+
+      if ((fe.age = this->getAge(iel,time.t)) < 0.0)
+        continue; // zero-area element or inactive element
 
       fe.idx = firstEl + doXelms+iel;
       fe.iel = abs(MLGE[doXelms+iel]);
@@ -2557,7 +2558,7 @@ int ASMs2D::findElementContaining (const double* param) const
   if (!surf) return -2;
 
   int p1   = surf->order_u() - 1;
-  int p2   = surf->order_u() - 1;
+  int p2   = surf->order_v() - 1;
   int nel1 = surf->numCoefs_u() - p1;
   int uEl  = surf->basis_u().knotInterval(param[0]) - p1;
   int vEl  = surf->basis_v().knotInterval(param[1]) - p2;
@@ -2940,6 +2941,8 @@ bool ASMs2D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
   Matrix   dNdu;
   Matrix3D d2Ndu2, Hess;
   Matrix4D d3Ndu3;
+  double   param[3] = { 0.0, 0.0, 0.0 };
+  Vec4     X(param,integrand.getTimeLevel());
 
   // Evaluate the secondary solution field at each point
   for (size_t i = 0; i < nPoints; i++, fe.iGP++)
@@ -2949,21 +2952,25 @@ bool ASMs2D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
     if (use3rdDer)
     {
       scatterInd(n1,n2,p1,p2,spline3[i].left_idx,ip);
-      fe.u = spline3[i].param[0];
-      fe.v = spline3[i].param[1];
+      fe.u = param[0] = spline3[i].param[0];
+      fe.v = param[1] = spline3[i].param[1];
     }
     else if (use2ndDer)
     {
       scatterInd(n1,n2,p1,p2,spline2[i].left_idx,ip);
-      fe.u = spline2[i].param[0];
-      fe.v = spline2[i].param[1];
+      fe.u = param[0] = spline2[i].param[0];
+      fe.v = param[1] = spline2[i].param[1];
     }
     else
     {
       scatterInd(n1,n2,p1,p2,spline1[i].left_idx,ip);
-      fe.u = spline1[i].param[0];
-      fe.v = spline1[i].param[1];
+      fe.u = param[0] = spline1[i].param[0];
+      fe.v = param[1] = spline1[i].param[1];
     }
+
+    int iel = this->findElementContaining(param) - 1;
+    if ((fe.age = this->getAge(iel,X.t)) < 0.0)
+      continue; // zero-area or inactive element
 
     // Fetch associated control point coordinates
     utl::gather(ip,nsd,Xnod,Xtmp);
@@ -2998,8 +3005,8 @@ bool ASMs2D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
 #endif
 
     // Now evaluate the solution field
-    utl::Point X4(Xtmp*fe.N,{fe.u,fe.v});
-    if (!integrand.evalSol(solPt,fe,X4,ip))
+    X.assign(Xtmp * fe.N);
+    if (!integrand.evalSol(solPt,fe,X,ip))
       return false;
     else if (sField.empty())
       sField.resize(solPt.size(),nPoints,true);

--- a/src/ASM/ASMs2DLag.C
+++ b/src/ASM/ASMs2DLag.C
@@ -308,10 +308,11 @@ bool ASMs2DLag::integrateElm (Integrand& integrand, GlobalIntegral& glInt,
     return false;
   }
 
-  if (!this->isElementActive(iel,time.t))
-    return true; // zero-area or inactive element, silently ignore
-
   FiniteElement fe;
+
+  if ((fe.age = this->getAge(iel,time.t)) < 0.0)
+    return true; // zero-area or de-activated element, silently ignore
+
   Matrix Def, Vel;
   Vec4 X(nullptr,time.t);
 
@@ -574,8 +575,6 @@ bool ASMs2DLag::integrate (Integrand& integrand, int lIndex,
     {
       if (!this->isElementInPartition(iel))
         continue; // this element is in the partition of another process
-      if (!this->isElementActive(iel,time.t))
-        continue; // zero-area or inactive element
 
       // Skip elements that are not on current boundary edge
       bool skipMe = false;
@@ -587,6 +586,9 @@ bool ASMs2DLag::integrate (Integrand& integrand, int lIndex,
         case  2: if (i2 < nely-1) skipMe = true; break;
       }
       if (skipMe) continue;
+
+      if ((fe.age = this->getAge(iel,time.t)) < 0.0)
+        continue; // zero-area or de-activated element
 
       fe.idx = firstEl + doXelms+iel;
       fe.iel = abs(MLGE[doXelms+iel]);
@@ -817,13 +819,16 @@ bool ASMs2DLag::evalSolution (Matrix& sField, const IntegrandBase& integrand,
   Vector        solPt;
   Vectors       globSolPt(nPoints);
   Matrix        dNdu;
+  Vec4          X(nullptr,integrand.getTimeLevel());
 
   // Evaluate the secondary solution field at each point
   for (size_t iel = 0; iel < nel; iel++)
   {
+    if ((fe.age = this->getAge(iel,X.t)) < 0.0)
+      continue; // zero-area or de-activated element
+
     fe.idx = firstEl + iel;
     fe.iel = MLGE[iel];
-    if (fe.iel < 1) continue; // zero-area element
 
     const IntVec& mnpc = MNPC[iel];
     this->getElementCoordinates(fe.Xn,1+iel);
@@ -846,8 +851,8 @@ bool ASMs2DLag::evalSolution (Matrix& sField, const IntegrandBase& integrand,
         }
 
         // Now evaluate the solution field
-        utl::Point X4(fe.Xn*fe.N,{fe.u,fe.v});
-        if (!integrand.evalSol(solPt,fe,X4,mnpc))
+        X.assign(fe.Xn * fe.N);
+        if (!integrand.evalSol(solPt,fe,X,mnpc))
           return false;
         else if (sField.empty())
           sField.resize(solPt.size(),nPoints,true);
@@ -895,9 +900,11 @@ bool ASMs2DLag::evalSolution (Matrix& sField, const IntegrandBase& integrand,
         return false;
     }
 
+    if ((fe.age = this->getAge(iel-1,integrand.getTimeLevel())) < 0.0)
+      continue; // zero-area or de-activated element
+
     fe.idx = firstEl + iel-1;
     fe.iel = MLGE[iel-1];
-    if (fe.iel < 1) continue; // zero-area element
 
     this->getElementCoordinates(fe.Xn,iel);
 

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -1025,7 +1025,7 @@ void ASMs3D::constrainFace (int dir, bool open, int dof,
 
   int bcode = code;
   if (code > 0) // Dirichlet projection will be performed
-    dirich.push_back(DirichletFace(this->getBoundary(dir,basis),dof,code));
+    dirich.emplace_back(this->getBoundary(dir,basis),dof,code);
   else if (code < 0)
     bcode = -code;
 
@@ -1046,7 +1046,7 @@ void ASMs3D::constrainFace (int dir, bool open, int dof,
 	    // the set of nodes to receive prescribed value from the projection
 	    // **unless this node already has a homogeneous constraint**
 	    if (this->prescribe(node,dof,-code) == 0 && code > 0)
-	      dirich.back().nodes.push_back(std::make_pair(n2*(i3-1)+i2,node));
+	      dirich.back().nodes.emplace_back(n2*(i3-1)+i2,node);
 	  }
       break;
 
@@ -1065,7 +1065,7 @@ void ASMs3D::constrainFace (int dir, bool open, int dof,
 	    // the set of nodes to receive prescribed value from the projection
 	    // **unless this node already has a homogeneous constraint**
 	    if (this->prescribe(node,dof,-code) == 0 && code > 0)
-	      dirich.back().nodes.push_back(std::make_pair(n1*(i3-1)+i1,node));
+	      dirich.back().nodes.emplace_back(n1*(i3-1)+i1,node);
 	  }
       break;
 
@@ -1084,7 +1084,7 @@ void ASMs3D::constrainFace (int dir, bool open, int dof,
 	    // the set of nodes to receive prescribed value from the projection
 	    // **unless this node already has a homogeneous constraint**
 	    if (this->prescribe(node,dof,-code) == 0 && code > 0)
-	      dirich.back().nodes.push_back(std::make_pair(n1*(i2-1)+i1,node));
+	      dirich.back().nodes.emplace_back(n1*(i2-1)+i1,node);
 	  }
       break;
     }
@@ -1205,7 +1205,7 @@ size_t ASMs3D::constrainFaceLocal (int dir, bool open, int dof, int code,
 
   int bcode = code;
   if (code > 0) // Dirichlet projection will be performed
-    dirich.push_back(DirichletFace(this->getBoundary(dir),dof,code));
+    dirich.emplace_back(this->getBoundary(dir),dof,code);
   else if (code < 0)
     bcode = -code;
 
@@ -1259,7 +1259,7 @@ size_t ASMs3D::constrainFaceLocal (int dir, bool open, int dof, int code,
       {
         this->prescribe(1+iMnod,dof,-code);
         if (code > 0)
-          dirich.back().nodes.push_back(std::make_pair(1+k,1+iMnod));
+          dirich.back().nodes.emplace_back(1+k,1+iMnod);
       }
 
       // Local-to-global transformation matrix at this point, created by
@@ -2018,7 +2018,7 @@ double ASMs3D::getElementCorners (int i1, int i2, int i3, Vec3Vec& XC,
     for (int j = 0; j < 2; j++)
       for (int i = 0; i < 2; i++, pt += dim)
       {
-        XC.push_back(Vec3(pt,nsd));
+        XC.emplace_back(pt,nsd);
         if (uC)
         {
           uC->push_back(u[i]);
@@ -2040,7 +2040,7 @@ void ASMs3D::getCornerPoints (int i1, int i2, int i3, PointVec& XC) const
   XC.clear();
   XC.reserve(8);
   for (int i = 0; i < 4; i++)
-    XC.push_back(utl::Point(XYZ[i], { uC[3*i], uC[3*i+1], uC[3*i+2] }));
+    XC.emplace_back(XYZ[i], RealArray{ uC[3*i], uC[3*i+1], uC[3*i+2] });
 }
 
 
@@ -2108,7 +2108,7 @@ bool ASMs3D::integrate (Integrand& integrand,
         if (dbgElm < 0 && 1+iel != -dbgElm)
           continue; // Skipping all elements, except for -dbgElm
 #endif
-        if (!this->isElementActive(iel,time.t))
+        if ((fe.age = this->getAge(iel,time.t)) < 0.0)
           continue; // zero-volume or inactive element
 
         fe.idx = firstEl + iel;
@@ -2383,7 +2383,7 @@ bool ASMs3D::integrate (Integrand& integrand,
 #endif
         if (itgPts[iel].empty())
           continue; // no integration points in this element
-        if (!this->isElementActive(iel,time.t))
+        if ((fe.age = this->getAge(iel,time.t)) < 0.0)
           continue; // zero-volume or inactive element
 
         fe.idx = firstEl + iel;
@@ -2643,7 +2643,7 @@ bool ASMs3D::integrate (Integrand& integrand, int lIndex,
         if (dbgElm < 0 && 1+iel != -dbgElm)
           continue; // Skipping all elements, except for -dbgElm
 #endif
-        if (!this->isElementActive(iel,time.t))
+        if ((fe.age = this->getAge(iel,time.t)) < 0.0)
           continue; // zero-volume or inactive element
 
         fe.idx = firstEl + doXelms+iel;
@@ -2876,8 +2876,6 @@ bool ASMs3D::integrateEdge (Integrand& integrand, int lEdge,
       {
         if (!this->isElementInPartition(iel))
           continue; // this element is in the partition of another process
-        if (!this->isElementActive(iel,time.t))
-          continue; // zero-volume or inactive element
 
 	// Skip elements that are not on current boundary edge
 	bool skipMe = false;
@@ -2897,6 +2895,9 @@ bool ASMs3D::integrateEdge (Integrand& integrand, int lEdge,
 	  case 12: if (i1 < n1 || i2 < n2) skipMe = true; break;
 	  }
 	if (skipMe) continue;
+
+	if ((fe.age = this->getAge(iel,time.t)) < 0.0)
+	  continue; // zero-volume or inactive element
 
 	// Get element edge length in the parameter space
 	double dS = 0.0;
@@ -3388,6 +3389,8 @@ bool ASMs3D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
   Vector        solPt;
   Matrix        dNdu, Jac;
   Matrix3D      d2Ndu2, Hess;
+  double        param[3];
+  Vec4          X(param,integrand.getTimeLevel());
 
   // Evaluate the secondary solution field at each point
   for (size_t i = 0; i < nPoints; i++, fe.iGP++)
@@ -3397,17 +3400,24 @@ bool ASMs3D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
     if (use2ndDer)
     {
       scatterInd(n1,n2,n3,p1,p2,p3,spline2[i].left_idx,ip);
-      fe.u = spline2[i].param[0];
-      fe.v = spline2[i].param[1];
-      fe.w = spline2[i].param[2];
+      fe.u = param[0] = spline2[i].param[0];
+      fe.v = param[1] = spline2[i].param[1];
+      fe.w = param[2] = spline2[i].param[2];
     }
     else
     {
       scatterInd(n1,n2,n3,p1,p2,p3,spline1[i].left_idx,ip);
-      fe.u = spline1[i].param[0];
-      fe.v = spline1[i].param[1];
-      fe.w = spline1[i].param[2];
+      fe.u = param[0] = spline1[i].param[0];
+      fe.v = param[1] = spline1[i].param[1];
+      fe.w = param[2] = spline1[i].param[2];
     }
+
+    int iel = this->findElementContaining(param) - 1;
+    if ((fe.age = this->getAge(iel,X.t)) < 0.0)
+      continue; // zero-volume or inactive element
+
+    fe.idx = firstEl + iel;
+    fe.iel = MLGE[iel];
 
     // Fetch associated control point coordinates
     utl::gather(ip,3,Xnod,Xtmp);
@@ -3432,8 +3442,8 @@ bool ASMs3D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
 #endif
 
     // Now evaluate the solution field
-    utl::Point X4(Xtmp*fe.N,{fe.u,fe.v,fe.w});
-    if (!integrand.evalSol(solPt,fe,X4,ip))
+    X.assign(Xtmp * fe.N);
+    if (!integrand.evalSol(solPt,fe,X,ip))
       return false;
     else if (sField.empty())
       sField.resize(solPt.size(),nPoints,true);

--- a/src/ASM/ASMs3DLag.C
+++ b/src/ASM/ASMs3DLag.C
@@ -377,7 +377,7 @@ bool ASMs3DLag::integrate (Integrand& integrand,
           ok = false;
           break;
         }
-        if (!this->isElementActive(iel,time.t))
+        if ((fe.age = this->getAge(iel,time.t)) < 0.0)
           continue; // zero-volume or inactive element
 
         fe.idx = firstEl + iel;
@@ -640,7 +640,7 @@ bool ASMs3DLag::integrate (Integrand& integrand, int lIndex,
           ok = false;
           break;
         }
-        if (!this->isElementActive(iel,time.t))
+        if ((fe.age = this->getAge(iel,time.t)) < 0.0)
           continue; // zero-volume or inactive element
 
         fe.idx = firstEl + doXelms+iel;
@@ -798,8 +798,6 @@ bool ASMs3DLag::integrateEdge (Integrand& integrand, int lEdge,
       {
         if (!this->isElementInPartition(iel))
           continue; // this element is in the partition of another process
-        if (!this->isElementActive(iel,time.t))
-          continue; // zero-volume or inactive element
 
         // Skip elements that are not on current boundary edge
         bool skipMe = false;
@@ -819,6 +817,9 @@ bool ASMs3DLag::integrateEdge (Integrand& integrand, int lEdge,
           case 12: if (i1 < nelx-1 || i2 < nely-1) skipMe = true; break;
         }
         if (skipMe) continue;
+
+        if ((fe.age = this->getAge(iel,time.t)) < 0.0)
+          continue; // zero-volume or inactive element
 
         if (lEdge < 5)
           ip = i1*ng;
@@ -1080,13 +1081,16 @@ bool ASMs3DLag::evalSolution (Matrix& sField, const IntegrandBase& integrand,
   Vector        solPt;
   Vectors       globSolPt(nPoints);
   Matrix        dNdu, Jac;
+  Vec4          X(nullptr,integrand.getTimeLevel());
 
   // Evaluate the secondary solution field at each point
   for (size_t iel = 0; iel < nel; iel++)
   {
+    if ((fe.age = this->getAge(iel,X.t)) < 0.0)
+      continue; // zero-volume or inactive element
+
     fe.idx = firstEl + iel;
     fe.iel = MLGE[iel];
-    if (fe.iel < 1) continue; // zero-volume element
 
     const IntVec& mnpc = MNPC[iel];
     this->getElementCoordinates(fe.Xn,1+iel);
@@ -1111,8 +1115,8 @@ bool ASMs3DLag::evalSolution (Matrix& sField, const IntegrandBase& integrand,
           }
 
           // Now evaluate the solution field
-          utl::Point X4(fe.Xn*fe.N,{fe.u,fe.v,fe.w});
-          if (!integrand.evalSol(solPt,fe,X4,mnpc))
+          X.assign(fe.Xn * fe.N);
+          if (!integrand.evalSol(solPt,fe,X,mnpc))
             return false;
           else if (sField.empty())
             sField.resize(solPt.size(),nPoints,true);
@@ -1161,9 +1165,11 @@ bool ASMs3DLag::evalSolution (Matrix& sField, const IntegrandBase& integrand,
         return false;
     }
 
+    if ((fe.age = this->getAge(iel-1,integrand.getTimeLevel())) < 0.0)
+      continue; // zero-volume or inactive element
+
     fe.idx = firstEl + iel-1;
     fe.iel = MLGE[iel-1];
-    if (fe.iel < 1) continue; // zero-volume element
 
     this->getElementCoordinates(fe.Xn,iel);
 

--- a/src/ASM/FiniteElement.h
+++ b/src/ASM/FiniteElement.h
@@ -30,7 +30,7 @@ class FiniteElement : public ItgPoint
 public:
   //! \brief Default constructor.
   explicit FiniteElement(size_t n = 0, size_t i = 0) : ItgPoint(i), N(n), Te(3)
-  { p = q = r = 0; h = 0.0; detJxW = 1.0; }
+  { p = q = r = 0; age = h = 0.0; detJxW = 1.0; }
 
   //! \brief Returns the number of bases.
   virtual size_t getNoBasis() const { return 1; }
@@ -73,20 +73,20 @@ public:
   Matrix     H;    //!< Hessian
 
   //! \brief Matrix holding Piola-mapped basis function values.
-  //! \details The column index \a i is cummulative, e.g., if
+  //! \details The column index \a i is cumulative, e.g., if
   //! N1 is the number of functions in basis 1 and
   //! N2 is the number of functions in basis 2, then
   //! 1 &le; \a i &le; N1 for the first basis and
-  //! N1+1 &le; \a i &le; N1+N2 or the second basis.
+  //! N1+1 &le; \a i &le; N1+N2 for the second basis.
   //! This matrix is therefore of dimension 2&times;(N1+N2).
   Matrix P;
 
   //! \brief Matrix holding Piola-mapped basis derivatives.
-  //! \details The column index \a i is cummulative, e.g., if
+  //! \details The column index \a i is cumulative, e.g., if
   //! N1 is the number of functions in basis 1 and
   //! N2 is the number of functions in basis 2, then
   //! 1 &le; \a i &le; N1 for the first basis and
-  //! N1+1 &le; \a i &le; N1+N2 or the second basis.
+  //! N1+1 &le; \a i &le; N1+N2 for the second basis.
   //! This matrix is therefore of dimension 4&times;(N1+N2),
   //! where the two first rows are the X-derivatives
   //! and the two last rows are the Y-derivatives.
@@ -96,6 +96,7 @@ public:
   short int           p;    //!< Polynomial order of the basis in u-direction
   short int           q;    //!< Polynomial order of the basis in v-direction
   short int           r;    //!< Polynomial order of the basis in r-direction
+  double              age;  //!< Time since birth of this element
   double              h;    //!< Characteristic element size/diameter
   Vec3Vec             XC;   //!< Array with element corner coordinate vectors
   Vector              Navg; //!< Volume-averaged basis function values

--- a/src/SIM/AdaptiveSIM.C
+++ b/src/SIM/AdaptiveSIM.C
@@ -249,7 +249,8 @@ bool AdaptiveSIM::writeGlv (const char* infile, int iStep)
     return false;
 
   if (solution.size() > 1)
-    if (!model.writeGlvS1(solution[1],iStep,nBlock,0.0,"Dual solution",90,-1))
+    if (model.writeGlvS1(solution[1],iStep,nBlock,0.0,
+                         "Dual solution",90,-1) < 0)
       return false;
 
   // Write projected solution fields

--- a/src/SIM/NewmarkSIM.C
+++ b/src/SIM/NewmarkSIM.C
@@ -663,13 +663,13 @@ bool NewmarkSIM::saveStep (int iStep, TimeStep& param)
 
   int nCmp = 10 + model.getNoFields();
   if (tolower(saveVelAc) != 'a')
-    if (!model.writeGlvS1(this->realSolution(1),iStep,nBlock,param.time.t,
-                          "velocity",40,nCmp,islower(saveVelAc)))
+    if (model.writeGlvS1(this->realSolution(1),iStep,nBlock,param.time.t,
+                         "velocity",40,nCmp,islower(saveVelAc)) < 0)
       return false;
 
   if (tolower(saveVelAc) != 'v')
-    if (!model.writeGlvS1(this->realSolution(2),iStep,nBlock,param.time.t,
-                          "acceleration",50,nCmp,islower(saveVelAc)))
+    if (model.writeGlvS1(this->realSolution(2),iStep,nBlock,param.time.t,
+                         "acceleration",50,nCmp,islower(saveVelAc)) < 0)
       return false;
 
   return true;


### PR DESCRIPTION
This adds support for age-dependent element properties.
An age attribute is added to the FiniteElement class, which is the time since the birth of the actual element.
By default the birth time is zero (i.e., the start of the simulation), but can be set to a value larger than zero when time dependent element activation is used.

For the SCENE-B project.