### PR TITLE
General support for nodal constraints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,6 @@ ifem_lto(TARGET IFEM)
 target_compile_definitions(IFEM PUBLIC $<$<CONFIG:Debug>:INDEX_CHECK=2>)
 if(VERBOSE_DEBUG GREATER 0)
   target_compile_definitions(IFEM PRIVATE $<$<CONFIG:Debug>:SP_DEBUG=${VERBOSE_DEBUG}>)
-  target_compile_definitions(IFEM INTERFACE $<$<CONFIG:Debug>:INT_DEBUG=${VERBOSE_DEBUG}>)
 endif()
 
 include(IFEMAddTargets)

--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -770,6 +770,33 @@ void ASMbase::makePeriodic (size_t master, size_t slave, int dirs)
 }
 
 
+/*!
+  If \a xtol is negative, the check for matching nodes is skipped.
+*/
+
+bool ASMbase::selfInterconnect (const std::vector<Ipair>& nodes, double xtol)
+{
+  size_t nonMatching = 0;
+  for (const Ipair& np : nodes)
+    if (xtol < 0.0 ||
+        this->getCoord(np.first).equal(this->getCoord(np.second),xtol))
+      ASMbase::collapseNodes(*this,np.first,*this,np.second);
+    else if (++nonMatching <= 20)
+      std::cerr <<" *** ASMbase::selfInterconnect: Non-matching nodes "
+                << np.first <<": "<< this->getCoord(np.first)
+                <<"\n                                               and "
+                << np.second <<": "<< this->getCoord(np.second) << std::endl;
+    else if (nonMatching == 21)
+      std::cerr <<"     ..."<< std::endl;
+
+  if (nonMatching > 20)
+    std::cerr <<" *** ASMbase::selfInterconnect: A total of "<< nonMatching
+              <<" nodes were detected."<< std::endl;
+
+  return nonMatching == 0;
+}
+
+
 void ASMbase::constrainPatch (int dof, int code)
 {
   if (code > 0)
@@ -1690,7 +1717,7 @@ bool ASMbase::deformedConfig (const Matrix& Xnod, Vectors& eVec, bool force2nd)
 
 int ASMbase::searchCtrlPt (RealArray::const_iterator cit,
                            RealArray::const_iterator end,
-                           const Vec3& X, int dimension, double tol) const
+                           const Vec3& X, int dimension, double xtol) const
 {
   Vec3 Xnod;
   double distance = 0.0;
@@ -1702,7 +1729,7 @@ int ASMbase::searchCtrlPt (RealArray::const_iterator cit,
     {
       i = -1;
       inod++;
-      if (X.equal(Xnod,tol))
+      if (X.equal(Xnod,xtol))
         if (iclose == 0 || (X-Xnod).length() < distance)
         {
           // In case of a very fine grid where several control points might

--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -556,12 +556,13 @@ bool ASMbase::add2PC (int slave, int dir, int master, int code)
 
   MPC* cons = new MPC(slave,dir);
   bool stat = this->addMPC(cons,code);
-  if (!cons) return stat;
-
-  cons->addMaster(master,dir);
+  if (cons)
+  {
+    cons->addMaster(master,dir);
 #if SP_DEBUG > 1
-  std::cout <<"Added constraint: "<< *cons;
+    std::cout <<"Added constraint: "<< *cons;
 #endif
+  }
   return stat;
 }
 
@@ -575,13 +576,14 @@ bool ASMbase::add3PC (int slave, int dir, int master1, int master2, int code)
 
   MPC* cons = new MPC(slave,dir);
   bool stat = this->addMPC(cons,code);
-  if (!cons) return stat;
-
-  if (master1 != slave) cons->addMaster(master1,dir);
-  if (master2 != slave) cons->addMaster(master2,dir);
+  if (cons)
+  {
+    if (master1 != slave) cons->addMaster(master1,dir);
+    if (master2 != slave) cons->addMaster(master2,dir);
 #if SP_DEBUG > 1
-  std::cout <<"Added constraint: "<< *cons;
+    std::cout <<"Added constraint: "<< *cons;
 #endif
+  }
   return stat;
 }
 
@@ -647,9 +649,7 @@ bool ASMbase::createRgdMasterNode (int& gMaster, const Vec3& Xpt)
 void ASMbase::addRigidMPC (int gSlave, int gMaster, const Vec3& dX)
 {
   for (unsigned short int dof = 1; dof <= nf; dof++)
-  {
-    MPC* cons = new MPC(gSlave,dof);
-    if (this->addMPC(cons) && cons)
+    if (MPC* cons = new MPC(gSlave,dof); this->addMPC(cons) && cons)
     {
       // Add one-to-one translation coupling
       cons->addMaster(gMaster,dof,1.0);
@@ -672,7 +672,6 @@ void ASMbase::addRigidMPC (int gSlave, int gMaster, const Vec3& dX)
       std::cout <<"Added constraint: "<< *cons;
 #endif
     }
-  }
 }
 
 
@@ -707,17 +706,15 @@ void ASMbase::addRigidCouplings (int gMaster, const Vec3& Xmaster,
     else if (nsd == 2 && nf > 1)
     {
       // Special for 2D problems with (at least) 2 nodal DOFs
-      MPC* cons = new MPC(MLGN[node-1],1);
-      if (this->addMPC(cons) && cons)
+      if (MPC* cons = new MPC(MLGN[node-1],1); this->addMPC(cons) && cons)
       {
         cons->addMaster(gMaster,1, 1.0);
         cons->addMaster(gMaster,3,-dX.y);
-      }
 #if SP_DEBUG > 1
-      std::cout <<"Added constraint: "<< *cons;
+        std::cout <<"Added constraint: "<< *cons;
 #endif
-      cons = new MPC(MLGN[node-1],2);
-      if (this->addMPC(cons) && cons)
+      }
+      if (MPC* cons = new MPC(MLGN[node-1],2); this->addMPC(cons) && cons)
       {
         cons->addMaster(gMaster,2, 1.0);
         cons->addMaster(gMaster,3, dX.x);
@@ -727,6 +724,21 @@ void ASMbase::addRigidCouplings (int gMaster, const Vec3& Xmaster,
       }
     }
   }
+}
+
+
+void ASMbase::addNodalCouplings (int slave, const IntVec& masters,
+                                 const RealArray& weights)
+{
+  for (unsigned short int dof = 1; dof <= nf; dof++)
+    if (MPC* cons = new MPC(MLGN[slave-1],dof); this->addMPC(cons) && cons)
+    {
+      for (size_t i = 0; i < masters.size() && i < weights.size(); i++)
+        cons->addMaster(MLGN[masters[i]-1],dof,weights[i]);
+#if SP_DEBUG > 1
+      std::cout <<"Added constraint: "<< *cons;
+#endif
+    }
 }
 
 

--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -73,7 +73,8 @@ ASMbase::ASMbase (unsigned char n_p, unsigned char n_s, unsigned char n_f)
 
 ASMbase::ASMbase (const ASMbase& patch, unsigned char n_f)
   : MLGE(patch.MLGE), MLGN(patch.MLGN), MNPC(patch.MNPC), shareFE('F'),
-    firstBp(patch.firstBp), myLMTypes(patch.myLMTypes), myLMs(patch.myLMs),
+    nodeSets(patch.nodeSets), firstBp(patch.firstBp),
+    myLMTypes(patch.myLMTypes), myLMs(patch.myLMs),
     myActiveEls(nullptr), myRmaster(patch.myRmaster)
 {
   nf = n_f > 0 ? n_f : patch.nf;
@@ -963,7 +964,7 @@ bool ASMbase::allDofs (int dirs) const
 }
 
 
-void ASMbase::mergeAndGetAllMPCs (const ASMVec& model, MPCSet& allMPCs)
+void ASMbase::mergeAndGetAllMPCs (const ASM::PatchVec& model, MPCSet& allMPCs)
 {
   // Build the set of constraint equations over all patches in the model
   if (model.size() == 1)
@@ -1050,7 +1051,7 @@ void ASMbase::mergeAndGetAllMPCs (const ASMVec& model, MPCSet& allMPCs)
 */
 
 void ASMbase::resolveMPCchains (const MPCSet& allMPCs,
-                                const ASMVec& model, bool setPtrOnly)
+                                const ASM::PatchVec& model, bool setPtrOnly)
 {
 #if SP_DEBUG > 1
   int count = 0;
@@ -1275,7 +1276,7 @@ bool ASMbase::mergeNodes (size_t inod, int globalNum, bool verbose)
     IFEM::cout <<"  ** Merging duplicated nodes "<< globalNum <<" and "<< oldNum
                <<" at X="<< this->getCoord(inod) << std::endl;
 
-  std::map<int,int> old2New;
+  IntMap old2New;
   myMLGN[inod-1] = old2New[oldNum] = globalNum;
   for (ASMbase* pch : neighbors)
     pch->renumberNodes(old2New,{},1);
@@ -1284,7 +1285,7 @@ bool ASMbase::mergeNodes (size_t inod, int globalNum, bool verbose)
 }
 
 
-int ASMbase::renumberNodes (const ASMVec& model, std::map<int,int>& old2new)
+int ASMbase::renumberNodes (const ASM::PatchVec& model, IntMap& old2new)
 {
   for (const ASMbase* pch : model)
     if (!pch->shareFE)
@@ -1308,7 +1309,7 @@ int ASMbase::renumberNodes (const ASMVec& model, std::map<int,int>& old2new)
 }
 
 
-int ASMbase::renumberNodes (std::map<int,int>& old2new, int& nNod)
+int ASMbase::renumberNodes (IntMap& old2new, int& nNod)
 {
   int renum = 0;
   if (!shareFE)
@@ -1337,9 +1338,8 @@ int ASMbase::renumberNodes (std::map<int,int>& old2new, int& nNod)
   such that that only the first instance of a duplicated node is referred.
 */
 
-bool ASMbase::renumberNodes (const std::map<int,int>& old2new,
-                             const std::vector<int>& new2old, int renumGN,
-                             std::map<int,int>* degenElm)
+bool ASMbase::renumberNodes (const IntMap& old2new, const IntVec& new2old,
+                             int renumGN, IntMap* degenElm)
 {
   bool renumAll = old2new.size() > 1 && renumGN < 2;
 #ifdef SP_DEBUG
@@ -1891,4 +1891,109 @@ double ASMbase::getAge (int iel, double time) const
 bool ASMbase::isElementInPartition (int iel) const
 {
   return myElms.empty() || utl::findIndex(myElms,iel) >= 0;
+}
+
+
+int ASMbase::getNodeSetIdx (const std::string& setName) const
+{
+  int idx = 1;
+  for (const ASM::NodeSet& ns : nodeSets)
+    if (ns.first == setName)
+      return idx;
+    else
+      ++idx;
+
+  return 0;
+}
+
+
+const IntVec& ASMbase::getNodeSet (int idx) const
+{
+  int count = 0;
+  for (const ASM::NodeSet& ns : nodeSets)
+    if (++count == idx)
+      return ns.second;
+
+  return Empty;
+}
+
+
+IntVec& ASMbase::getNodeSet (const std::string& setName, int& idx)
+{
+  idx = 1;
+  for (ASM::NodeSet& ns : nodeSets)
+    if (ns.first == setName)
+      return ns.second;
+    else
+      ++idx;
+
+  nodeSets.emplace_back(setName,IntVec());
+  return nodeSets.back().second;
+}
+
+
+/*!
+  If \a inod is negative, the absolute value is taken as the external node ID.
+  Otherwise, it is taken as the 1-based internal node index within the patch.
+*/
+
+bool ASMbase::isInNodeSet (int iset, int inod) const
+{
+  if (iset < 1 || iset > static_cast<int>(nodeSets.size()))
+    return false;
+
+  if (inod < 0)
+    inod = this->getNodeIndex(-inod);
+
+  return utl::findIndex(nodeSets[iset-1].second,inod) >= 0;
+}
+
+
+int ASMbase::parseNodeSet (const std::string& setName, const char* cset,
+                           bool assumeZeroBased)
+{
+  int iset = this->getNodeSetIdx(setName)-1;
+  if (iset < 0)
+  {
+    iset = nodeSets.size();
+    nodeSets.emplace_back(setName,IntVec());
+  }
+
+  utl::parseIntegers(nodeSets[iset].second,cset);
+  if (assumeZeroBased)
+    for (int& n : nodeSets[iset].second)
+      ++n;
+
+  return 1+iset;
+}
+
+
+void ASMbase::convertNodeSets ()
+{
+  if (nodeSets.empty())
+    return;
+
+  IFEM::cout <<"Node sets in patch P"<< idx+1 <<": "<< nodeSets.size();
+  for (ASM::NodeSet& ns : nodeSets)
+  {
+    size_t nidx = 0;
+    for (int nodeNo : ns.second)
+      if (nodeNo > 0)
+      {
+        if (int inod = this->getNodeIndex(nodeNo); inod > 0)
+          ns.second[nidx++] = inod;
+        else
+          IFEM::cout <<"\n  ** Warning: Non-existing node number "<< nodeNo
+                     <<" in set \""<< ns.first <<"\" (ignored).";
+      }
+
+    if (nidx < ns.second.size())
+      ns.second.resize(nidx);
+    IFEM::cout <<"\n\t\""<< ns.first <<"\": "<< ns.second.size();
+    if (!ns.second.empty())
+      IFEM::cout <<" ["
+                 << *std::min_element(ns.second.begin(),ns.second.end()) <<","
+                 << *std::max_element(ns.second.begin(),ns.second.end()) <<"]";
+  }
+  IFEM::cout << std::endl;
 }

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -897,6 +897,13 @@ public:
   void addRigidCouplings(int gMaster, const Vec3& Xmaster,
                          const IntVec& slaveNodes);
 
+  //! \brief Adds MPC-equations for general nodal couplings in this patch.
+  //! \param[in] slave Local node number of the slave node
+  //! \param[in] masters Local node numbers of the master nodes
+  //! \param[in] weights Weight factors for each master node
+  void addNodalCouplings(int slave, const IntVec& masters,
+                         const RealArray& weights);
+
 protected:
 
   // Internal methods for preprocessing of boundary conditions

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -24,6 +24,7 @@
 
 using IntVec = std::vector<int>;    //!< General integer vector
 using IntMat = std::vector<IntVec>; //!< General 2D integer matrix
+using Ipair  = std::pair<int,int>;  //!< A pair of integers
 
 using MPCMap  = std::map<MPC*,int,MPCLess>; //!< MPC-to-function code mapping
 using MPCSet  = std::set<MPC*,MPCLess>; //!< Sorted set of MPC-equations
@@ -938,9 +939,9 @@ protected:
   //! \param[in] end iterator of array of control point coordinates
   //! \param[in] X Coordinates of point to search for
   //! \param[in] dimension Number of spatial dimensions of the splines object
-  //! \param[in] tol Zero tolerance
+  //! \param[in] xtol Coordinate tolerance
   int searchCtrlPt(RealArray::const_iterator cit, RealArray::const_iterator end,
-                   const Vec3& X, int dimension, double tol = 0.001) const;
+                   const Vec3& X, int dimension, double xtol = 0.001) const;
 
   //! \brief Finds the patch-local element numbers on a patch boundary.
   //! \param[out] elms Array of element numbers
@@ -997,6 +998,10 @@ public:
   //! \param[in] dof Local indices of the DOFs to check
   //! \param[in] all Returns \e true only if all DOFs are fixed
   bool isFixed(int node, int dof, bool all = false) const;
+  //! \brief Connects a list of node pairs to each other.
+  //! \param[in] nodes List of node number pairs that should share common DOFs.
+  //! \param[in] xtol Coordinate tolerance for matching nodes
+  bool selfInterconnect(const std::vector<Ipair>& nodes, double xtol = 1.0e-8);
 
 protected:
   //! \brief Returns \e true if \a dirs constains all local DOFs in the patch.

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -48,10 +48,15 @@ class Vec3;
 class Tensor;
 class SAM;
 
-namespace ASM { class InterfaceChecker; }
-namespace utl { template<class Arg, class Result> class Function; }
+namespace ASM {
+  class InterfaceChecker;
+  using NodeSet  = std::pair<std::string,IntVec>; //!< Named set container type
+  using PatchVec = std::vector<ASMbase*>; //!< Spline patch container type
+}
 
-using ASMVec  = std::vector<ASMbase*>;     //!< Spline patch container type
+namespace utl {
+  template<class Arg,class Result> class Function;
+}
 using IntFunc = utl::Function<int,double>; //!< Real-valued integer function
 
 
@@ -287,15 +292,21 @@ public:
                        int orient = -1, bool local = false) const;
 
   //! \brief Returns (1-based) index of a predefined node set in the patch.
-  virtual int getNodeSetIdx(const std::string&) const { return 0; }
+  int getNodeSetIdx(const std::string& setName) const;
   //! \brief Returns an indexed predefined node set.
-  virtual const IntVec& getNodeSet(int) const { return Empty; }
-  //! \brief Checks if a node is within a predefined node set.
-  virtual bool isInNodeSet(int, int) const { return false; }
+  const IntVec& getNodeSet(int iset) const;
+  //! \brief Returns a named node set for update.
+  IntVec& getNodeSet(const std::string& setName, int& idx);
+
+  //! \brief Checks if node \a inod is within predefined node set \a iset.
+  bool isInNodeSet(int iset, int inod) const;
   //! \brief Defines a node set by parsing a list of node numbers.
-  virtual int parseNodeSet(const std::string&, const char*) { return 0; }
+  int parseNodeSet(const std::string& setName, const char* cset,
+                   bool assumeZeroBased = false);
   //! \brief Defines a node set by parsing a 3D bounding box.
   virtual int parseNodeBox(const std::string&, const char*) { return 0; }
+  //! \brief Converts node number sets to internal (1-based) node indices.
+  void convertNodeSets();
 
   //! \brief Returns (1-based) index of a predefined element set in the patch.
   virtual int getElementSetIdx(const std::string&) const { return 0; }
@@ -442,7 +453,8 @@ public:
   //! The new node numbers computed by this method preserve the relative
   //! ordering of the nodes. That is not the case when the non-static version
   //! is used.
-  static int renumberNodes(const ASMVec& model, std::map<int,int>& old2new);
+  static int renumberNodes(const ASM::PatchVec& model,
+                           std::map<int,int>& old2new);
 
   //! \brief Renumbers the global node numbers in this patch.
   //! \param old2new Old-to-new node number mapping
@@ -471,14 +483,15 @@ public:
   //! interface nodes between patches (to enforce higher order regularity) may
   //! be defined on both neighboring patches. This method will also merge such
   //! multiply defined equations into a single equation.
-  static void mergeAndGetAllMPCs(const ASMVec& model, MPCSet& allMPCs);
+  static void mergeAndGetAllMPCs(const ASM::PatchVec& model, MPCSet& allMPCs);
 
   //! \brief Resolves (possibly multi-level) chaining in MPC-equations.
   //! \param[in] allMPCs All multi-point constraint equations in the model
   //! \param[in] model All spline patches in the model
   //! \param[in] setPtrOnly If \e true, only set pointer to next MPC in chain
   static void resolveMPCchains(const MPCSet& allMPCs,
-                               const ASMVec& model, bool setPtrOnly = false);
+                               const ASM::PatchVec& model,
+                               bool setPtrOnly = false);
 
   //! \brief Initializes the multi-point constraint coefficients.
   virtual bool initConstraints() { return true; }
