### PR TITLE
Added: New method SIMoutput::openGlv()

### DIFF
--- a/src/SIM/MultiStepSIM.C
+++ b/src/SIM/MultiStepSIM.C
@@ -108,26 +108,18 @@ void MultiStepSIM::setStartGeo (int gID)
 
 bool MultiStepSIM::saveModel (const char* fileName)
 {
-  geoBlk = nBlock = 0; // initialize the VTF block counters
-  return this->saveModel(geoBlk,nBlock,fileName);
+  return model.openGlv(fileName) && this->saveModel();
 }
 
 
-bool MultiStepSIM::saveModel (int& gBlock, int& rBlock,
-                              const char* fileName, bool clearG)
+bool MultiStepSIM::saveModel (double initialTime)
 {
-  PROFILE1("MultiStepSIM::saveModel");
-
   // Reset nViz to 1 if less than 3 parametric dimensions
   for (unsigned short int i = model.getNoParamDim(); i < 3; i++)
     model.opt.nViz[i] = 1;
 
-  // Write VTF-file with model geometry
-  if (!model.writeGlvG(gBlock,fileName,clearG))
-    return false;
-
-  // Write Dirichlet boundary conditions
-  return !saveBCs || model.writeGlvBC(rBlock);
+  geoBlk = nBlock = 0; // initialize the VTF block counters
+  return this->saveModel(geoBlk,nBlock,initialTime);
 }
 
 
@@ -135,8 +127,12 @@ bool MultiStepSIM::saveModel (int& gBlock, int& rBlock, double time)
 {
   PROFILE1("MultiStepSIM::saveModel");
 
-  // Write model geometry and BCs to already opened VTF-file
-  return model.writeGlvG(gBlock,time) && (!saveBCs || model.writeGlvBC(rBlock));
+  // Write VTF-file with model geometry
+  if (!model.writeGlvG(gBlock,time))
+    return false;
+
+  // Write Dirichlet boundary conditions
+  return !saveBCs || model.writeGlvBC(rBlock);
 }
 
 

--- a/src/SIM/MultiStepSIM.h
+++ b/src/SIM/MultiStepSIM.h
@@ -104,20 +104,14 @@ public:
   //! \brief Opens a new VTF-file and writes the model geometry to it.
   //! \param[in] fileName File name used to construct the VTF-file name from
   bool saveModel(const char* fileName);
-
-  //! \brief Opens a new VTF-file and writes the model geometry to it.
-  //! \param gBlock Running geometry block counter
-  //! \param rBlock Running result block counter
-  //! \param[in] fileName File name used to construct the VTF-file name from
-  //! \param[in] clearG If \e true, clear geometry blocks if \a filename is null
-  bool saveModel(int& gBlock, int& rBlock, const char* fileName = nullptr,
-                 bool clearG = true);
-
+  //! \brief Writes the model geometry to the currently opened VTF-file.
+  //! \param[in] initialTime Start- or restart time of the simulation
+  bool saveModel(double initialTime = 0.0);
   //! \brief Writes the model geometry and BCs to an already opened VTF-file.
   //! \param gBlock Running geometry block counter
   //! \param rBlock Running result block counter
   //! \param[in] time Time parameter for evolving grids
-  bool saveModel(int& gBlock, int& rBlock, double time);
+  bool saveModel(int& gBlock, int& rBlock, double time = 0.0);
 
   //! \brief Saves the converged solution to VTF file of a given time/load step.
   //! \param[in] iStep Time/load step identifier

--- a/src/SIM/NonLinSIM.C
+++ b/src/SIM/NonLinSIM.C
@@ -21,8 +21,6 @@
 #include <sstream>
 #include <iomanip>
 
-using namespace SIM;
-
 const char* NonLinSIM::inputContext = "nonlinearsolver";
 
 
@@ -39,7 +37,7 @@ NonLinSIM::NonLinSIM (SIMbase& sim, CNORM n) : MultiStepSIM(sim), iteNorm(n)
   divgLim = 10.0;
   alpha   = alphaO = 1.0;
   eta     = 0.0;
