### PR TITLE
Added: Account for linear couplings when flagging non-zero terms

### DIFF
--- a/src/LinAlg/DenseMatrix.C
+++ b/src/LinAlg/DenseMatrix.C
@@ -223,7 +223,7 @@ bool DenseMatrix::load (const char* fileName, bool binary)
   else
     ipiv = nullptr;
 
-  return is.good() && this->flagNonZeroEqs();
+  return is.good() && this->flagNonZeroEq();
 }
 
 
@@ -321,7 +321,7 @@ bool DenseMatrix::assemble (const Matrix& eM, const SAM& sam, int e)
   addem2 (eM.ptr(), sam.ttcc, sam.mpar,
 	  sam.madof, sam.meqn, sam.mpmnpc, sam.mmnpc, sam.mpmceq, sam.mmceq,
 	  e, eM.rows(), sam.neq, 6, 0, myMat.ptr(), &dummyRHS, work, ierr);
-  if (ierr == 0 && !this->flagNonZeroEqs({work,work+eM.rows()}))
+  if (ierr == 0 && !this->flagNonZeroEqs(sam,{work,work+eM.rows()}))
     ierr = 2;
   delete[] work;
 #else
@@ -330,7 +330,7 @@ bool DenseMatrix::assemble (const Matrix& eM, const SAM& sam, int e)
   if (sam.getElmEqns(meen,e,eM.rows()))
   {
     assemDense(eM,myMat,dummyB,meen,sam.meqn,sam.mpmceq,sam.mmceq,sam.ttcc);
-    if (!this->flagNonZeroEqs(meen)) ierr = 2;
+    if (!this->flagNonZeroEqs(sam,meen)) ierr = 2;
   }
   else
     ierr = 1;
@@ -351,7 +351,7 @@ bool DenseMatrix::assemble (const Matrix& eM, const SAM& sam,
   addem2 (eM.ptr(), sam.ttcc, sam.mpar,
 	  sam.madof, sam.meqn, sam.mpmnpc, sam.mmnpc, sam.mpmceq, sam.mmceq,
 	  e, eM.rows(), sam.neq, 6, 1, myMat.ptr(), B.getPtr(), work, ierr);
-  if (ierr == 0 && !this->flagNonZeroEqs({work,work+eM.rows()}))
+  if (ierr == 0 && !this->flagNonZeroEqs(sam,{work,work+eM.rows()}))
     ierr = 2;
   delete[] work;
 #else
@@ -360,7 +360,7 @@ bool DenseMatrix::assemble (const Matrix& eM, const SAM& sam,
   if (Bptr && sam.getElmEqns(meen,e,eM.rows()))
   {
     assemDense(eM,myMat,*Bptr,meen,sam.meqn,sam.mpmceq,sam.mmceq,sam.ttcc);
-    if (!this->flagNonZeroEqs(meen)) ierr = 2;
+    if (!this->flagNonZeroEqs(sam,meen)) ierr = 2;
   }
   else
     ierr = 1;
@@ -383,15 +383,19 @@ bool DenseMatrix::assemble (const Matrix& eM, const SAM& sam,
 
   assemDense(eM,myMat,*Bptr,meq,sam.meqn,sam.mpmceq,sam.mmceq,sam.ttcc);
 
-  return this->flagNonZeroEqs(meq);
+  return this->flagNonZeroEqs(sam,meq);
 }
 
 
 bool DenseMatrix::assemble (const Matrix& eM, const IntVec& meq)
 {
+  for (int ieq : meq)
+    if (ieq < 0 || !this->flagNonZeroEq(ieq+1))
+      return false;
+
   for (size_t i = 0; i < meq.size(); ++i)
     for (size_t j = 0; j < meq.size(); ++j)
-      (*this)(meq[i]+1, meq[j]+1) += eM(i+1, j+1);
+      myMat(meq[i]+1, meq[j]+1) += eM(i+1, j+1);
 
   return true;
 }
@@ -493,10 +497,7 @@ bool DenseMatrix::add (Real sigma, int ieq)
   else
     cblas_daxpy(myMat.rows(),sigma,&sigma,0,myMat.ptr(),myMat.rows()+1);
 
-  if (ieq == 0)
-    return this->flagNonZeroEqs();
-  else
-    return this->flagNonZeroEqs({ieq});
+  return this->flagNonZeroEq(ieq);
 }
 
 

--- a/src/LinAlg/DenseMatrix.h
+++ b/src/LinAlg/DenseMatrix.h
@@ -110,8 +110,6 @@ public:
   //! \param[in] eM  The element matrix
   //! \param[in] meq Matrix of element equation numbers (0 based)
   //! \return \e true on successful assembly, otherwise \e false
-  //!
-  //! \details To be used when there is no underlying SAM
   virtual bool assemble(const Matrix& eM, const IntVec& meq);
 
   //! \brief Augments a similar matrix symmetrically to the current matrix.

--- a/src/LinAlg/DiagMatrix.C
+++ b/src/LinAlg/DiagMatrix.C
@@ -100,7 +100,7 @@ bool DiagMatrix::assemble (const Matrix& eM, const SAM& sam,
                 if (sam.mmceq[ip] > 0 && sam.meqn[sam.mmceq[ip]-1] == jeq)
                   myMat(jeq) += sam.ttcc[ip]*sam.ttcc[jp]*eM(i,j);
 
-  return this->flagNonZeroEqs(meq);
+  return this->flagNonZeroEqs(sam,meq);
 }
 
 
@@ -136,7 +136,7 @@ bool DiagMatrix::assembleStruct (int val, const SAM& sam, const IntVec& meq)
                 if (sam.mmceq[ip] > 0 && sam.meqn[sam.mmceq[ip]-1] == jeq)
                   addEq(jeq);
 
-  return this->flagNonZeroEqs(meq);
+  return this->flagNonZeroEqs(sam,meq);
 }
 
 