@@ -1053,6 +1066,8 @@ protected:
   MPCMap dCode; //!< Inhomogeneous Dirichlet condition codes for the MPCs
   MPCSet mpcs;  //!< All multi-point constraints with the slave in this patch
 
+  std::vector<ASM::NodeSet> nodeSets; //!< Node sets for explicit Dirichlet BCs
+
   IntVec myMLGE; //!< The actual Matrix of Local to Global Element numbers
   IntVec myMLGN; //!< The actual Matrix of Local to Global Node numbers
   IntMat myMNPC; //!< The actual Matrix of Nodal Point Correspondance
@@ -1074,7 +1089,7 @@ protected:
   //! Global indices to first integration point for the Neumann boundaries
   std::map<char,size_t> firstBp;
 
-  ASMVec neighbors; //!< Patches having nodes in common with this one
+  ASM::PatchVec neighbors; //!< Patches having nodes in common with this one
 
   //! Auxilliary node number map used when establishing Dirichlet constraints
   static std::map<int,int> xNode;

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -46,8 +46,7 @@ ASMs1D::ASMs1D (unsigned char n_s, unsigned char n_f)
 
 
 ASMs1D::ASMs1D (const ASMs1D& patch, unsigned char n_f)
-  : ASMstruct(patch,n_f),
-    elmCS(patch.myCS), nodalT(patch.myT), nodeSets(patch.nodeSets)
+  : ASMstruct(patch,n_f), elmCS(patch.myCS), nodalT(patch.myT)
 {
   curv = patch.curv;
   proj = patch.proj;
@@ -436,76 +435,6 @@ void ASMs1D::applyTwist (const RealFunc& twist)
       myCS[i].print(std::cout,15);
 #endif
     }
