### PR TITLE
HDF5 output of element results not necessarily from norm integration

### DIFF
--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -1449,6 +1449,23 @@ void ASMbase::extractElmRes (const Matrix& globRes, Matrix& elmRes,
 }
 
 
+void ASMbase::extractElmRes (const Matrix& globRes, Vector& elmRes,
+                             size_t irow) const
+{
+  elmRes.clear();
+  elmRes.reserve(MLGE.size());
+
+  for (size_t i = 0; i < MLGE.size(); i++)
+    if (MLGE[i] > 0 && MNPC[i].size() > 1)
+    {
+      if (size_t icol = MLGE[i]; icol <= globRes.cols())
+        elmRes.push_back(globRes(irow,icol));
+      else
+        elmRes.push_back(0.0);
+    }
+}
+
+
 bool ASMbase::extractNodalVec (const RealArray& globRes, RealArray& nodeVec,
                                const int* madof, int ngnod) const
 {

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -800,22 +800,30 @@ public:
   // Methods for result extraction
   // =============================
 
+  //! \brief Returns the master patch to use for VTF- and HDF5-output.
+  virtual const ASMbase* getOutputMaster() const { return this; }
+
   //! \brief Extracts element results for this patch from a global vector.
   //! \param[in] globRes Global vector of element results
   //! \param[out] elmRes Element results for this patch
   //! \param[in] internalFirst If non-zero, the data in \a globRes are assumed
   //! to be ordered w.r.t. the internal element ordering, and the actual value
   //! is the global index of the first element in the patch
-  virtual void extractElmRes(const Vector& globRes, Vector& elmRes,
-                             size_t internalFirst = 0) const;
-  //! \brief Extracts element results for this patch from a global vector.
+  void extractElmRes(const Vector& globRes, Vector& elmRes,
+                     size_t internalFirst = 0) const;
+  //! \brief Extracts element results for this patch from a global matrix.
   //! \param[in] globRes Global matrix of element results
   //! \param[out] elmRes Element results for this patch
   //! \param[in] internalFirst If non-zero, the data in \a globRes are assumed
   //! to be ordered w.r.t. the internal element ordering, and the actual value
   //! is the global index of the first element in the patch
-  virtual void extractElmRes(const Matrix& globRes, Matrix& elmRes,
-                             size_t internalFirst = 0) const;
+  void extractElmRes(const Matrix& globRes, Matrix& elmRes,
+                     size_t internalFirst = 0) const;
+  //! \brief Extracts element results for this patch from a global matrix.
+  //! \param[in] globRes Global matrix of element results
+  //! \param[out] elmRes Element results for this patch
+  //! \param[in] irow 1-based index of the row to extract from \a globRes
+  void extractElmRes(const Matrix& globRes, Vector& elmRes, size_t irow) const;
 
   //! \brief Extracts nodal results for this patch from the global vector.
   //! \param[in] globVec Global solution vector in DOF-order

--- a/src/ASM/IntegrandBase.C
+++ b/src/ASM/IntegrandBase.C
@@ -423,6 +423,14 @@ std::string IntegrandBase::getField2Name (size_t idx, const char* prefix) const
 }
 
 