@@ -149,8 +149,12 @@ bool DiagMatrix::assemble (const Matrix& eM, const SAM& sam,
 
 bool DiagMatrix::assemble (const Matrix& eM, const IntVec& meq)
 {
+  for (int ieq : meq)
+    if (ieq < 0 || !this->flagNonZeroEq(ieq+1))
+      return false;
+
   for (size_t i = 0; i < meq.size(); ++i)
-    (*this)(meq[i]+1) += eM(i+1, i+1);
+    myMat[meq[i]] += eM(i+1, i+1);
 
   return true;
 }
@@ -177,10 +181,7 @@ bool DiagMatrix::add (Real sigma, int ieq)
   else for (Real& v : myMat)
     v += sigma;
 
-  if (ieq == 0)
-    return this->flagNonZeroEqs();
-  else
-    return this->flagNonZeroEqs({ieq});
+  return this->flagNonZeroEq(ieq);
 }
 
 

--- a/src/LinAlg/DiagMatrix.h
+++ b/src/LinAlg/DiagMatrix.h
@@ -97,8 +97,6 @@ public:
   //! \param[in] eM  The element matrix
   //! \param[in] meq Matrix of element equation numbers (0 based)
   //! \return \e true on successful assembly, otherwise \e false
-  //!
-  //! \details To be used when there is no underlying SAM
   virtual bool assemble(const Matrix& eM, const IntVec& meq);
 
   //! \brief Assembles a validation matrix assuming unit element contributions.

--- a/src/LinAlg/PETScMatrix.C
+++ b/src/LinAlg/PETScMatrix.C
@@ -631,7 +631,7 @@ bool PETScMatrix::assemble (const Matrix& eM, const SAM& sam, int e)
 #pragma omp critical
   assemPETSc(eM,*this,nullptr,adm.dd,glb2Blk,meen,sam.meqn,sam.mpmceq,sam.mmceq,sam.ttcc);
 
