### PR TITLE
Removal of some (now) unused methods

### DIFF
--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -1430,25 +1430,6 @@ void ASMbase::extractElmRes (const Vector& globRes, Vector& elmRes,
 }
 
 
-void ASMbase::extractElmRes (const Matrix& globRes, Matrix& elmRes,
-                             size_t internalFirst) const
-{
-  elmRes.resize(globRes.rows(),MLGE.size(),true);
-
-  size_t ivel = 0, jel = internalFirst;
-  for (size_t i = 0; i < MLGE.size(); i++)
-    if (MLGE[i] > 0 && MNPC[i].size() > 1)
-    {
-      ++ivel;
-      size_t icol = internalFirst ? jel++ : MLGE[i];
-      if (icol <= globRes.cols())
-        elmRes.fillColumn(ivel,globRes.getColumn(icol));
-    }
-
-  elmRes.resize(globRes.rows(),ivel);
-}
-
-
 void ASMbase::extractElmRes (const Matrix& globRes, Vector& elmRes,
                              size_t irow) const
 {

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -814,14 +814,6 @@ public:
   //! \brief Extracts element results for this patch from a global matrix.
   //! \param[in] globRes Global matrix of element results
   //! \param[out] elmRes Element results for this patch
-  //! \param[in] internalFirst If non-zero, the data in \a globRes are assumed
-  //! to be ordered w.r.t. the internal element ordering, and the actual value
-  //! is the global index of the first element in the patch
-  void extractElmRes(const Matrix& globRes, Matrix& elmRes,
-                     size_t internalFirst = 0) const;
-  //! \brief Extracts element results for this patch from a global matrix.
-  //! \param[in] globRes Global matrix of element results
-  //! \param[out] elmRes Element results for this patch
   //! \param[in] irow 1-based index of the row to extract from \a globRes
   void extractElmRes(const Matrix& globRes, Vector& elmRes, size_t irow) const;
 

--- a/src/ASM/Integrand.h
+++ b/src/ASM/Integrand.h
@@ -57,9 +57,6 @@ public:
   //! which you need to have two (or more) distinct Neumann boundary conditions.
   virtual void setNeumannOrder(char) {}
 
-  //! \brief Define the index of the patch being processed.
-  virtual void initPatch(size_t) {}
-
 
   // Element-level initialization interface
   // ======================================

--- a/src/ASM/IntegrandBase.C
+++ b/src/ASM/IntegrandBase.C
@@ -40,18 +40,6 @@ void IntegrandBase::setMode (SIM::SolutionMode mode)
 
 
 /*!
-  Override this method if the integrand needs some patch-specific data
-  to be initialized before performing the numerical integration.
-  The default version only passes the patch index to the initPatch() method.
-*/
-
-void IntegrandBase::initForPatch (const ASMbase* pch)
-{
-  if (pch) this->initPatch(pch->idx);
-}
-
-
-/*!
   Override this method if the problem to be solved consists of multiple
   IntegrandBase objects. This method is then supposed to return the
   corresponding integrated quantity for this integrand.

--- a/src/ASM/IntegrandBase.h
+++ b/src/ASM/IntegrandBase.h
@@ -96,7 +96,9 @@ public:
   //! \brief Returns the system quantity to be integrated by \a *this.
   virtual GlobalIntegral& getGlobalInt(GlobalIntegral* gq) const;
   //! \brief Interface for initialization of integrand with patch-specific data.
-  virtual void initForPatch(const ASMbase* pch);
+  //! \details Override this method if the integrand needs some patch-specific
+  //! data to be initialized before performing the numerical integration.
+  virtual void initForPatch(const ASMbase*) {}
 
 
   // Element-level initialization interface
@@ -390,6 +392,10 @@ public:
   void initProjection(size_t nproj);
   //! \brief Sets a vector of LocalIntegrals to be used during norm integration.
   void setLocalIntegrals(LintegralVec* elementNorms) { lints = elementNorms; }
+  //! \brief Interface for initialization of integrand with patch-specific data.
+  //! \details Override this method if the integrand needs some patch-specific
+  //! data to be initialized before performing the numerical integration.
+  virtual void initForPatch(const ASMbase*) {}
 
   using Integrand::getLocalIntegral;
   //! \brief Returns a local integral container for the element \a iEl.

--- a/src/SIM/AdaptiveSIM.C
+++ b/src/SIM/AdaptiveSIM.C
@@ -53,13 +53,6 @@ bool AdaptiveSIM::initAdaptor (size_t normGroup)
   if (model.haveDualSol())
     projd.resize(opt.project.size());
 
-  if (opt.format >= 0)
-  {
-    prefix.reserve(opt.project.size());
-    for (const SIMoptions::ProjectionMap::value_type& prj : opt.project)
-      prefix.push_back(prj.second);
-  }
-
   return true;
 }
 
@@ -139,15 +132,15 @@ bool AdaptiveSIM::solveStep (const char* inputfile, int iStep, bool withRF,
     return failure();
 
   // Project the secondary solution onto the splines basis
-  size_t idx = 0;
   model.setMode(SIM::RECOVERY);
-  for (const SIMoptions::ProjectionMap::value_type& prj : opt.project)
-    if (prj.first <= SIMoptions::NONE)
-      idx++; // No projection for this norm group
-    else if (!model.project(projs[idx++],solution.front(),prj.first))
+  SIMoptions::ProjectionMap::const_iterator pit = opt.project.begin();
+  for (size_t idx = 0; pit != opt.project.end(); ++idx, ++pit)
+    if (pit->first <= SIMoptions::NONE)
+      continue; // No projection for this norm group
+    else if (!model.project(projs[idx],solution.front(),pit->first))
       return failure();
-    else if (idx == adaptor && idx <= projd.size() && solution.size() > 1)
-      if (!model.project(projd[idx-1],solution[1],prj.first))
+    else if (1+idx == adaptor && idx < projd.size() && solution.size() > 1)
+      if (!model.project(projd[idx],solution[1],pit->first))
         return failure();
 
   if (msgLevel > 1 && !projs.empty())
@@ -255,20 +248,16 @@ bool AdaptiveSIM::writeGlv (const char* infile, int iStep)
 
   // Write projected solution fields
   SIMoptions::ProjectionMap::const_iterator pit = opt.project.begin();
-  for (size_t i = 0; i < projs.size(); i++, ++pit)
+  for (size_t i = 0; i < projs.size(); ++i, ++pit)
     if (!model.writeGlvP(projs[i],iStep,nBlock,100+10*i,pit->second.c_str()))
       return false;
 
   // Write element norms
-  if (!model.writeGlvN(eNorm,iStep,nBlock,prefix))
+  if (!model.writeGlvN(eNorm,iStep,nBlock))
     return false;
 
-  if (!fNorm.empty())
-  {
-    std::vector<std::string> prefix = { "Dual projected" };
-    if (!model.writeGlvN(fNorm,iStep,nBlock,prefix,300,"Dual"))
-      return false;
-  }
+  if (!model.writeGlvN(fNorm,iStep,nBlock,300,"Dual"))
+    return false;
 
   // Write state information
   return model.writeGlvStep(iStep,iStep,1);

--- a/src/SIM/AdaptiveSIM.h
+++ b/src/SIM/AdaptiveSIM.h
@@ -31,10 +31,8 @@ public:
   //! \param sim The FE model
   //! \param[in] sa If \e true, this is a stand-alone driver
   explicit AdaptiveSIM(SIMoutput& sim, bool sa = true);
-  //! \brief Empty destructor.
-  virtual ~AdaptiveSIM() {}
 
-  //! \brief Initializes the \a projs and \a prefix arrays.
+  //! \brief Initializes the \ref projs and \ref projd arrays.
   //! \param[in] normGroup Index to the norm group to base mesh adaptation on
   bool initAdaptor(size_t normGroup = 0);
 
@@ -96,6 +94,8 @@ protected:
   virtual bool savePoints(int iStep) const;
 
 private:
+  Vectors projs; //!< Projected secondary solutions
+  Vectors projd; //!< Projected dual solutions
   Vectors gNorm; //!< Global norms
   Vectors dNorm; //!< Dual global norms
   Matrix  eNorm; //!< Element norms
@@ -103,10 +103,6 @@ private:
 
   int geoBlk; //!< Running VTF geometry block counter
   int nBlock; //!< Running VTF result block counter
-
-  std::vector<Vector>      projs;  //!< Projected secondary solutions
-  std::vector<Vector>      projd;  //!< Projected dual solutions
-  std::vector<std::string> prefix; //!< Norm prefices for VTF-output
 
 protected:
   Vectors solution; //!< All solutions (including Galerkin projections)

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -1880,7 +1880,8 @@ bool SIMbase::solutionNorms (const TimeDomain& time,
       else
         pch->extractNodeVec(ssol[k],norm->getProjection(k),nCmp,1);
 
-    norm->initPatch(pch->idx);
+    norm->initForPatch(pch);
+
     if (mySol)
       mySol->initPatch(pch->idx);
 
@@ -2007,7 +2008,7 @@ bool SIMbase::solutionNorms (const TimeDomain& time,
           {
             if (p->patch != lp)
               ok = this->extractPatchSolution(psol,p->patch-1);
-            norm->initPatch(pch->idx);
+            norm->initForPatch(pch);
             if (mySol)
               mySol->initPatch(pch->idx);
             ok &= pch->integrate(*norm,p->lindx,globalNorm,time);
@@ -2021,7 +2022,7 @@ bool SIMbase::solutionNorms (const TimeDomain& time,
           {
             if (p->patch != lp)
               ok = this->extractPatchSolution(psol,p->patch-1);
-            norm->initPatch(pch->idx);
+            norm->initForPatch(pch);
             if (mySol)
               mySol->initPatch(pch->idx);
             ok &= pch->integrateEdge(*norm,p->lindx,globalNorm,time);

--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -1787,7 +1787,6 @@ bool SIMoutput::writeGlvM (const Mode& mode, bool freq, int& nBlock)
 */
 
 bool SIMoutput::writeGlvN (const Matrix& norms, int iStep, int& nBlock,
-                           const std::vector<std::string>& prefix,
                            int idBlock, const char* dualPrefix)
 {
   if (norms.empty() || !myVtf)

--- a/src/SIM/SIMoutput.h
+++ b/src/SIM/SIMoutput.h
@@ -217,11 +217,9 @@ public:
   //! \param[in] norms The element norms to output
   //! \param[in] iStep Load/time step identifier
   //! \param nBlock Running result block counter
-  //! \param[in] prefix Prefices for projected solutions
   //! \param[in] idBlock Starting value of result block numbering
   //! \param[in] dualPrefix Prefix for dual solution norms
   bool writeGlvN(const Matrix& norms, int iStep, int& nBlock,
-                 const std::vector<std::string>& prefix = {},
                  int idBlock = 200, const char* dualPrefix = nullptr);
 
   //! \brief Writes a scalar function to the VTF-file.


### PR DESCRIPTION
The extractElmRes() method extracting to a patch-level matrix is no longer used and can be removed.
Also the prefix argument of the writeGlvN() method is no longer used and therefore removed (require downstream updates).
Finally, the `Integrand::initPatch()` interface is replaced by an `initForPatch()` interface in the NormBase class, for consistency with the IntegrandBase class.