-}
-
-
-int ASMs1D::getNodeSetIdx (const std::string& setName) const
-{
-  int iset = 1;
-  for (const ASM::NodeSet& ns : nodeSets)
-    if (ns.first == setName)
-      return iset;
-    else
-      ++iset;
-
-  return 0;
-}
-
-
-const IntVec& ASMs1D::getNodeSet (int iset) const
-{
-  if (iset > 0 && iset <= static_cast<int>(nodeSets.size()))
-    return nodeSets[iset-1].second;
-
-  return this->ASMbase::getNodeSet(iset);
-}
-
-
-/*!
-  If \a inod is negative, the absolute value is taken as the external node ID.
-  Otherwise, it is taken as the 1-based internal node index within the patch.
-*/
-
-bool ASMs1D::isInNodeSet (int iset, int inod) const
-{
-  if (iset < 1 || iset > static_cast<int>(nodeSets.size()))
-    return false;
-
-  if (inod < 0)
-    inod = this->getNodeIndex(-inod);
-
-  return utl::findIndex(nodeSets[iset-1].second,inod) >= 0;
-}
-
-
-int ASMs1D::parseNodeSet (const std::string& setName, const char* cset)
-{
-  int iset = this->getNodeSetIdx(setName)-1;
-  if (iset < 0)
-  {
-    iset = nodeSets.size();
-    nodeSets.emplace_back(setName,IntVec());
-  }
-
-  IntVec& mySet = nodeSets[iset].second;
-  size_t ifirst = mySet.size();
-  utl::parseIntegers(mySet,cset);
-
-  // Transform to internal node indices
-  for (size_t i = ifirst; i < mySet.size(); i++)
-    if (mySet[i] > 0)
-    {
-      if (int inod = this->getNodeIndex(mySet[i]); inod > 0)
-        mySet[ifirst++] = inod;
-      else
-        IFEM::cout <<"  ** Warning: Non-existing node "<< mySet[i]
-                   <<" in the set \""<< setName <<"\" (ignored)."<< std::endl;
-    }
-
-  if (ifirst < mySet.size())
-    mySet.resize(ifirst);
-
-  return 1+iset;
 }
 
 

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -17,7 +17,6 @@
 #include "ASMstruct.h"
 #include "ASMunstruct.h"
 #include "ASM1D.h"
