### PR TITLE
Fixed: Catch GoTools exceptions more gracefully

### DIFF
--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -34,6 +34,7 @@
 #include "Tensor.h"
 #include "IFEM.h"
 #include <numeric>
+#include <exception>
 
 
 ASMs1D::ASMs1D (unsigned char n_s, unsigned char n_f)
@@ -63,9 +64,19 @@ bool ASMs1D::read (std::istream& is)
 {
   if (shareFE) return true;
 
-  Go::ObjectHeader head;
-  curv = std::make_shared<Go::SplineCurve>();
-  is >> head >> *curv;
+  try
+  {
+    Go::ObjectHeader head;
+    curv = std::make_shared<Go::SplineCurve>();
+    is >> head >> *curv;
+  }
+  catch (const std::exception& e)
+  {
+    std::cerr <<" *** ASMs1D::read: Failure reading splines data ("
+              << e.what() <<")."<< std::endl;
+    curv.reset();
+    return false;
+  }
 
   // Eat white-space characters to see if there is more data to read
   char c;
@@ -78,23 +89,23 @@ bool ASMs1D::read (std::istream& is)
 
   if (!is.good() && !is.eof())
   {
-    std::cerr <<" *** ASMs1D::read: Failure reading spline data"<< std::endl;
+    std::cerr <<" *** ASMs1D::read: Failure reading splines data."<< std::endl;
     curv.reset();
     return false;
   }
   else if (curv->dimension() < 1)
   {
     std::cerr <<" *** ASMs1D::read: Invalid spline curve patch, dim="
-	      << curv->dimension() << std::endl;
+              << curv->dimension() <<"."<< std::endl;
     curv.reset();
     return false;
   }
   else if (curv->dimension() < nsd)
   {
-    std::cerr <<"  ** ASMs1D::read: The dimension of this curve patch "
-	      << curv->dimension() <<" is less than nsd="<< (int)nsd
-	      <<".\n                   Resetting nsd to "<< curv->dimension()
-	      <<" for this patch."<< std::endl;
+    IFEM::cout <<"  ** ASMs1D::read: The dimension of this curve patch "
+               << curv->dimension() <<" is less than nsd="<< (int)nsd
+               <<".\n                   Resetting nsd to "<< curv->dimension()
+               <<" for this patch."<< std::endl;
     nsd = curv->dimension();
   }
 

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -41,6 +41,7 @@
 #include "IFEM.h"
 #include <array>
 #include <utility>
+#include <exception>
 
 
 ASMs2D::ASMs2D (unsigned char n_s, unsigned char n_f)
@@ -140,9 +141,19 @@ bool ASMs2D::read (std::istream& is)
 {
   if (shareFE) return true;
 
-  Go::ObjectHeader head;
-  surf = std::make_shared<Go::SplineSurface>();
-  is >> head >> *surf;
+  try
+  {
+    surf = std::make_shared<Go::SplineSurface>();
+    Go::ObjectHeader head;
+    is >> head >> *surf;
+  }
+  catch (const std::exception& e)
+  {
+    std::cerr <<" *** ASMs2D::read: Failure reading splines data ("
+              << e.what() <<")."<< std::endl;
+    surf.reset();
+    return false;
+  }
 
   // Eat white-space characters to see if there is more data to read
   char c;
@@ -155,23 +166,23 @@ bool ASMs2D::read (std::istream& is)
 
   if (!is.good() && !is.eof())
   {
-    std::cerr <<" *** ASMs2D::read: Failure reading spline data"<< std::endl;
+    std::cerr <<" *** ASMs2D::read: Failure reading splines data."<< std::endl;
     surf.reset();
     return false;
   }
   else if (surf->dimension() < 2)
   {
     std::cerr <<" *** ASMs2D::read: Invalid spline surface patch, dim="
-          << surf->dimension() << std::endl;
+              << surf->dimension() <<"."<< std::endl;
     surf.reset();
     return false;
   }
   else if (surf->dimension() < nsd)
   {
-    std::cerr <<"  ** ASMs2D::read: The dimension of this surface patch "
-	      << surf->dimension() <<" is less than nsd="<< (int)nsd
-	      <<".\n                   Resetting nsd to "<< surf->dimension()
-	      <<" for this patch."<< std::endl;
+    IFEM::cout <<"  ** ASMs2D::read: The dimension of this surface patch "
+               << surf->dimension() <<" is less than nsd="<< (int)nsd
+               <<".\n                   Resetting nsd to "<< surf->dimension()
+               <<" for this patch."<< std::endl;
     nsd = surf->dimension();
   }
 

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -29,6 +29,7 @@
 #include <array>
 #include <numeric>
 #include <utility>
+#include <exception>
 
 
 ASMs2Dmx::ASMs2Dmx (unsigned char n_s, const CharVec& n_f)
@@ -94,9 +95,20 @@ bool ASMs2Dmx::readBasis (std::istream& is, size_t basis)
     nb.resize(nfx.size(), 0);
   }
 
-  Go::ObjectHeader head;
-  m_basis[--basis] = std::make_shared<Go::SplineSurface>();
-  is >> head >> *m_basis[basis];
+  try
+  {
+    Go::ObjectHeader head;
+    m_basis[--basis] = std::make_shared<Go::SplineSurface>();
+    is >> head >> *m_basis[basis];
+  }
+  catch (const std::exception& e)
+  {
+    std::cerr <<" *** ASMs2Dmx::readBasis: Failure reading splines data ("
+              << e.what() <<")."<< std::endl;
+    m_basis[basis].reset();
+    return false;
+  }
+
   nb[basis] = m_basis[basis]->numCoefs_u() * m_basis[basis]->numCoefs_v();
 
   return true;

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -38,6 +38,7 @@
 #include "IFEM.h"
 #include <array>
 #include <utility>
+#include <exception>
 
 
 ASMs3D::ASMs3D (unsigned char n_f) : ASMstruct(3,3,n_f), nodeInd(myNodeInd)
@@ -117,9 +118,19 @@ bool ASMs3D::read (std::istream& is)
 {
   if (shareFE) return true;
 
-  Go::ObjectHeader head;
-  svol = std::make_shared<Go::SplineVolume>();
-  is >> head >> *svol;
+  try
+  {
+    Go::ObjectHeader head;
+    svol = std::make_shared<Go::SplineVolume>();
+    is >> head >> *svol;
+  }
+  catch (const std::exception& e)
+  {
+    std::cerr <<" *** ASMs3D::read: Failure reading splines data ("
+              << e.what() <<")."<< std::endl;
+    svol.reset();
+    return false;
+  }
 
   // Eat white-space characters to see if there is more data to read
   char c;
@@ -132,14 +143,14 @@ bool ASMs3D::read (std::istream& is)
 
   if (!is.good() && !is.eof())
   {
-    std::cerr <<" *** ASMs3D::read: Failure reading spline data"<< std::endl;
+    std::cerr <<" *** ASMs3D::read: Failure reading splines data."<< std::endl;
     svol.reset();
     return false;
   }
   else if (svol->dimension() < 3)
   {
     std::cerr <<" *** ASMs3D::read: Invalid spline volume patch, dim="
-              << svol->dimension() << std::endl;
+              << svol->dimension() <<"."<< std::endl;
     svol.reset();
     return false;
   }

--- a/src/ASM/ASMs3Dmx.C
+++ b/src/ASM/ASMs3Dmx.C
@@ -29,6 +29,7 @@
 #include <array>
 #include <numeric>
 #include <utility>
+#include <exception>
 #ifdef USE_OPENMP
 #include <omp.h>
 #endif
@@ -90,9 +91,20 @@ bool ASMs3Dmx::readBasis (std::istream& is, size_t basis)
     nb.resize(nfx.size(), 0);
   }
 
-  Go::ObjectHeader head;
-  m_basis[--basis] = std::make_shared<Go::SplineVolume>();
-  is >> head >> *m_basis[basis];
+  try
+  {
+    Go::ObjectHeader head;
+    m_basis[--basis] = std::make_shared<Go::SplineVolume>();
+    is >> head >> *m_basis[basis];
+  }
+  catch (const std::exception& e)
+  {
+    std::cerr <<" *** ASMs3Dmx::readBasis: Failure reading splines data ("
+              << e.what() <<")."<< std::endl;
+    m_basis[basis].reset();
+    return false;
+  }
+
   nb[basis] = m_basis[basis]->numCoefs(0) *
               m_basis[basis]->numCoefs(1) *
               m_basis[basis]->numCoefs(2);

--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -42,6 +42,7 @@
 #include <fstream>
 #include <numeric>
 #include <utility>
+#include <exception>
 
 
 ASMu2D::ASMu2D (unsigned char n_s, unsigned char n_f)
@@ -111,8 +112,17 @@ bool ASMu2D::read (std::istream& is)
   }
   else {
     // Probably a SplineSurface, so we'll read that and convert
-    tensorspline = new Go::SplineSurface();
-    is >> *tensorspline;
+    try {
+      tensorspline = new Go::SplineSurface();
+      is >> *tensorspline;
+    }
+    catch (const std::exception& e) {
+      std::cerr <<" *** ASMu2D::read: Failure reading splines data ("
+                << e.what() <<")."<< std::endl;
+      delete tensorspline;
+      tensorspline = nullptr;
+      return false;
+    }
     lrspline.reset(new LR::LRSplineSurface(tensorspline));
   }
 