-  return this->flagNonZeroEqs(meen);
+  return this->flagNonZeroEqs(sam,meen);
 }
 
 
@@ -648,7 +648,7 @@ bool PETScMatrix::assemble (const Matrix& eM, const SAM& sam,
 #pragma omp critical
   assemPETSc(eM,*this,Bptr,adm.dd,glb2Blk,meen,sam.meqn,sam.mpmceq,sam.mmceq,sam.ttcc);
 
-  return this->flagNonZeroEqs(meen);
+  return this->flagNonZeroEqs(sam,meen);
 }
 
 
@@ -664,12 +664,16 @@ bool PETScMatrix::assemble (const Matrix& eM, const SAM& sam,
 #pragma omp critical
   assemPETSc(eM,*this,Bptr,adm.dd,glb2Blk,meq,sam.meqn,sam.mpmceq,sam.mmceq,sam.ttcc);
 
-  return this->flagNonZeroEqs(meq);
+  return this->flagNonZeroEqs(sam,meq);
 }
 
 
 bool PETScMatrix::assemble (const Matrix& eM, const IntVec& meq)
 {
+  for (int ieq : meq)
+    if (ieq < 0 || !this->flagNonZeroEq(ieq+1))
+      return false;
+
 #pragma omp critical
   for (size_t i = 0; i < meq.size(); ++i)
     for (size_t j = 0; j < meq.size(); ++j)
@@ -689,7 +693,7 @@ bool PETScMatrix::endAssembly ()
   MatAssemblyEnd(pA,MAT_FINAL_ASSEMBLY);
   assembled = true;
 
-  return true;
+  return this->SystemMatrix::endAssembly();
 }
 
 
@@ -1013,17 +1017,12 @@ bool PETScMatrix::setParameters (bool setup)
     PCFieldSplitGetSubKSP(pc,&nsplit,&subksp);
 
     // Preconditioner for blocks
-    char pchar = '1';
-    for (PetscInt m = 0; m < nsplit; ++m, ++pchar) {
-      std::string prefix;
-      if (nsplit == 2) {
-        if (m == 0)
-          prefix = "fieldsplit_u";
-        else
-          prefix = "fieldsplit_p";
-      } else
-        prefix = std::string("fieldsplit_b")+pchar;
-
+    for (PetscInt m = 0; m < nsplit; ++m) {
+      std::string prefix("fieldsplit_");
+      if (nsplit == 2)
+        prefix += (m == 0 ? 'u' : 'p');
+      else
+        prefix += "b" + std::to_string(1+m);
       KSPSetType(subksp[m],"preonly");
       KSPGetPC(subksp[m],&subpc[m]);
       if (solParams.getBlock(m).getStringValue("pc") == "schur")

--- a/src/LinAlg/SAM.h
+++ b/src/LinAlg/SAM.h
@@ -357,6 +357,7 @@ protected:
   friend class SparseMatrix;
   friend class DiagMatrix;
   friend class PETScMatrix;
+  friend class SystemMatrix;
 };
 
 #endif

--- a/src/LinAlg/SPRMatrix.C
+++ b/src/LinAlg/SPRMatrix.C
@@ -559,7 +559,7 @@ bool SPRMatrix::load (const char* fileName, bool binary)
         is >> values[i];
   }
 
-  return is.good() && this->flagNonZeroEqs();
+  return is.good() && this->flagNonZeroEq();
 }
 
 
@@ -610,7 +610,7 @@ bool SPRMatrix::assemble (int e, const Matrix& eM, const SAM& sam, Real* B)
           msica, mtrees, msifa, mvarnc, values, B ? B : rWork.data(),
           IWORK.data(), e, eM.rows(), 6, B ? 1 : 0, ierr);
   if (ierr == 0)