-#include "ASMutils.h"
 #include "Tensor.h"
 
 using TensorVec = std::vector<Tensor>; //!< An array of non-symmetric tensors
@@ -124,15 +123,6 @@ public:
   //! \param[in] local If \e true, return patch-local node numbers
   virtual void getBoundaryNodes(int lIndex, IntVec& nodes,
                                 int, int thick, int, bool local) const;
-
-  //! \brief Returns (1-based) index of a predefined node set in the patch.
-  virtual int getNodeSetIdx(const std::string& setName) const;
-  //! \brief Returns an indexed pre-defined node set.
-  virtual const IntVec& getNodeSet(int iset) const;
-  //! \brief Checks if node \a inod is within predefined node set \a iset.
-  virtual bool isInNodeSet(int iset, int inod) const;
-  //! \brief Defines a node set by parsing a list of node numbers.
-  virtual int parseNodeSet(const std::string& setName, const char* cset);
 
   //! \brief Finds the node that is closest to the given point.
   //! \param[in] X Global coordinates of point to search for
@@ -476,8 +466,6 @@ protected:
   TensorVec myCS;  //!< The actual element coordinate systems
   TensorVec myT;   //!< The actual nodal rotation tensors
   TensorVec prevT; //!< Nodal rotation tensors of last converged configuration
-
-  std::vector<ASM::NodeSet> nodeSets; //!< Node sets for Dirichlet BCs
 
 private:
   bool updatedT; //!< If \e true, nodal rotation matrices have been updated

--- a/src/ASM/ASMsupel.C
+++ b/src/ASM/ASMsupel.C
@@ -122,43 +122,6 @@ bool ASMsupel::generateFEMTopology ()
 }
 
 