+std::string IntegrandBase::getEFieldName (size_t idx) const
+{
+  char name[32];
+  sprintf(name,"parameter %zu",1+idx);
+  return name;
+}
+
+
 bool IntegrandBase::inActive (int iel) const
 {
   if (elmGrp.empty()) return false;

--- a/src/ASM/IntegrandBase.h
+++ b/src/ASM/IntegrandBase.h
@@ -290,17 +290,22 @@ public:
   size_t getNoSpaceDim() const { return nsd; }
   //! \brief Returns the number of primary/secondary solution field components.
   virtual size_t getNoFields(int = 2) const { return 0; }
+  //! \brief Returns the number of element-wise constant field components.
+  virtual size_t getNoElmFields() const { return 0; }
   //! \brief Returns the number of global %Lagrange multipliers in the model.
   virtual size_t getNoGLMs() const { return 0; }
 
   //! \brief Returns the name of a primary solution field component.
-  //! \param[in] idx Field component index
+  //! \param[in] idx Field component index (0-based)
   //! \param[in] prefix Name prefix for all components
   virtual std::string getField1Name(size_t idx, const char* prefix = 0) const;
   //! \brief Returns the name of a secondary solution field component.
-  //! \param[in] idx Field component index
+  //! \param[in] idx Field component index (0-based)
   //! \param[in] prefix Name prefix for all components
   virtual std::string getField2Name(size_t idx, const char* prefix = 0) const;
+  //! \brief Returns the name of an element-wise solution field component.
+  //! \param[in] idx Field component index (0-based)
+  virtual std::string getEFieldName(size_t idx) const;
   //! \brief Filters a result components for output.
   virtual bool suppressOutput(size_t, ASM::ResultClass) const { return false; }
 
@@ -473,7 +478,7 @@ public:
 
   //! \brief Sets a projected secondary solution as a field quantity.
   //! \param[in] f The field defining the projected secondary solution
-  //! \param[in] idx Projection index
+  //! \param[in] idx Projection index (0-based)
   virtual void setProjectedFields(Fields* f, size_t idx);
 
   //! \brief Assigns a parameter value to property functions of the integrand.

--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -50,6 +50,7 @@ ASMu2D::ASMu2D (unsigned char n_s, unsigned char n_f)
 {
   aMin = 0.0;
   tensorspline = tensorPrjBas = nullptr;
+  outputMaster = this;
 }
 
 
@@ -59,6 +60,8 @@ ASMu2D::ASMu2D (const ASMu2D& patch, unsigned char n_f)
 {
   aMin = 0.0;
   tensorspline = tensorPrjBas = nullptr;
+  outputMaster = this;
+
   is_rational = patch.is_rational;
 
   // Need to set nnod here,
@@ -1965,10 +1968,10 @@ double ASMu2D::findPoint (Vec3&, double*) const
 
 bool ASMu2D::getGridParameters (RealArray& prm, int dir, int nSegPerSpan) const
 {
-  if (!lrspline) return false;
-
-  if (outputMaster)
+  if (outputMaster && outputMaster != this)
     return outputMaster->getGridParameters(prm, dir, nSegPerSpan);
+
+  if (!lrspline) return false;
 
   double eps = ElementBlock::eps;
 
@@ -3058,16 +3061,6 @@ void ASMu2D::storeMesh (const std::string& fName, int fType) const
     else
       lrspline->writePostscriptMeshWithControlPoints(meshFile);
   }
-}
-
-
-void ASMu2D::extractElmRes (const Matrix& globRes, Matrix& elmRes,
-                            size_t internalFirst) const
-{
-  if (outputMaster)
-    outputMaster->extractElmRes(globRes, elmRes, internalFirst);
-  else
-    this->ASMbase::extractElmRes(globRes, elmRes, internalFirst);
 }
 
 

--- a/src/ASM/LR/ASMu2D.h
+++ b/src/ASM/LR/ASMu2D.h
@@ -249,13 +249,6 @@ public:
   //! \param[in] globalNum If \e true, \a elmId is global otherwise patch-local
   virtual bool checkElementSize(int elmId, bool globalNum = true) const;
 
-  //! \brief Extracts element results for this patch from a global vector.
-  //! \param[in] globRes Global matrix of element results
-  //! \param[out] elmRes Element results for this patch
-  //! \param[in] internalFirst Global index of first element in the patch
-  virtual void extractElmRes(const Matrix& globRes, Matrix& elmRes,
-                             size_t internalFirst) const;
-
   //! \brief Copies the refinement to another surface.
   //! \param basis Surface to copy refinement to
   //! \param[in] multiplicity Wanted multiplicity
@@ -481,10 +474,10 @@ public:
   //! \param[in] fType Flag telling which file type(s) to write
   virtual void storeMesh(const std::string& fName, int fType) const;
 
-  //! \brief Set master patch for VTF output.
-  //! \param pch Master patch to use
-  void setOutputMaster(const ASMu2D* pch)
-  { outputMaster = pch; }
+  //! \brief Sets the master patch to use for VTF- and HDF5-output.
+  void setOutputMaster(const ASMu2D* pch) { outputMaster = pch; }
+  //! \brief Returns the master patch to use for VTF- and HDF5-output.
+  virtual const ASMbase* getOutputMaster() const { return outputMaster; }
 
 protected:
   //! \brief Struct representing an inhomogeneous Dirichlet boundary condition.

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -49,6 +49,7 @@ ASMu3D::ASMu3D (unsigned char n_f)
 {
   vMin = 0.0;
   tensorspline = tensorPrjBas = nullptr;
+  outputMaster = this;
 }
 
 
@@ -58,6 +59,7 @@ ASMu3D::ASMu3D (const ASMu3D& patch, unsigned char n_f)
 {
   vMin = 0.0;
   tensorspline = tensorPrjBas = nullptr;
+  outputMaster = this;
 
   // Need to set nnod here,
   // as hasXNodes might be invoked before the FE data is generated
@@ -1428,10 +1430,10 @@ double ASMu3D::findPoint (Vec3&, double*) const
 
 bool ASMu3D::getGridParameters (RealArray& prm, int dir, int nSegPerSpan) const
 {
-  if (!lrspline) return false;
-
-  if (outputMaster)
+  if (outputMaster && outputMaster != this)
     return outputMaster->getGridParameters(prm, dir, nSegPerSpan);
+
+  if (!lrspline) return false;
 
   double eps = ElementBlock::eps;
 
@@ -2442,16 +2444,6 @@ void ASMu3D::generateThreadGroupsFromElms (const IntVec& elms)
 void ASMu3D::generateProjThreadGroupsFromElms (const IntVec& elms)
 {
   projThreadGroups = projThreadGroups.filter(elms);
-}
-
-
-void ASMu3D::extractElmRes (const Matrix& globRes, Matrix& elmRes,
-                            size_t internalFirst) const
-{
-  if (outputMaster)
-    outputMaster->extractElmRes(globRes, elmRes, internalFirst);
-  else
-    this->ASMbase::extractElmRes(globRes, elmRes, internalFirst);
 }
 
 

--- a/src/ASM/LR/ASMu3D.h
+++ b/src/ASM/LR/ASMu3D.h
@@ -479,17 +479,10 @@ public:
   //! \param[in] coefs The coefficients for the field
   virtual Fields* getProjectedFields(const Vector& coefs, size_t = 0) const;
 
-  //! \brief Set master patch for VTF output.
-  //! \param pch Master patch to use
-  void setOutputMaster(const ASMu3D* pch)
-  { outputMaster = pch; }
-
-  //! \brief Extracts element results for this patch from a global vector.
-  //! \param[in] globRes Global matrix of element results
-  //! \param[out] elmRes Element results for this patch
-  //! \param[in] internalFirst Global index of first element in the patch
-  virtual void extractElmRes(const Matrix& globRes, Matrix& elmRes,
-                             size_t internalFirst) const;
+  //! \brief Sets the master patch to use for VTF- and HDF5-output.
+  void setOutputMaster(const ASMu3D* pch) { outputMaster = pch; }
+  //! \brief Returns the master patch to use for VTF- and HDF5-output.
+  virtual const ASMbase* getOutputMaster() const { return outputMaster; }
 
 protected:
   //! \brief Struct representing an inhomogeneous Dirichlet boundary condition.

--- a/src/LinAlg/Test/TestMatrix.C
+++ b/src/LinAlg/Test/TestMatrix.C
@@ -127,6 +127,16 @@ TEST_CASE("TestMatrix.AugmentRows")
         REQUIRE(a(i,j) == static_cast<int>(i+na*(j-1)));
       else
         REQUIRE(a(i,j) == static_cast<int>(nA-na+i+nb*(j-1)));
+  REQUIRE(a.augmentRows(b,true));
+  std::cout <<"C:"<< a;
+  for (size_t j = 1; j <= a.cols(); j++)
+    for (size_t i = 1; i <= a.rows(); i++)
+      if (i <= nb)
+        REQUIRE(a(i,j) == b(i,j));
+      else if (i > nb+na)
+        REQUIRE(a(i,j) == b(i-nb-na,j));
+      else
+        REQUIRE(a(i,j) == static_cast<int>(i-nb+na*(j-1)));
 }
 
 

--- a/src/LinAlg/matrix.h
+++ b/src/LinAlg/matrix.h
@@ -524,21 +524,28 @@ namespace utl //! General utility classes and functions.
     }
 
     //! \brief Increase the number of rows by augmenting the given matrix.
-    bool augmentRows(const matrix<T>& B)
+    //! \details If \a prepend is \e true, the matrix \b B is inserted as the
+    //! first rows of this matrix. Otherwise, it is appended as the last rows.
+    bool augmentRows(const matrix<T>& B, bool prepend = false)
     {
       if (B.ncol != ncol)
         return false;
 
       size_t oldRows = nrow;
+      size_t offset = prepend ? B.nrow : 0;
       nrow += B.nrow;
       this->elem.resize(nrow*ncol,RETAIN);
       T* oldMat = this->ptr() + oldRows*(ncol-1);
       for (size_t c = ncol; c > 0; c--, oldMat -= oldRows)
       {
-        if (c > 1)
-          memmove(this->ptr(c-1),oldMat,oldRows*sizeof(T));
-        for (size_t r = nrow; r > oldRows; r--)
-          this->elem[r-1+nrow*(c-1)] = B(r-oldRows,c);
+        if (c > 1 || prepend)
+          memmove(this->ptr(c-1)+offset,oldMat,oldRows*sizeof(T));
+        if (prepend)
+          for (size_t r = 1; r <= B.nrow; r++)
+            this->elem[r-1+nrow*(c-1)] = B(r,c);
+        else
+          for (size_t r = nrow; r > oldRows; r--)
+            this->elem[r-1+nrow*(c-1)] = B(r-oldRows,c);
       }
       return true;
     }

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -2631,13 +2631,92 @@ bool SIMbase::fieldProjections () const
 }
 
 
