### PR TITLE
Fix doxy generation for IFEM and add tag file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,7 +535,7 @@ target_compile_definitions(IFEM PUBLIC
 )
 
 include(IFEMDoxy)
-ifem_add_doc_target(APP ifem DOX IFEM)
+ifem_add_doc_target(TARGET IFEM DOX IFEM)
 
 enable_testing()
 include(IFEMTesting)

--- a/cmake/IFEMDoxy.cmake
+++ b/cmake/IFEMDoxy.cmake
@@ -26,19 +26,15 @@ function(ifem_add_doc_target)
     string(APPEND EXTRA_DOXY_PATHS "${DIR} \\\n")
   endforeach()
 
-  if(IFEM_AS_SUBMODULE)
-    configure_file(${IFEM_PATH}/doc/Doxyfile.in Doxyfile)
-  else()
-    configure_file(doc/Doxyfile.in Doxyfile)
-  endif()
-  configure_file(doc/${PARAM_DOX}.dox.in ${PARAM_DOX}.dox)
+  configure_file(${PROJECT_SOURCE_DIR}/doc/Doxyfile.in Doxyfile.${PARAM_TARGET})
+  configure_file(${PROJECT_SOURCE_DIR}/doc/${PARAM_DOX}.dox.in ${PARAM_DOX}.dox)
 
   if(IFEM_INSTALL_DOXY)
     if(NOT CMAKE_INSTALL_DOCDIR)
       set(CMAKE_INSTALL_DOCDIR share/doc)
     endif()
     install(CODE "EXECUTE_PROCESS(COMMAND ${CMAKE_BUILD_TOOL} doc WORKING_DIRECTORY \"${CMAKE_CURRENT_BINARY_DIR}\")")
-    if(appname STREQUAL "ifem")
+    if(PARAM_TARGET STREQUAL "IFEM")
       set(dest_path ${CMAKE_INSTALL_DOCDIR}/IFEM)
     else()
       set(dest_path ${CMAKE_INSTALL_DOCDIR}/IFEM/Apps/${PARAM_TARGET})