-int ASMsupel::getNodeSetIdx (const std::string& setName) const
-{
-  int iset = 1;
-  for (const ASM::NodeSet& ns : nodeSets)
-    if (ns.first == setName)
-      return iset;
-    else
-      ++iset;
-
-  return 0;
-}
-
-
-const IntVec& ASMsupel::getNodeSet (int iset) const
-{
-  if (iset > 0 && iset <= static_cast<int>(nodeSets.size()))
-    return nodeSets[iset-1].second;
-
-  return this->ASMbase::getNodeSet(iset);
-}
-
-
-int ASMsupel::parseNodeSet (const std::string& setName, const char* cset)
-{
-  int iset = this->getNodeSetIdx(setName)-1;
-  if (iset < 0)
-  {
-    iset = nodeSets.size();
-    nodeSets.emplace_back(setName,IntVec());
-  }
-
-  utl::parseIntegers(nodeSets[iset].second,cset);
-
-  return 1+iset;
-}
-
-
 void ASMsupel::getBoundaryNodes (int lIndex, IntVec& nodes,
                                  int, int, int, bool local) const
 {

--- a/src/ASM/ASMsupel.h
+++ b/src/ASM/ASMsupel.h
@@ -15,7 +15,6 @@
 #define _ASM_SUPEL_H
 
 #include "ASMbase.h"
-#include "ASMutils.h"
 #include "ElmMats.h"
 #include "Vec3.h"
 
@@ -46,13 +45,6 @@ public:
   virtual bool generateFEMTopology();
   //! \brief Checks if this patch is empty.
   virtual bool empty() const { return myElmMat.empty(); }
-
-  //! \brief Returns (1-based) index of a predefined node set in the patch.
-  virtual int getNodeSetIdx(const std::string& setName) const;
-  //! \brief Returns an indexed pre-defined node set.
-  virtual const IntVec& getNodeSet(int iset) const;
-  //! \brief Defines a node set by parsing a list of node numbers.
-  virtual int parseNodeSet(const std::string& setName, const char* cset);
 
   //! \brief Returns the global coordinates for the given node.
   //! \param[in] inod 1-based node index local to current patch.
@@ -120,8 +112,6 @@ public:
 private:
   Vec3Vec myNodes;  //!< Supernode coordinates
   ElmMats myElmMat; //!< Duperelement matrices
-
-  std::vector<ASM::NodeSet> nodeSets; //!< Node sets for Dirichlet BCs
 };
 
 #endif

--- a/src/ASM/ASMu1DLag.C
+++ b/src/ASM/ASMu1DLag.C
@@ -12,6 +12,7 @@
 //==============================================================================
 
 #include "ASMu1DLag.h"
+#include "ASMutils.h"
 #include "ElementBlock.h"
 #include "Utilities.h"
 #include "IFEM.h"

--- a/src/ASM/ASMu2DLag.C
+++ b/src/ASM/ASMu2DLag.C
@@ -12,6 +12,7 @@
 //==============================================================================
 
 #include "ASMu2DLag.h"
+#include "ASMutils.h"
 #include "ElementBlock.h"
 #include "GlobalIntegral.h"
 #include "Integrand.h"
@@ -36,16 +37,14 @@ ASMu2DLag::ASMu2DLag (unsigned char n_s,
 }
 
 
-ASMu2DLag::ASMu2DLag (const ASMu2DLag& p, unsigned char n_f) :
-  ASMs2DLag(p,n_f), nodeSets(p.nodeSets)
+ASMu2DLag::ASMu2DLag (const ASMu2DLag& p, unsigned char n_f) : ASMs2DLag(p,n_f)
 {
   fileType = 0;
   swapNode34 = p.swapNode34;
 }
 
 
-ASMu2DLag::ASMu2DLag (const ASMu2DLag& p) :
-  ASMs2DLag(p), nodeSets(p.nodeSets)
+ASMu2DLag::ASMu2DLag (const ASMu2DLag& p) : ASMs2DLag(p)
 {
   fileType = 0;
   swapNode34 = p.swapNode34;
@@ -110,28 +109,6 @@ bool ASMu2DLag::generateFEMTopology ()
 }
 
 
-int ASMu2DLag::getNodeSetIdx (const std::string& setName) const
-{
-  int iset = 1;
-  for (const ASM::NodeSet& ns : nodeSets)
-    if (ns.first == setName)
-      return iset;
-    else
-      ++iset;
-
-  return 0;
-}
-
-
-const IntVec& ASMu2DLag::getNodeSet (int iset) const
-{
-  if (iset > 0 && iset <= static_cast<int>(nodeSets.size()))
-    return nodeSets[iset-1].second;
-
-  return this->ASMbase::getNodeSet(iset);
-}
-
-
 bool ASMu2DLag::getNodeSet (int iset, std::string& name) const
 {
   if (iset < 0 || iset > static_cast<int>(nodeSets.size()))
@@ -141,54 +118,6 @@ bool ASMu2DLag::getNodeSet (int iset, std::string& name) const
 
   name = nodeSets[iset-1].first;
   return true;
-}
-
-
-/*!
-  If \a inod is negative, the absolute value is taken as the external node ID.
-  Otherwise, it is taken as the 1-based internal node index within the patch.
-*/
-
-bool ASMu2DLag::isInNodeSet (int iset, int inod) const
-{
-  if (iset < 1 || iset > static_cast<int>(nodeSets.size()))
-    return false;
-
-  if (inod < 0)
-    inod = this->getNodeIndex(-inod);
-
-  return utl::findIndex(nodeSets[iset-1].second,inod) >= 0;
-}
-
-
-int ASMu2DLag::parseNodeSet (const std::string& setName, const char* cset)
-{
-  int iset = this->getNodeSetIdx(setName)-1;
-  if (iset < 0)
-  {
-    iset = nodeSets.size();
-    nodeSets.emplace_back(setName,IntVec());
-  }
-
-  IntVec& mySet = nodeSets[iset].second;
-  size_t ifirst = mySet.size();
-  utl::parseIntegers(mySet,cset);
-
-  // Transform to internal node indices
-  for (size_t i = ifirst; i < mySet.size(); i++)
-    if (mySet[i] > 0)
-    {
-      if (int inod = this->getNodeIndex(mySet[i]); inod > 0)
-        mySet[ifirst++] = inod;
-      else
-        IFEM::cout <<"  ** Warning: Non-existing node "<< mySet[i]
-                   <<" in the set \""<< setName <<"\" (ignored)."<< std::endl;
-    }
-
-  if (ifirst < mySet.size())
-    mySet.resize(ifirst);
-
-  return 1+iset;
 }
 
 