@@ -127,23 +137,23 @@ bool ASMu2D::read (std::istream& is)
   int readDim = lrspline->dimension();
   if (!is.good() && !is.eof())
   {
-    std::cerr <<" *** ASMu2D::read: Failure reading spline data"<< std::endl;
+    std::cerr <<" *** ASMu2D::read: Failure reading splines data."<< std::endl;
     lrspline.reset();
     return false;
   }
   else if (readDim < 2)
   {
     std::cerr <<" *** ASMu2D::read: Invalid lrspline patch, dim="
-              << readDim << std::endl;
+              << readDim <<"."<< std::endl;
     lrspline.reset();
     return false;
   }
   else if (readDim < nsd)
   {
-    std::cout <<"  ** ASMu2D::read: The dimension of this lrspline patch "
-              << readDim <<" is less than nsd="<< nsd
-              <<".\n                   Resetting nsd to "<< readDim
-              <<" for this patch."<< std::endl;
+    IFEM::cout <<"  ** ASMu2D::read: The dimension of this lrspline patch "
+               << readDim <<" is less than nsd="<< nsd
+               <<".\n                   Resetting nsd to "<< readDim
+               <<" for this patch."<< std::endl;
     nsd = readDim;
   }
 

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -41,6 +41,7 @@
 #include <array>
 #include <numeric>
 #include <utility>