-    return this->flagNonZeroEqs({IWORK.begin(),IWORK.begin()+eM.rows()});
+    return this->flagNonZeroEqs(sam,{IWORK.begin(),IWORK.begin()+eM.rows()});
 
   std::cerr <<"SAM::SPRADM: Failure "<< ierr << std::endl;
 #endif
@@ -646,10 +646,8 @@ bool SPRMatrix::add (Real sigma, int ieq)
   sprdad_(mpar, mtrees, msifa, values, sigma, 6, ierr);
   if (ierr < 0)
     std::cerr <<"SAM::SPRDAD: Failure "<< ierr << std::endl;
-  else if (ieq > 0)
-    return this->flagNonZeroEqs({ieq});
   else
-    return this->flagNonZeroEqs();
+    return this->flagNonZeroEq(ieq);
 #endif
 
   return false;

--- a/src/LinAlg/SPRMatrix.h
+++ b/src/LinAlg/SPRMatrix.h
@@ -96,8 +96,6 @@ public:
   //! \param[in] eM  The element matrix
   //! \param[in] meq Matrix of element equation numbers (0 based)
   //! \return \e true on successful assembly, otherwise \e false
-  //!
-  //! \details To be used when there is no underlying SAM
   virtual bool assemble(const Matrix& eM, const IntVec& meq);
 
   //! \brief Multiplication with a scalar.

--- a/src/LinAlg/SparseMatrix.C
+++ b/src/LinAlg/SparseMatrix.C
@@ -571,10 +571,7 @@ bool SparseMatrix::add (Real sigma, int ieq)
   else for (size_t i = 1; i <= nrow && i <= ncol; i++)
     this->operator()(i,i) += sigma;
 
-  if (ieq > 0)
-    return this->flagNonZeroEqs({ieq});
-  else
-    return this->flagNonZeroEqs();
+  return this->flagNonZeroEq(ieq);
 }
 
 
@@ -813,7 +810,7 @@ bool SparseMatrix::assemble (const Matrix& eM, const SAM& sam, int e)
   Vector dummyB;
   assemSparse(eM,*this,dummyB,meen,sam.meqn,sam.mpmceq,sam.mmceq,sam.ttcc);
 
-  return this->flagNonZeroEqs(meen);
+  return this->flagNonZeroEqs(sam,meen);
 }
 
 
@@ -829,7 +826,7 @@ bool SparseMatrix::assemble (const Matrix& eM, const SAM& sam,
 
   assemSparse(eM,*this,*Bptr,meen,sam.meqn,sam.mpmceq,sam.mmceq,sam.ttcc);
 
-  return this->flagNonZeroEqs(meen);
+  return this->flagNonZeroEqs(sam,meen);
 }
 
 
@@ -844,12 +841,16 @@ bool SparseMatrix::assemble (const Matrix& eM, const SAM& sam,
 
   assemSparse(eM,*this,*Bptr,meq,sam.meqn,sam.mpmceq,sam.mmceq,sam.ttcc);
 
-  return this->flagNonZeroEqs(meq);
+  return this->flagNonZeroEqs(sam,meq);
 }
 
 
 bool SparseMatrix::assemble (const Matrix& eM, const IntVec& meq)
 {
+  for (int ieq : meq)
+    if (ieq < 0 || !this->flagNonZeroEq(ieq+1))
+      return false;
+
   for (size_t i = 0; i < eM.rows(); ++i)
     for (size_t j = 0; j < eM.cols(); ++j)
       (*this)(meq[i]+1, meq[j]+1) += eM(i+1, j+1);
@@ -868,7 +869,7 @@ bool SparseMatrix::assembleCol (const RealArray& V, const SAM& sam,
 
   assemSparse(V,*this,col,mnen,sam.meqn,sam.mpmceq,sam.mmceq,sam.ttcc);
 
-  return this->flagNonZeroEqs(mnen);
+  return this->flagNonZeroEqs(sam,mnen);
 }
 
 

--- a/src/LinAlg/SparseMatrix.h
+++ b/src/LinAlg/SparseMatrix.h
@@ -161,8 +161,6 @@ public:
   //! \param[in] eM  The element matrix
   //! \param[in] meq Matrix of element equation numbers (0 based)
   //! \return \e true on successful assembly, otherwise \e false
-  //!
-  //! \details To be used when there is no underlying SAM
   virtual bool assemble(const Matrix& eM, const IntVec& meq);
 
   //! \brief Adds a nodal vector into columns of a non-symmetric sparse matrix.

--- a/src/LinAlg/SystemMatrix.C
+++ b/src/LinAlg/SystemMatrix.C
@@ -22,6 +22,7 @@
 #ifdef HAS_ISTL
 #include "ISTLMatrix.h"
 #endif
+#include "SAM.h"
 #include "LinSolParams.h"
 #include <fstream>
 
@@ -180,15 +181,38 @@ void SystemMatrix::initNonZeroEqs ()
 }
 
 