@@ -432,7 +361,7 @@ int ASMu2DLag::addToElemSet (const std::string& setName, int iel, bool extId)
 void ASMu2DLag::getBoundaryNodes (int lIndex, IntVec& nodes,
                                   int, int, int, bool local) const
 {
-  nodes = this->getNodeSet(lIndex);
+  nodes = this->ASMs2DLag::getNodeSet(lIndex);
   if (!local)
     for (int& node : nodes)
       node = this->getNodeID(node);

--- a/src/ASM/ASMu2DLag.h
+++ b/src/ASM/ASMu2DLag.h
@@ -15,7 +15,6 @@
 #define _ASM_U2D_LAG_H
 
 #include "ASMs2DLag.h"
-#include "ASMutils.h"
 
 
 /*!
@@ -67,14 +66,6 @@ public:
   //! \brief Checks if this patch is empty.
   virtual bool empty() const { return nel == 0; }
 
-  //! \brief Returns (1-based) index of a predefined node set in the patch.
-  virtual int getNodeSetIdx(const std::string& setName) const;
-  //! \brief Returns an indexed predefined node set.
-  virtual const IntVec& getNodeSet(int iset) const;
-  //! \brief Checks if node \a inod is within predefined node set \a iset.
-  virtual bool isInNodeSet(int iset, int inod) const;
-  //! \brief Defines a node set by parsing a list of node numbers.
-  virtual int parseNodeSet(const std::string& setName, const char* cset);
   //! \brief Defines a node set by parsing a 3D bounding box.
   virtual int parseNodeBox(const std::string& setName, const char* bbox);
   //! \brief Adds a node to a named node set.
@@ -157,7 +148,6 @@ protected:
 
   bool swapNode34; //!< If \e true, element nodes 3 and 4 should be swapped
 
-  std::vector<ASM::NodeSet> nodeSets; //!< Node sets for Dirichlet BCs
   std::vector<ASM::NodeSet> elemSets; //!< Element sets for properties
 
 private:

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -168,7 +168,7 @@ ASMbase* SIMbase::getPatch (int idx, bool glbIndex) const
 
 #if SP_DEBUG > 2
 namespace {
-void printNodalConnectivity (const ASMVec& model, std::ostream& os)
+void printNodalConnectivity (const ASM::PatchVec& model, std::ostream& os)
 {
   typedef std::pair<int,int> Ipair;
   typedef std::vector<Ipair> Ipairs;
@@ -226,6 +226,11 @@ bool SIMbase::preprocessC (const IntVec& ignored, bool fixDup, double time0)
     ASMbase* pch = this->getPatch(idx);
     if (pch) pch->clear();
   }
+
+  // Convert node sets to internal node indices
+  for (ASMbase* pch : myModel)
+    if (!pch->empty())
+      pch->convertNodeSets();
 
   // If material properties are specified for at least one patch, assign the
   // property code 999999 to all patches with no material property code yet

--- a/src/SIM/SIMinput.C
+++ b/src/SIM/SIMinput.C
@@ -68,9 +68,7 @@ bool SIMinput::readPatches (std::istream& isp, const char* whiteSpace)
 {
   unsigned short int maxSpaceDim = 0;
   for (int pchInd = myModel.size(); isp.good(); pchInd++)
-  {
-    ASMbase* pch = this->readPatch(isp,pchInd,CharVec(),whiteSpace);
-    if (pch)
+    if (ASMbase* pch = this->readPatch(isp,pchInd,CharVec(),whiteSpace); pch)
     {
       myModel.push_back(pch);
       if (pch->getNoSpaceDim() > maxSpaceDim)
@@ -78,7 +76,6 @@ bool SIMinput::readPatches (std::istream& isp, const char* whiteSpace)
     }
     else if (this->getLocalPatchIndex(pchInd+1) > 0)
       return false;
-  }
 
   // Reset number of space dimensions if all patches have less than nsd
   if (maxSpaceDim > 0 && maxSpaceDim < nsd)
@@ -148,18 +145,14 @@ bool SIMinput::parseGeometryTag (const tinyxml2::XMLElement* elem)
     else if (strstr(file,".hdf5"))
     {
       IFEM::cout <<"\tReading global node numbers from "<< file << std::endl;
-      ProcessAdm adm;
-      HDF5Reader hdf5(file,adm);
-      const char* field = elem->Attribute("field");
+      ProcessAdm dummyAdm;
+      HDF5Reader hdf5(file,dummyAdm);
+      const char* fld = elem->Attribute("field");
+      std::string grp = "/0/" + std::string(fld ? fld : "node numbers") + "/";
       for (int i = 1; i <= nGlPatches; i++)
-      {
-        IntVec nodes;
-        ASMbase* pch = this->getPatch(i,true);
-        std::stringstream str;
-        str << "/0/" << (field ? field : "node numbers") << "/" << i;
-        if (pch && hdf5.readVector(str.str(),nodes))
-          pch->setNodeNumbers(nodes);
-      }
+        if (ASMbase* pch = this->getPatch(i,true); pch)
+          if (IntVec nodes; hdf5.readVector(grp + std::to_string(i),nodes))
+            pch->setNodeNumbers(nodes);
     }
   }
 
@@ -242,6 +235,7 @@ bool SIMinput::parseGeometryTag (const tinyxml2::XMLElement* elem)
       {
         int idim = 3;
         utl::getAttribute(set,"type",type,true);
+        bool nodes0 = type == "nodes0";
         if (type == "volume")
           idim = 3;
         else if (type == "face" || type == "surface")
@@ -250,7 +244,7 @@ bool SIMinput::parseGeometryTag (const tinyxml2::XMLElement* elem)
           idim = 1;
         else if (type == "vertex" || type == "point")
           idim = 0;
-        else if (type == "nodes")
+        else if (type == "nodes" || nodes0)
           idim = 4;
         else if (type == "elements")
           idim = 5;
@@ -267,11 +261,10 @@ bool SIMinput::parseGeometryTag (const tinyxml2::XMLElement* elem)
         {
           const tinyxml2::XMLNode* child = item->FirstChild();
 
-          int pid = 0;
           IntVec patches;
           this->parsePatchList(item,patches);
           for (int patch : patches)
-            if ((pid = this->getLocalPatchIndex(patch)) > 0)
+            if (int pid = this->getLocalPatchIndex(patch); pid > 0)
             {
               int setIndex = 0;
               ASMbase* pch = myModel[pid-1];
@@ -282,7 +275,7 @@ bool SIMinput::parseGeometryTag (const tinyxml2::XMLElement* elem)
                 if (!child)
                   setIndex = pch->getNodeSetIdx(name);
                 else
-                  setIndex = pch->parseNodeSet(name,child->Value());
+                  setIndex = pch->parseNodeSet(name,child->Value(),nodes0);
                 if (setIndex > 0)
                   top.emplace(pid,setIndex,idim);
               }
@@ -361,8 +354,7 @@ bool SIMinput::parseGeometryTag (const tinyxml2::XMLElement* elem)
                 << patch <<"."<< std::endl;
       return false;
     }
-    ASMbase* pch = this->getPatch(patch,true);
-    if (pch)
+    if (ASMbase* pch = this->getPatch(patch,true); pch)
     {
       const char* funcdef = elem->FirstChild()->Value();
       IFEM::cout <<"\tActivation function for P"<< patch
@@ -397,8 +389,7 @@ bool SIMinput::parsePeriodic (const tinyxml2::XMLElement* elem)
     return false;
   }
 
-  ASMbase* pch = this->getPatch(patch,true);
-  if (pch)
+  if (ASMbase* pch = this->getPatch(patch,true); pch)
   {
     IFEM::cout <<"\tPeriodic "<< char('H'+pedir) <<"-direction P"<< patch
                << std::endl;
@@ -498,12 +489,10 @@ bool SIMinput::parseBCTag (const tinyxml2::XMLElement* elem)
       IFEM::cout <<" order "<< order;
       // Flag Neumann order by increasing the topology index by 10
       for (; i < myProps.size(); i++)
-      {
         // But not for edge boundaries in 3D
-        ASMbase* pch = this->getPatch(myProps[i].patch);
-        if (pch && myProps[i].ldim+1 == pch->getNoParamDim())
-          myProps[i].lindx += 10*(order-1);
-      }
+        if (ASMbase* pch = this->getPatch(myProps[i].patch); pch)
+          if (myProps[i].ldim+1 == pch->getNoParamDim())
+            myProps[i].lindx += 10*(order-1);
     }
 
     if (type == "anasol")
@@ -1093,8 +1082,7 @@ bool SIMinput::parse (char* keyWord, std::istream& is)
         if (is.good())
         {
           IFEM::cout <<"\nReading patch file "<< cline << std::endl;
-          ASMbase* pch = this->readPatch(is,i);
-          if (pch)
+          if (ASMbase* pch = this->readPatch(is,i); pch)
             myModel.push_back(pch);
         }
         else
@@ -1341,8 +1329,7 @@ bool SIMinput::createFEMmodel (char resetNumb)
       // This patch shares its FE data with another patch, but has been assigned
       // additional nodes due to constraints in local coordinate systems,
       // Lagrange multipliers, etc. Need therefore to unshare the FE data.
-      ASMbase* newPatch = myModel[i]->cloneUnShared();
-      if (newPatch)
+      if (ASMbase* newPatch = myModel[i]->cloneUnShared(); newPatch)
       {
         IFEM::cout <<"\tNote: Unsharing FE data of P"<< 1+i << std::endl;
         newPatch->setGlobalNodeNums(myModel[i]->getMyNodeNums());
@@ -1391,9 +1378,8 @@ bool SIMinput::createPropertySet (const std::string& setName, int pc)
     return false;
   }
 
-  auto pit = std::find_if(myProps.begin(),myProps.end(),
-                         [pc](const Property& p){ return abs(p.pindx) == pc; });
-  if (pit != myProps.end())
+  if (std::find_if(myProps.begin(), myProps.end(), [pc](const Property& p)
+                   { return abs(p.pindx) == pc; }) != myProps.end())
   {
     std::cerr <<" *** SIMinput::createPropertySet: Duplicated property code "
               << pc <<"."<< std::endl;
@@ -1447,8 +1433,8 @@ size_t SIMinput::setPropertyType (int code, Property::Type ptype,
         }
         else if (ptype >= Property::DIRICHLET && pindex <= LOCAL_AXES)
         {
-          ASMbase* pch = this->getPatch(p->patch);
-          if (pch && abs(p->ldim)+1 == pch->getNoParamDim())
+          if (ASMbase* pch = this->getPatch(p->patch); pch &&
+              abs(p->ldim)+1 == pch->getNoParamDim())
           {
             p->lindx *= -1; // flag the use of local axis directions
             if (abs(p->ldim) == 2 && pindex < -10)
@@ -1525,10 +1511,8 @@ IntVec SIMinput::getFunctionsForElements (const IntVec& elements)
   IntSet functions;
 #ifdef HAS_LRSPLINE
   for (ASMbase* pch : myModel)
-  {
-    ASMLRSpline* lrPch = dynamic_cast<ASMLRSpline*>(pch);
-    if (lrPch) lrPch->getFunctionsForElements(functions,elements);
-  }
+    if (ASMLRSpline* lrPch = dynamic_cast<ASMLRSpline*>(pch); lrPch)
+      lrPch->getFunctionsForElements(functions,elements);
 #ifdef SP_DEBUG
   size_t j = 0, k = 0;
   std::cout <<"SIMinput::getFunctionsForElements: nel="<< elements.size();
@@ -1550,9 +1534,8 @@ IntVec SIMinput::getFunctionsForElements (const IntVec& elements)
 int SIMinput::refine (const RealFunc& refC, double refTol)
 {
   IntVec elements;
-  ASMunstruct* uspch = nullptr;
   for (ASMbase* pch : myModel)
-    if ((uspch = dynamic_cast<ASMunstruct*>(pch)))
+    if (ASMunstruct* uspch = dynamic_cast<ASMunstruct*>(pch); uspch)
       for (size_t iel = 1; iel <= pch->getNoElms(true); iel++)
         if (refC(uspch->getElementCenter(iel)) < refTol)
           elements.push_back(pch->getElmID(iel)-1);
@@ -1639,18 +1622,16 @@ bool SIMinput::refine (const LR::RefineData& prm, Vectors& sol)
     for (size_t i = 0; i < myModel.size(); i++)
     {
       // Extract local indices from the vector of global indices
-      int locId;
       for (int k : prm.elements)
-        if (!prm.MLGN.empty()) {
-          const auto it = std::find(prm.MLGN[i].begin(), prm.MLGN[i].end(), k);
-          if (it != prm.MLGN[i].end())
-            if (refineIndices[i].insert(std::distance(prm.MLGN[i].begin(), it)).second)
-              changed = true;
-        } else {
-          if ((locId = myModel[i]->getNodeIndex(k+1)) > 0)
-            if (refineIndices[i].insert(locId-1).second)
-              changed = true;
-        }
+      {
+        int locId;
+        if (prm.MLGN.empty())
+          locId = myModel[i]->getNodeIndex(k+1)-1;
+        else
+          locId = utl::findIndex(prm.MLGN[i],k);
+        if (locId >= 0 && refineIndices[i].insert(locId).second)
+          changed = true;
+      }
 
       // Fetch boundary nodes covered (may need to pass this to other patches)
       IntVec bndry_nodes = pch[i]->getBoundaryCovered(refineIndices[i]);
@@ -1677,19 +1658,17 @@ bool SIMinput::refine (const LR::RefineData& prm, Vectors& sol)
         else
           globId = prm.MLGN[i][k];
         for (size_t j = 0; j < myModel.size(); j++)
-          if (j != i) {
-            if (prm.MLGN.empty()) {
-              if ((locId = myModel[j]->getNodeIndex(globId)) > 0) {
-                conformingIndices[j].insert(locId-1);
-                conformingIndices[i].insert(k);
-              }
-            } else {
-              const auto it = std::find(prm.MLGN[j].begin(),
-                                        prm.MLGN[j].end(), globId);
-              if (it != prm.MLGN[j].end()) {
-                conformingIndices[j].insert(std::distance(prm.MLGN[j].begin(), it));
-                conformingIndices[i].insert(k);
-              }
+          if (j != i)
+          {
+            int locId;
+            if (prm.MLGN.empty())
+              locId = myModel[j]->getNodeIndex(globId)-1;
+            else
+              locId = utl::findIndex(prm.MLGN[j],globId);
+            if (locId >= 0)
+            {
+              conformingIndices[j].insert(locId);
+              conformingIndices[i].insert(k);
             }
           }
       }
@@ -1779,7 +1758,7 @@ bool SIMinput::setInitialCondition (SIMdependency* fieldHolder,
   }
 
   // Clean up basis patches
-  for (const auto& itb : basisMap)
+  for (const std::pair<const std::string,PatchVec>& itb : basisMap)
     for (ASMbase* pch : itb.second)
       delete pch;
 
@@ -1793,7 +1772,7 @@ bool SIMinput::setInitialConditions (SIMdependency* fieldHolder)
     fieldHolder = this;
 
   bool result = true;
-  for (const auto& it : myICs)
+  for (const std::pair<const std::string,InitialCondVec>& it : myICs)
     if (it.first != "nofile")
       result &= this->setInitialCondition(fieldHolder,it.first,it.second);
     else for (const ICInfo& ic : it.second)
@@ -1818,7 +1797,7 @@ bool SIMinput::setInitialConditions (SIMdependency* fieldHolder)
 
 bool SIMinput::hasIC (const std::string& name) const
 {
-  for (const auto& it : myICs)
+  for (const std::pair<const std::string,InitialCondVec>& it : myICs)
     for (const ICInfo& ic : it.second)
       if (ic.sim_field.compare(0,name.size(),name) == 0)
         return true;
@@ -1980,8 +1959,7 @@ SIMinput::IdxVec3* SIMinput::getDiscretePoint (int idx)
 
 bool SIMinput::getTopItemNodes (const TopItem& titem, IntVec& glbNodes) const
 {
-  ASMbase* pch = this->getPatch(titem.patch);
-  if (pch)
+  if (ASMbase* pch = this->getPatch(titem.patch); pch)
     pch->getBoundaryNodes(titem.item,glbNodes);
   else if (!titem.patch && titem.item >= 0 && titem.item < (int)myTopPts.size())
     glbNodes.push_back(myTopPts[titem.item].first);

--- a/src/Utility/Test/TestUtilities.C
+++ b/src/Utility/Test/TestUtilities.C
@@ -20,14 +20,18 @@
 
 TEST_CASE("TestUtilities.ParseIntegers")
 {
-  std::vector<int> values1, values2, values3;
+  std::vector<int> values1, values2, values3, values4, values5;
   REQUIRE(utl::parseIntegers(values1,"1"));
   REQUIRE(utl::parseIntegers(values2,"1:5"));
   REQUIRE(utl::parseIntegers(values3,"1 3 5:8 10"));
+  REQUIRE(utl::parseIntegers(values4,"1, 2, 3, 4"));
+  REQUIRE(utl::parseIntegers(values5,",1,,3,"));
 
   REQUIRE(values1.size() == 1);
   REQUIRE(values2.size() == 5);
   REQUIRE(values3.size() == 7);
+  REQUIRE(values4.size() == 4);
+  REQUIRE(values5.size() == 5);
   REQUIRE(values1.front() == 1);
   for (size_t i = 0; i < values2.size(); i++)
     REQUIRE(values2[i] == 1+static_cast<int>(i));
@@ -36,6 +40,12 @@ TEST_CASE("TestUtilities.ParseIntegers")
   for (int i = 2; i < 6; i++)
     REQUIRE(values3[i] == 3+i);
   REQUIRE(values3.back() == 10);
+  for (size_t i = 0; i < values4.size(); i++)
+    REQUIRE(values4[i] == static_cast<int>(1+i));
+  for (size_t i = 0; i < values5.size(); i++)
+    REQUIRE(values5[i] == static_cast<int>(i%2 == 0 ? 0 : i));
+
+  REQUIRE(!utl::parseIntegers(values1,"5 2.4 1.3"));
 }
 
 

--- a/src/Utility/Utilities.C
+++ b/src/Utility/Utilities.C
@@ -25,16 +25,32 @@ bool utl::parseIntegers (std::vector<int>& values, const char* argv)
 
   size_t old = values.size();
   char* endp = const_cast<char*>(argv);
-  while (endp && strlen(endp) > 0)
+  while (strlen(endp) > 0)
   {
+    char* oldp = endp;
     values.push_back(strtol(endp,&endp,10));
-    if (endp && *endp == ':')
+    if (!endp)
+      break;
+    else if (*endp == ',')
+      ++endp;
+    else if (*endp == ':')
     {
       int endVal = strtol(endp+1,&endp,10);
       while (values.back() < endVal)
         values.push_back(values.back()+1);
     }
+    else if (endp == oldp)
+    {
+      std::cerr <<" *** utl::parsIntegers(): Malformed integer values: "<< argv
+                <<"\n"<< std::string(26,' ') << std::string(26+endp-argv,'-')
+                << '^' << std::endl;
+      return false;
+    }
   }
+
+  // A trailing comma should imply 0 as the last value
+  if (strlen(argv) > 0 && *(endp-1) == ',')
+    values.push_back(0);
 
   return values.size() > old;
 }


### PR DESCRIPTION
The handling of constraints on nodes is moved to ASMbase such that it can be used for patches of any type. Also adding functionality to have any nodes within the same patch share common DOFs and generalized linear couplings between nodal points within the patch.