-bool SIMbase::extractPatchElmRes (const Matrix& glbRes, Matrix& elRes,
-				  int pindx) const
-{
-  ASMbase* pch = pindx >= 0 ? this->getPatch(pindx+1) : nullptr;
-  if (!pch || glbRes.empty()) return false;
+/*!
+  This method is used by the HDF5Writer, to extract patch-level element results
+  from a global norm array, together with the associated component name from
+  the underlying NormBase object of the integrand. If \a pindx is negative,
+  only the component name is extracted and no results data.
+*/
 
-  pch->extractElmRes(glbRes,elRes);
+bool SIMbase::extractElmRes (const Matrix& glbRes, Vector& elRes,
+                             size_t row, int pindx, std::string& name,
+                             const char* prefix) const
+{
+  size_t iField = myProblem->getNoElmFields();
+  if (iField > 0 && row <= iField)
+    name = myProblem->getEFieldName(row-1); // Element-wise material parameter
+
+  else if (NormBase* norm = myProblem->getNormIntegrand(mySol); norm)
+  {
+    const size_t normGrp = std::max(norm->getNoFields(0), 1+opt.project.size());
+    SIMoptions::ProjectionMap::const_iterator pit = opt.project.end();
+
+    // Find the name of this result norm from the NormBase object.
+    // The first norm group uses the name as it is. The other groups assume
+    // the corresponding projection method name as prefix. If the prefix
+    // argument is specified, it is used as a common prefix for all norm groups.
+    bool found = false;
+    size_t iGroup = 0, iComp = 0;
+    while (!found && ++iGroup <= normGrp)
+    {
+      if (iGroup == 2)
+        pit = opt.project.begin();
+      else if (iGroup > 2 && pit != opt.project.end())
+        ++pit;
+
+      iComp = 0;
+      while (!found && ++iComp <= norm->getNoFields(iGroup))
+        found = ++iField == row;
+    }
+
+    if (found)
+    {
+      // Check if the norm has element contributions
+      if (iGroup > 1 || !prefix)
+        found = norm->hasElementContributions(iGroup,iComp);
+      else if (iComp > 2) // hack: dual refinement indicators as norm #2
+        found = false;
+    }
+
+    if (found)
+    {
+      const bool project = pit != opt.project.end();
+      if (project)
+        name = prefix ? std::string(prefix) + " " + pit->second : pit->second;
+      name = norm->getName(iGroup, iComp, project ? name.c_str() : prefix);
+    }
+
+    delete norm;
+    if (!found)
+      return false; // No element contribution for this component
+  }
+  else
+    name = "norm_" + std::to_string(row);
+
+  return pindx >= 0 ? this->extractElmRes(glbRes,elRes,row,pindx) : true;
+}
+
+
+bool SIMbase::extractElmRes (const Matrix& glbRes, Vector& elRes,
+                             size_t row, int pindx) const
+{
+  if (row > glbRes.rows()) return false;
+
+  ASMbase* pch = this->getPatch(pindx+1);
+  if (!pch) return false;
+
+  pch->getOutputMaster()->extractElmRes(glbRes,elRes,row);
+  return true;
+}
+
+
+bool SIMbase::extractElmRes (const Vector& glbRes, Vector& elRes,
+                             int pindx) const
+{
+  ASMbase* pch = this->getPatch(pindx+1);
+  if (!pch) return false;
+
+  pch->getOutputMaster()->extractElmRes(glbRes,elRes);
   return true;
 }
 

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -586,12 +586,12 @@ public:
 
 protected:
   //! \brief Returns a vector function associated with given patch and property.
-  //! \param[in] patch 1-based index of the patch to retrieve property for
+  //! \param[in] patch One-based index of the patch to retrieve property for
   //! \param[in] ptype The property type associated with the vector function
   VecFunc* getVecFunc(size_t patch, Property::Type ptype) const;
 
   //! \brief Preprocesses a user-defined Dirichlet boundary property.
-  //! \param[in] patch 1-based index of the patch to receive the property
+  //! \param[in] patch One-based index of the patch to receive the property
   //! \param[in] lndx Local index of the boundary item to receive the property
   //! \param[in] ldim Dimension of the boundary item to receive the property
   //! \param[in] dirs Which local DOFs to constrain
@@ -673,8 +673,25 @@ public:
   //! \brief Extracts element results for a specified patch.
   //! \param[in] glbRes Global element result array
   //! \param[out] elRes Patch-level element result array
+  //! \param[in] row One-based index of the row to extract from \a glbRes
   //! \param[in] pindx Local patch index to extract element results for
-  bool extractPatchElmRes(const Matrix& glbRes, Matrix& elRes, int pindx) const;
+  //! \param[out] name Name of the result component associated with row \a row
+  //! \param[in] prefix Optional common prefix for all result components
+  bool extractElmRes(const Matrix& glbRes, Vector& elRes,
+                     size_t row, int pindx, std::string& name,
+                     const char* prefix = nullptr) const;
+  //! \brief Extracts element results for a specified patch.
+  //! \param[in] glbRes Global element result array
+  //! \param[out] elRes Patch-level element result array
+  //! \param[in] row One-based index of the row to extract from \a glbRes
+  //! \param[in] pindx Local patch index to extract element results for
+  bool extractElmRes(const Matrix& glbRes, Vector& elRes,
+                     size_t row, int pindx) const;
+  //! \brief Extracts element results for a specified patch.
+  //! \param[in] glbRes Global element result array
+  //! \param[out] elRes Patch-level element result array
+  //! \param[in] pindx Local patch index to extract element results for
+  bool extractElmRes(const Vector& glbRes, Vector& elRes, int pindx) const;
 
   //! \brief Returns the local patch index for the given global patch number.
   //! \details For serial applications this is an identity mapping only, whereas
@@ -686,7 +703,7 @@ public:
   //! \brief Returns a const reference to our FEM model.
   const PatchVec& getFEModel() const { return myModel; }
   //! \brief Returns a pointer to a specified patch of our FEM model.
-  //! \param[in] idx 1-based patch index
+  //! \param[in] idx One-based patch index
   //! \param[in] glbIndex If \e true, the patch index is assumed to be global
   //! for the whole model, otherwise it is assumed local within current process.
   //! For serial applications this option has no effect.

--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -1795,92 +1795,72 @@ bool SIMoutput::writeGlvN (const Matrix& norms, int iStep, int& nBlock,
   if (mergeVtf && myModel.size() > 1)
     return true; // not implemented for merged patches, ignore
 
-  NormBase* norm = myProblem->getNormIntegrand(mySol);
-
-  // Lambda function telling whether a norm quantity should be saved or not.
-  auto&& writeNorm = [norm,dualPrefix](size_t iGroup, size_t iNorm)
-  {
-    if (iGroup == 1 && dualPrefix)
-      return iNorm <= 2; // hack: dual refinement indicators as norm #2
-    else
-      return norm->hasElementContributions(iGroup,iNorm);
-  };
-
-  const size_t nEField = myProblem->getNoElmFields();
-
-  size_t idxW = 0;
   size_t nrow = norms.rows();
-  if (dualField && dualPrefix) idxW = ++nrow;
-  std::vector<IntVec> sID(nrow);
-  Matrix field;
+  size_t idxW = dualField && dualPrefix ? ++nrow : 0;
 
-  size_t i, j, k, l;
+  Vector field;
+  std::vector<IntVec> sID(nrow);
+  std::vector<std::string> names;
+  names.reserve(nrow);
+
   int geomID = myGeomID;
-  for (const ASMbase* pch : myModel)
+  for (size_t pidx = 0; pidx < myModel.size(); pidx++)
   {
-    if (pch->empty())
+    if (myModel[pidx]->empty())
       continue; // skip empty patches
 
     if (msgLevel > 1)
       IFEM::cout <<"Writing element norms for patch "
-                 << pch->idx+1 << std::endl;
+                 << myModel[pidx]->idx+1 << std::endl;
 
     const ElementBlock* grid = myVtf->getBlock(++geomID);
-    pch->extractElmRes(norms,field);
+    const size_t ngel = grid ? grid->getNoElms() : 0;
 
-    size_t ncol = grid ? grid->getNoElms() : 0;
-    if (ncol != field.cols() || nrow > field.rows())
+    size_t i, k = 0;
+    for (i = 1; i <= nrow; i++)
     {
-      // Expand/compress the element result array to match current grid block
-      Matrix efield(field);
-      field.resize(nrow,ncol);
-      for (j = 1; j <= ncol; j++)
-        field.fillColumn(j,efield.getColumn(grid->getElmId(j)));
-      if (idxW && dualField->initPatch(pch->idx))
-        for (j = 1; j <= ncol; j++)
-          field(idxW,j) = dualField->getScalarValue(grid->getCenter(j));
-    }
+      field.clear();
+      field.reserve(ngel);
+      std::string normName;
 
-    for (k = l = 0, i = j = 1; i <= nrow; i++)
-    {
-      if (i > nEField && ++l > norm->getNoFields(j))
-        l = 1, ++j;
-
-      if (i <= nEField || i == idxW || writeNorm(j,l))
+      if (i != idxW)
       {
-        if (!myVtf->writeEres(field.getRow(i),++nBlock,geomID))
+        // Extract the i'th element norm for this patch from the global array
+        if (this->extractElmRes(norms,field,i,pidx,normName,dualPrefix))
+          if (field.size() != ngel)
+          {
+            // Expand the element result array to match current grid block
+            Vector efield(field);
+            field.clear();
+            for (size_t j = 1; j <= ngel; j++)
+              field.push_back(efield(grid->getElmId(j)));
+          }
+      }
+      else if (dualField->initPatch(pidx))
+      {
+        // Extract the piece-wise constant dual solution field (w)
+        for (size_t j = 1; j <= ngel; j++)
+          field.push_back(dualField->getScalarValue(grid->getCenter(j)));
+        normName = std::string(dualPrefix) + " extraction function";
+      }
+
+      if (!field.empty())
+      {
+        if (myVtf->writeEres(field,++nBlock,geomID))
+          sID[k++].push_back(nBlock);
+        else
           return false;
 
-        sID[k++].push_back(nBlock);
+        if (names.size() < k)
+          names.push_back(normName);
       }
     }
   }
 
-  std::string normName;
-  for (k = l = 0, i = j = 1; k < sID.size() && !sID[k].empty(); i++)
-  {
-    if (i > nEField && ++l > norm->getNoFields(j))
-      l = 1, ++j;
+  for (size_t k = 0; k < sID.size() && !sID[k].empty(); k++)
+    if (!myVtf->writeSblk(sID[k],names[k].c_str(),++idBlock,iStep,true))
+      return false;
 
-    if (i <= nEField || i == idxW || writeNorm(j,l))
-    {
-      if (i <= nEField)
-        normName = "Element " + myProblem->getEFieldName(i-1);
-      else if (i == idxW && dualPrefix)
-        normName = std::string(dualPrefix) + " extraction function";
-      else if (j == 1 && dualPrefix)
-        normName = norm->getName(j,l,dualPrefix);
-      else if (j > 1 && j-2 < prefix.size())
-        normName = norm->getName(j,l,prefix[j-2].c_str());
-      else
-        normName = norm->getName(j,l);
-
-      if (!myVtf->writeSblk(sID[k++],normName.c_str(),++idBlock,iStep,true))
-        return false;
-    }
-  }
-
-  delete norm;
   return true;
 }
 

--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -1806,6 +1806,8 @@ bool SIMoutput::writeGlvN (const Matrix& norms, int iStep, int& nBlock,
       return norm->hasElementContributions(iGroup,iNorm);
   };
 
+  const size_t nEField = myProblem->getNoElmFields();
+
   size_t idxW = 0;
   size_t nrow = norms.rows();
   if (dualField && dualPrefix) idxW = ++nrow;
@@ -1839,12 +1841,12 @@ bool SIMoutput::writeGlvN (const Matrix& norms, int iStep, int& nBlock,
           field(idxW,j) = dualField->getScalarValue(grid->getCenter(j));
     }
 
-    for (k = 0, i = j = l = 1; i <= nrow; i++, l++)
+    for (k = l = 0, i = j = 1; i <= nrow; i++)
     {
-      if (l > norm->getNoFields(j))
+      if (i > nEField && ++l > norm->getNoFields(j))
         l = 1, ++j;
 
-      if (writeNorm(j,l) || i == idxW)
+      if (i <= nEField || i == idxW || writeNorm(j,l))
       {
         if (!myVtf->writeEres(field.getRow(i),++nBlock,geomID))
           return false;
@@ -1855,14 +1857,16 @@ bool SIMoutput::writeGlvN (const Matrix& norms, int iStep, int& nBlock,
   }
 
   std::string normName;
-  for (k = 0, i = j = l = 1; k < sID.size() && !sID[k].empty(); i++, l++)
+  for (k = l = 0, i = j = 1; k < sID.size() && !sID[k].empty(); i++)
   {
-    if (l > norm->getNoFields(j))
+    if (i > nEField && ++l > norm->getNoFields(j))
       l = 1, ++j;
 
-    if (writeNorm(j,l) || i == idxW)
+    if (i <= nEField || i == idxW || writeNorm(j,l))
     {
-      if (i == idxW && dualPrefix)
+      if (i <= nEField)
+        normName = "Element " + myProblem->getEFieldName(i-1);
+      else if (i == idxW && dualPrefix)
         normName = std::string(dualPrefix) + " extraction function";
       else if (j == 1 && dualPrefix)
         normName = norm->getName(j,l,dualPrefix);

--- a/src/Utility/HDF5Writer.C
+++ b/src/Utility/HDF5Writer.C
@@ -277,23 +277,6 @@ void HDF5Writer::writeSIM (int level, double time, const DataEntry& entry,
       this->writeBasis(sim, sim->getName() + "-proj", -1, level);
   }
 
-  const IntegrandBase* prob = sim->getProblem();
-  NormBase* norm = eNorm ? sim->getNormIntegrand() : nullptr;
-  size_t normGrp = norm ? norm->getNoFields(0) : 0;
-
-  // Extract names for the projection methods used
-  std::vector<const char*> projPfx;
-  if (proj || norm)
-  {
-    projPfx.reserve(sim->opt.project.size());
-    for (const auto& pfx : sim->opt.project)
-      projPfx.push_back(pfx.second.c_str());
-    if (normGrp > 1+projPfx.size())
-      projPfx.resize(normGrp-1,nullptr);
-    else
-      normGrp = 1+projPfx.size();
-  }
-
   bool exportSol = results & (DataExporter::PRIMARY | DataExporter::SECONDARY);
   std::string str = std::to_string(level) + "/" + sim->getName();
   std::vector<hid_t> egroup, group;
@@ -302,7 +285,7 @@ void HDF5Writer::writeSIM (int level, double time, const DataEntry& entry,
   for (size_t b = 1; b <= sim->getNoBasis(); ++b) {
     std::string basis = str + "-" + std::to_string(b);
     this->addGroup(basis);
-    if (norm || (results & DataExporter::ELEMENT_MASK))
+    if (eNorm || (results & DataExporter::ELEMENT_MASK))
       egroup.push_back(this->getGroup(basis + "/knotspan"));
     if (exportSol && !sol->empty())
       group.push_back(this->getGroup(basis + "/fields"));
@@ -337,6 +320,10 @@ void HDF5Writer::writeSIM (int level, double time, const DataEntry& entry,
   static std::vector<size_t> old_count;
   if ((results & DataExporter::ELEMENT_MASK) && old_count.empty())
     old_count.resize(sim->getNoPatches(),0);
+
+  const IntegrandBase* prob = sim->getProblem();
+  Vector values;
+  std::string name;
 
 
   //============================================================================
@@ -398,14 +385,15 @@ void HDF5Writer::writeSIM (int level, double time, const DataEntry& entry,
       // if another projection already has been performed
       if (proj) {
         hid_t gid = sim->fieldProjections() ? group.back() : group.front();
-        for (size_t p = 0; p < proj->size(); p++)
+        SIMoptions::ProjectionMap::const_iterator it = sim->opt.project.begin();
+        for (size_t p = 0; p < proj->size(); ++p, ++it)
           if (!proj->at(p).empty())
           {
             Matrix field;
             extractProjection(pch, proj->at(p), field, p+1 == proj->size());
             for (size_t j = 0; j < field.rows(); j++)
               if (!prob->suppressOutput(j,ASM::PROJECTED))
-                this->writeArray(gid, prob->getField2Name(j,projPfx[p]),
+                this->writeArray(gid, prob->getField2Name(j,it->second.c_str()),
                                  idx, field.cols(), field.getRow(j+1).ptr(),
                                  H5T_NATIVE_DOUBLE);
           }
@@ -438,17 +426,12 @@ void HDF5Writer::writeSIM (int level, double time, const DataEntry& entry,
                              H5T_NATIVE_DOUBLE);
       }
 
-      if (norm) {
-        Matrix patchEnorm;
-        sim->extractPatchElmRes(*eNorm,patchEnorm,loc-1);
-        for (size_t j = 1; j <= normGrp; ++j)
-          for (size_t k = 1; k <= norm->getNoFields(j); ++k)
-            if (norm->hasElementContributions(j,k))
-              this->writeArray(egroup.front(),
-                               prefix+norm->getName(j, k, j > 1 ? projPfx[j-2] : nullptr),
-                               idx, patchEnorm.cols(), patchEnorm.getRow(k).ptr(),
-                               H5T_NATIVE_DOUBLE);
-      }
+      if (eNorm)
+        for (size_t k = 1; k <= eNorm->rows(); k++)
+          if (sim->extractElmRes(*eNorm,values,k,loc-1,name))
+            this->writeArray(egroup.front(), prefix+name,
+                             idx, values.size(), values.ptr(),
+                             H5T_NATIVE_DOUBLE);
 
       if (results & DataExporter::ELEMENT_MASK) {
         std::vector<char> mask(pch->getNoElms());
@@ -516,33 +499,31 @@ void HDF5Writer::writeSIM (int level, double time, const DataEntry& entry,
         for (size_t j = 0; j < prob->getNoFields(2); j++)
           if (!prob->suppressOutput(j,rClass))
             writeArray(gid, prefix+prob->getField2Name(j),
-                       idx, 0, &dummy,H5T_NATIVE_DOUBLE);
+                       idx, 0, &dummy, H5T_NATIVE_DOUBLE);
       }
 
       if (proj) {
         hid_t gid = sim->fieldProjections() ? group.back() : group.front();
-        for (size_t p = 0; p < proj->size(); p++)
+        SIMoptions::ProjectionMap::const_iterator it = sim->opt.project.begin();
+        for (size_t p = 0; p < proj->size(); ++p, ++it)
           if (!proj->at(p).empty())
             for (size_t j = 0; j < prob->getNoFields(2); j++)
               if (!prob->suppressOutput(j,ASM::PROJECTED))
-                writeArray(gid, prob->getField2Name(j,projPfx[p]),
-                           idx, 0, &dummy,H5T_NATIVE_DOUBLE);
+                writeArray(gid, prob->getField2Name(j,it->second.c_str()),
+                           idx, 0, &dummy, H5T_NATIVE_DOUBLE);
       }
 
-      if (norm)
-        for (size_t j = 1; j <= normGrp; j++)
-          for (size_t k = 1; k <= norm->getNoFields(j); k++)
-            if (norm->hasElementContributions(j,k))
-              writeArray(egroup.front(),
-                         prefix+norm->getName(j, k, j > 1 ? projPfx[j-2] : nullptr),
-                         idx, 0, &dummy,H5T_NATIVE_DOUBLE);
+      if (eNorm)
+        for (size_t k = 1; k <= eNorm->rows(); k++)
+          if (sim->extractElmRes(*eNorm,values,k,-1,name))
+            this->writeArray(egroup.front(), prefix+name,
+                             idx, 0, &dummy, H5T_NATIVE_DOUBLE);
 
       if (results & DataExporter::EIGENMODES) // TODO (akva?)
         std::cerr <<"  ** HDF5Writer: Oops, eigenmodes not yet supported for distributed patches"
                   <<"\n     The HDF5-file will most likely be inconsistent."<< std::endl;
     }
 
-  delete norm;
   for (hid_t g : group)
     if (g != -1)
       H5Gclose(g);
@@ -564,28 +545,24 @@ void HDF5Writer::writeKnotspan (int level, const DataEntry& entry,
 #ifdef HAS_HDF5
   std::string str = std::to_string(level) + "/" + sim->getName() + "-1";
   this->addGroup(str);
-
   hid_t group = this->getGroup(str + "/knotspan");
 
-  Matrix infield(1,sol->size());
-  infield.fillRow(1,sol->ptr());
-  double dummy = 0.0;
+  Vector elmRes;
 
   for (int idx = 1; idx <= sim->getNoPatches(); idx++)
     if (int loc = sim->getLocalPatchIndex(idx); loc > 0 &&
         (sim->getProcessAdm().getProcId() == 0 ||
          sim->getProcessAdm().isParallel()))
     {
-      Matrix elmRes;
-      sim->extractPatchElmRes(infield,elmRes,loc-1);
+      sim->extractElmRes(*sol,elmRes,loc-1);
       writeArray(group,prefix+entry.second.description,idx,
-                 elmRes.cols(),elmRes.getRow(1).ptr(),H5T_NATIVE_DOUBLE);
+                 elmRes.size(),elmRes.ptr(),H5T_NATIVE_DOUBLE);
     }
     else
       // Write empty dummy records for patches
       // not owned by current processor
       writeArray(group,prefix+entry.second.description,idx,
-                 0,&dummy,H5T_NATIVE_DOUBLE);
+                 0,elmRes.ptr(),H5T_NATIVE_DOUBLE);
 
   H5Gclose(group);
 #else


### PR DESCRIPTION
The HDF5Writer class can output element-wise results, but so far it has been assumed they originate from norm integration with some complex logic to extract the name of the result components. This logic is now moved to a new `SIMbase::extractElmResult()` method which extracts a single component together with its component name. The same method is also used int the VTF-export (method `SIMoutput::writeGlvn()`), simplifying the logic there.

This also fixes a so far undetected bug in the HDF-export: When exporting for many norm groups (i.e., more than one projection method was used), it looks like the same element norm values (those associated with the first group), where exported for all groups, producing identical results. This is fixed now but not tested.