-  saveExL = updNewN = false;
+  updNewN = saveExL = false;
 }
 
 
@@ -153,8 +151,10 @@ bool NonLinSIM::parse (const tinyxml2::XMLElement* elem)
     }
     else if (!strcasecmp(child->Value(),"fromZero"))
       fromIni = true;
+    else if ((value = utl::getValue(child,"updateNewNodes")))
+      updNewN = atoi(value);
     else if (!strcasecmp(child->Value(),"updateNewNodes"))
-      updNewN = true;
+      updNewN = 1;
     else if (!strcasecmp(child->Value(),"printCond"))
       rCond = 0.0; // Compute and report condition number in the iteration log
 
@@ -192,23 +192,27 @@ bool NonLinSIM::advanceStep (TimeStep& param, bool updateTime)
 {
   bool status = this->MultiStepSIM::advanceStep(param,updateTime);
   if (status && updateTime && updNewN && model.hasElementActivator())
-    model.updateForNewElements(solution.front(),param.time);
+    model.updateForNewElements(solution.front(),param.time,updNewN-1);
   this->pushSolution(); // Update solution vectors between time steps
   return status;
 }
 
 
-ConvStatus NonLinSIM::solve (double zero_tol, std::streamsize outPrec)
+SIM::ConvStatus NonLinSIM::solve (double zero_tol, std::streamsize outPrec)
 {
   TimeStep singleStep; // Solves the nonlinear equations in one single step
-  return this->solveStep(singleStep,STATIC,zero_tol,outPrec);
+  return this->solveStep(singleStep,SIM::STATIC,zero_tol,outPrec);
 }
 
 
-ConvStatus NonLinSIM::solveStep (TimeStep& param, SolutionMode mode,
-                                 double zero_tolerance, std::streamsize outPrec)
+SIM::ConvStatus NonLinSIM::solveStep (TimeStep& param,
+                                      SIM::SolutionMode mode,
+                                      double zero_tolerance,
+                                      std::streamsize outPrec)
 {
   PROFILE1("NonLinSIM::solveStep");
+
+  using namespace SIM;
 
   if (solution.empty())
     return FAILURE;
@@ -402,8 +406,10 @@ bool NonLinSIM::lineSearch (TimeStep& param)
 }
 
 
