### PR TITLE
Save element activation mask to HDF5

### DIFF
--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -1831,7 +1831,7 @@ bool ASMbase::inActive (double time) const
   if (myElActive)
   {
     for (size_t iel = 0; iel < nel; iel++)
-      if (MLGE[iel] > 0 && time+1.0e-12 > (*myElActive)(iel))
+      if (MLGE[iel] > 0 && time+1.0e-12 > (*myElActive)(1+iel))
         return false; // we have at least one active element
     return true; // no elements activated at this time
   }

--- a/src/Utility/DataExporter.C
+++ b/src/Utility/DataExporter.C
@@ -116,9 +116,10 @@ bool DataExporter::dumpTimeLevel (const TimeStep* tp, bool geoUpd, bool doLog)
   PROFILE1("DataExporter::dumpTimeLevel");
 
   ++m_level;
+  double time = tp ? tp->time.t : 0.0;
   if (tp && doLog)
     IFEM::cout <<"  Dumping results for step="<< tp->step <<" time="
-               << tp->time.t <<" (time level "<< m_level <<")"<< std::endl;
+               << time <<" (time level "<< m_level <<")"<< std::endl;
 
   for (DataWriter* writer : m_writers) {
     writer->openFile(m_level);
@@ -131,7 +132,7 @@ bool DataExporter::dumpTimeLevel (const TimeStep* tp, bool geoUpd, bool doLog)
           writer->writeVector(m_level,it);
           break;
         case SIM:
-          writer->writeSIM(m_level,it,geoUpd,it.second.prefix);
+          writer->writeSIM(m_level,time,it,geoUpd,it.second.prefix);
           break;
         case NODALFORCES:
           writer->writeNodalForces(m_level,it);
@@ -149,7 +150,7 @@ bool DataExporter::dumpTimeLevel (const TimeStep* tp, bool geoUpd, bool doLog)
       }
     }
     if (tp && tp->multiSteps())
-      writer->writeTimeInfo(m_level,m_ndump,*tp);
+      writer->writeTimeInfo(m_level,time);
 
     writer->closeFile(m_level);
   }

--- a/src/Utility/DataExporter.h
+++ b/src/Utility/DataExporter.h
@@ -57,7 +57,8 @@ public:
     ONCE         = 32, //!< Only write field once
     GRID         = 128, //!< Always store an updated grid
     REDUNDANT    = 256, //!< Field is redundantly calculated on all processes
-    L2G_NODE     = 512 //!< Store local-to-global node mapping
+    L2G_NODE     = 512, //!< Storage of local-to-global node mapping
+    ELEMENT_MASK = 1024 //!< Storage of element activation flags
   };
 
   //! \brief A structure holding information about registered fields
@@ -144,8 +145,8 @@ protected:
   int  m_last_step; //!< Last time step we dumped for
 };
 
