### PR TITLE
Added: Support for merged patches in SIMoutput::writeGlvP()

### DIFF
--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -30,10 +30,9 @@
 bool ASMbase::fixHomogeneousDirichlet = true;
 int  ASMbase::dbgElm = 0;
 
-//! This quantitiy is used to scale the characteristic element sizes which
-//! are used by residual error estimates, etc., such that they always are in
-//! the range [0,1.0]. The applications have to set an appropriate value,
-//! when needed.
+//! This quantity is used to scale the characteristic element sizes which are
+//! used by residual error estimates, etc., such that they always are in the
+//! range [0,1.0]. Applications have to set an appropriate value, when needed.
 double ASMbase::modelSize = 1.0;
 
 int ASMbase::gEl = 0;
@@ -44,15 +43,15 @@ IntVec ASMbase::Empty;
 ASM::CachePolicy ASM::cachePolicy = ASM::PRE_CACHE;
 
 
-/*!
-  \brief Convenience function writing error message for non-implemented methods.
-*/
-
-static bool Aerror (const char* name)
+namespace
 {
-  std::cerr <<" *** ASMbase::"<< name
-	    <<": Must be implemented in sub-class."<< std::endl;
-  return false;
+  //! \brief Helper function writing error message for non-implemented methods.
+  bool Aerror (const char* name)
+  {
+    std::cerr <<" *** ASMbase::"<< name
+              <<": Must be implemented in a sub-class."<< std::endl;
+    return false;
+  }
 }
 
 
@@ -68,6 +67,7 @@ ASMbase::ASMbase (unsigned char n_p, unsigned char n_s, unsigned char n_f)
   idx = 0;
   firstEl = firstIp = 0;
   myElActive = nullptr;
+  active = true;
 }
 
 
@@ -89,6 +89,7 @@ ASMbase::ASMbase (const ASMbase& patch, unsigned char n_f)
   firstIp = patch.firstIp;
   // Note: Properties are _not_ copied
   myElActive = nullptr; // Element activation function is not copied
+  active = true;
 }
 
 
@@ -130,6 +131,7 @@ ASMbase::ASMbase (const ASMbase& patch)
 
   myElActive = nullptr; // Element activation function is not copied
   nLag = 0; // Lagrange multipliers are not copied
+  active = true;
 }
 
 
@@ -448,6 +450,8 @@ void ASMbase::printElements (std::ostream& os) const
 }
 
 
