### PR TITLE
AdaptiveSetup: add tests for error limits code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -572,6 +572,7 @@ IFEM_add_test_app(
       src/LinAlg/Test/TestMatVec.C
       src/LinAlg/Test/TestSAM.C
       src/LinAlg/Test/TestSparseMatrix.C
+      src/SIM/Test/TestAdaptiveSetup.C
       src/SIM/Test/TestInitialConditions.C
       src/SIM/Test/TestModelGenerator.C
       src/SIM/Test/TestNewmark.C

--- a/src/SIM/AdaptiveSetup.C
+++ b/src/SIM/AdaptiveSetup.C
@@ -244,13 +244,6 @@ bool AdaptiveSetup::initPrm (size_t normGroup)
 }
 
 
-//! \brief Element error and associated index.
-//! \note The error value must be first and the index second, such that the
-//! internally defined greater-than operator can be used when sorting the
-//! error+index pairs in decreasing error order.
-typedef std::pair<double,int> DblIdx;
-
-
 int AdaptiveSetup::calcRefinement (LR::RefineData& prm, int iStep,
                                    const Vectors& gNorm,
                                    const Vector& refIn, int currDofs) const
@@ -393,39 +386,12 @@ int AdaptiveSetup::calcRefinement (LR::RefineData& prm, int iStep,
   // The variable prm.elements will contain one of the following:
   // - list of elements to be refined (if fullspan or minspan)
   // - list of basis functions to be refined (if structured mesh)
-  double limit, sumErr = 0.0, curErr = 0.0;
-  switch (threshold) {
-  case MAXIMUM: // beta percent of max error (less than 100%)
-    limit = error.front().first * prm.options[0]*0.01;
-    break;
-  case AVERAGE: // beta percent of avg error (typical 100%)
-    for (const DblIdx& e : error) sumErr += e.first;
-    limit = (sumErr/error.size()) * prm.options[0]*0.01;
-    break;
-  case MINIMUM: // beta percent of min error (more than 100%)
-    limit = error.back().first * prm.options[0]*0.01;
-    break;
-  case DORFEL:
-    limit = error.back().first;
-    for (const DblIdx& e : error) sumErr += e.first;
-    sumErr *= prm.options[0]*0.01;
-    for (const DblIdx& e : error)
-      if (curErr < sumErr)
-        curErr += e.first;
-      else
-      {
-        limit = e.first;
-        break;
-      }
-    break;
-  default:
-    limit = 0.0;
-  }
+  const ErrorInfo info = errorLimits(error, prm.options[0], threshold);
 
   if (threshold == NONE || threshold == SYMMETRIZED)
     refineSize = ceil(error.size()*prm.options[0]/100.0);
   else
-    refineSize = std::upper_bound(error.begin(), error.end(), DblIdx(limit,0),
+    refineSize = std::upper_bound(error.begin(), error.end(), DblIdx(info.limit,0),
                                   std::greater_equal<DblIdx>()) - error.begin();
 
   if (threshold == SYMMETRIZED)
@@ -466,16 +432,16 @@ int AdaptiveSetup::calcRefinement (LR::RefineData& prm, int iStep,
     IFEM::cout << 100.0*refineSize/error.size() <<"% of all "<< str;
     break;
   case MAXIMUM:
-    IFEM::cout << prm.options[0] <<"% of max error ("<< limit <<")";
+    IFEM::cout << prm.options[0] <<"% of max error ("<< info.limit <<")";
     break;
   case AVERAGE:
-    IFEM::cout << prm.options[0] <<"% of average error ("<< limit <<")";
+    IFEM::cout << prm.options[0] <<"% of average error ("<< info.limit <<")";
     break;
   case MINIMUM:
-    IFEM::cout << prm.options[0] <<"% of min error ("<< limit <<")";
+    IFEM::cout << prm.options[0] <<"% of min error ("<< info.limit <<")";
     break;
   case DORFEL:
-    IFEM::cout << prm.options[0] <<"% of total error ("<< limit <<")";
+    IFEM::cout << prm.options[0] <<"% of total error ("<< info.limit <<")";
     break;
   default:
     break;
@@ -582,4 +548,44 @@ bool AdaptiveSetup::writeMesh (int iStep) const
     }
 
   return true;
+}
+
+
+AdaptiveSetup::ErrorInfo
+AdaptiveSetup::errorLimits(const std::vector<DblIdx>& error,
+                           const double beta,
+                           const Threshold threshold)
+{
+  ErrorInfo result;
+  switch (threshold) {
+  case MAXIMUM: // beta percent of max error (less than 100%)
+    result.limit = error.front().first * beta*0.01;
+    break;
+  case AVERAGE: // beta percent of avg error (typical 100%)
+    for (const DblIdx& e : error)
+      result.sumErr += e.first;
+    result.limit = (result.sumErr/error.size()) * beta*0.01;
+    break;
+  case MINIMUM: // beta percent of min error (more than 100%)
+    result.limit = error.back().first * beta*0.01;
+    break;
+  case DORFEL:
+    result.limit = error.back().first;
+    for (const DblIdx& e : error)
+      result.sumErr += e.first;
+    result.sumErr *= beta*0.01;
+    for (const DblIdx& e : error)
+      if (result.curErr < result.sumErr)
+        result.curErr += e.first;
+      else
+      {
+        result.limit = e.first;
+        break;
+      }
+    break;
+  default:
+    result.limit = 0.0;
+  }
+
+  return result;
 }

--- a/src/SIM/AdaptiveSetup.h
+++ b/src/SIM/AdaptiveSetup.h
@@ -16,6 +16,8 @@
 
 #include "MatVec.h"
 
+#include <utility>
+
 class ScalarFunc;
 class SIMoutput;
 namespace tinyxml2 { class XMLElement; }
@@ -95,6 +97,32 @@ protected:
   size_t eRow;    //!< Row-index in \a eNorm of the norm to use for adaptation
   double rCond;   //!< Actual reciprocal condition number of the last mesh
 
+  //! \brief Element error and associated index.
+  //! \note The error value must be first and the index second, such that the
+  //! internally defined greater-than operator can be used when sorting the
+  //! error+index pairs in decreasing error order.
+  using DblIdx = std::pair<double,int>;
+
+  //! \brief Struct holding info about errors.
+  struct ErrorInfo
+  {
+    double limit = 0.0; //!< Limit for errors
+    double sumErr = 0.0; //!< Sum of errors, beta-scaled target for DORFEL
+    double curErr = 0.0; //!< Current error
+  };
+
+  //! \brief Enum defining the refinement threshold flag values.
+  enum Threshold { NONE=0, MAXIMUM, AVERAGE, MINIMUM, TRUE_BETA,
+                   DORFEL, SYMMETRIZED };
+
+  //! \brief Calculate error limits for a vector of errors.
+  //! \param errors The vector with the errors
+  //! \param beta Percentage of elements to mark for refinement
+  //! \param threshold Type of error thresholding to use
+  static ErrorInfo errorLimits(const std::vector<DblIdx>& errors,
+                               const double beta,
+                               const Threshold threshold);
+
 private:
   bool   alone;      //!< If \e false, this class is wrapped by SIMSolver
   bool   linIndep;   //!< Test mesh for linear independence after refinement
@@ -109,10 +137,6 @@ private:
   double maxAspect;  //!< Maximum element aspect ratio
   bool   closeGaps;  //!< Split elements with a hanging node on each side
   double symmEps;    //!< Epsilon used for symmetrized selection method
-
-  //! \brief Enum defining the refinement threshold flag values.
-  enum Threshold { NONE=0, MAXIMUM, AVERAGE, MINIMUM, TRUE_BETA,
-                   DORFEL, SYMMETRIZED };
 
   //! \brief Enum defining available refinement scheme options.
   enum RefScheme { FULLSPAN=0, MINSPAN=1,

--- a/src/SIM/Test/TestAdaptiveSetup.C
+++ b/src/SIM/Test/TestAdaptiveSetup.C
@@ -1,0 +1,133 @@
+//==============================================================================
+//!
+//! \file TestAdaptiveSetup.C
+//!
+//! \date May 12 2026
+//!
+//! \author Arne Morten Kvarving / SINTEF
+//!
+//! \brief Tests for AdaptiveSetup.
+//!
+//==============================================================================
+
+#include "AdaptiveSetup.h"
+#include "SIMdummy.h"
+#include "SIMgeneric.h"
+
+#include "Catch2Support.h"
+
+#include <algorithm>
+#include <numeric>
+#include <string>
+
+namespace {
+
+class SIMA : public SIMdummy<SIMgeneric>
+{
+public:
+  SIMA() {}
+};
+
+class TestAdaptiveSetupSimHolder
+{
+protected:
+  SIMA simDummy;
+};
+
+class TestAdaptiveSetup : private TestAdaptiveSetupSimHolder,
+                          public AdaptiveSetup
+{
+public:
+  explicit TestAdaptiveSetup(size_t N)
+    : AdaptiveSetup(simDummy)
+  {
+    for (size_t i = 0; i < N; ++i)
+      errors.emplace_back(i+1.0, i);
+    std::reverse(errors.begin(), errors.end());
+  }
+
+  double sum() const
+  {
+    return std::accumulate(errors.begin(), errors.end(), 0.0,
+                           [](const double acc, const DblIdx& a)
+                           { return acc + a.first; });
+  }
+
+  size_t size() const { return errors.size(); }
+
+  using AdaptiveSetup::ErrorInfo;
+  ErrorInfo errorInfo(const double beta,
+                      const Threshold threshold)
+  {
+    return this->errorLimits(errors, beta, threshold);
+  }
+
+  std::pair<double,double>
+  dorfelLimits(const double limit)
+  {
+    double currErr = 0.0;
+    size_t i = 0;
+    while (currErr < limit && i < errors.size()) {
+      currErr += errors[i].first;
+      ++i;
+    }
+
+    return i == errors.size() ? std::make_pair(errors.back().first, currErr)
+                              : std::make_pair(errors[i].first, currErr);
+  }
+
+  using Threshold = AdaptiveSetup::Threshold;
+
+private:
+  std::vector<DblIdx> errors;
+};
+
+}
+
+
+TEST_CASE("TestAdaptiveSetup.ErrorLimits")
+{
+  const size_t N = GENERATE(10, 13, 25);
+
+  SECTION("N = " + std::to_string(N))
+  {
+    TestAdaptiveSetup setup(N);
+    const double sum = setup.sum();
+    const size_t size = setup.size();
+    const double minErr = 1.0;
+
+    const double beta = GENERATE(1.0, 10.0, 50.0, 101.0);
+
+    SECTION("MAXIMUM, beta = " + std::to_string(beta))
+    {
+      const TestAdaptiveSetup::ErrorInfo info =
+        setup.errorInfo(beta, TestAdaptiveSetup::Threshold::MAXIMUM);
+      REQUIRE_THAT(info.limit, WithinRel(size*beta*0.01));
+    }
+
+    SECTION("AVERAGE, beta = " + std::to_string(beta))
+    {
+      const TestAdaptiveSetup::ErrorInfo info =
+        setup.errorInfo(beta, TestAdaptiveSetup::Threshold::AVERAGE);
+      REQUIRE_THAT(info.sumErr, WithinRel(sum));
+      REQUIRE_THAT(info.limit, WithinRel(sum / size  * beta * 0.01));
+    }
+
+    SECTION("MINIMUM, beta = " + std::to_string(beta))
+    {
+      const TestAdaptiveSetup::ErrorInfo info =
+        setup.errorInfo(beta, TestAdaptiveSetup::Threshold::MINIMUM);
+      REQUIRE_THAT(info.limit, WithinRel(minErr * beta * 0.01));
+    }
+
+    SECTION("DÖRFEL, beta = " + std::to_string(beta))
+    {
+      const TestAdaptiveSetup::ErrorInfo info =
+        setup.errorInfo(beta, TestAdaptiveSetup::Threshold::DORFEL);
+      const auto& [limit, curr] = setup.dorfelLimits(sum * beta * 0.01);
+      REQUIRE_THAT(info.limit, WithinRel(limit));
+      REQUIRE_THAT(info.sumErr, WithinRel(sum * beta * 0.01));
+      REQUIRE_THAT(info.curErr, WithinRel(curr));
+    }
+  }
+}


### PR DESCRIPTION
Reorganize the code for calculating error limits in AdaptiveSetup, and add a test.

The dörfel regression test in IFEM-Poisson is unstable across machines. Replace with a unit test,
then we can drop the unstable regression test without coverage loss.