@@ -61,7 +57,7 @@ function(ifem_add_doc_target)
     add_custom_target(
       ${PARAM_TARGET}_doc
       COMMAND
-        Doxygen::doxygen ${PROJECT_BINARY_DIR}/Doxyfile
+        Doxygen::doxygen ${PROJECT_BINARY_DIR}/Doxyfile.${PARAM_TARGET}
       WORKING_DIRECTORY
         ${PROJECT_SOURCE_DIR}
       COMMENT

--- a/cmake/IFEMDoxy.cmake
+++ b/cmake/IFEMDoxy.cmake
@@ -3,6 +3,7 @@
 # Single-valued parameters:
 #   DOX        - Name of .dox file for application
 #   TARGET     - Name of application
+#   DEPENDENCIES - List of doxy targets that this target depends on
 # Multi-valued parameters:
 #   EXTRA_DIRS - Extra directories to add to doxy
 #     Used for external directories and optional dependencies
@@ -13,7 +14,7 @@ function(ifem_add_doc_target)
   endif()
 
   set(oneValueArgs TARGET DOX)
-  set(multiValueArgs EXTRA_DIRS)
+  set(multiValueArgs EXTRA_DIRS DEPENDENCIES)
   cmake_parse_arguments(PARAM "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
   if(NOT PARAM_DOX)
@@ -26,6 +27,17 @@ function(ifem_add_doc_target)
     string(APPEND EXTRA_DOXY_PATHS "${DIR} \\\n")
   endforeach()
 
+  set(DOXYGEN_TAG_FILE ${CMAKE_BINARY_DIR}/doc/${PARAM_TARGET}.tag)
+
+  if(IFEM_AS_SUBMODULE)
+    set(DOXYGEN_TAG_FILES ${CMAKE_BINARY_DIR}/doc/IFEM.tag=../../../html)
+    if(IFEM_COMMON_APP_BUILD)
+      foreach(dep ${PARAM_DEPENDENCIES})
+        string(APPEND DOXYGEN_TAG_FILES " \\\n ${CMAKE_BINARY_DIR}/doc/${dep}.tag=../../${dep}/html")
+      endforeach()
+    endif()
+  endif()
+
   configure_file(${PROJECT_SOURCE_DIR}/doc/Doxyfile.in Doxyfile.${PARAM_TARGET})
   configure_file(${PROJECT_SOURCE_DIR}/doc/${PARAM_DOX}.dox.in ${PARAM_DOX}.dox)
 
@@ -33,15 +45,18 @@ function(ifem_add_doc_target)
     if(NOT CMAKE_INSTALL_DOCDIR)
       set(CMAKE_INSTALL_DOCDIR share/doc)
     endif()
-    install(CODE "EXECUTE_PROCESS(COMMAND ${CMAKE_BUILD_TOOL} doc WORKING_DIRECTORY \"${CMAKE_CURRENT_BINARY_DIR}\")")
+    install(CODE "EXECUTE_PROCESS(COMMAND ${CMAKE_BUILD_TOOL} doc WORKING_DIRECTORY \"${CMAKE_BINARY_DIR}\")")
     if(PARAM_TARGET STREQUAL "IFEM")
+      set(src_path ${CMAKE_BINARY_DIR}/doc/html)
       set(dest_path ${CMAKE_INSTALL_DOCDIR}/IFEM)
     else()
+      set(src_path ${CMAKE_BINARY_DIR}/doc/Apps/${PARAM_TARGET}/html)
       set(dest_path ${CMAKE_INSTALL_DOCDIR}/IFEM/Apps/${PARAM_TARGET})
+      file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/doc/Apps/${PARAM_TARGET})
     endif()
     install(
       DIRECTORY
-        ${PROJECT_BINARY_DIR}/doc/html
+        ${src_path}
       DESTINATION
         ${dest_path}
       PATTERN
@@ -58,19 +73,23 @@ function(ifem_add_doc_target)
       ${PARAM_TARGET}_doc
       COMMAND
         Doxygen::doxygen ${PROJECT_BINARY_DIR}/Doxyfile.${PARAM_TARGET}
-      WORKING_DIRECTORY
-        ${PROJECT_SOURCE_DIR}
       COMMENT
         "Generating API documentation" VERBATIM
     )
+    add_dependencies(${PARAM_TARGET}_doc IFEM_doc)
     add_dependencies(doc ${PARAM_TARGET}_doc)
+    if(PARAM_DEPENDENCIES)
+      foreach(dep ${PARAM_DEPENDENCIES})
+        if(TARGET ${dep}_doc)
+          add_dependencies(${PARAM_TARGET}_doc ${dep}_doc)
+        endif()
+      endforeach()
+    endif()
   else()
     add_custom_target(
       doc
       COMMAND
-        Doxygen::doxygen ${PROJECT_BINARY_DIR}/Doxyfile
-      WORKING_DIRECTORY
-        ${PROJECT_SOURCE_DIR}
+        Doxygen::doxygen ${PROJECT_BINARY_DIR}/Doxyfile.${PARAM_TARGET}
       COMMENT
         "Generating API documentation" VERBATIM
     )

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -38,7 +38,7 @@ PROJECT_NUMBER         = 90A354
 # If a relative path is entered, it will be relative to the location 
 # where doxygen was started. If left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = @PROJECT_BINARY_DIR@/doc
+OUTPUT_DIRECTORY       = @CMAKE_BINARY_DIR@/doc
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 
 # 4096 sub-directories (in 2 levels) under the output directory of each output 
@@ -1296,7 +1296,7 @@ TAGFILES               =
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create 
 # a tag file that is based on the input files it reads.
 
-GENERATE_TAGFILE       = 
+GENERATE_TAGFILE       = @DOXYGEN_TAG_FILE@
 
 # If the ALLEXTERNALS tag is set to YES all external classes will be listed 
 # in the class index. If set to NO only the inherited external classes 


### PR DESCRIPTION
The tag file can be used to link between ifem doxy and application doxys.