+#include <exception>
 
 
 ASMu3D::ASMu3D (unsigned char n_f)
@@ -108,8 +109,17 @@ bool ASMu3D::read (std::istream& is)
   }
   else {
     // Probably a SplineVolume, so we'll read that and convert
-    tensorspline = new Go::SplineVolume();
-    is >> *tensorspline;
+    try {
+      tensorspline = new Go::SplineVolume();
+      is >> *tensorspline;
+    }
+    catch (const std::exception& e) {
+      std::cerr <<" *** ASMu3D::read: Failure reading splines data ("
+                << e.what() <<")."<< std::endl;
+      delete tensorspline;
+      tensorspline = nullptr;
+      return false;
+    }
     lrspline.reset(new LR::LRSplineVolume(tensorspline));
   }
 
@@ -123,14 +133,14 @@ bool ASMu3D::read (std::istream& is)
 
   if (!is.good() && !is.eof())
   {
-    std::cerr <<" *** ASMu3D::read: Failure reading spline data"<< std::endl;
+    std::cerr <<" *** ASMu3D::read: Failure reading splines data."<< std::endl;
     lrspline.reset();
     return false;
   }
   else if (lrspline->dimension() < 3)
   {
     std::cerr <<" *** ASMu3D::read: Invalid spline volume patch, dim="
-              << lrspline->dimension() << std::endl;
+              << lrspline->dimension() <<"."<< std::endl;
     lrspline.reset();
     return false;
   }


### PR DESCRIPTION
If you, by error, provide an invalid g2-file as the patch geometry, GoTools will just throw an exception and dump without a useful error message. This will catch these exceptions in a better way and abort the program in a controlled manner.