-ConvStatus NonLinSIM::checkConvergence (TimeStep& param)
+SIM::ConvStatus NonLinSIM::checkConvergence (TimeStep& param)
 {
+  using namespace SIM;
+
   if (iteNorm <= NONE)
     return CONVERGED; // No iterations, we are solving a linear problem
 

--- a/src/SIM/NonLinSIM.h
+++ b/src/SIM/NonLinSIM.h
@@ -129,7 +129,7 @@ protected:
   int    nupdat;  //!< Number of iterations with updated tangent
   int    prnSlow; //!< How many DOFs to print out on slow convergence
   bool   saveExL; //!< If \e true, the external load vector will be saved to VTF
-  bool   updNewN; //!< If \e true, update newly activated nodes before new step
+  char   updNewN; //!< If &gt; 0, update newly activated nodes before new step
 
   std::map<int,int> slowNodes; //!< Nodes for which slow convergence is detected
 

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -1008,12 +1008,12 @@ bool SIMbase::hasElementActivator (double t1, double t0) const
 /*!
   The nodes that are connected only to elements that are activated in
   the current (not yet calculated) step, are assigned initial values
-  equal to the mean of the other already activated nodes, that are
-  connected to the newly activated element.
+  equal to the mean of the other already activated nodes,
+  that are connected to the newly activated element.
 */
 
-void SIMbase::updateForNewElements (Vector& solution,
-                                    const TimeDomain& time) const
+void SIMbase::updateForNewElements (Vector& solution, const TimeDomain& time,
+                                    int verbose) const
 {
   // Find all elements and nodes that were active in the previous time step
   IntSet oldElms, oldNodes;
@@ -1049,33 +1049,47 @@ void SIMbase::updateForNewElements (Vector& solution,
             if (oldNodes.find(pch->getNodeID(1+inod)) != oldNodes.end())
             {
               if (++count == 1)
-                oldSol.fill(solution.ptr()+nf*inod);
+                oldSol.fill(pchSol.data()+nf*inod);
               else
-                oldSol.add(Vector(solution.ptr()+nf*inod,nf));
+                oldSol.add(Vector(pchSol.data()+nf*inod,nf));
+              if (verbose > 2)
+              {
+                IFEM::cout <<"\n\tActive node "<< 1+inod <<" ["
+                           << pch->getNodeID(1+inod) <<"]:";
+                for (size_t i = 0; i < nf; i++)
+                  IFEM::cout <<" "<< pchSol[nf*inod+i];
+              }
             }
-          if (count > 1) oldSol /= static_cast<double>(count);
-#ifdef SP_DEBUG
-          std::cout <<"\nAverage solution of new active element "
-                    << pch->getElmID(iel) <<":";
-          for (double v : oldSol) std::cout <<" "<< v;
-#endif
+          if (count > 1)
+            oldSol /= static_cast<double>(count);
+          if (verbose > 0)
+          {
+            IFEM::cout <<"\n  Average solution of new active element "
+                       << pch->getElmID(iel) <<" (from "<< count
+                       <<" of "<< elmNodes.size() <<" nodes):";
+            for (double v : oldSol) IFEM::cout <<" "<< v;
+          }
 
           // Assign this solution to the newly activated nodes
           for (int inod : elmNodes)
             if (int nodeId = pch->getNodeID(1+inod);
                 oldNodes.find(nodeId) == oldNodes.end())
             {
-#ifdef SP_DEBUG
-              std::cout <<"\n\tAssigned to new node "<< nodeId;
-#endif
               double* ptr = solution.ptr() + nf*(nodeId-1);
+              if (verbose > 0)
+                IFEM::cout <<"\n\tAssigned to new node "<< nodeId;
+              if (verbose > 1)
+              {
+                IFEM::cout <<" (replacing";
+                for (size_t i = 0; i < nf; i++) IFEM::cout <<" "<< ptr[i];
+                IFEM::cout <<")";
+              }
               for (size_t i = 0; i < nf; i++, ptr++)
                 if (mySam->getEquation(nodeId,i+1) > 0)
                   *ptr = oldSol[i];
             }
-#ifdef SP_DEBUG
-          std::cout << std::endl;
-#endif
+          if (verbose > 0)
+            IFEM::cout << std::endl;
         }
     }
 }
@@ -2877,6 +2891,7 @@ void SIMbase::dumpSolVec (const Vector& x, bool isExpanded, bool expOnly)
       os << std::setprecision(17);
       double old_tol = utl::zero_print_tol;
       utl::zero_print_tol = dmp.eps;
+
       char vecName[16];
       if (dmp.step.size() == 1)
         strcpy(vecName,"x");
@@ -2885,11 +2900,9 @@ void SIMbase::dumpSolVec (const Vector& x, bool isExpanded, bool expOnly)
       if (dmp.expand == isExpanded)
         StdVector::dump(x,vecName,dmp.format,os);
       else if (mySam)
-      {
-        StdVector solVec;
-        if (mySam->getSolVec(solVec,x))
+        if (StdVector solVec; mySam->getSolVec(solVec,x))
           StdVector::dump(solVec,vecName,dmp.format,os);
-      }
+
       utl::zero_print_tol = old_tol;
     }
 }

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -273,7 +273,9 @@ public:
   //! \brief Modifies the current solution vector when activating elements.
   //! \param solution Current primary solution vector
   //! \param[in] time Parameters for nonlinear/time-dependent simulations