-//! \brief Convenience type
-typedef std::pair<std::string,DataExporter::FileEntry> DataEntry;
+//! \brief Convenience type alias
+using DataEntry = std::pair<std::string,DataExporter::FileEntry>;
 
 
 /*!
@@ -184,10 +185,11 @@ public:
 
   //! \brief Writes data from a SIM object to file.
   //! \param[in] level The time level to write the data at
+  //! \param[in] time Current time
   //! \param[in] entry The DataEntry describing the vector
   //! \param[in] geometryUpdated Whether or not geometries should be written
   //! \param[in] prefix Field name prefix
-  virtual void writeSIM(int level, const DataEntry& entry,
+  virtual void writeSIM(int level, double time, const DataEntry& entry,
                         bool geometryUpdated, const std::string& prefix) = 0;
 
   //! \brief Writes nodal forces to file.
@@ -211,10 +213,8 @@ public:
 
   //! \brief Writes time stepping info to file.
   //! \param[in] level The time level to write the info at
-  //! \param[in] interval The number of time steps between each data dump
-  //! \param[in] tp The current time stepping info
-  virtual bool writeTimeInfo(int level, int interval,
-                             const TimeStep& tp) = 0;
+  //! \param[in] time Current time
+  virtual bool writeTimeInfo(int level, double time) = 0;
 
   //! \brief Write a log to output file.
   //! \param data Text to write

--- a/src/Utility/Functions.C
+++ b/src/Utility/Functions.C
@@ -849,15 +849,18 @@ const RealFunc* utl::parseRealFunc (char* cline, Real A, bool print)
 
 IntFunc* utl::parseIntFunc (const std::string& func, const std::string& type)
 {
-  class Identity : public IntFunc
+  class Linear : public IntFunc
   {
-    Real s; // Scaling factor
+    Real s, o; // Scaling factor and offset
 
   public:
-    Identity(Real sf) : s(sf) {}
+    Linear(Real sf, Real ofs) : s(sf), o(ofs) {}
 
   protected:
-    Real evaluate(const int& x) const override { return s*Real(x > 1 ? x : 0); }
+    Real evaluate(const int& x) const override
+    {
+      return s*Real(x > 1 || o > Real(0) ? x : 0) + o;
+    }
   };
 
   // This class can be used as an element activation function, where a bunch of
@@ -919,17 +922,21 @@ IntFunc* utl::parseIntFunc (const std::string& func, const std::string& type)
     return new Parametric(ne0,ne1,ts,sf);
   }
 
-  Real scaling(1);
+  Real scaling(1), offset(0);
   if (func.empty())
     IFEM::cout <<"  ** utl::parseIntFunc: \""<< type
                <<"\" not implemented - returning identity"<< std::endl;
   else
   {
+    // This will take simple expressions on the form <a>*t+/-<b>
+    // where <a> and <b> are numerical values, and not much else
     char* prms = strdup(func.c_str());
-    scaling = atof(strtok(prms," "));
+    scaling = atof(strtok(prms," *t"));
+    if (char* s = strtok(nullptr," *t"); s)
+      offset = atof(s);
     free(prms);
   }
-  return new Identity(scaling);
+  return new Linear(scaling,offset);
 }
 
 

--- a/src/Utility/HDF5Writer.C
+++ b/src/Utility/HDF5Writer.C
@@ -361,6 +361,15 @@ void HDF5Writer::writeSIM (int level, const DataEntry& entry,
             ndof1 = psol.size();
           }
         }
+        if (entry.second.ncmps == 6)
+        {
+          // This is a model with rotational degrees of freedom.
+          // We want the translations only.
+          for (size_t i = 1; 6*i < psol.size(); i++)
+            memcpy(psol.ptr()+3*i,psol.ptr()+6*i,3*sizeof(double));
+          ndof1 /= 2;
+          psol.resize(ndof1,utl::RETAIN);
+        }
         const double* data = psol.ptr();
         if (usedescription)
           // Field assumed to be on basis 1 for now

--- a/src/Utility/HDF5Writer.C
+++ b/src/Utility/HDF5Writer.C
@@ -65,20 +65,13 @@ int HDF5Writer::getLastTimeLevel ()
   hid_t acc_tpl = H5P_DEFAULT;
 #endif
 
-  m_file = H5Fopen(m_name.c_str(),m_flag,acc_tpl);
-  if (m_file < 0)
-  {
+  if (hid_t fid = H5Fopen(m_name.c_str(),m_flag,acc_tpl); fid >= 0) {
+    for (bool ok = true; ok; result++)
+      ok = checkGroupExistence(fid, ("/" + std::to_string(result)).c_str());
+    H5Fclose(fid);
+  }
+  else
     std::cerr <<" *** HDF5Writer: Failed to open "<< m_name << std::endl;
-    return -2;
-  }
-
-  for (bool ok = true; ok; result++) {
-    std::stringstream str;
-    str << '/' << result;
-    ok = checkGroupExistence(m_file,str.str().c_str());
-  }
-  H5Fclose(m_file);
-  m_file = -1;
 #endif
   return result-1;
 }
@@ -90,32 +83,25 @@ void HDF5Writer::openFile(int level)
   if (m_file != -1)
     return;
 
-  if (m_flag == H5F_ACC_RDWR) {
-    struct stat buffer;
-    if (stat(m_name.c_str(),&buffer) != 0)
+  if (m_flag == H5F_ACC_RDWR)
+    if (struct stat buffer; stat(m_name.c_str(),&buffer) != 0)
       m_flag = H5F_ACC_TRUNC;
-  }
 
   if (m_flag == H5F_ACC_RDWR) {
 #ifdef HAVE_GET_CURRENT_DIR_NAME
-      char* cwd = get_current_dir_name();
-      struct statvfs vfs;
-      statvfs(cwd,&vfs);
-      if (((int64_t)vfs.f_bavail)*vfs.f_bsize < HDF5_SANITY_LIMIT) {
-        std::cerr << "HDF5Writer: Low disk space detected, bailing" << std::endl;
-        exit(1);
-      }
-      free(cwd);
+    char* cwd = get_current_dir_name();
+    struct statvfs vfs;
+    statvfs(cwd,&vfs);
+    if (static_cast<int64_t>(vfs.f_bavail)*vfs.f_bsize < HDF5_SANITY_LIMIT) {
+      std::cerr <<" *** HDF5Writer: Low disk space detected, bailing.\n";
+      exit(1);
+    }
+    free(cwd);
 #endif
   }
 
-  if (!HDF5Base::openFile(m_flag))
-    return;
-
-  std::stringstream str;
-  str << '/' << level;
-  if (!checkGroupExistence(m_file,str.str().c_str()))
-    H5Gclose(H5Gcreate2(m_file,str.str().c_str(),0,H5P_DEFAULT,H5P_DEFAULT));
+  if (HDF5Base::openFile(m_flag))
+    this->addGroup("/" + std::to_string(level));
 #endif
 }
 
@@ -123,7 +109,7 @@ void HDF5Writer::openFile(int level)
 void HDF5Writer::closeFile(int level)
 {
 #ifdef HAS_HDF5
-  if (m_file) {
+  if (m_file != -1) {
     H5Fflush(m_file,H5F_SCOPE_GLOBAL);
     H5Fclose(m_file);
   }
@@ -134,6 +120,27 @@ void HDF5Writer::closeFile(int level)
 
 
 #ifdef HAS_HDF5
+void HDF5Writer::addGroup(const std::string& path) const
+{
+  if (checkGroupExistence(m_file, path.c_str()))
+    return;
+
+  H5Gclose(H5Gcreate2(m_file, path.c_str(), 0, H5P_DEFAULT, H5P_DEFAULT));
+}
+
+
+hid_t HDF5Writer::getGroup(const std::string& path, hid_t group) const
+{
+  if (group < 0)
+    group = m_file;
+
+  if (checkGroupExistence(group, path.c_str()))
+    return H5Gopen2(group, path.c_str(), H5P_DEFAULT);
+  else
+    return H5Gcreate2(group, path.c_str(), 0, H5P_DEFAULT, H5P_DEFAULT);
+}
+
+
 void HDF5Writer::writeArray(hid_t group, const std::string& name, int patch,
                             int len, const void* data, hid_t type)
 {
@@ -141,39 +148,28 @@ void HDF5Writer::writeArray(hid_t group, const std::string& name, int patch,
   std::cout <<"HDF5Writer::writeArray: "<< name <<" for patch "<< patch
             <<" size="<< len << std::endl;
 #endif
+  hsize_t siz = static_cast<hsize_t>(len);
+  hsize_t start = 0;
 #ifdef HAVE_MPI
-  hsize_t siz;
-  hsize_t start;
-  if (m_adm.dd.isPartitioned()) {
-    siz = static_cast<hsize_t>(len);
-    start = 0;
-  } else {
+  if (!m_adm.dd.isPartitioned()) {
     std::vector<int> lens(m_size), lens2(m_size);
     std::fill(lens.begin(), lens.end(), len);
     MPI_Alltoall(lens.data(),1,MPI_INT,lens2.data(),1,MPI_INT,*m_adm.getCommunicator());
     siz   = std::accumulate(lens2.begin(), lens2.end(), hsize_t(0));
     start = std::accumulate(lens2.begin(), lens2.begin() + m_rank, hsize_t(0));
   }
-#else
-  hsize_t siz   = (hsize_t)len;
-  hsize_t start = 0;
 #endif
   hid_t space, set;
   hid_t group1 = -1;
   if (patch > -1) {
-    if (checkGroupExistence(group, name.c_str()))
-      group1 = H5Gopen2(group, name.c_str(),H5P_DEFAULT);
-    else
-      group1 = H5Gcreate2(group, name.c_str(),0,H5P_DEFAULT,H5P_DEFAULT);
+    group1 = this->getGroup(name,group);
     space = H5Screate_simple(1,&siz,nullptr);
-    std::stringstream str;
-    str << patch;
-    set = H5Dcreate2(group1,str.str().c_str(),
-                     type,space,H5P_DEFAULT,H5P_DEFAULT,H5P_DEFAULT);
+    set = H5Dcreate2(group1, std::to_string(patch).c_str(), type, space,
+                     H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
   } else {
     space = H5Screate_simple(1,&siz,nullptr);
-    set = H5Dcreate2(group,name.c_str(),
-                     type,space,H5P_DEFAULT,H5P_DEFAULT,H5P_DEFAULT);
+    set = H5Dcreate2(group, name.c_str(), type, space,
+                     H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
   }
   if (len > 0) {
     hid_t file_space = H5Dget_space(set);
@@ -204,9 +200,7 @@ void HDF5Writer::writeVector(int level, const DataEntry& entry)
   if (redundant)
     MPI_Comm_rank(*m_adm.getCommunicator(), &rank);
 #endif
-  std::stringstream str;
-  str << level;
-  hid_t group = H5Gopen2(m_file,str.str().c_str(),H5P_DEFAULT);
+  hid_t group = H5Gopen2(m_file, std::to_string(level).c_str(), H5P_DEFAULT);
   if (entry.second.field == DataExporter::VECTOR) {
     Vector* dvec = (Vector*)entry.second.data;
     int len = !redundant || rank == 0 ? dvec->size() : 0;
@@ -305,42 +299,21 @@ void HDF5Writer::writeSIM (int level, const DataEntry& entry,
       normGrp = 1+projPfx.size();
   }
 
+  bool exportSol = results & (DataExporter::PRIMARY | DataExporter::SECONDARY);
+  std::string str = std::to_string(level) + "/" + sim->getName();
   std::vector<hid_t> egroup, group;
   egroup.reserve(sim->getNoBasis());
   group.reserve(sim->getNoBasis()+1);
   for (size_t b = 1; b <= sim->getNoBasis(); ++b) {
-    std::stringstream str;
-    str << level;
-    str << '/' << sim->getName() << "-" << b;
-    if (!checkGroupExistence(m_file,str.str().c_str()))
-      H5Gclose(H5Gcreate2(m_file,str.str().c_str(),0,H5P_DEFAULT,H5P_DEFAULT));
-    if (norm) {
-      std::stringstream str2;
-      str2 << str.str() << "/knotspan";
-      if (checkGroupExistence(m_file,str2.str().c_str()))
-        egroup.push_back(H5Gopen2(m_file,str2.str().c_str(),H5P_DEFAULT));
-      else
-        egroup.push_back(H5Gcreate2(m_file,str2.str().c_str(),0,H5P_DEFAULT,H5P_DEFAULT));
-    }
-    if (results & (DataExporter::PRIMARY | DataExporter::SECONDARY) && !sol->empty()) {
-      str << "/fields";
-      if (checkGroupExistence(m_file,str.str().c_str()))
-        group.push_back(H5Gopen2(m_file,str.str().c_str(),H5P_DEFAULT));
-      else
-        group.push_back(H5Gcreate2(m_file,str.str().c_str(),0,H5P_DEFAULT,H5P_DEFAULT));
-    }
+    std::string basis = str + "-" + std::to_string(b);
+    this->addGroup(basis);
+    if (norm)
+      egroup.push_back(this->getGroup(basis + "/knotspan"));
+    if (exportSol && !sol->empty())
+      group.push_back(this->getGroup(basis + "/fields"));
   }
-
-  if (proj && sim->fieldProjections()) {
-    std::stringstream str;
-    str << level;
-    str << '/' << sim->getName() << "-proj";
-    str << "/fields";
-    if (checkGroupExistence(m_file,str.str().c_str()))
-      group.push_back(H5Gopen2(m_file,str.str().c_str(),H5P_DEFAULT));
-    else
-      group.push_back(H5Gcreate2(m_file,str.str().c_str(),0,H5P_DEFAULT,H5P_DEFAULT));
-  }
+  if (proj && sim->fieldProjections())
+    group.push_back(this->getGroup(str + "-proj/fields"));
 
   // Lambda function for extracting projected solution for a patch.
   size_t projOfs = 0;
@@ -465,29 +438,18 @@ void HDF5Writer::writeSIM (int level, const DataEntry& entry,
         const std::vector<Mode>* modes = static_cast<const std::vector<Mode>*>(entry.second.data2.front());
         for (const Mode& mode : *modes)
         {
-          std::stringstream str;
-          str << level << '/' << sim->getName() << "-1/Eigenmode";
-          hid_t gid;
-          if (checkGroupExistence(m_file,str.str().c_str()))
-            gid = H5Gopen2(m_file,str.str().c_str(),H5P_DEFAULT);
-          else
-            gid = H5Gcreate2(m_file,str.str().c_str(),0,H5P_DEFAULT,H5P_DEFAULT);
-
-          std::stringstream str2;
-          str2 << ++iMode;
-          size_t ndof1 = sim->extractPatchSolution(mode.eigVec,psol,pch);
-          this->writeArray(gid, str2.str(), idx, ndof1, psol.ptr(),
-                           H5T_NATIVE_DOUBLE);
+          hid_t gid = this->getGroup(str + "-1/Eigenmode");
+          std::string str2 = std::to_string(++iMode);
+          size_t len = sim->extractPatchSolution(mode.eigVec,psol,pch);
+          this->writeArray(gid, str2, idx, len, psol.ptr(), H5T_NATIVE_DOUBLE);
           if (sim->opt.eig == 3 || sim->opt.eig == 4 || sim->opt.eig == 6)
-            str2 << "/Frequency";
+            str2 += "/Frequency";
           else
-            str2 << "/Value";
-          this->writeArray(gid, str2.str(), -1, 1, &mode.eigVal,
-                           H5T_NATIVE_DOUBLE);
+            str2 += "/Value";
+          this->writeArray(gid, str2, -1, 1, &mode.eigVal, H5T_NATIVE_DOUBLE);
           if (idx == 1) {
-            std::stringstream str3;
-            str3 << iMode << "/eqn/";
-            this->writeArray(gid, str3.str(), idx, mode.eqnVec.size(),
+            str2 = std::to_string(iMode) + "/eqn/";
+            this->writeArray(gid, str2, idx, mode.eqnVec.size(),
                              mode.eqnVec.ptr(), H5T_NATIVE_DOUBLE);
           }
           H5Gclose(gid);
@@ -569,40 +531,31 @@ void HDF5Writer::writeKnotspan (int level, const DataEntry& entry,
   const Vector* sol = static_cast<const Vector*>(entry.second.data2.front());
   if (!sim || !sol) return;
 
+#ifdef HAS_HDF5
+  std::string str = std::to_string(level) + "/" + sim->getName() + "-1";
+  this->addGroup(str);
+
+  hid_t group = this->getGroup(str + "/knotspan");
+
   Matrix infield(1,sol->size());
   infield.fillRow(1,sol->ptr());
+  double dummy = 0.0;
 
-#ifdef HAS_HDF5
-  std::stringstream str;
-  str << level << '/' << sim->getName() << "-" << 1;
-  if (!checkGroupExistence(m_file,str.str().c_str())) {
-    hid_t group = H5Gcreate2(m_file,str.str().c_str(),0,H5P_DEFAULT,H5P_DEFAULT);
-    H5Gclose(group);
-  }
-
-  str << "/knotspan";
-  hid_t group2;
-  if (checkGroupExistence(m_file,str.str().c_str()))
-    group2 = H5Gopen2(m_file,str.str().c_str(),H5P_DEFAULT);
-  else
-    group2 = H5Gcreate2(m_file,str.str().c_str(),0,H5P_DEFAULT,H5P_DEFAULT);
-  for (int idx = 1; idx <= sim->getNoPatches(); idx++) {
-    int loc = sim->getLocalPatchIndex(idx);
-    if (loc > 0 && (sim->getProcessAdm().isParallel() ||
+  for (int idx = 1; idx <= sim->getNoPatches(); idx++)
+    if (int loc = sim->getLocalPatchIndex(idx);
+        loc > 0 && (sim->getProcessAdm().isParallel() ||
                     sim->getGlobalProcessID() == 0)) // we own the patch
     {
-      Matrix patchEnorm;
-      sim->extractPatchElmRes(infield,patchEnorm,loc-1);
-      writeArray(group2,prefix+entry.second.description,idx,patchEnorm.cols(),
-                 patchEnorm.getRow(1).ptr(),H5T_NATIVE_DOUBLE);
+      Matrix elmRes;
+      sim->extractPatchElmRes(infield,elmRes,loc-1);
+      writeArray(group,prefix+entry.second.description,idx,
+                 elmRes.cols(),elmRes.getRow(1).ptr(),H5T_NATIVE_DOUBLE);
     }
-    else { // must write empty dummy records for the other patches
-      double dummy=0.0;
-      writeArray(group2,prefix+entry.second.description,idx,0,&dummy,H5T_NATIVE_DOUBLE);
-    }
+    else // must write empty dummy records for the other patches
+      writeArray(group,prefix+entry.second.description,idx,
+                 0,&dummy,H5T_NATIVE_DOUBLE);
 
-  }
-  H5Gclose(group2);
+  H5Gclose(group);
 #else
   std::cout << "HDF5Writer: compiled without HDF5 support, no data written" << std::endl;
 #endif
@@ -613,18 +566,13 @@ void HDF5Writer::writeKnotspan (int level, const DataEntry& entry,
 void HDF5Writer::writeBasis (const SIMbase* sim, const std::string& name,
                              int basis, int level, bool redundant, bool l2g)
 {
-  std::stringstream str;
-  str << "/" << level << '/' << name;
-  hid_t group;
   int rank = 0;
 #ifdef HAVE_MPI
   if (redundant)
     MPI_Comm_rank(*m_adm.getCommunicator(), &rank);
 #endif
-  if (checkGroupExistence(m_file,str.str().c_str()))
-    group = H5Gopen2(m_file,str.str().c_str(),H5P_DEFAULT);
-  else
-    group = H5Gcreate2(m_file,str.str().c_str(),0,H5P_DEFAULT,H5P_DEFAULT);
+
+  hid_t group = this->getGroup("/" + std::to_string(level) + "/" + name);
 
   std::map<int, int> l2gNode;
   std::map<int, int> prevNode;
@@ -685,7 +633,6 @@ void HDF5Writer::writeBasis (const SIMbase* sim, const std::string& name,
       adm.send(iNode, adm.getProcId() + 1);
     }
 #endif
-
   }
 
   for (int idx = 1; idx <= sim->getNoPatches(); idx++) {
@@ -731,17 +678,9 @@ void HDF5Writer::writeBasis (const SIMbase* sim, const std::string& name,
 bool HDF5Writer::writeTimeInfo (int level, int interval, const TimeStep& tp)
 {
 #ifdef HAS_HDF5
-  std::stringstream str;
-  str << "/" << level << "/timeinfo";
-  hid_t group;
-  if (checkGroupExistence(m_file,str.str().c_str()))
-    group = H5Gopen2(m_file,str.str().c_str(),H5P_DEFAULT);
-  else
-    group = H5Gcreate2(m_file,str.str().c_str(),0,H5P_DEFAULT,H5P_DEFAULT);
-
+  hid_t group = this->getGroup("/" + std::to_string(level) + "/timeinfo");
   // parallel nodes != 0 write dummy entries
-  int toWrite=(m_rank == 0);
-
+  int toWrite = (m_rank == 0);
   // !TODO: different names
   writeArray(group,"level",-1,toWrite,&tp.time.t,H5T_NATIVE_DOUBLE);
   H5Gclose(group);
@@ -753,20 +692,10 @@ bool HDF5Writer::writeTimeInfo (int level, int interval, const TimeStep& tp)
 void HDF5Writer::writeNodalForces (int level, const DataEntry& entry)
 {
 #ifdef HAS_HDF5
-  std::stringstream str;
-  str << level << "/nodal";
+  std::string str = std::to_string(level) + "/nodal";
+  this->addGroup(str);
 
-  hid_t group2;
-  if (!checkGroupExistence(m_file,str.str().c_str())) {
-    hid_t group = H5Gcreate2(m_file,str.str().c_str(),0,H5P_DEFAULT,H5P_DEFAULT);
-    H5Gclose(group);
-  }
-
-  str << "/" << entry.first;
-  if (checkGroupExistence(m_file,str.str().c_str()))
-    group2 = H5Gopen2(m_file,str.str().c_str(),H5P_DEFAULT);
-  else
-    group2 = H5Gcreate2(m_file,str.str().c_str(),0,H5P_DEFAULT,H5P_DEFAULT);
+  hid_t group = this->getGroup(str + "/" + entry.first);
 
   if (m_rank == 0) {
     SIMbase* sim = static_cast<SIMbase*>(const_cast<void*>(entry.second.data));
@@ -783,14 +712,14 @@ void HDF5Writer::writeNodalForces (int level, const DataEntry& entry)
         values[i*3+j] = val[j];
       }
     }
-    writeArray(group2,"values",-1,values.size(),values.ptr(),H5T_NATIVE_DOUBLE);
-    writeArray(group2,"coords",-1,coords.size(),coords.ptr(),H5T_NATIVE_DOUBLE);
+    writeArray(group,"values",-1,values.size(),values.ptr(),H5T_NATIVE_DOUBLE);
+    writeArray(group,"coords",-1,coords.size(),coords.ptr(),H5T_NATIVE_DOUBLE);
   } else {
     double dummy=0.0;
-    writeArray(group2,"values",-1,0,&dummy,H5T_NATIVE_DOUBLE);
-    writeArray(group2,"coords",-1,0,&dummy,H5T_NATIVE_DOUBLE);
+    writeArray(group,"values",-1,0,&dummy,H5T_NATIVE_DOUBLE);
+    writeArray(group,"coords",-1,0,&dummy,H5T_NATIVE_DOUBLE);
   }
-  H5Gclose(group2);
+  H5Gclose(group);
 #else
   std::cout << "HDF5Writer: compiled without HDF5 support, no data written" << std::endl;
 #endif
@@ -800,11 +729,7 @@ void HDF5Writer::writeNodalForces (int level, const DataEntry& entry)
 bool HDF5Writer::writeLog (const std::string& data, const std::string& name)
 {
 #ifdef HAS_HDF5
-  hid_t group;
-  if (checkGroupExistence(m_file,"/log"))
-    group = H5Gopen2(m_file,"/log",H5P_DEFAULT);
-  else
-    group = H5Gcreate2(m_file,"/log",0,H5P_DEFAULT,H5P_DEFAULT);
+  hid_t group = this->getGroup("/log");
 
   int rank = 0;
   int size = 1;
@@ -816,8 +741,8 @@ bool HDF5Writer::writeLog (const std::string& data, const std::string& name)
   for (int i = 0; i < size; i++)
     writeArray(group, name.c_str(), i, rank == i ? data.size() : 0, data.data(), H5T_NATIVE_CHAR);
   H5Gclose(group);
-  return true;
 
+  return true;
 #else
   return false;
 #endif

--- a/src/Utility/HDF5Writer.C
+++ b/src/Utility/HDF5Writer.C
@@ -16,7 +16,6 @@
 #include "SIMbase.h"
 #include "ASMsupel.h"
 #include "IntegrandBase.h"
-#include "TimeStep.h"
 #include "Vec3.h"
 #include <sstream>
 
@@ -159,18 +158,15 @@ void HDF5Writer::writeArray(hid_t group, const std::string& name, int patch,
     start = std::accumulate(lens2.begin(), lens2.begin() + m_rank, hsize_t(0));
   }
 #endif
-  hid_t space, set;
-  hid_t group1 = -1;
-  if (patch > -1) {
-    group1 = this->getGroup(name,group);
-    space = H5Screate_simple(1,&siz,nullptr);
+  hid_t group1 = patch > -1 ? this->getGroup(name,group) : -1;
+  hid_t space = H5Screate_simple(1,&siz,nullptr);
+  hid_t set;
+  if (patch > -1)
     set = H5Dcreate2(group1, std::to_string(patch).c_str(), type, space,
                      H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  } else {
-    space = H5Screate_simple(1,&siz,nullptr);
+  else
     set = H5Dcreate2(group, name.c_str(), type, space,
                      H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  }
   if (len > 0) {
     hid_t file_space = H5Dget_space(set);
     siz = len;
@@ -194,21 +190,20 @@ void HDF5Writer::writeVector(int level, const DataEntry& entry)
   if (!entry.second.enabled)
     return;
 #ifdef HAS_HDF5
-  int redundant = entry.second.results & DataExporter::REDUNDANT;
   int rank = 0;
 #ifdef HAVE_MPI
-  if (redundant)
+  if (entry.second.results & DataExporter::REDUNDANT)
     MPI_Comm_rank(*m_adm.getCommunicator(), &rank);
 #endif
   hid_t group = H5Gopen2(m_file, std::to_string(level).c_str(), H5P_DEFAULT);
   if (entry.second.field == DataExporter::VECTOR) {
     Vector* dvec = (Vector*)entry.second.data;
-    int len = !redundant || rank == 0 ? dvec->size() : 0;
+    int len = rank == 0 ? dvec->size() : 0;
     this->writeArray(level,entry.first,1,len,dvec->ptr(),H5T_NATIVE_DOUBLE);
   }
   else if (entry.second.field == DataExporter::INTVECTOR) {
     std::vector<int>* ivec = (std::vector<int>*)entry.second.data;
-    int len = !redundant || rank == 0 ? ivec->size() : 0;
+    int len = rank == 0 ? ivec->size() : 0;
     this->writeArray(group,entry.first,1,len,ivec->data(),H5T_NATIVE_INT);
   }
   H5Gclose(group);
@@ -233,7 +228,7 @@ void HDF5Writer::writeBasis (int level, const DataEntry& entry,
 }
 
 
-void HDF5Writer::writeSIM (int level, const DataEntry& entry,
+void HDF5Writer::writeSIM (int level, double time, const DataEntry& entry,
                            bool geometryUpdated, const std::string& prefix)
 {
   if (!entry.second.enabled || !entry.second.data || entry.second.data2.empty())
@@ -307,7 +302,7 @@ void HDF5Writer::writeSIM (int level, const DataEntry& entry,
   for (size_t b = 1; b <= sim->getNoBasis(); ++b) {
     std::string basis = str + "-" + std::to_string(b);
     this->addGroup(basis);
-    if (norm)
+    if (norm || (results & DataExporter::ELEMENT_MASK))
       egroup.push_back(this->getGroup(basis + "/knotspan"));
     if (exportSol && !sol->empty())
       group.push_back(this->getGroup(basis + "/fields"));
@@ -339,15 +334,27 @@ void HDF5Writer::writeSIM (int level, const DataEntry& entry,
     field.fill(pchVec.ptr());
   };
 
-  for (int idx = 1; idx <= sim->getNoPatches(); idx++) {
-    int loc = sim->getLocalPatchIndex(idx);
-    if ((!sim->getProcessAdm().dd.isPartitioned() || sim->getProcessAdm().getProcId() == 0) && loc > 0 &&
-        (!(results & DataExporter::REDUNDANT) || sim->getGlobalProcessID() == 0)) // we own the patch
+  static std::vector<size_t> old_count;
+  if ((results & DataExporter::ELEMENT_MASK) && old_count.empty())
+    old_count.resize(sim->getNoPatches(),0);
+
+
+  //============================================================================
+  // Loop over all patches in the sim
+
+  for (int idx = 1; idx <= sim->getNoPatches(); idx++)
+    if (int loc = sim->getLocalPatchIndex(idx); loc > 0 &&
+        (sim->getProcessAdm().getProcId() == 0 ||
+         !sim->getProcessAdm().dd.isPartitioned() ||
+         !(results & DataExporter::REDUNDANT)))
     {
       ASMbase* pch = sim->getPatch(loc);
       if (!pch) continue;
 
-      if (results & DataExporter::PRIMARY && !sol->empty()) {
+      if (pch->empty() || pch->inActive(time))
+        continue; // skip empty and inactive patches
+
+      if ((results & DataExporter::PRIMARY) && !sol->empty()) {
         Vector psol;
         size_t ndof1 = sim->extractPatchSolution(*sol,psol,pch,entry.second.ncmps,
                                                  usedescription ? 1 : 0);
@@ -388,7 +395,7 @@ void HDF5Writer::writeSIM (int level, const DataEntry& entry,
                            idx, ndof1, data, H5T_NATIVE_DOUBLE);
       }
 
-      if (results & DataExporter::SECONDARY && !sol->empty()) {
+      if ((results & DataExporter::SECONDARY) && !sol->empty()) {
         Matrix field;
         ASM::ResultClass rClass;
         hid_t gid = group.front();
@@ -441,6 +448,16 @@ void HDF5Writer::writeSIM (int level, const DataEntry& entry,
                                H5T_NATIVE_DOUBLE);
       }
 
+      if (results & DataExporter::ELEMENT_MASK) {
+        std::vector<char> mask(pch->getNoElms());
+        for (size_t i = 0; i < mask.size(); ++i)
+          mask[i] = pch->isElementActive(i,time) ? 1 : 0;
+        size_t count = std::count(mask.begin(),mask.end(),1);
+        if (count > old_count[idx-1])
+          this->writeArray(egroup.front(), "mask", idx, mask.size(), mask.data(), H5T_NATIVE_CHAR);
+        old_count[idx-1] = count;
+      }
+
       if (results & DataExporter::EIGENMODES) {
         size_t iMode = 0;
         Vector psol;
@@ -465,8 +482,10 @@ void HDF5Writer::writeSIM (int level, const DataEntry& entry,
         }
       }
     }
-    else // must write empty dummy records for the other patches
+    else
     {
+      // Write empty dummy records for patches
+      // not owned by current processor
       double dummy=0.0;
       if (results & DataExporter::PRIMARY) {
         if (usedescription)
@@ -519,7 +538,6 @@ void HDF5Writer::writeSIM (int level, const DataEntry& entry,
         std::cerr <<"  ** HDF5Writer: Oops, eigenmodes not yet supported for distributed patches"
                   <<"\n     The HDF5-file will most likely be inconsistent."<< std::endl;
     }
-  }
 
   delete norm;
   for (hid_t g : group)
@@ -551,16 +569,18 @@ void HDF5Writer::writeKnotspan (int level, const DataEntry& entry,
   double dummy = 0.0;
 
   for (int idx = 1; idx <= sim->getNoPatches(); idx++)
-    if (int loc = sim->getLocalPatchIndex(idx);
-        loc > 0 && (sim->getProcessAdm().isParallel() ||
-                    sim->getGlobalProcessID() == 0)) // we own the patch
+    if (int loc = sim->getLocalPatchIndex(idx); loc > 0 &&
+        (sim->getProcessAdm().getProcId() == 0 ||
+         sim->getProcessAdm().isParallel()))
     {
       Matrix elmRes;
       sim->extractPatchElmRes(infield,elmRes,loc-1);
       writeArray(group,prefix+entry.second.description,idx,
                  elmRes.cols(),elmRes.getRow(1).ptr(),H5T_NATIVE_DOUBLE);
     }
-    else // must write empty dummy records for the other patches
+    else
+      // Write empty dummy records for patches
+      // not owned by current processor
       writeArray(group,prefix+entry.second.description,idx,
                  0,&dummy,H5T_NATIVE_DOUBLE);
 
@@ -588,7 +608,7 @@ void HDF5Writer::writeBasis (const SIMbase* sim, const std::string& name,
   if (l2g && sim->getNoBasis() > 1) {
     int iNode = 1;
     const ProcessAdm& adm = sim->getProcessAdm();
-    bool parallel = sim->getProcessAdm().isParallel() && !adm.dd.isPartitioned();
+    bool parallel = adm.isParallel() && !adm.dd.isPartitioned();
     const std::vector<int>& MLGN = adm.dd.getMLGN();
 
 #if defined(HAS_PETSC) || defined(HAVE_MPI)
@@ -598,7 +618,7 @@ void HDF5Writer::writeBasis (const SIMbase* sim, const std::string& name,
       std::vector<int> flatMap(nNodes);
       adm.receive(flatMap, adm.getProcId()-1);
       for (size_t n = 0; n < flatMap.size(); n += 2)
-        prevNode.insert({flatMap[n], flatMap[n+1]});
+        prevNode.emplace(flatMap[n], flatMap[n+1]);
       adm.receive(iNode, adm.getProcId() - 1);
     }
 #endif
@@ -613,7 +633,7 @@ void HDF5Writer::writeBasis (const SIMbase* sim, const std::string& name,
       for (size_t n = ofs; n < ofs + pch->getNoNodes(basis); ++n) {
         int node = pch->getNodeID(n+1);
         if (parallel) {
-          auto prevIt = prevNode.find(MLGN[node-1]);
+          std::map<int,int>::const_iterator prevIt = prevNode.find(MLGN[node-1]);
           if (prevIt != prevNode.end()) {
             l2gNode[node] = prevIt->second;
             continue;
@@ -626,15 +646,15 @@ void HDF5Writer::writeBasis (const SIMbase* sim, const std::string& name,
 
 #if defined(HAS_PETSC) || defined(HAVE_MPI)
     if (parallel && adm.getProcId() < adm.getNoProcs() - 1) {
-      std::vector<int> flatMap(2*l2gNode.size() + 2*prevNode.size());
-      auto flatIt = flatMap.begin();
-      for (const auto& it : l2gNode) {
-        *flatIt++ = MLGN[it.first-1];
-        *flatIt++ = it.second;
+      std::vector<int> flatMap;
+      flatMap.reserve(2*l2gNode.size() + 2*prevNode.size());
+      for (const std::pair<const int,int>& it : l2gNode) {
+        flatMap.push_back(MLGN[it.first-1]);
+        flatMap.push_back(it.second);
       }
-      for (const auto& it : prevNode) {
-        *flatIt++ = it.first;
-        *flatIt++ = it.second;
+      for (const std::pair<const int,int>& it : prevNode) {
+        flatMap.push_back(it.first);
+        flatMap.push_back(it.second);
       }
       int size = flatMap.size();
       adm.send(size, adm.getProcId() + 1);
@@ -682,16 +702,14 @@ void HDF5Writer::writeBasis (const SIMbase* sim, const std::string& name,
 #endif
 
 
-// TODO: implement for variable time steps.
-// (named time series to allow different timelevels for different fields)
-bool HDF5Writer::writeTimeInfo (int level, int interval, const TimeStep& tp)
+bool HDF5Writer::writeTimeInfo (int level, double time)
 {
 #ifdef HAS_HDF5
   hid_t group = this->getGroup("/" + std::to_string(level) + "/timeinfo");
   // parallel nodes != 0 write dummy entries
   int toWrite = (m_rank == 0);
   // !TODO: different names
-  writeArray(group,"level",-1,toWrite,&tp.time.t,H5T_NATIVE_DOUBLE);
+  writeArray(group,"level",-1,toWrite,&time,H5T_NATIVE_DOUBLE);
   H5Gclose(group);
 #endif
   return true;

--- a/src/Utility/HDF5Writer.h
+++ b/src/Utility/HDF5Writer.h
@@ -99,6 +99,14 @@ public:
 
 #ifdef HAS_HDF5
 protected:
+  //! \brief Internal helper adding a new empty group, unless already existing.
+  //! \param[in] path Path to the new/existing data group
+  void addGroup(const std::string& path) const;
+  //! \brief Internal helper returning the handle to a new or existing group.
+  //! \param[in] path Path to the new/existing data group
+  //! \param[in] group Parent group of the new group
+  hid_t getGroup(const std::string& path, hid_t group = -1) const;
+
   //! \brief Internal helper function writing a data array to file.
   //! \param[in] group The HDF5 group to write data into
   //! \param[in] name The name of the array

--- a/src/Utility/HDF5Writer.h
+++ b/src/Utility/HDF5Writer.h
@@ -57,6 +57,7 @@ public:
 
   //! \brief Writes data from a SIM to file.
   //! \param[in] level The time level to write the data at
+  //! \param[in] time Current time
   //! \param[in] entry The DataEntry describing the data to write
   //! \param[in] geometryUpdated Whether or not geometries should be written
   //! \param[in] prefix Field name prefix
@@ -64,7 +65,7 @@ public:
   //! \details If prefix is non-empty and we are asked to dump secondary
   //! solutions, we assume they come from different projections
   //! \sa SIMbase::project
-  virtual void writeSIM(int level, const DataEntry& entry,
+  virtual void writeSIM(int level, double time, const DataEntry& entry,
                         bool geometryUpdated, const std::string& prefix);
 
   //! \brief Writes nodal forces to file.
@@ -88,9 +89,8 @@ public:
 
   //! \brief Writes time stepping info to file.
   //! \param[in] level The time level to write the info at
-  //! \param[in] interval The number of time steps between each data dump
-  //! \param[in] tp The current time stepping info
-  virtual bool writeTimeInfo(int level, int interval, const TimeStep& tp);
+  //! \param[in] time Current time
+  virtual bool writeTimeInfo(int level, double time);
 
   //! \brief Write a log to output file.
   //! \param data Text to write


### PR DESCRIPTION
This sits on top of #843 since that also involves some hdf5 issues.
Now the element mask array (0/1 toggles for each element) can be stored as a knot-span array,
but only if difference from the previous array stored.
Besides, all result output is skipped for patches with no active elements.