+namespace {
+
 /*!
   \brief A helper class used by ASMbase::isFixed().
   \details The class is just an unary function that checks whether a DOF object
@@ -479,6 +483,7 @@ public:
     return false;
   }
 };
+}
 
 
 bool ASMbase::isFixed (int node, int dof, bool all) const
@@ -1863,17 +1868,29 @@ bool ASMbase::isElementActive (int iel, double time) const
 }
 
 
+/*!
+  If \a time is negative, the cached value \ref active (computed from an earlier
+  call with non-negative time) is used instead. This enables the usage of this
+  method also by callers where the current time is not available.
+*/
+
 bool ASMbase::inActive (double time) const
 {
-  if (myElActive)
+  if (time < 0.0)
+    return !active;
+  else if (myElActive)
   {
-    for (size_t iel = 0; iel < nel; iel++)
+    active = false;
+    for (size_t iel = 0; iel < nel && !active; iel++)
       if (MLGE[iel] > 0 && time+1.0e-12 > (*myElActive)(1+iel))
-        return false; // we have at least one active element
-    return true; // no elements activated at this time
+        active = true; // we have at least one active element
   }
+  else if (myActiveEls)
+    active = !myActiveEls->empty();
+  else
+    active = true;
 
-  return myActiveEls ? myActiveEls->empty() : false;
+  return !active;
 }
 
 

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -348,7 +348,7 @@ public:
   //! \brief Returns \e true if element with 0-based index \a iel is active.
   bool isElementActive(int iel, double time = -1.0) const;
   //! \brief Returns \e true if none of the elements in the patch are active.
-  bool inActive(double time) const;
+  bool inActive(double time = -1.0) const;
   //! \brief Returns the age of the element with 0-based index \a iel.
   double getAge(int iel, double time) const;
   //! \brief Returns \e true if element is in process partition.
@@ -1104,8 +1104,9 @@ private:
   std::vector<char> myLMTypes; //!< Type of %Lagrange multiplier ('L' or 'G')
   std::set<size_t>  myLMs;     //!< Nodal indices of the %Lagrange multipliers
 
-  IntFunc* myElActive; //!< Function returning activatiation time of element
+  IntFunc* myElActive; //!< Function returning activation time of an element
   IntVec* myActiveEls; //!< List of active elements during element assembly
+  mutable bool active; //!< If \e true, the patch is currently active
   static IntVec Empty; //!< Empty integer vector used when a reference is needed
 
 protected:

--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -1103,7 +1103,7 @@ int SIMoutput::writeGlvS1 (const Vector& psol, int iStep, int& nBlock,
   size_t lastActive = 0;
   if (mergeVtf)
     for (const ASMbase* pch : myModel)
-      if (!pch->empty() && !pch->inActive(time))
+      if (!pch->empty() && !pch->inActive())
         lastActive = pch->idx;
 
   Matrix singleField;
@@ -1118,7 +1118,7 @@ int SIMoutput::writeGlvS1 (const Vector& psol, int iStep, int& nBlock,
   {
     if (!this->extractNodeVec(psol,lovec,pch,psolComps%10,empty))
       return -1;
-    else if (pch->empty() || pch->inActive(time))
+    else if (pch->empty() || pch->inActive())
       continue; // skip empty and inactive patches
 
     if (msgLevel > 1)
@@ -1318,7 +1318,7 @@ int SIMoutput::writeGlvS2 (const Vector& psol, int iStep, int& nBlock,
   size_t lastActive = 0;
   if (mergeVtf)
     for (const ASMbase* pch : myModel)
-      if (!pch->empty() && !pch->inActive(time))
+      if (!pch->empty() && !pch->inActive())
         lastActive = pch->idx;
 
   Matrix singleField, projField;
@@ -1333,7 +1333,7 @@ int SIMoutput::writeGlvS2 (const Vector& psol, int iStep, int& nBlock,
   {
     if (!this->extractNodeVec(psol,patchSol,pch,psolComps,empty))
       return -1;
-    else if (pch->empty() || pch->inActive(time))
+    else if (pch->empty() || pch->inActive())
       continue; // skip empty and inactive patches
 
     myProblem->initResultPoints(time,!lastActive); // include principal stresses
@@ -1519,8 +1519,6 @@ bool SIMoutput::writeGlvP (const RealArray& ssol, int iStep, int& nBlock,
 {
   if (ssol.empty() || !myVtf)
     return true; // no projected solution
-  if (mergeVtf && myModel.size() > 1)
-    return true; // not implemented for merged patches, ignore
 
   // Lambda function for updating (patch-wise) maximum result values.
   auto&& updateMaxVal = [](PointValues& maxVal, double res,
@@ -1539,6 +1537,14 @@ bool SIMoutput::writeGlvP (const RealArray& ssol, int iStep, int& nBlock,
   size_t nComp = myProblem->getNoFields(2);
   if (iStep > 0) sID.reserve(nComp);
 
+  // Find the last active patch at current time
+  size_t lastActive = 0;
+  if (mergeVtf)
+    for (const ASMbase* pch : myModel)
+      if (!pch->empty() && !pch->inActive())
+        lastActive = pch->idx;
+
+  Matrix singleField;
   Matrix field;
   Vector lovec;
 
@@ -1546,8 +1552,8 @@ bool SIMoutput::writeGlvP (const RealArray& ssol, int iStep, int& nBlock,
   int geomID = myGeomID;
   for (const ASMbase* pch : myModel)
   {
-    if (pch->empty())
-      continue; // skip empty patches
+    if (pch->empty() || pch->inActive())
+      continue; // skip empty and inactive patches
 
     if (this->fieldProjections())
     {
@@ -1566,6 +1572,19 @@ bool SIMoutput::writeGlvP (const RealArray& ssol, int iStep, int& nBlock,
 
     if (!pch->evalProjSolution(field,lovec,opt.nViz,nComp))
       return false;
+
+    if (lastActive > 0)
+    {
+      // We need to merge the results for all patches before writing them
+      if (singleField.empty())
+        std::swap(singleField,field);
+      else
+        singleField.augmentCols(field);
+      if (lastActive == pch->idx)
+        std::swap(field,singleField);
+      else
+        continue;
+    }
 
     const ElementBlock* grid = myVtf->getBlock(++geomID);
     size_t j = 0;
@@ -1775,7 +1794,7 @@ bool SIMoutput::writeGlvN (const Matrix& norms, int iStep, int& nBlock,
   size_t lastActive = myModel.back()->idx;
   if (mergeVtf)
     for (const ASMbase* pch : myModel)
-      if (!pch->empty() && !pch->inActive(time))
+      if (!pch->empty() && !pch->inActive())
         lastActive = pch->idx;
 
   std::string normName;
@@ -1789,7 +1808,7 @@ bool SIMoutput::writeGlvN (const Matrix& norms, int iStep, int& nBlock,
   for (size_t pidx = 0; pidx < myModel.size(); pidx++)
   {
     const ASMbase* pch = myModel[pidx];
-    if (pch->empty() || pch->inActive(time))
+    if (pch->empty() || pch->inActive())
       continue; // skip empty and inactive patches
 
     if (msgLevel > 1)


### PR DESCRIPTION
Whether a patch has any active elements or not is stored as a bool flag in ASMbase (updated when writing VTF-geometry) such that whenever some results are saved later at the sme time step, it can be done without knowing the current time.