-  void updateForNewElements(Vector& solution, const TimeDomain& time) const;
+  //! \param[in] verbose If &gt;0, print out the newly activated nodes
+  void updateForNewElements(Vector& solution, const TimeDomain& time,
+                            int verbose = 0) const;
 
 
   // Computational methods

--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -658,60 +658,30 @@ bool SIMoutput::getElementSet (int iset, std::string& name,
 }
 
 
-bool SIMoutput::writeGlvG (int& nBlock, const char* inpFile, bool doClear)
+bool SIMoutput::writeGlvG (int& nBlock, const char* inpFile, bool append)
 {
-  if (adm.dd.isPartitioned() && adm.getProcId() != 0)
-    return true; // write VTF-file only for procId=0 when domain decomposition
+  if (inpFile && !this->openGlv(inpFile))
+    return false;
 
-  // Lambda function for creating a new VTF-file name.
-  auto&& getVTFname = [this](const char* inpFile)
-  {
-    char* vtfName = new char[strlen(inpFile)+10];
-    strtok(strcpy(vtfName,inpFile),".");
-    if (!adm.dd.isPartitioned() && nProc > 1)
-      sprintf(vtfName+strlen(vtfName),"_p%04d",myPid);
-#if HAS_VTFAPI == 2
-    strcat(vtfName,".vtfx");
-#else
-    strcat(vtfName,".vtf");
-#endif
-    return vtfName;
-  };
-
-  if (inpFile)
-  {
-    if (myVtf)
-    {
-      std::cerr <<" *** SIMoutput::writeGlvG: Logic error,"
-                <<" VTF file is already opened."<< std::endl;
-      return false;
-    }
-
-    // Open a new VTF-file
-    const char* fName = getVTFname(opt.vtf.empty() ? inpFile : opt.vtf.c_str());
-    IFEM::cout <<"\nWriting VTF-file "<< fName << std::endl;
-    myVtf = new VTF(fName,opt.format);
-    delete[] fName;
-  }
-
-  return this->writeGlvG(nBlock, doClear ? 0.0 : -1.0);
+  return this->writeGlvG(nBlock,0.0,append);
 }
 
 
 /*!
+  This method tesselates the spline patches into linear finite elements with
+  a fixed number of elements within each knot-span of non-zero length.
+  The solution fields are then evaluated at the nodal points of the generated FE
+  mesh and written to the VTF-file as vector and scalar fields by other methods.
+
   When \a time &gt; 0 and there already exist some geometry blocks in the VTF,
   this method assumes that the new geometry blocks are based on the same set of
   nodes such that new node blocks are not required to be written.
 */
 
-bool SIMoutput::writeGlvG (int& nBlock, double time)
+bool SIMoutput::writeGlvG (int& nBlock, double time, bool append)
 {
   if (!myVtf)
-  {
-    std::cerr <<" *** SIMoutput::writeGlvG: Logic error,"
-              <<" VTF file is not opened yet."<< std::endl;
-    return false;
-  }
+    return true; // no VTF output (silently ignore)
 
   // Get the ID list of current node blocks, if any
   IntVec nodeBlocks;
@@ -721,10 +691,10 @@ bool SIMoutput::writeGlvG (int& nBlock, double time)
   {
     for (i = 1; (nodeBlock = myVtf->getNodeBlock(i)); i++)
       nodeBlocks.push_back(nodeBlock);
-    if (mergeVtf) // Get the size of the last node block written
+    if (i > 1 && mergeVtf) // Get the size of the last node block written
       nNodeLast = myVtf->getBlock(i-1)->getNoNodes();
   }
-  if (time >= 0.0)
+  if (!append)
     myVtf->clearGeometryBlocks();
 
   ElementBlock* singlePart = nullptr;
@@ -1912,6 +1882,41 @@ bool SIMoutput::writeGlvE (const Vector& field, int iStep, int& nBlock,
   }
 
   return sID.empty() ? true : myVtf->writeSblk(sID,name,idBlock,iStep,true);
+}
+
+
+bool SIMoutput::openGlv (const char* inpFile)
+{
+  if (myVtf)
+  {
+    std::cerr <<" *** SIMoutput::openGlv: Logic error,"
+              <<" VTF-file is already opened."<< std::endl;
+    return false;
+  }
+  else if (opt.format < 0)
+    return true; // no VTF output in this run
+  else if (adm.dd.isPartitioned() && adm.getProcId() != 0)
+    return true; // write VTF-file only for procId=0 when domain decomposition
+
+  if (!opt.vtf.empty())
+    inpFile = opt.vtf.c_str();
+
+  // Create a valid VTF-file name
+  char* fName = new char[strlen(inpFile)+12];
+  strtok(strcpy(fName,inpFile),".");
+  if (!adm.dd.isPartitioned() && nProc > 1)
+    sprintf(fName+strlen(fName),"_p%04d",myPid);
+#if HAS_VTFAPI == 2
+  strcat(fName,".vtfx");
+#else
+  strcat(fName,".vtf");
+#endif
+
+  // Open a new VTF-file
+  IFEM::cout <<"\nWriting VTF-file "<< fName << std::endl;
+  myVtf = new VTF(fName,opt.format);
+  delete[] fName;
+  return true;
 }
 
 