-bool SystemMatrix::flagNonZeroEqs (const IntVec& meq)
+bool SystemMatrix::flagNonZeroEq (int ieq)
 {
-  if (meq.empty() || nonZeroEqs.size() == 1)
+  if (nonZeroEqs.size() == 1)
+    nonZeroEqs.front() = true;
+  else if (ieq == 0)
     std::fill(nonZeroEqs.begin(),nonZeroEqs.end(),true);
+  else if (ieq < 0 || ieq > static_cast<int>(nonZeroEqs.size()))
+    return false;
+  else
+    nonZeroEqs[ieq-1] = true;
+
+  return true;
+}
+
+
+bool SystemMatrix::flagNonZeroEqs (const SAM& sam, const IntVec& meq)
+{
+  if (nonZeroEqs.size() == 1)
+    nonZeroEqs.front() = true;
   else
   {
     for (int ieq : meq)
-      if (ieq < 0 || ieq > static_cast<int>(nonZeroEqs.size()))
-        return false; //TODO: for ieq < 0, find the actual master dofs
+      if (ieq > static_cast<int>(nonZeroEqs.size()))
+        return false;
+      else if (ieq < 0)
+      {
+        // This is a dependent DOF, flag the associated independent DOFs instead
+        int iceq = -ieq;
+        for (int ip = sam.mpmceq[iceq-1]; ip < sam.mpmceq[iceq]-1; ip++)
+          if (int jdof = sam.mmceq[ip]; jdof > 0)
+            nonZeroEqs[sam.meqn[jdof-1]-1] = true;
+      }
       else if (ieq > 0)
         nonZeroEqs[ieq-1] = true;
   }

--- a/src/LinAlg/SystemMatrix.h
+++ b/src/LinAlg/SystemMatrix.h
@@ -270,8 +270,10 @@ public:
 
   //! \brief Initializes the \ref nonZeroEqs flags.
   void initNonZeroEqs();
+  //! \brief Flags equation \a ieq as pivot element with non-zero contributions.
+  bool flagNonZeroEq(int ieq = 0);
   //! \brief Flags the equations \a meq as pivots with non-zero contributions.
-  bool flagNonZeroEqs(const IntVec& meq = {});
+  bool flagNonZeroEqs(const SAM& sam, const IntVec& meq);
   //! \brief Flags the non-zero equations from \a B as non-zero pivots in this.
   bool flagNonZeroEqs(const SystemMatrix& B);
 
@@ -312,7 +314,7 @@ public:
   //! \param[in] meq Matrix of element equation numbers (0 based)
   //! \return \e true on successful assembly, otherwise \e false
   //!
-  //! \details To be used when there is no underlying SAM
+  //! \details To be used when there is no associated SAM object.
   virtual bool assemble(const Matrix& eM, const IntVec& meq) = 0;
 
   //! \brief Augments a similar matrix symmetrically to the current matrix.


### PR DESCRIPTION
And call flagNonZeroEq() also for the SAM-less assembly methods (used in L2-projection v2).