--- a/src/SIM/SIMoutput.h
+++ b/src/SIM/SIMoutput.h
@@ -72,21 +72,14 @@ public:
   //! \brief Writes current model geometry to the VTF-file.
   //! \param nBlock Running result block counter
   //! \param[in] inpFile File name used to construct the VTF-file name from
-  //! \param[in] doClear If \e true, clear geometry block if \a inpFile is null
-  //!
-  //! \details The spline patches are tesselated into linear finite elements
-  //! with a fixed number of elements within each knot-span of non-zero length.
-  //! The solution fields are then evaluated at the nodal points of the
-  //! generated FE mesh and written to the VTF-file as vector and scalar fields
-  //! by the other \a writeGlv* methods.
-  virtual bool writeGlvG(int& nBlock, const char* inpFile, bool doClear = true);
+  //! \param[in] append If \e true, append new blocks to existing ones, if any
+  bool writeGlvG(int& nBlock, const char* inpFile, bool append = false);
 
   //! \brief Writes current model geometry to the currently open VTF-file.
   //! \param nBlock Running result block counter
-  //! \param[in] time The time from which this (new) geometry applies,
-  //! in case of time-evolution. If negative, the current geometry is appended
-  //! to the already existing geometry blocks.
-  bool writeGlvG(int& nBlock, double time);
+  //! \param[in] time The time from which this (new) geometry applies
+  //! \param[in] append If \e true, append new blocks to existing ones
+  virtual bool writeGlvG(int& nBlock, double time, bool append = false);
 
   //! \brief Writes additional, problem-specific, results to the VTF-file.
   virtual bool writeGlvA(int&, int, double, int = 1) const { return true; }
@@ -242,6 +235,9 @@ public:
   //! \param[in] itype Type identifier of the step
   bool writeGlvStep(int iStep, double value = 0.0, int itype = 0);
 
+  //! \brief Opens a new VTF-file.
+  //! \param[in] inpFile File name used to construct the VTF-file name from
+  bool openGlv(const char* inpFile);
   //! \brief Closes the current VTF-file.
   void closeGlv();
 


### PR DESCRIPTION
Changed: Signature of `SIMoutput::writeGlvG()`, the virtual method now takes the running geometry block counter, the time from which the new geometry applies and an optional `append` flag (replacing the `doClear` argument). The non-virtual method takes the file name as argument instead of time, and can be used for stationary problems, or transient problems on constant geometry. The latter method just calls `opengGlv()` and the virtual `writeGlvG()` method.

Changed: One of the overloaded `MultiStepSIM::saveModel()` is replaced by an instance only taking the time for when the geometry applies as argument. This method is used to account for restart simulations with evolving geometries.