### PR TITLE
Support projection with element activation

### DIFF
--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -691,11 +691,11 @@ public:
   virtual bool evaluate(const Field* f, RealArray& vec, int basisNum = 1) const;
 
   //! \brief Evaluates and interpolates a scalar function over a given geometry.
-  //! \param[in] f The function to evaluate
+  //! \param[in] func The function to evaluate
   //! \param[out] vec The obtained coefficients after interpolation
   //! \param[in] basisNum The basis to evaluate for (mixed)
   //! \param[in] time Current time
-  virtual bool evaluate(const FunctionBase* f, RealArray& vec,
+  virtual bool evaluate(const FunctionBase* func, RealArray& vec,
                         int basisNum = 1, double time = 0.0) const;
 
   //! \brief Evaluates the secondary solution field at all visualization points.
@@ -768,19 +768,19 @@ public:
 
   //! \brief Projects an explicit function using a continuous global L2-fit.
   //! \param[out] fVals Control point values of the function
-  //! \param[in] function The function to project
+  //! \param[in] func The function to project
   //! \param[in] t Current time
   //!
   //! \note The implementation of this method is placed in GlbL2projector.C
-  bool L2projection(Matrix& fVals, FunctionBase* function, double t = 0.0);
+  bool L2projection(Matrix& fVals, FunctionBase* func, double t = 0.0);
   //! \brief Projects explicit functions using a continuous global L2-fit.
   //! \param[out] fVals Control point values of the functions
-  //! \param[in] function The functions to project
+  //! \param[in] funcs The functions to project
   //! \param[in] t Current time
   //!
   //! \note The implementation of this method is placed in GlbL2projector.C
   bool L2projection(const std::vector<Matrix*>& fVals,
-                    const std::vector<FunctionBase*>& function, double t = 0.0);
+                    const std::vector<FunctionBase*>& funcs, double t = 0.0);
 
   //! \brief Returns the number of projection nodes for this patch.
   virtual size_t getNoProjectionNodes() const { return this->getNoNodes(1); }

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -1779,10 +1779,16 @@ bool ASMs1D::assembleL2matrices (SystemMatrix& A, SystemVector& B,
                                  const L2Integrand& integrand,
                                  bool continuous) const
 {
-  const size_t nnod = this->getNoProjectionNodes();
-  const int p1 = proj->order();
+  const bool checkAge = this->getElementActivator() != nullptr;
+  if (proj != curv && checkAge)
+  {
+    std::cerr <<" *** ASMs1D::assembleL2matrices: Separate projection basis "
+              <<" can not be used with element activation."<< std::endl;
+    return false;
+  }
 
   // Get Gaussian quadrature point coordinates (and weights if continuous)
+  const int     p1 = proj->order();
   const int     ng = continuous ? this->getNoGaussPt(p1,true) : p1 - 1;
   const double* xg = GaussQuadrature::getCoord(ng);
   const double* wg = continuous ? GaussQuadrature::getWeight(ng) : nullptr;
@@ -1807,6 +1813,7 @@ bool ASMs1D::assembleL2matrices (SystemMatrix& A, SystemVector& B,
 
   const IntVec& mlge = projMLGE.empty() ? MLGE : projMLGE;
   const IntMat& mnpc = projMNPC.empty() ? MNPC : projMNPC;
+  const size_t npnod = this->getNoProjectionNodes();
 
 
   // === Assembly loop over all elements in the patch ==========================
@@ -1815,6 +1822,8 @@ bool ASMs1D::assembleL2matrices (SystemMatrix& A, SystemVector& B,
   for (size_t iel = 0; iel < mlge.size(); iel++)
   {
     if (mlge[iel] < 1) continue; // zero-length element
+    if (checkAge && !this->isElementActive(iel,integrand.getTimeLevel()))
+      continue; // inactive element
 
     if (continuous)
     {
@@ -1857,7 +1866,7 @@ bool ASMs1D::assembleL2matrices (SystemMatrix& A, SystemVector& B,
         eB[r-1].add(phi,sField(r,ip+1)*dJw);
 
       A.assemble(eA, mnpc[iel]);
-      B.assemble(eB, mnpc[iel], nnod);
+      B.assemble(eB, mnpc[iel], npnod);
     }
   }
 

--- a/src/ASM/ASMs2DLag.C
+++ b/src/ASM/ASMs2DLag.C
@@ -1089,21 +1089,29 @@ bool ASMs2DLag::assembleL2matrices (SystemMatrix& A, SystemVector& B,
                                     const L2Integrand& integrand,
                                     bool continuous) const
 {
+  const Go::SplineSurface* srf = this->getBasis(ASM::PROJECTION_BASIS);
+  const bool checkAge = this->getElementActivator() != nullptr;
+  if (srf != surf.get() && checkAge)
+  {
+    std::cerr <<" *** ASMs2DLag::assembleL2matrices: Separate projection basis "
+              <<" can not be used with element activation."<< std::endl;
+    return false;
+  }
+
   ASMs2D::BasisFunctionCache& cache = *myCache.front();
   cache.init(1);
 
   const std::array<const double*,2>& wg = cache.weight();
   const std::array<int,2> nGP = cache.nGauss();
 
+  const int pp1 = srf->order_u();
+  const int pp2 = srf->order_v();
+  const int nelx = (nx-1) / (pp1-1);
+  const int neln = pp1*pp2;
+
+  const size_t npnod = this->getNoProjectionNodes();
   const IntMat gmnpc = this->getElmNodes(ASM::PROJECTION_BASIS);
   A.preAssemble(gmnpc, gmnpc.size());
-
-  const Go::SplineSurface* srf = this->getBasis(ASM::PROJECTION_BASIS);
-  const int p1 = srf->order_u();
-  const int p2 = srf->order_v();
-  const int nelx = (nx-1) / (p1-1);
-
-  const size_t nnod = this->getNoProjectionNodes();
 
 
   // === Assembly loop over all elements in the patch ==========================
@@ -1114,7 +1122,11 @@ bool ASMs2DLag::assembleL2matrices (SystemMatrix& A, SystemVector& B,
     for (const IntVec& group : projThreadGroups[g])
     {
       Matrix dNdX, Xnod, J;
-      for (int iel : group) {
+      for (int iel : group)
+      {
+        if (checkAge && !this->isElementActive(iel,integrand.getTimeLevel()))
+          continue; // inactive element
+
         if (!this->getElementCoordinates(Xnod,1+iel)) {
           ok = false;
           continue;
@@ -1122,6 +1134,7 @@ bool ASMs2DLag::assembleL2matrices (SystemMatrix& A, SystemVector& B,
 
         const int i1 = nelx > 0 ? iel % nelx : 0;
         const int i2 = nelx > 0 ? iel / nelx : 0;
+
         std::array<RealArray,2> GP;
         GP[0].reserve(nGP[0]*nGP[1]);
         GP[1].reserve(nGP[0]*nGP[1]);
@@ -1136,8 +1149,8 @@ bool ASMs2DLag::assembleL2matrices (SystemMatrix& A, SystemVector& B,
 
         // --- Integration loop over all Gauss points in each direction --------
 
-        Matrix eA(p1*p2, p1*p2);
-        Vectors eB(sField.rows(), Vector(p1*p2));
+        Matrix eA(neln,neln);
+        Vectors eB(sField.rows(), Vector(neln));
         size_t ip = 0;
         for (int j = 0; j < nGP[1]; ++j)
           for (int i = 0; i < nGP[0]; ++i, ++ip) {
@@ -1157,7 +1170,7 @@ bool ASMs2DLag::assembleL2matrices (SystemMatrix& A, SystemVector& B,
           }
 
         A.assemble(eA, gmnpc[iel]);
-        B.assemble(eB, gmnpc[iel], nnod);
+        B.assemble(eB, gmnpc[iel], npnod);
       }
     }
 

--- a/src/ASM/ASMs2Drecovery.C
+++ b/src/ASM/ASMs2Drecovery.C
@@ -158,18 +158,22 @@ bool ASMs2D::assembleL2matrices (SystemMatrix& A, SystemVector& B,
                                  const L2Integrand& integrand,
                                  bool continuous) const
 {
-  const size_t nnod = this->getNoProjectionNodes();
-
-  const Go::SplineSurface* geo = this->getBasis(ASM::GEOMETRY_BASIS);
+  const Go::SplineSurface* geo  = this->getBasis(ASM::GEOMETRY_BASIS);
   const Go::SplineSurface* proj = this->getBasis(ASM::PROJECTION_BASIS);
   const bool separateProjBasis = proj != geo;
   const bool singleBasis = !separateProjBasis && this->getNoBasis() == 1;
+  const bool checkAge = this->getElementActivator() != nullptr;
+  if (separateProjBasis && checkAge)
+  {
+    std::cerr <<" *** ASMs2D::assembleL2matrices: Separate projection basis "
+              <<" can not be used with element activation."<< std::endl;
+    return false;
+  }
 
   const int p1 = proj->order_u();
   const int p2 = proj->order_v();
   const int n1 = proj->numCoefs_u();
-  int nel1 = proj->numCoefs_u() - p1 + 1;
-
+  const int nel1 = n1 - p1 + 1;
   const int pmax = p1 > p2 ? p1 : p2;
 
   // Get Gaussian quadrature point coordinates (and weights if continuous)
@@ -204,8 +208,10 @@ bool ASMs2D::assembleL2matrices (SystemMatrix& A, SystemVector& B,
     return false;
   }
 
+  const size_t npnod = this->getNoProjectionNodes();
   const IntMat gmnpc = this->getElmNodes(ASM::PROJECTION_BASIS);
   A.preAssemble(gmnpc, gmnpc.size());
+
 
   // === Assembly loop over all elements in the patch ==========================
 
@@ -219,40 +225,46 @@ bool ASMs2D::assembleL2matrices (SystemMatrix& A, SystemVector& B,
       Matrix dNdu, Xnod, J;
       for (int iel : projThreadGroups[g][t])
       {
-        int i1 = iel % nel1;
-        int i2 = iel / nel1;
-        int ip = (i2*ng1*nel1 + i1)*ng2;
+        if (checkAge && !this->isElementActive(iel,integrand.getTimeLevel()))
+          continue; // inactive element
+
         const IntVec& mnpc = gmnpc[iel];
         if (mnpc.empty())
           continue;
 
+        int i1 = iel % nel1;
+        int i2 = iel / nel1;
+        int ip = (i2*ng1*nel1 + i1)*ng2;
+
         if (continuous)
         {
           // Set up control point (nodal) coordinates for current element
+          bool skip = false;
           if (singleBasis)
           {
-            if (!this->getElementCoordinates(Xnod,1+iel)) {
-              ok = false;
-              continue;
-            } else if ((dA = this->getParametricArea(1+iel)) < 0.0) {
-              ok = false;
-              continue;
-            }
+            if (!this->getElementCoordinates(Xnod,1+iel))
+              skip = true;
+            if ((dA = 0.25*this->getParametricArea(1+iel)) < 0.0)
+              skip = true;
           }
           else
           {
-            if (!this->getElementCoordinatesPrm(Xnod,gpar[0][i1*ng1],gpar[1][i2*ng2])) {
-              ok = false;
-              continue;
-            } else if ((dA = 0.25 * proj->knotSpan(0,mnpc.back() % n1)
-                                  * proj->knotSpan(1,mnpc.back() / n1)) < 0.0) {
-              ok = false;
-              continue; // topology error (probably logic error)
-            }
+            if (!this->getElementCoordinatesPrm(Xnod,
+                                                gpar[0][i1*ng1],
+                                                gpar[1][i2*ng2]))
+              skip = true;
+            if ((dA = 0.25 * proj->knotSpan(0,mnpc.back() % n1)
+                           * proj->knotSpan(1,mnpc.back() / n1)) < 0.0)
+              skip = true; // topology error (probably logic error)
+          }
+          if (skip)
+          {
+            ok = false;
+            continue;
           }
         }
 
-        // --- Integration loop over all Gauss points in each direction ----------
+        // --- Integration loop over all Gauss points in each direction --------
 
         Matrix eA(p1*p2, p1*p2);
         Vectors eB(sField.rows(), Vector(p1*p2));
@@ -282,30 +294,11 @@ bool ASMs2D::assembleL2matrices (SystemMatrix& A, SystemVector& B,
           }
 
         A.assemble(eA, mnpc);
-        B.assemble(eB, mnpc, nnod);
+        B.assemble(eB, mnpc, npnod);
       }
     }
 
   return ok;
-}
-
-
-/*!
-  \brief Evaluates monomials in 2D up to the specified order.
-*/
-
-static void evalMonomials (int p1, int p2, double x, double y, Vector& P)
-{
-  P.resize(p1*p2);
-  P.fill(1.0);
-
-  int i, j, k, ip = 1;
-  for (j = 0; j < p2; j++)
-    for (i = 0; i < p1; i++, ip++)
-    {
-      for (k = 0; k < i; k++) P(ip) *= x;
-      for (k = 0; k < j; k++) P(ip) *= y;
-    }
 }
 
 
@@ -351,6 +344,21 @@ Go::SplineSurface* ASMs2D::scRecovery (const IntegrandBase& integrand) const
 
   const size_t nCmp = sField.rows(); // Number of result components
   const size_t nPol = (n1+1)*(n2+1); // Number of terms in polynomial expansion
+
+  // Lambda functions evaluating the monomials in 2D up to the specified order.
+  auto evalMonomials = [n1,n2,nPol](double x, double y, Vector& P)
+  {
+    P.resize(nPol);
+    P.fill(1.0);
+
+    int i, j, k, ip = 1;
+    for (j = 0; j <= n2; j++)
+      for (i = 0; i <= n1; i++, ip++)
+      {
+        for (k = 0; k < i; k++) P(ip) *= x;
+        for (k = 0; k < j; k++) P(ip) *= y;
+      }
+  };
 
   Matrix sValues(nCmp,gpar[0].size()*gpar[1].size());
   Vector P(nPol);
@@ -402,7 +410,7 @@ Go::SplineSurface* ASMs2D::scRecovery (const IntegrandBase& integrand) const
 
 		  // Evaluate the polynomial expansion at current Gauss point
 		  surf->point(X,u,v);
-		  evalMonomials(n1+1,n2+1,X[0]-G[0],X[1]-G[1],P);
+		  evalMonomials(X[0]-G[0],X[1]-G[1],P);
 
 #if SP_DEBUG > 1
 		  std::cout <<"Itg. point "<< i <<","<< j <<" (u,v) = "

--- a/src/ASM/ASMs3DLag.C
+++ b/src/ASM/ASMs3DLag.C
@@ -1430,36 +1430,54 @@ bool ASMs3DLag::assembleL2matrices (SystemMatrix& A, SystemVector& B,
                                     const L2Integrand& integrand,
                                     bool continuous) const
 {
-  BasisFunctionCache& cache = static_cast<BasisFunctionCache&>(*myCache.front());
+  const Go::SplineVolume* sv = this->getBasis(ASM::PROJECTION_BASIS);
+  const bool checkAge = this->getElementActivator() != nullptr;
+  if (sv != svol.get() && checkAge)
+  {
+    std::cerr <<" *** ASMs3DLag::assembleL2matrices: Separate projection basis "
+              <<" can not be used with element activation."<< std::endl;
+    return false;
+  }
+
+  ASMs3D::BasisFunctionCache& cache = *myCache.front();
   cache.init(1);
 
   const std::array<const double*,3>& wg = cache.weight();
   const std::array<int,3> nGP = cache.nGauss();
 
+  const int pp1 = sv->order(0);
+  const int pp2 = sv->order(1);
+  const int pp3 = sv->order(2);
+  const int nelx = (nx-1) / (pp1-1);
+  const int nely = (ny-1) / (pp2-1);
+  const int neln = pp1*pp2*pp3;
+
+  const size_t npnod = this->getNoProjectionNodes();
   const IntMat gmnpc = this->getElmNodes(ASM::PROJECTION_BASIS);
   A.preAssemble(gmnpc, gmnpc.size());
 
-  const size_t nnod = this->getNoProjectionNodes();
-
-  const int nel1 = (nx-1)/(p1-1);
-  const int nel2 = (ny-1)/(p2-1);
 
   // === Assembly loop over all elements in the patch ==========================
+
   bool ok = true;
   for (size_t g = 0; g < projThreadGroups.size() && ok; g++)
 #pragma omp parallel for schedule(static)
     for (const IntVec& group : projThreadGroups[g])
     {
       Matrix dNdX, Xnod, J;
-      for (int iel : group) {
+      for (int iel : group)
+      {
+        if (checkAge && !this->isElementActive(iel,integrand.getTimeLevel()))
+          continue; // inactive element
+
         if (!this->getElementCoordinates(Xnod,1+iel)) {
           ok = false;
           continue;
         }
 
-        int i1 = nel1*nel2 > 0 ?  iel % nel1         : 0;
-        int i2 = nel1*nel2 > 0 ? (iel / nel1) % nel2 : 0;
-        int i3 = nel1*nel2 > 0 ?  iel / (nel1*nel2)  : 0;
+        const int i1 = nelx*nely > 0 ?  iel % nelx         : 0;
+        const int i2 = nelx*nely > 0 ? (iel / nelx) % nely : 0;
+        const int i3 = nelx*nely > 0 ?  iel / (nelx*nely)  : 0;
 
         std::array<RealArray,3> GP;
         GP[0].reserve(nGP[0]*nGP[1]*nGP[2]);
@@ -1478,16 +1496,18 @@ bool ASMs3DLag::assembleL2matrices (SystemMatrix& A, SystemVector& B,
 
         // --- Integration loop over all Gauss points in each direction --------
 
-        Matrix eA(p1*p2*p3, p1*p2*p3);
-        Vectors eB(sField.rows(), Vector(p1*p2*p3));
+        Matrix eA(neln,neln);
+        Vectors eB(sField.rows(), Vector(neln));
         size_t ip = 0;
         for (int k = 0; k < nGP[2]; ++k)
           for (int j = 0; j < nGP[1]; ++j)
             for (int i = 0; i < nGP[0]; ++i, ++ip) {
               const BasisFunctionVals& bfs = cache.getVals(iel,ip);
 
-              double dJw = (wg[0][i]*wg[1][j]*wg[2][k] *
-                            utl::Jacobian(J,dNdX,Xnod,bfs.dNdu));
+              double dJw = utl::Jacobian(J,dNdX,Xnod,bfs.dNdu);
+              if (dJw == 0.0) continue; // skip singular points
+
+              dJw *= wg[0][i]*wg[1][j]*wg[2][k];
 
               // Integrate the mass matrix
               eA.outer_product(bfs.N, bfs.N, true, dJw);
@@ -1497,9 +1517,8 @@ bool ASMs3DLag::assembleL2matrices (SystemMatrix& A, SystemVector& B,
                 eB[r-1].add(bfs.N,sField(r,ip+1)*dJw);
             }
 
-        const IntVec& mnpc = gmnpc[iel];
-        A.assemble(eA, mnpc);
-        B.assemble(eB, mnpc, nnod);
+        A.assemble(eA, gmnpc[iel]);
+        B.assemble(eB, gmnpc[iel], npnod);
       }
     }
 

--- a/src/ASM/ASMs3Drecovery.C
+++ b/src/ASM/ASMs3Drecovery.C
@@ -158,12 +158,17 @@ bool ASMs3D::assembleL2matrices (SystemMatrix& A, SystemVector& B,
                                  const L2Integrand& integrand,
                                  bool continuous) const
 {
-  const size_t nnod = this->getNoProjectionNodes();
-
-  const Go::SplineVolume* geo = this->getBasis(ASM::GEOMETRY_BASIS);
+  const Go::SplineVolume* geo  = this->getBasis(ASM::GEOMETRY_BASIS);
   const Go::SplineVolume* proj = this->getBasis(ASM::PROJECTION_BASIS);
   const bool separateProjBasis = proj != geo;
   const bool singleBasis = !separateProjBasis && this->getNoBasis() == 1;
+  const bool checkAge = this->getElementActivator() != nullptr;
+  if (separateProjBasis && checkAge)
+  {
+    std::cerr <<" *** ASMs3D::assembleL2matrices: Separate projection basis "
+              <<" can not be used with element activation."<< std::endl;
+    return false;
+  }
 
   const int p1 = proj->order(0);
   const int p2 = proj->order(1);
@@ -212,10 +217,13 @@ bool ASMs3D::assembleL2matrices (SystemMatrix& A, SystemVector& B,
     return false;
   }
 
+  const size_t npnod = this->getNoProjectionNodes();
   const IntMat gmnpc = this->getElmNodes(ASM::PROJECTION_BASIS);
   A.preAssemble(gmnpc, gmnpc.size());
 
+
   // === Assembly loop over all elements in the patch ==========================
+
   bool ok = true;
   for (size_t g = 0; g < projThreadGroups.size() && ok; g++)
 #pragma omp parallel for schedule(static)
@@ -225,37 +233,45 @@ bool ASMs3D::assembleL2matrices (SystemMatrix& A, SystemVector& B,
       Matrix dNdu, Xnod, J;
       for (int iel : projThreadGroups[g][t])
       {
-        int i1 = iel % nel1;
-        int i2 = (iel / nel1) % nel2;
-        int i3 = iel / (nel1*nel2);
+        if (checkAge && !this->isElementActive(iel,integrand.getTimeLevel()))
+          continue; // inactive element
 
-        int ip = ((i3*ng2*nel2 + i2)*ng1*nel1 + i1)*ng3;
         const IntVec& mnpc = gmnpc[iel];
         if (mnpc.empty())
           continue;
 
+        int i1 = iel % nel1;
+        int i2 = (iel / nel1) % nel2;
+        int i3 = iel / (nel1*nel2);
+        int ip = ((i3*ng2*nel2 + i2)*ng1*nel1 + i1)*ng3;
+
         if (continuous)
         {
           // Set up control point (nodal) coordinates for current element
-          if (singleBasis) {
-            if (!this->getElementCoordinates(Xnod,1+iel)) {
-              ok = false;
-              continue;
-            } else if ((dV = 0.125*this->getParametricVolume(1+iel)) < 0.0) {
-              ok = false;
-              continue; // topology error (probably logic error)
-            }
-          } else {
-            if (!this->getElementCoordinatesPrm(Xnod,gpar[0][i1*ng1],
-                                                gpar[1][i2*ng2],gpar[2][i3*ng3])) {
-              ok = false;
-              continue;
-            } else if ((dV = 0.125 * proj->knotSpan(0, mnpc.back() % n1)
-                                   * proj->knotSpan(1,(mnpc.back() / n1) % n2)
-                                   * proj->knotSpan(2, mnpc.back() / (n1*n2))) < 0.0) {
-              ok = false;
-              continue;
-            }
+          bool skip = false;
+          if (singleBasis)
+          {
+            if (!this->getElementCoordinates(Xnod,1+iel))
+              skip = true;
+            if ((dV = 0.125*this->getParametricVolume(1+iel)) < 0.0)
+              skip = true; // topology error (probably logic error)
+          }
+          else
+          {
+            if (!this->getElementCoordinatesPrm(Xnod,
+                                                gpar[0][i1*ng1],
+                                                gpar[1][i2*ng2],
+                                                gpar[2][i3*ng3]))
+              skip = true;
+            if ((dV = 0.125 * proj->knotSpan(0, mnpc.back() % n1)
+                            * proj->knotSpan(1,(mnpc.back() / n1) % n2)
+                            * proj->knotSpan(2, mnpc.back() / (n1*n2))) < 0.0)
+              skip = true;
+          }
+          if (skip)
+          {
+            ok = false;
+            continue;
           }
         }
 
@@ -290,7 +306,7 @@ bool ASMs3D::assembleL2matrices (SystemMatrix& A, SystemVector& B,
             }
 
         A.assemble(eA, mnpc);
-        B.assemble(eB, mnpc, nnod);
+        B.assemble(eB, mnpc, npnod);
       }
     }
 

--- a/src/ASM/GlbL2projector.C
+++ b/src/ASM/GlbL2projector.C
@@ -7,7 +7,7 @@
 //!
 //! \author Knut Morten Okstad / SINTEF
 //!
-//! \brief General integrand for L2-projection of secondary solutions.
+//! \brief General integrands for global L2-projection.
 //!
 //==============================================================================
 
@@ -28,10 +28,18 @@
 #include "LinSolParams.h"
 #include "ProcessAdm.h"
 #endif
+#include <numeric>
 
 
-LinAlg::MatrixType GlbL2::MatrixType   = LinAlg::SPARSE;
-LinSolParams*      GlbL2::SolverParams = nullptr;
+namespace GlbL2
+{
+  //! Matrix type for global L2-projection (version 1 only)
+  LinAlg::MatrixType MatrixType = LinAlg::SPARSE;
+  //! Linear solver parameters for the global L2-projection (version 1 only)
+  LinSolParams* SolverParams = nullptr;
+  //! Process administrator for the global L2-projection (version 1 only)
+  const ProcessAdm* Adm = nullptr;
+}
 
 
 namespace
@@ -103,10 +111,10 @@ namespace
 
 
 L2ProbIntegrand::L2ProbIntegrand (const ASMbase& patch,
-                                  const IntegrandBase& itg,
-                                  const ProcessAdm& adm) :
-  L2Integrand(patch, adm), m_itg(itg)
+                                  const IntegrandBase& itg)
+  : L2Integrand(patch), m_itg(itg)
 {
+  myTime = itg.getTimeLevel();
 }
 
 
@@ -123,10 +131,10 @@ size_t L2ProbIntegrand::dim () const
 
 
 L2FuncIntegrand::L2FuncIntegrand (const ASMbase& patch,
-                                  const FunctionBase& func,
-                                  const ProcessAdm& adm) :
-  L2Integrand(patch, adm), m_func(func)
+                                  const FunctionBase& func, double time)
+  : L2Integrand(patch), m_func(func)
 {
+  myTime = time;
 }
 
 
@@ -148,7 +156,7 @@ bool L2FuncIntegrand::evaluate (Matrix& sField, const RealArray* gpar) const
 
   double xi[3];    // Normalized spline domain parameters always in [0,1]
   double param[3]; // Actual domain parameters to be used for evaluation
-  Vec4   X(param);
+  Vec4   X(param,myTime);
   for (size_t i = 0; i < gpar[0].size(); ++i) {
     for (size_t j = 0; j < 3 && j < m_patch.getNoSpaceDim(); ++j)
       xi[j] = u[j][0] + gpar[j][i] / (u[j][1] - u[j][0]);
@@ -166,308 +174,362 @@ size_t L2FuncIntegrand::dim () const
 }
 
 
-/*!
-  \brief Local integral container class for L2-projections.
-*/
-
-class L2Mats : public ElmMats
+namespace
 {
-public:
-  //! \brief The constructor initializes pointers and references.
-  //! \param[in] p The global L2 integrand object containing projection matrices
-  //! \param[in] nen Number of element nodes
-  //! \param[in] nf Number of field components
-  //! \param[in] q Pointer to element data associated with the problem integrand
-  L2Mats(GlbL2& p, size_t nen, size_t nf, LocalIntegral* q = nullptr)
-    : gl2Int(p), elmData(q)
+  using uIntVec = std::vector<size_t>; //!< Convenience type alias
+
+  class GL2;
+
+
+  /*!
+    \brief Local integral container class for L2-projections (version 2).
+  */
+
+  class L2Mats : public ElmMats
   {
-    this->resize(1,nf);
-    this->redim(nen);
-  }
-
-  //! \brief Empty destructor.
-  virtual ~L2Mats() {}
-
-  //! \brief Destruction method to clean up after numerical integration.
-  virtual void destruct() { delete elmData; delete this; }
-
-  GlbL2&         gl2Int;  //!< The global L2-projection integrand
-  LocalIntegral* elmData; //!< Element data associated with problem integrand
-
-  IntVec  mnpc;        //!< Matrix of element nodal correspondance
-  uIntVec elem_sizes;  //!< Size of each basis on the element
-  uIntVec basis_sizes; //!< Size of each basis on the patch
-};
-
-
-/*!
-  \brief Global integral container class for L2-projections.
-*/
-
-class L2GlobalInt : public GlobalIntegral
-{
-public:
-  //! \brief The constructor initializes the system matrix references.
-  L2GlobalInt(SparseMatrix& A_, StdVector& B_) : A(A_), B(B_) {}
-
-  //! \brief Empty destructor.
-  virtual ~L2GlobalInt() {}
-
-  //! \brief Adds a LocalIntegral object into a corresponding global object.
-  virtual bool assemble(const LocalIntegral* elmObj, int)
-  {
-    const L2Mats* elm = static_cast<const L2Mats*>(elmObj);
-    for (size_t i = 0; i < elm->mnpc.size(); i++)
+  public:
+    //! \brief The constructor initializes pointers and references.
+    //! \param[in] p Global L2 integrand object containing projection matrices
+    //! \param[in] iEl Global element number (1-based)
+    //! \param[in] nen Number of element nodes
+    //! \param[in] nf Number of field components
+    //! \param[in] q The main problem integrand
+    L2Mats(GL2& p, size_t iEl, size_t nen, size_t nf, Integrand* q)
+      : gl2Int(p)
     {
-      int inod = elm->mnpc[i]+1;
-      for (size_t j = 0; j < elm->mnpc.size(); j++)
-      {
-        int jnod = elm->mnpc[j]+1;
-        A(inod,jnod) += elm->A.front()(i+1,j+1);
-      }
-      for (const Vector& b : elm->b)
-      {
-        B(inod) += b[i];
-        inod += A.dim();
-      }
+      elmData = q ? q->getLocalIntegral(nen,iEl) : nullptr;
+      this->resize(1,nf);
+      this->redim(nen);
     }
-    return true;
-  }
 
-private:
-  SparseMatrix& A; //!< Reference to left-hand-side matrix
-  StdVector&    B; //!< Reference to right-hand-side vector
-};
+    //! \brief Destruction method to clean up after numerical integration.
+    void destruct() override { delete elmData; delete this; }
 
+    GL2&           gl2Int;  //!< The global L2-projection integrand
+    LocalIntegral* elmData; //!< Element data associated with problem integrand
 
-GlbL2::GlbL2 (IntegrandBase* p, size_t n) : problem(p)
-{
-  nrhs = p->getNoFields(2);
-  this->allocate(n);
-}
+    IntVec  mnpc;        //!< Matrix of element nodal correspondance
+    uIntVec elem_sizes;  //!< Size of each basis on the element
+    uIntVec basis_sizes; //!< Size of each basis on the patch
+  };
 
 
-GlbL2::GlbL2 (FunctionBase* f, size_t n) : problem(nullptr), functions({f})
-{
-  nrhs = f->dim();
-  this->allocate(n);
-}
+  /*!
+    \brief General integrand for L2-projection of secondary solutions.
+    \details This class is used only for version 2 of the L2-projection.
+  */
 
-
-GlbL2::GlbL2 (const FunctionVec& f, size_t n) : problem(nullptr), functions(f)
-{
-  nrhs = 0;
-  for (FunctionBase* func : f)
-    nrhs += func->dim();
-  this->allocate(n);
-}
-
-
-GlbL2::~GlbL2()
-{
-  delete pA;
-  delete pB;
-}
-
-
-void GlbL2::allocate (size_t n)
-{
-  pA = new SparseMatrix(SparseMatrix::SUPERLU);
-  pB = new StdVector(n*nrhs);
-  static_cast<SparseMatrix*>(pA)->redim(n,n);
-}
-
-
-int GlbL2::getIntegrandType () const
-{
-  if (problem)
-    // Mask off the element interface flag
-    return problem->getIntegrandType() & ~INTERFACE_TERMS;
-  else
-    return STANDARD;
-}
-
-
-LocalIntegral* GlbL2::getLocalIntegral (size_t nen, size_t iEl,
-                                        bool neumann) const
-{
-  if (problem)
-    return new L2Mats(*const_cast<GlbL2*>(this),nen,nrhs,
-                      problem->getLocalIntegral(nen,iEl,neumann));
-  else
-    return new L2Mats(*const_cast<GlbL2*>(this),nen,nrhs);
-}
-
-
-bool GlbL2::initElement (const IntVec& MNPC, const FiniteElement& fe,
-                         const Vec3& Xc, size_t nPt,
-                         LocalIntegral& elmInt)
-{
-  L2Mats& gl2 = static_cast<L2Mats&>(elmInt);
-
-  gl2.mnpc = MNPC;
-  if (problem && gl2.elmData)
-    return problem->initElement(MNPC,fe,Xc,nPt,*gl2.elmData);
-  else
-    return true;
-}
-
-
-bool GlbL2::initElement (const IntVec& MNPC1,
-                         const MxFiniteElement& fe,
-                         const uIntVec& elem_sizes,
-                         const uIntVec& basis_sizes,
-                         LocalIntegral& elmInt)
-{
-  L2Mats& gl2 = static_cast<L2Mats&>(elmInt);
-
-  gl2.mnpc = MNPC1;
-  gl2.elem_sizes = elem_sizes;
-  gl2.basis_sizes = basis_sizes;
-  if (problem && gl2.elmData)
-    return problem->initElement(MNPC1,fe,elem_sizes,basis_sizes,*gl2.elmData);
-  else
-    return true;
-}
-
-
-bool GlbL2::evalInt (LocalIntegral& elmInt,
-                     const FiniteElement& fe,
-                     const Vec3& X) const
-
-{
-  L2Mats& gl2 = static_cast<L2Mats&>(elmInt);
-
-  Vector solPt;
-  solPt.reserve(nrhs);
-  if (problem)
+  class GL2 : public Integrand
   {
-    if (!problem->evalSol(solPt,fe,X,gl2.mnpc))
-      if (!problem->diverged(fe.iGP+1))
+    using FunctionVec = std::vector<FunctionBase*>; //!< Convenience type alias
+
+  public:
+    //! \brief The constructor initializes the projection matrices.
+    //! \param[in] prb The main problem integrand
+    //! \param[in] n Dimension of the L2-projection matrices (number of nodes)
+    GL2(IntegrandBase* prb, size_t n) : A(SparseMatrix::SUPERLU)
+    {
+      problem = prb;
+      nrhs = prb->getNoFields(2);
+      A.redim(n,n);
+      B.redim(n*nrhs);
+    }
+
+    //! \brief Alternative constructor for projection of an explicit function.
+    //! \param[in] func The function to do L2-projection on
+    //! \param[in] n Dimension of the L2-projection matrices (number of nodes)
+    GL2(FunctionBase* func, size_t n) : A(SparseMatrix::SUPERLU)
+    {
+      problem = nullptr;
+      functions = { func };
+      nrhs = func->dim();
+      A.redim(n,n);
+      B.redim(n*nrhs);
+    }
+
+    //! \brief Alternative constructor for projection of explicit functions.
+    //! \param[in] funcs The functions to do L2-projection on
+    //! \param[in] n Dimension of the L2-projection matrices (number of nodes)
+    GL2(const FunctionVec& funcs, size_t n) : A(SparseMatrix::SUPERLU)
+    {
+      problem = nullptr;
+      functions = funcs;
+      nrhs = std::accumulate(funcs.begin(), funcs.end(), 0u,
+                             [](size_t a, const FunctionBase* f)
+                             { return a + f->dim(); });
+      A.redim(n,n);
+      B.redim(n*nrhs);
+    }
+
+    //! \brief Returns current solution mode.
+    SIM::SolutionMode getMode(bool) const override { return SIM::RECOVERY; }
+
+    //! \brief Defines which FE quantities are needed by the integrand.
+    int getIntegrandType() const override
+    {
+      if (problem) // Mask off the element interface flag
+        return problem->getIntegrandType() & ~INTERFACE_TERMS;
+      else
+        return STANDARD;
+    }
+
+    using Integrand::getLocalIntegral;
+    //! \brief Returns a local integral object for the given element.
+    //! \param[in] nen Number of nodes on element
+    //! \param[in] iEl Global element number (1-based)
+    LocalIntegral* getLocalIntegral(size_t nen, size_t iEl, bool) const override
+    {
+      return new L2Mats(*const_cast<GL2*>(this),iEl,nen,nrhs,problem);
+    }
+
+    //! \brief Initializes current element for numerical integration.
+    //! \param[in] MNPC Matrix of nodal point correspondance for current element
+    //! \param[in] fe Nodal and integration point data for current element
+    //! \param[in] X0 Cartesian coordinates of the element center
+    //! \param[in] nPt Number of integration points in this element
+    //! \param elmInt Local integral for element
+    bool initElement(const IntVec& MNPC, const FiniteElement& fe,
+                     const Vec3& X0, size_t nPt,
+                     LocalIntegral& elmInt) override
+    {
+      L2Mats& gl2 = static_cast<L2Mats&>(elmInt);
+
+      gl2.mnpc = MNPC;
+      if (problem && gl2.elmData)
+        return problem->initElement(MNPC,fe,X0,nPt,*gl2.elmData);
+      else
+        return true;
+    }
+
+    //! \brief Initializes current element for numerical integration (mixed).
+    //! \param[in] MNPC1 Matrix of nodal point correspondance for the element
+    //! \param[in] fe Nodal and integration point data for current element
+    //! \param[in] elem_sizes Size of each basis on the element
+    //! \param[in] basis_sizes Size of each basis on the patch
+    //! \param elmInt Local integral for element
+    bool initElement(const IntVec& MNPC1, const MxFiniteElement& fe,
+                     const uIntVec& elem_sizes, const uIntVec& basis_sizes,
+                     LocalIntegral& elmInt) override
+    {
+      L2Mats& gl2 = static_cast<L2Mats&>(elmInt);
+
+      gl2.mnpc = MNPC1;
+      gl2.elem_sizes = elem_sizes;
+      gl2.basis_sizes = basis_sizes;
+      if (problem && gl2.elmData)
+        return problem->initElement(MNPC1,fe,elem_sizes,basis_sizes,
+                                    *gl2.elmData);
+      else
+        return true;
+    }
+
+    //! \brief Dummy implementation.
+    bool initElement(const IntVec&, LocalIntegral&) override { return false; }
+    //! \brief Dummy implementation.
+    bool initElement(const IntVec&, const uIntVec&, const uIntVec&,
+                     LocalIntegral&) override { return false; }
+
+    //! \brief Dummy implementation.
+    bool initElementBou(const IntVec&,
+                        LocalIntegral&) override { return false; }
+    //! \brief Dummy implementation.
+    bool initElementBou(const IntVec&, const uIntVec&, const uIntVec&,
+                        LocalIntegral&) override { return false; }
+
+    using Integrand::evalInt;
+    //! \brief Evaluates the integrand at an interior point.
+    //! \param elmInt The local integral object to receive the contributions
+    //! \param[in] fe Finite element data of current integration point
+    //! \param[in] X Cartesian coordinates of current integration point
+    bool evalInt(LocalIntegral& elmInt,
+                 const FiniteElement& fe, const Vec3& X) const override
+    {
+      L2Mats& gl2 = static_cast<L2Mats&>(elmInt);
+
+      Vector solPt;
+      solPt.reserve(nrhs);
+      if (problem)
+      {
+        if (!problem->evalSol(solPt,fe,X,gl2.mnpc))
+          if (!problem->diverged(fe.iGP+1))
+            return false;
+      }
+      else if (functions.size() == 1)
+        solPt = functions.front()->getValue(X);
+      else for (FunctionBase* func : functions)
+      {
+        RealArray funcPt = func->getValue(X);
+        solPt.push_back(funcPt.begin(),funcPt.end());
+      }
+
+      gl2.A.front().outer_product(fe.N,fe.N,true,fe.detJxW);
+      for (size_t j = 0; j < solPt.size(); j++)
+        gl2.b[j].add(fe.N,solPt[j]*fe.detJxW);
+
+      return true;
+    }
+
+    using Integrand::evalIntMx;
+    //! \brief Evaluates the integrand at an interior point.
+    //! \param elmInt The local integral object to receive the contributions
+    //! \param[in] fe Mixed finite element data of current integration point
+    //! \param[in] X Cartesian coordinates of current integration point
+    bool evalIntMx(LocalIntegral& elmInt, const MxFiniteElement& fe,
+                   const Vec3& X) const override
+    {
+      if (!problem)
+        return this->evalInt(elmInt,fe,X);
+
+      L2Mats& gl2 = static_cast<L2Mats&>(elmInt);
+
+      Vector solPt;
+      if (!problem->evalSol(solPt,fe,X,gl2.mnpc,gl2.elem_sizes,gl2.basis_sizes))
+        if (!problem->diverged(fe.iGP+1))
+          return false;
+
+      gl2.A.front().outer_product(fe.N,fe.N,true,fe.detJxW);
+      for (size_t j = 0; j < solPt.size(); j++)
+        gl2.b[j].add(fe.N,solPt[j]*fe.detJxW);
+
+      return true;
+    }
+
+    //! \brief Pre-computes the sparsity pattern of the projection matrix \b A.
+    //! \param[in] MMNPC Matrix of matrices of nodal point correspondances
+    //! \param[in] nel Number of elements
+    void preAssemble(const std::vector<IntVec>& MMNPC, size_t nel)
+    {
+      A.preAssemble(MMNPC,nel);
+    }
+
+    //! \brief Solves the projection equation system and evaluates nodal values.
+    //! \param[out] sField Nodal/control-point values of the projected results.
+    bool solve(Matrix& sField)
+    {
+      // Insert a 1.0 value on the diagonal for equations with no contributions.
+      // Needed when immersed boundaries with "totally outside" elements.
+      const size_t nnod = A.dim();
+      for (size_t i = 1; i <= nnod; i++)
+        if (A(i,i) == 0.0) A(i,i) = 1.0;
+
+#if SP_DEBUG > 1
+      std::cout <<"\nGlobal L2-projection matrix:\n"<< A;
+      std::cout <<"\nGlobal L2-projection RHS:"<< B;
+#endif
+
+      // Solve the patch-global equation system
+      if (!A.solve(B)) return false;
+
+      // Store the nodal values of the projected field
+      sField.resize(nrhs,nnod);
+      for (size_t i = 1; i <= nnod; i++)
+        for (size_t j = 1; j <= nrhs; j++)
+          sField(j,i) = B(i+(j-1)*nnod);
+
+#if SP_DEBUG > 1
+      std::cout <<"\nSolution:"<< sField;
+#endif
+      return true;
+    }
+
+    //! \brief Solves the projection equation system and evaluates nodal values.
+    //! \param[out] sField Nodal/control-point values of the projected results.
+    bool solve(const std::vector<Matrix*>& sField)
+    {
+      if (sField.size() != functions.size())
+      {
+        std::cerr <<" *** GL2::solve: Logic error, size(field)="<< sField.size()
+                  <<" != size(functions)="<< functions.size() << std::endl;
         return false;
-  }
-  else if (functions.size() == 1)
-    solPt = functions.front()->getValue(X);
-  else for (FunctionBase* func : functions)
+      }
+
+      // Insert a 1.0 value on the diagonal for equations with no contributions.
+      // Needed when immersed boundaries with "totally outside" elements.
+      const size_t nnod = A.dim();
+      for (size_t i = 1; i <= nnod; i++)
+        if (A(i,i) == 0.0) A(i,i) = 1.0;
+
+#if SP_DEBUG > 1
+      std::cout <<"\nGlobal L2-projection matrix:\n"<< A;
+      std::cout <<"\nGlobal L2-projection RHS:"<< B;
+#endif
+
+      // Solve the patch-global equation system
+      if (!A.solve(B)) return false;
+
+      // Store the nodal values of the projected fields
+      size_t offset = 0;
+      for (size_t k = 0; k < sField.size(); k++)
+      {
+        size_t ncomp = functions[k]->dim();
+        sField[k]->resize(ncomp,nnod);
+        for (size_t i = 1; i <= nnod; i++)
+          for (size_t j = 1; j <= ncomp; j++)
+            (*sField[k])(j,i) = B(i+(offset+j-1)*nnod);
+        offset += ncomp;
+
+#if SP_DEBUG > 1
+        std::cout <<"\nSolution "<< k <<":"<< *sField[k];
+#endif
+      }
+      return true;
+    }
+
+  private:
+    SparseMatrix A; //!< Left-hand-side matrix of the L2-projection
+    StdVector    B; //!< Right-hand-side vectors of the L2-projection
+
+    IntegrandBase* problem; //!< The main problem integrand
+    FunctionVec  functions; //!< Explicit functions to L2-project
+    size_t            nrhs; //!< Number of right-hand-size vectors
+
+    friend class L2GlobalInt;
+  };
+
+
+  /*!
+    \brief Global integral container class for L2-projections (version 2).
+  */
+
+  class L2GlobalInt : public GlobalIntegral
   {
-    RealArray funcPt = func->getValue(X);
-    solPt.push_back(funcPt.begin(),funcPt.end());
-  }
+  public:
+    //! \brief The constructor initializes the system matrix references.
+    L2GlobalInt(GL2& gl2) : A(gl2.A), B(gl2.B) {}
 
-  gl2.A.front().outer_product(fe.N,fe.N,true,fe.detJxW);
-  for (size_t j = 0; j < solPt.size(); j++)
-    gl2.b[j].add(fe.N,solPt[j]*fe.detJxW);
+    //! \brief Adds a LocalIntegral object into a corresponding global object.
+    bool assemble(const LocalIntegral* elmObj, int) override
+    {
+      const L2Mats* elm = static_cast<const L2Mats*>(elmObj);
+      for (size_t i = 0; i < elm->mnpc.size(); i++)
+      {
+        int inod = elm->mnpc[i]+1;
+        A.flagNonZeroEq(inod);
+        for (size_t j = 0; j < elm->mnpc.size(); j++)
+        {
+          int jnod = elm->mnpc[j]+1;
+          A(inod,jnod) += elm->A.front()(i+1,j+1);
+        }
+        for (const Vector& b : elm->b)
+        {
+          B(inod) += b[i];
+          inod += A.dim();
+        }
+      }
+      return true;
+    }
 
-  return true;
+  private:
+    SparseMatrix& A; //!< Reference to left-hand-side matrix
+    StdVector&    B; //!< Reference to right-hand-side vector
+  };
 }
 
 
-bool GlbL2::evalIntMx (LocalIntegral& elmInt,
-                       const MxFiniteElement& fe,
-                       const Vec3& X) const
-
-{
-  if (!problem)
-    return this->evalInt(elmInt,fe,X);
-
-  L2Mats& gl2 = static_cast<L2Mats&>(elmInt);
-
-  Vector solPt;
-  if (!problem->evalSol(solPt,fe,X,gl2.mnpc,gl2.elem_sizes,gl2.basis_sizes))
-    if (!problem->diverged(fe.iGP+1))
-      return false;
-
-  gl2.A.front().outer_product(fe.N,fe.N,true,fe.detJxW);
-  for (size_t j = 0; j < solPt.size(); j++)
-    gl2.b[j].add(fe.N,solPt[j]*fe.detJxW);
-
-  return true;
-}
-
-
-void GlbL2::preAssemble (const IntMat& MMNPC, size_t nel)
-{
-  pA->preAssemble(MMNPC,nel);
-}
-
-
-bool GlbL2::solve (Matrix& sField)
-{
-  SparseMatrix& A = static_cast<SparseMatrix&>(*pA);
-  StdVector&    B = static_cast<StdVector&>(*pB);
-
-  // Insert a 1.0 value on the diagonal for equations with no contributions.
-  // Needed in immersed boundary calculations with "totally outside" elements.
-  size_t i, j, nnod = A.dim();
-  for (i = 1; i <= nnod; i++)
-    if (A(i,i) == 0.0) A(i,i) = 1.0;
-
-#if SP_DEBUG > 1
-  std::cout <<"\nGlobal L2-projection matrix:\n"<< A;
-  std::cout <<"\nGlobal L2-projection RHS:"<< B;
-#endif
-
-  // Solve the patch-global equation system
-  if (!A.solve(B)) return false;
-
-  // Store the nodal values of the projected field
-  sField.resize(nrhs,nnod);
-  for (i = 1; i <= nnod; i++)
-    for (j = 1; j <= nrhs; j++)
-      sField(j,i) = B(i+(j-1)*nnod);
-
-#if SP_DEBUG > 1
-  std::cout <<"\nSolution:"<< sField;
-#endif
-  return true;
-}
-
-
-bool GlbL2::solve (const std::vector<Matrix*>& sField)
-{
-  if (sField.size() != functions.size())
-  {
-    std::cerr <<" *** GlbL2::solve: Logic error, size(sField)="<< sField.size()
-              <<" != size(functions)="<< functions.size() << std::endl;
-    return false;
-  }
-
-  SparseMatrix& A = *pA;
-  StdVector&    B = *pB;
-
-  // Insert a 1.0 value on the diagonal for equations with no contributions.
-  // Needed in immersed boundary calculations with "totally outside" elements.
-  size_t i, j, nnod = A.dim();
-  for (i = 1; i <= nnod; i++)
-    if (A(i,i) == 0.0) A(i,i) = 1.0;
-
-#if SP_DEBUG > 1
-  std::cout <<"\nGlobal L2-projection matrix:\n"<< A;
-  std::cout <<"\nGlobal L2-projection RHS:"<< B;
-#endif
-
-  // Solve the patch-global equation system
-  if (!A.solve(B)) return false;
-
-  // Store the nodal values of the projected fields
-  size_t offset = 0;
-  for (size_t k = 0; k < sField.size(); k++)
-  {
-    size_t ncomp = functions[k]->dim();
-    sField[k]->resize(ncomp,nnod);
-    for (i = 1; i <= nnod; i++)
-      for (j = 1; j <= ncomp; j++)
-        (*sField[k])(j,i) = B(i+(offset+j-1)*nnod);
-    offset += ncomp;
-
-#if SP_DEBUG > 1
-    std::cout <<"\nSolution "<< k <<":"<< *sField[k];
-#endif
-  }
-
-  return true;
-}
-
+/*!
+  This method implements version 2 of the global L2-projection
+  for secondary solution variables of the provided \a integrand.
+*/
 
 bool ASMbase::L2projection (Matrix& sField,
                             IntegrandBase* integrand,
@@ -475,40 +537,53 @@ bool ASMbase::L2projection (Matrix& sField,
 {
   PROFILE2("ASMbase::L2projection");
 
-  GlbL2 gl2(integrand,this->getNoNodes(1));
-  L2GlobalInt dummy(*gl2.pA,*gl2.pB);
+  GL2 gl2(integrand,this->getNoNodes(1));
+  L2GlobalInt dummy(gl2);
 
   gl2.preAssemble(MNPC,this->getNoElms(true));
   return this->integrate(gl2,dummy,time) && gl2.solve(sField);
 }
 
 
-bool ASMbase::L2projection (Matrix& sField, FunctionBase* function, double t)
+/*!
+  This method implements version 2 of the global L2-projection
+  of an explicit function.
+*/
+
+bool ASMbase::L2projection (Matrix& fVals, FunctionBase* func, double t)
 {
   PROFILE2("ASMbase::L2projection");
 
-  GlbL2 gl2(function,this->getNoNodes(1));
-  L2GlobalInt dummy(*gl2.pA,*gl2.pB);
-  TimeDomain time; time.t = t;
+  GL2 gl2(func,this->getNoNodes(1));
+  L2GlobalInt dummy(gl2);
 
   gl2.preAssemble(MNPC,this->getNoElms(true));
-  return this->integrate(gl2,dummy,time) && gl2.solve(sField);
+  return this->integrate(gl2,dummy,TimeDomain(t)) && gl2.solve(fVals);
 }
 
 
-bool ASMbase::L2projection (const std::vector<Matrix*>& sField,
-                            const FunctionVec& function, double t)
+/*!
+  This method implements version 2 of the global L2-projection
+  of a set of explicit functions.
+*/
+
+bool ASMbase::L2projection (const std::vector<Matrix*>& fVals,
+                            const std::vector<FunctionBase*>& funcs, double t)
 {
   PROFILE2("ASMbase::L2projection");
 
-  GlbL2 gl2(function,this->getNoNodes(1));
-  L2GlobalInt dummy(*gl2.pA,*gl2.pB);
-  TimeDomain time; time.t = t;
+  GL2 gl2(funcs,this->getNoNodes(1));
+  L2GlobalInt dummy(gl2);
 
   gl2.preAssemble(MNPC,this->getNoElms(true));
-  return this->integrate(gl2,dummy,time) && gl2.solve(sField);
+  return this->integrate(gl2,dummy,TimeDomain(t)) && gl2.solve(fVals);
 }
 
+
+/*!
+  This method implements version 1 of the global L2-projection,
+  and supports both discrete and continuous projections.
+*/
 
 bool ASMbase::globalL2projection (Matrix& sField,
                                   const L2Integrand& integrand,
@@ -520,8 +595,6 @@ bool ASMbase::globalL2projection (Matrix& sField,
 
 #ifdef HAS_PETSC
   ProcessAdm singleAdm;
-  const bool isPart = integrand.getAdm().dd.isPartitioned();
-  const ProcessAdm& adm = isPart ? integrand.getAdm() : singleAdm;
 #endif
 
   // Assemble the projection matrices
@@ -536,8 +609,10 @@ bool ASMbase::globalL2projection (Matrix& sField,
     break;
 #ifdef HAS_PETSC
   case LinAlg::PETSC:
-    if (GlbL2::SolverParams)
+    if (GlbL2::SolverParams && GlbL2::Adm)
     {
+      ProcessAdm& adm = GlbL2::Adm->dd.isPartitioned() ? *GlbL2::Adm : singleAdm;
+
       PETScMatrix* Ap;
       A = Ap = new PETScMatrix(adm, *GlbL2::SolverParams);
 

--- a/src/ASM/GlbL2projector.C
+++ b/src/ASM/GlbL2projector.C
@@ -397,9 +397,12 @@ namespace
     //! \brief Pre-computes the sparsity pattern of the projection matrix \b A.
     //! \param[in] MMNPC Matrix of matrices of nodal point correspondances
     //! \param[in] nel Number of elements
-    void preAssemble(const std::vector<IntVec>& MMNPC, size_t nel)
+    //! \param[in] checkNZ If \e true, flag non-zero contributions in assembly
+    void preAssemble(const std::vector<IntVec>& MMNPC, size_t nel, bool checkNZ)
     {
       A.preAssemble(MMNPC,nel);
+      if (checkNZ)
+        A.initNonZeroEqs();
     }
 
     //! \brief Solves the projection equation system and evaluates nodal values.
@@ -540,7 +543,7 @@ bool ASMbase::L2projection (Matrix& sField,
   GL2 gl2(integrand,this->getNoNodes(1));
   L2GlobalInt dummy(gl2);
 
-  gl2.preAssemble(MNPC,this->getNoElms(true));
+  gl2.preAssemble(MNPC,this->getNoElms(true),this->getElementActivator());
   return this->integrate(gl2,dummy,time) && gl2.solve(sField);
 }
 
@@ -557,7 +560,7 @@ bool ASMbase::L2projection (Matrix& fVals, FunctionBase* func, double t)
   GL2 gl2(func,this->getNoNodes(1));
   L2GlobalInt dummy(gl2);
 
-  gl2.preAssemble(MNPC,this->getNoElms(true));
+  gl2.preAssemble(MNPC,this->getNoElms(true),this->getElementActivator());
   return this->integrate(gl2,dummy,TimeDomain(t)) && gl2.solve(fVals);
 }
 
@@ -575,7 +578,7 @@ bool ASMbase::L2projection (const std::vector<Matrix*>& fVals,
   GL2 gl2(funcs,this->getNoNodes(1));
   L2GlobalInt dummy(gl2);
 
-  gl2.preAssemble(MNPC,this->getNoElms(true));
+  gl2.preAssemble(MNPC,this->getNoElms(true),this->getElementActivator());
   return this->integrate(gl2,dummy,TimeDomain(t)) && gl2.solve(fVals);
 }
 
@@ -593,13 +596,13 @@ bool ASMbase::globalL2projection (Matrix& sField,
 
   PROFILE2("ASMbase::globalL2");
 
+  const size_t npnod = this->getNoProjectionNodes();
+  const size_t ncomp = integrand.dim();
 #ifdef HAS_PETSC
   ProcessAdm singleAdm;
 #endif
 
   // Assemble the projection matrices
-  size_t i, npnod = this->getNoProjectionNodes();
-  size_t j, ncomp = integrand.dim();
   SystemMatrix* A;
   SystemVector* B;
   switch (GlbL2::MatrixType) {
@@ -607,35 +610,38 @@ bool ASMbase::globalL2projection (Matrix& sField,
     A = new SparseMatrix(npnod,npnod,SparseMatrix::UMFPACK);
     B = new StdVector(npnod*ncomp);
     break;
+
 #ifdef HAS_PETSC
   case LinAlg::PETSC:
     if (GlbL2::SolverParams && GlbL2::Adm)
     {
-      ProcessAdm& adm = GlbL2::Adm->dd.isPartitioned() ? *GlbL2::Adm : singleAdm;
-
-      PETScMatrix* Ap;
-      A = Ap = new PETScMatrix(adm, *GlbL2::SolverParams);
-
       const IntMat nodes = this->getElmNodes(ASM::PROJECTION_BASIS);
-      const bool useAdmPart = this->neighbors.empty() &&
-                              nodes.size() == nel;
+      const bool useAdm = neighbors.empty() && nodes.size() == nel;
+      const ProcessAdm& adm = GlbL2::Adm->dd.isPartitioned() ? *GlbL2::Adm : singleAdm;
 
       IntMat neighs;
-      if (adm.dd.isPartitioned() && !useAdmPart && adm.getProcId() == 0) {
+      if (adm.dd.isPartitioned() && !useAdm && adm.getProcId() == 0) {
         neighs.resize(nodes.size());
         this->getElmConnectivities(neighs, ASM::PROJECTION_BASIS);
       }
-      Ap->init(npnod, &nodes, &neighs, useAdmPart ? &adm.dd.getElms() : nullptr);
+
+      PETScMatrix* Ap;
+      A = Ap = new PETScMatrix(adm, *GlbL2::SolverParams);
+      Ap->init(npnod, &nodes, &neighs, useAdm ? &adm.dd.getElms() : nullptr);
       if (adm.dd.isPartitioned())
         const_cast<ASMbase*>(this)->generateProjThreadGroupsFromElms(Ap->getDD().getElms());
-      B = new PETScVectors(static_cast<PETScMatrix&>(*A), ncomp);
+      B = new PETScVectors(*Ap, ncomp);
       break;
     }
 #endif
+
   default:
     A = new SparseMatrix(npnod,npnod,SparseMatrix::SUPERLU);
     B = new StdVector(npnod*ncomp);
   }
+
+  if (this->getElementActivator())
+    A->initNonZeroEqs();
 
   if (!this->assembleL2matrices(*A,*B,integrand,continuous))
   {
@@ -654,35 +660,28 @@ bool ASMbase::globalL2projection (Matrix& sField,
             <<"-------------------"<< std::endl;
 #endif
 
-
+  // Solve the patch-global equation system
+  sField.resize(ncomp,npnod);
+  bool ok = false;
 #ifdef HAS_PETSC
-  if (GlbL2::MatrixType == LinAlg::PETSC) {
-    PETScVectors& Bp = static_cast<PETScVectors&>(*B);
-    sField.resize(ncomp, npnod);
-    if (!static_cast<PETScMatrix*>(A)->solveMultipleRhs(Bp, sField))
-    {
-      delete A;
-      delete B;
-      return false;
-    }
-  }
+  if (Ap)
+    ok = Ap->solveMultipleRhs(static_cast<PETScVectors&>(*B),sField);
   else
 #endif
-  {
-    // Solve the patch-global equation system
-    if (!A->solve(*B))
+    if ((ok = A->solve(*B)))
     {
-      delete A;
-      delete B;
-      return false;
+      // Store the control-point values of the projected field
+      const StdVector& stdB = dynamic_cast<const StdVector&>(*B);
+      for (size_t i = 1; i <= npnod; i++)
+        for (size_t j = 1; j <= ncomp; j++)
+          sField(j,i) = stdB(i+(j-1)*npnod);
     }
-
-    // Store the control-point values of the projected field
-    const StdVector& stdB = dynamic_cast<const StdVector&>(*B);
-    sField.resize(ncomp,npnod);
-    for (i = 1; i <= npnod; i++)
-      for (j = 1; j <= ncomp; j++)
-        sField(j,i) = stdB(i+(j-1)*npnod);
+  if (!ok)
+  {
+    delete A;
+    delete B;
+    sField.clear();
+    return false;
   }
 
 #if SP_DEBUG > 1
@@ -705,7 +704,7 @@ bool ASMbase::globalL2projection (Matrix& sField,
     return false;
 
   // Enforce the corner values in the projected field
-  for (i = 0; i < corners.size(); i++)
+  for (size_t i = 0; i < corners.size(); i++)
   {
 #if SP_DEBUG > 1
     std::cout <<"Replacing end/corner-point values of projected field at node "

--- a/src/ASM/GlbL2projector.C
+++ b/src/ASM/GlbL2projector.C
@@ -421,13 +421,7 @@ namespace
 #endif
 
       // Solve the patch-global equation system
-      if (!A.solve(B)) return false;
-
-      // Store the nodal values of the projected field
-      sField.resize(nrhs,nnod);
-      for (size_t i = 1; i <= nnod; i++)
-        for (size_t j = 1; j <= nrhs; j++)
-          sField(j,i) = B(i+(j-1)*nnod);
+      if (!A.solve(B,sField)) return false;
 
 #if SP_DEBUG > 1
       std::cout <<"\nSolution:"<< sField;
@@ -458,23 +452,27 @@ namespace
 #endif
 
       // Solve the patch-global equation system
-      if (!A.solve(B)) return false;
+      Matrix& solutions = *sField.front();
+      if (!A.solve(B,solutions)) return false;
 
-      // Store the nodal values of the projected fields
-      size_t offset = 0;
-      for (size_t k = 0; k < sField.size(); k++)
+      if (sField.size() > 1)
       {
-        size_t ncomp = functions[k]->dim();
-        sField[k]->resize(ncomp,nnod);
-        for (size_t i = 1; i <= nnod; i++)
-          for (size_t j = 1; j <= ncomp; j++)
-            (*sField[k])(j,i) = B(i+(offset+j-1)*nnod);
-        offset += ncomp;
-
+        // Split the solution vectors into one for each function
+        size_t irow = functions.front()->dim() + 1;
+        for (size_t k = 1; k < sField.size(); k++)
+        {
+          size_t ncomp = functions[k]->dim();
+          sField[k]->resize(ncomp,nnod);
+          for (size_t j = 1; j <= ncomp; j++, irow++)
+            for (size_t i = 1; i <= nnod; i++)
+              (*sField[k])(j,i) = solutions(irow,i);
+        }
+        sField.front()->expandRows(functions.front()->dim(),true);
+      }
 #if SP_DEBUG > 1
+      for (size_t k = 0; k < sField.size(); k++)
         std::cout <<"\nSolution "<< k <<":"<< *sField[k];
 #endif
-      }
       return true;
     }
 
@@ -656,27 +654,19 @@ bool ASMbase::globalL2projection (Matrix& sField,
 #if SP_DEBUG > 1
   std::cout <<"---- Matrix A -----\n"<< *A
             <<"-------------------"<< std::endl;
-  std::cout <<"---- Vector B -----\n"<< *B
-            <<"-------------------"<< std::endl;
+  const Vector& bVec = B->vec();
+  if (!bVec.empty())
+  {
+    std::cout <<"---- Vector B -----";
+    for (size_t i = 1; i <= npnod; i++)
+      for (size_t j = 0; j < ncomp; j++)
+        std::cout << (j > 0 ? " " : "\n") << bVec(i+npnod*j);
+    std::cout <<"\n-------------------"<< std::endl;
+  }
 #endif
 
   // Solve the patch-global equation system
-  sField.resize(ncomp,npnod);
-  bool ok = false;
-#ifdef HAS_PETSC
-  if (Ap)
-    ok = Ap->solveMultipleRhs(static_cast<PETScVectors&>(*B),sField);
-  else
-#endif
-    if ((ok = A->solve(*B)))
-    {
-      // Store the control-point values of the projected field
-      const StdVector& stdB = dynamic_cast<const StdVector&>(*B);
-      for (size_t i = 1; i <= npnod; i++)
-        for (size_t j = 1; j <= ncomp; j++)
-          sField(j,i) = stdB(i+(j-1)*npnod);
-    }
-  if (!ok)
+  if (!A->solve(*B,sField))
   {
     delete A;
     delete B;

--- a/src/ASM/GlbL2projector.h
+++ b/src/ASM/GlbL2projector.h
@@ -7,14 +7,13 @@
 //!
 //! \author Knut Morten Okstad / SINTEF
 //!
-//! \brief General integrand for L2-projection of secondary solutions.
+//! \brief General integrands for global L2-projection.
 //!
 //==============================================================================
 
 #ifndef _GLB_L2_PROJECTOR_H
 #define _GLB_L2_PROJECTOR_H
 
-#include "Integrand.h"
 #include "LinAlgenums.h"
 #include "MatVec.h"
 
@@ -22,13 +21,15 @@ class ASMbase;
 class IntegrandBase;
 class FunctionBase;
 class LinSolParams;
-class SparseMatrix;
-class StdVector;
 class ProcessAdm;
 
-typedef std::vector<int>           IntVec;      //!< Vector of integers
-typedef std::vector<size_t>        uIntVec;     //!< Vector of unsigned integers
-typedef std::vector<FunctionBase*> FunctionVec; //!< Vector of functions
+
+namespace GlbL2 //! Global control parameters for L2-projection
+{
+  extern LinAlg::MatrixType MatrixType;
+  extern LinSolParams*      SolverParams;
+  extern const ProcessAdm*  Adm;
+}
 
 
 /*!
@@ -40,9 +41,9 @@ class L2Integrand
 public:
   //! \brief The constructor initializes the patch reference.
   //! \param[in] patch ASM holding geometry to evaluate on
-  //! \param[in] adm Process administrator
-  L2Integrand(const ASMbase& patch, const ProcessAdm& adm)
-    : m_patch(patch), m_adm(adm) {}
+  L2Integrand(const ASMbase& patch) : m_patch(patch) { myTime = 0.0; }
+  //! \brief Empty destructor.
+  virtual ~L2Integrand() {}
 
   //! \brief Evaluates the entity in a set of points.
   //! \param[out] sField Matrix with results
@@ -52,12 +53,12 @@ public:
   //! \brief Returns dimension of entity to evaluate.
   virtual size_t dim() const = 0;
 
-  //! \brief Returns a const-ref to associated process administrator.
-  const ProcessAdm& getAdm() const { return m_adm; }
+  //! \brief Returns current time/load parameter for 2ndary solution evaluation.
+  double getTimeLevel() const { return myTime; }
 
 protected:
   const ASMbase& m_patch; //!< Reference to ASM holding geometry
-  const ProcessAdm& m_adm; //!< Reference to process administrator
+  double         myTime;  //!< Current time or load parameter
 };
 
 
@@ -71,10 +72,7 @@ public:
   //! \brief The constructor initializes the integrand reference.
   //! \param[in] patch ASM holding geometry to evaluate on
   //! \param[in] itg Integrand to evaluate
-  //! \param[in] adm Process administrator
-  L2ProbIntegrand(const ASMbase& patch,
-                  const IntegrandBase& itg,
-                  const ProcessAdm& adm);
+  L2ProbIntegrand(const ASMbase& patch, const IntegrandBase& itg);
 
   //! \brief Evaluates the secondary solutions in a set of points.
   //! \param[out] sField Matrix with results
@@ -99,10 +97,10 @@ public:
   //! \brief The constructor initializes the function reference.
   //! \param[in] patch ASM holding geometry to evaluate on
   //! \param[in] func Function to evaluate
-  //! \param[in] adm Process administrator
+  //! \param[in] time Current time
   L2FuncIntegrand(const ASMbase& patch,
                   const FunctionBase& func,
-                  const ProcessAdm& adm);
+                  double time = 0.0);
 
   //! \brief Evaluates the function in a set of points.
   //! \param[out] sField Matrix with results
@@ -114,121 +112,6 @@ public:
 
 private:
   const FunctionBase& m_func; //!< Reference to function
-};
-
-
-/*!
-  \brief General integrand for L2-projection of secondary solutions.
-*/
-
-class GlbL2 : public Integrand
-{
-public:
-  static LinAlg::MatrixType MatrixType;   //!< Matrix type for projection
-  static LinSolParams*      SolverParams; //!< Linear solver params projection
-
-  //! \brief The constructor initializes the projection matrices.
-  //! \param[in] p The main problem integrand
-  //! \param[in] n Dimension of the L2-projection matrices (number of nodes)
-  GlbL2(IntegrandBase* p, size_t n);
-  //! \brief Alternative constructor for projection of an explicit function.
-  //! \param[in] f The function to do L2-projection on
-  //! \param[in] n Dimension of the L2-projection matrices (number of nodes)
-  GlbL2(FunctionBase* f, size_t n);
-  //! \brief Alternative constructor for projection of explicit functions.
-  //! \param[in] f The functions to do L2-projection on
-  //! \param[in] n Dimension of the L2-projection matrices (number of nodes)
-  GlbL2(const FunctionVec& f, size_t n);
-  //! \brief The destructor frees the system matrix and system vector.
-  virtual ~GlbL2();
-
-  //! \brief Returns current solution mode.
-  virtual SIM::SolutionMode getMode(bool) const { return SIM::RECOVERY; }
-  //! \brief Defines which FE quantities are needed by the integrand.
-  virtual int getIntegrandType() const;
-
-  using Integrand::getLocalIntegral;
-  //! \brief Returns a local integral contribution object for the given element.
-  //! \param[in] nen Number of nodes on element
-  //! \param[in] iEl Global element number (1-based)
-  //! \param[in] neumann Whether or not we are assembling Neumann BCs
-  virtual LocalIntegral* getLocalIntegral(size_t nen, size_t iEl,
-                                          bool neumann) const;
-
-  //! \brief Initializes current element for numerical integration.
-  //! \param[in] MNPC Matrix of nodal point correspondance for current element
-  //! \param[in] fe Nodal and integration point data for current element
-  //! \param[in] X0 Cartesian coordinates of the element center
-  //! \param[in] nPt Number of integration points in this element
-  //! \param elmInt Local integral for element
-  virtual bool initElement(const IntVec& MNPC, const FiniteElement& fe,
-                           const Vec3& X0, size_t nPt,
-                           LocalIntegral& elmInt);
-  //! \brief Initializes current element for numerical integration (mixed).
-  //! \param[in] MNPC1 Matrix of nodal point correspondance for current element
-  //! \param[in] fe Nodal and integration point data for current element
-  //! \param[in] elem_sizes Size of each basis on the element
-  //! \param[in] basis_sizes Size of each basis on the patch
-  //! \param elmInt Local integral for element
-  virtual bool initElement(const IntVec& MNPC1,
-                           const MxFiniteElement& fe,
-                           const uIntVec& elem_sizes,
-                           const uIntVec& basis_sizes,
-                           LocalIntegral& elmInt);
-
-  //! \brief Dummy implementation.
-  virtual bool initElement(const IntVec& MNPC1,
-                           const uIntVec& elem_sizes,
-                           const uIntVec& basis_sizes,
-                           LocalIntegral& elmInt) { return false; }
-  //! \brief Dummy implementation.
-  virtual bool initElement(const IntVec&, LocalIntegral&) { return false; }
-  //! \brief Dummy implementation.
-  virtual bool initElementBou(const IntVec&, LocalIntegral&) { return false; }
-  //! \brief Dummy implementation.
-  virtual bool initElementBou(const IntVec&, const uIntVec&, const uIntVec&,
-                              LocalIntegral&) { return false; }
-
-  using Integrand::evalInt;
-  //! \brief Evaluates the integrand at an interior point.
-  //! \param elmInt The local integral object to receive the contributions
-  //! \param[in] fe Finite element data of current integration point
-  //! \param[in] X Cartesian coordinates of current integration point
-  virtual bool evalInt(LocalIntegral& elmInt,
-                       const FiniteElement& fe, const Vec3& X) const;
-
-  using Integrand::evalIntMx;
-  //! \brief Evaluates the integrand at an interior point.
-  //! \param elmInt The local integral object to receive the contributions
-  //! \param[in] fe Mixed finite element data of current integration point
-  //! \param[in] X Cartesian coordinates of current integration point
-  virtual bool evalIntMx(LocalIntegral& elmInt, const MxFiniteElement& fe,
-                         const Vec3& X) const;
-
-  //! \brief Pre-computes the sparsity pattern of the projection matrix \b A.
-  //! \param[in] MMNPC Matrix of matrices of nodal point correspondances
-  //! \param[in] nel Number of elements
-  void preAssemble(const std::vector<IntVec>& MMNPC, size_t nel);
-
-  //! \brief Solves the projection equation system and evaluates nodal values.
-  //! \param[out] sField Nodal/control-point values of the projected results.
-  bool solve(Matrix& sField);
-  //! \brief Solves the projection equation system and evaluates nodal values.
-  //! \param[out] sField Nodal/control-point values of the projected results.
-  bool solve(const std::vector<Matrix*>& sField);
-
-private:
-  //! \brief Allocates the system L2-projection matrices.
-  void allocate(size_t n);
-
-public:
-  mutable SparseMatrix* pA; //!< Left-hand-side matrix of the L2-projection
-  mutable StdVector*    pB; //!< Right-hand-side vectors of the L2-projection
-
-private:
-  IntegrandBase* problem; //!< The main problem integrand
-  FunctionVec  functions; //!< Explicit functions to L2-project
-  size_t            nrhs; //!< Number of right-hand-size vectors
 };
 
 #endif

--- a/src/LinAlg/PETScMatrix.C
+++ b/src/LinAlg/PETScMatrix.C
@@ -793,10 +793,10 @@ bool PETScMatrix::solve (const Vec& b, Vec& x, bool knoll)
   }
 
 #if PETSC_VERSION_MINOR < 5
-    KSPSetOperators(ksp,pA,pA, factored ? SAME_PRECONDITIONER : SAME_NONZERO_PATTERN);
+  KSPSetOperators(ksp,pA,pA, factored ? SAME_PRECONDITIONER : SAME_NONZERO_PATTERN);
 #else
-    KSPSetOperators(ksp,pA,pA);
-    KSPSetReusePreconditioner(ksp, factored ? PETSC_TRUE : PETSC_FALSE);
+  KSPSetOperators(ksp,pA,pA);
+  KSPSetReusePreconditioner(ksp, factored ? PETSC_TRUE : PETSC_FALSE);
 #endif
 
   if (setParams) {
@@ -831,37 +831,43 @@ bool PETScMatrix::solve (const Vec& b, Vec& x, bool knoll)
 }
 
 
-bool PETScMatrix::solveMultipleRhs (PETScVectors& B, Matrix& sField)
+bool PETScMatrix::solve (SystemVector& B, Matrix& sol)
 {
+  PETScVectors* Bptr = dynamic_cast<PETScVectors*>(&B);
+  if (!Bptr)
+    return false;
+
+  sol.resize(Bptr->size(),nrow);
+
   Vec xg;
   VecScatter ctx;
   if (m_dd && m_dd->isPartitioned())
-    VecScatterCreateToAll(B.get(0), &ctx, &xg);
+    VecScatterCreateToAll(Bptr->get(0), &ctx, &xg);
 
   Vec x;
-  VecDuplicate(B.get(0), &x);
+  VecDuplicate(Bptr->get(0), &x);
 
-  for (size_t i = 0; i < B.size(); ++i) {
-    VecAssemblyBegin(B.get(i));
-    VecAssemblyEnd(B.get(i));
-
-    if (!this->solve(B.get(i), x, false))
-      return false;
-
-    if (m_dd && m_dd->isPartitioned()) {
+  bool ok = true;
+  for (size_t i = 0; i < Bptr->size() && ok; ++i) {
+    Vec b = Bptr->get(i);
+    VecAssemblyBegin(b);
+    VecAssemblyEnd(b);
+    if (!this->solve(b, x, false))
+      ok = false;
+    else if (m_dd && m_dd->isPartitioned()) {
       VecScatterBegin(ctx, x, xg, INSERT_VALUES, SCATTER_FORWARD);
       VecScatterEnd(ctx, x, xg, INSERT_VALUES, SCATTER_FORWARD);
       PetscScalar* ga;
       VecGetArray(xg, &ga);
       const auto& g2leq = m_dd->getG2LEQ(0);
       for (const auto& it : g2leq)
-        sField(i+1, it.second) = ga[it.first-1];
+        sol(i+1, it.second) = ga[it.first-1];
       VecRestoreArray(xg, &ga);
     } else {
       PetscScalar* xa;
       VecGetArray(x, &xa);
-      for (size_t eq = 0; eq < B.dim(); ++eq)
-        sField(i+1, eq+1) = xa[eq];
+      for (size_t eq = 0; eq < Bptr->dim(); ++eq)
+        sol(i+1, eq+1) = xa[eq];
       VecRestoreArray(x, &xa);
     }
   }
@@ -873,7 +879,7 @@ bool PETScMatrix::solveMultipleRhs (PETScVectors& B, Matrix& sField)
     VecScatterDestroy(&ctx);
   }
 
-  return true;
+  return ok;
 }
 
 

--- a/src/LinAlg/PETScMatrix.h
+++ b/src/LinAlg/PETScMatrix.h
@@ -262,6 +262,11 @@ public:
   //! \param[out] x Solution vector
   bool solve(const SystemVector& B, SystemVector& x) override;
 
+  //! \brief Solves a linear system of equations for multiple right-hand-sides.
+  //! \param B Right-hand-side vectors to solve for
+  //! \param[out] sol Matrix of solution vectors (row-oriented)
+  bool solve(SystemVector& B, Matrix& sol) override;
+
   //! \brief Multiplication with a scalar.
   void mult(Real alpha) override;
 
@@ -301,11 +306,6 @@ public:
 
   //! \brief Returns a const-ref to process administrator.
   const ProcessAdm& getAdm() const { return adm; }
-
-  //! \brief Solve for multiple right-hand-side vectors.
-  //! \param B Vectors with right-hand-sides to solve for
-  //! \param sField Resulting vectors stored as a matrix
-  bool solveMultipleRhs(PETScVectors& B, Matrix& sField);
 
   //! \brief Returns a const-ref to domain decompositioning.
   const DomainDecomposition& getDD() const;

--- a/src/LinAlg/SystemMatrix.C
+++ b/src/LinAlg/SystemMatrix.C
@@ -297,3 +297,26 @@ void SystemMatrix::dump (const char* fileName, std::streamsize precision,
     this->dump(fs,format);
   }
 }
+
+
+bool SystemMatrix::solve (SystemVector& b, Matrix& x)
+{
+  const size_t neqs = this->dim();
+  const size_t nrhs = neqs > 0 ? b.dim() / neqs : 0;
+  if (neqs*nrhs != b.dim())
+  {
+    std::cerr <<"SystemMatrix::solve: Incompatible vector size, dim(A)="
+              << neqs <<" dim(b)="<< b.dim() << std::endl;
+    return false;
+  }
+  else if (!this->solve(b))
+    return false;
+
+  x.resize(nrhs,neqs);
+  const Real* s = b.getRef();
+  for (size_t j = 1; j <= nrhs; j++)
+    for (size_t i = 1; i <= neqs; i++, s++)
+      x(j,i) = *s;
+
+  return true;
+}

--- a/src/LinAlg/SystemMatrix.h
+++ b/src/LinAlg/SystemMatrix.h
@@ -349,6 +349,11 @@ public:
     return this->solve(x.copy(b));
   }
 
+  //! \brief Solves a linear system of equations for multiple right-hand-sides.
+  //! \param b Right-hand-side vectors on input, solution vectors on output
+  //! \param[out] x Matrix of solution vectors (row-oriented)
+  virtual bool solve(SystemVector& b, Matrix& x);
+
   //! \brief Returns the L-infinity norm of the matrix.
   virtual Real Linfnorm() const = 0;
 

--- a/src/LinAlg/Test/TestMatrix.C
+++ b/src/LinAlg/Test/TestMatrix.C
@@ -105,6 +105,22 @@ TEST_CASE("TestMatrix.AddRows")
   for (size_t j = 1; j <= a.cols(); j++, fasit++)
     for (size_t i = 1; i <= 2; i++, fasit++)
       REQUIRE(a(i,j) == fasit);
+
+  a.expandRows(3,true);
+  std::cout <<"D:"<< a;
+  fasit = 1;
+  for (size_t j = 1; j <= a.cols(); j++, fasit++)
+  {
+    for (size_t i = 1; i <= 2; i++, fasit++)
+      REQUIRE(a(i,j) == fasit);
+    REQUIRE(a(3,j) == 0);
+  }
+
+  a.expandRows(1,true);
+  std::cout <<"E:"<< a;
+  fasit = 1;
+  for (size_t j = 1; j <= a.cols(); j++, fasit += 3)
+    REQUIRE(a(1,j) == fasit);
 }
 
 

--- a/src/LinAlg/matrix.h
+++ b/src/LinAlg/matrix.h
@@ -491,9 +491,14 @@ namespace utl //! General utility classes and functions.
     }
 
     //! \brief Increase or decrease the number of rows in the matrix.
-    matrix<T>& expandRows(int incRows)
+    //! \param[in] incRows Number of rows to add (or remove if negative)
+    //! \param[in] setRows If \e true, \a incRows is the new number of rows
+    //! in the matrix and not the number of rows to add or remove
+    matrix<T>& expandRows(int incRows, bool setRows = false)
     {
-      int newRows = nrow + incRows;
+      const int curRows = nrow;
+      if (setRows) incRows -= curRows;
+      const int newRows = curRows + incRows;
       if (newRows < 1 || ncol < 1)
         // The matrix is empty
         this->clear();

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -45,6 +45,20 @@ bool SIMbase::preserveNOrder  = false;
 bool SIMbase::ignoreDirichlet = false;
 
 
+namespace
+{
+  //! \brief Helper struct ensuring GlbL2 pointers are nullified when leaving.
+  struct GlbL2guard
+  {
+    ~GlbL2guard()
+    {
+      GlbL2::SolverParams = nullptr;
+      GlbL2::Adm = nullptr;
+    }
+  };
+}
+
+
 SIMbase::SIMbase (IntegrandBase* itg) : g2l(&myGlb2Loc)
 {
   nsd = 3;
@@ -2278,8 +2292,16 @@ bool SIMbase::project (Matrix& ssol, const Vector& psol,
       if (!pch->empty())
         ngNodes += pch->getNoProjectionNodes();
 
+  GlbL2guard guard;
   if (method == SIMoptions::DGL2 || method == SIMoptions::CGL2)
+  {
+    // Set integration scheme for recovery
+    // (usually higher than for the main problem)
     const_cast<SIMbase*>(this)->setQuadratureRule(opt.nGauss[1]);
+    // Set global solver parameters associated with this simulator
+    GlbL2::SolverParams = myGl2Params;
+    GlbL2::Adm = &adm;
+  }
   else if (method == SIMoptions::CGL2_INT)
   {
     // Reinitialize the integration point buffers within the integrands (if any)
@@ -2320,20 +2342,18 @@ bool SIMbase::project (Matrix& ssol, const Vector& psol,
     case SIMoptions::DGL2:
       if (msgLevel > 1 && i == 0)
         IFEM::cout <<"\tDiscrete global L2-projection"<< std::endl;
-      ok = myModel[i]->globalL2projection(values,L2ProbIntegrand(*myModel[i],*myProblem,adm));
+      ok = myModel[i]->globalL2projection(values,L2ProbIntegrand(*myModel[i],*myProblem));
       break;
 
     case SIMoptions::CGL2:
       if (msgLevel > 1 && i == 0)
         IFEM::cout <<"\tContinuous global L2-projection"<< std::endl;
-      GlbL2::SolverParams = myGl2Params;
-      ok = myModel[i]->globalL2projection(values,L2ProbIntegrand(*myModel[i],*myProblem,adm),true);
+      ok = myModel[i]->globalL2projection(values,L2ProbIntegrand(*myModel[i],*myProblem),true);
       break;
 
     case SIMoptions::CGL2_INT:
       if (msgLevel > 1 && i == 0)
         IFEM::cout <<"\tContinuous global L2-projection"<< std::endl;
-      GlbL2::SolverParams = myGl2Params;
       ok = myModel[i]->L2projection(values,myProblem,time);
       break;
 
@@ -2415,6 +2435,14 @@ bool SIMbase::project (RealArray& values, const FunctionBase* f,
                        int basis, int iField, int nFields,
                        SIMoptions::ProjectionMethod method, double time) const
 {
+  GlbL2guard guard;
+  if (method == SIMoptions::DGL2 || method == SIMoptions::CGL2)
+  {
+    // Set global solver parameters associated with this simulator
+    GlbL2::SolverParams = myGl2Params;
+    GlbL2::Adm = &adm;
+  }
+
   bool ok = true;
   for (size_t j = 0; j < myModel.size() && ok; j++)
   {
@@ -2439,7 +2467,7 @@ bool SIMbase::project (RealArray& values, const FunctionBase* f,
           return false;
         }
         Matrix ftmp(loc_values);
-        ok = myModel[j]->globalL2projection(ftmp,L2FuncIntegrand(*myModel[j],*f,adm),true);
+        ok = myModel[j]->globalL2projection(ftmp,L2FuncIntegrand(*myModel[j],*f),true);
         values = loc_values;
         return ok;
       }

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -2316,69 +2316,71 @@ bool SIMbase::project (Matrix& ssol, const Vector& psol,
   // of the result evaluation buffers.
   myProblem->initResultPoints(time.t,-1);
 
-  size_t i, ofs = 0;
-  for (i = 0; i < myModel.size(); i++)
+  bool printMsg = msgLevel > 1;
+  size_t idx = 0, ofs = 0;
+  for (ASMbase* pch : myModel)
   {
-    if (myModel[i]->empty()) continue; // skip empty patches
+    LocalSystem::patch = idx++; // Hack: For patch-wise max-value calculation
+
+    if (pch->empty() || pch->inActive(time.t))
+      continue; // skip empty or inactive patches
 
     // Extract the primary solution control point values for this patch
-    if (!this->extractPatchSolution(myProblem,Vectors(1,psol),i))
+    if (!this->extractPatchSolution(myProblem,{psol},idx-1))
       return false;
 
     // Initialize material properties for this patch in case of multiple regions
-    this->setPatchMaterial(i+1);
-
-    LocalSystem::patch = i; // Hack: Used for patch-wise max-value calculation
+    this->setPatchMaterial(idx);
 
     // Project the secondary solution and retrieve control point values
     bool ok = false;
     switch (method) {
     case SIMoptions::GLOBAL:
-      if (msgLevel > 1 && i == 0)
+      if (printMsg)
         IFEM::cout <<"\tGreville point projection"<< std::endl;
-      ok = myModel[i]->evalSolution(values,*myProblem);
+      ok = pch->evalSolution(values,*myProblem);
       break;
 
     case SIMoptions::DGL2:
-      if (msgLevel > 1 && i == 0)
+      if (printMsg)
         IFEM::cout <<"\tDiscrete global L2-projection"<< std::endl;
-      ok = myModel[i]->globalL2projection(values,L2ProbIntegrand(*myModel[i],*myProblem));
+      ok = pch->globalL2projection(values,L2ProbIntegrand(*pch,*myProblem));
       break;
 
     case SIMoptions::CGL2:
-      if (msgLevel > 1 && i == 0)
+      if (printMsg)
         IFEM::cout <<"\tContinuous global L2-projection"<< std::endl;
-      ok = myModel[i]->globalL2projection(values,L2ProbIntegrand(*myModel[i],*myProblem),true);
+      ok = pch->globalL2projection(values,L2ProbIntegrand(*pch,*myProblem),true);
       break;
 
     case SIMoptions::CGL2_INT:
-      if (msgLevel > 1 && i == 0)
+      if (printMsg)
         IFEM::cout <<"\tContinuous global L2-projection"<< std::endl;
-      ok = myModel[i]->L2projection(values,myProblem,time);
+      ok = pch->L2projection(values,myProblem,time);
       break;
 
     case SIMoptions::SCR:
-      if (msgLevel > 1 && i == 0)
+      if (printMsg)
         IFEM::cout <<"\tSuperconvergent recovery"<< std::endl;
-      ok = myModel[i]->evalSolution(values,*myProblem,nullptr,'S');
+      ok = pch->evalSolution(values,*myProblem,nullptr,'S');
       break;
 
     case SIMoptions::VDSA:
-      if (msgLevel > 1 && i == 0)
+      if (printMsg)
         IFEM::cout <<"\tVariation diminishing projection"<< std::endl;
-      ok = myModel[i]->evalSolution(values,*myProblem,nullptr,'A');
+      ok = pch->evalSolution(values,*myProblem,nullptr,'A');
       break;
 
     case SIMoptions::QUASI:
-      if (msgLevel > 1 && i == 0)
+      if (printMsg)
         IFEM::cout <<"\tQuasi interpolation"<< std::endl;
-      ok = myModel[i]->evalSolution(values,*myProblem,nullptr,'L');
+      ok = pch->evalSolution(values,*myProblem,nullptr,'L');
       break;
 
     case SIMoptions::LEASTSQ:
-      if (msgLevel > 1 && i == 0)
+      if (printMsg)
         IFEM::cout <<"\tLeast squares projection"<< std::endl;
-      ok = myModel[i]->evalSolution(values,*myProblem,nullptr,'W');
+      ok = pch->evalSolution(values,*myProblem,nullptr,'W');
       break;
 
     default:
@@ -2389,18 +2391,21 @@ bool SIMbase::project (Matrix& ssol, const Vector& psol,
     if (!ok)
     {
       std::cerr <<" *** SIMbase::project: Failure when projecting patch "
-                << myModel[i]->idx+1 <<"."<< std::endl;
+                << pch->idx+1 <<"."<< std::endl;
       return false;
     }
 
-    // If true, we cannot assume we have a multi-patch numbering for
-    // patch projections, so simply append each vector successively.
-    if (this->fieldProjections()) {
+    if (this->fieldProjections())
+    {
+      // We cannot assume we have a multi-patch numbering for patch projections,
+      // so simply append each vector successively here
       if (ssol.empty())
         ssol.resize(myProblem->getNoFields(2),ngNodes);
-      ssol.fillBlock(values, 1, ofs+1);
-      ofs += myModel[i]->getNoProjectionNodes();
-    } else {
+      ssol.fillBlock(values,1,ofs+1);
+      ofs += pch->getNoProjectionNodes();
+    }
+    else
+    {
       size_t nComps = values.rows();
       size_t nNodes = values.cols();
       if (ssol.empty())
@@ -2410,15 +2415,16 @@ bool SIMbase::project (Matrix& ssol, const Vector& psol,
       // (these are typically the interface nodes)
       for (size_t n = 1; n <= nNodes; n++)
         if (count.empty())
-          ssol.fillColumn(myModel[i]->getNodeID(n),values.getColumn(n));
+          ssol.fillColumn(pch->getNodeID(n),values.getColumn(n));
         else
         {
-          int inod = myModel[i]->getNodeID(n);
+          int inod = pch->getNodeID(n);
           for (size_t j = 1; j <= nComps; j++)
             ssol(j,inod) += values(j,n);
           count(inod) ++;
         }
     }
+    printMsg = false;
   }
 
   // Divide through by count(n) to get the nodal average at the interface nodes
@@ -2436,45 +2442,52 @@ bool SIMbase::project (RealArray& values, const FunctionBase* f,
                        SIMoptions::ProjectionMethod method, double time) const
 {
   GlbL2guard guard;
-  if (method == SIMoptions::DGL2 || method == SIMoptions::CGL2)
+  if (method >= SIMoptions::DGL2 && method <= SIMoptions::CGL2_INT)
   {
     // Set global solver parameters associated with this simulator
     GlbL2::SolverParams = myGl2Params;
     GlbL2::Adm = &adm;
   }
 
-  bool ok = true;
-  for (size_t j = 0; j < myModel.size() && ok; j++)
+  for (ASMbase* pch : myModel)
   {
-    if (myModel[j]->empty()) continue; // skip empty patches
+    if (pch->empty() || pch->inActive(time))
+      continue; // skip empty or inactive patches
 
+    bool ok = true;
     Vector loc_values;
+    Matrix ftmp(loc_values);
+
     switch (method) {
     case SIMoptions::GLOBAL:
       // Greville point projection
-      ok = myModel[j]->evaluate(f,loc_values,basis,time);
+      ok = pch->evaluate(f,loc_values,basis,time);
       break;
 
-    case SIMoptions::CGL2:
     case SIMoptions::CGL2_INT:
-      // Continuous global L2-projection
-      if (myModel[j]->separateProjectionBasis())
+      // Continuous global L2-projection (version 2)
+      if (!pch->separateProjectionBasis())
       {
-        if (myModel.size() > 1) {
-          std::cerr <<" *** L2 projection of explicit functions onto a"
-                    <<" separate basis is not available for multi-patch models."
-                    << std::endl;
-          return false;
-        }
-        Matrix ftmp(loc_values);
-        ok = myModel[j]->globalL2projection(ftmp,L2FuncIntegrand(*myModel[j],*f),true);
+        ok = pch->L2projection(ftmp,const_cast<FunctionBase*>(f),time);
+        break;
+      }
+      // fall back to version 1 if separate projection basis
+
+    case SIMoptions::CGL2:
+      // Continuous global L2-projection (version 1)
+      if (myModel.size() > 1 && pch->separateProjectionBasis())
+      {
+        std::cerr <<" *** L2 projection of explicit functions onto a separate"
+                  <<" basis is not available for multi-patch models."
+                  << std::endl;
+        return false;
+      }
+
+      ok = pch->globalL2projection(ftmp,L2FuncIntegrand(*pch,*f,time),true);
+      if (myModel.size() == 1 && pch->separateProjectionBasis())
+      {
         values = loc_values;
         return ok;
-      }
-      else
-      {
-        Matrix ftmp(loc_values);
-        ok = myModel[j]->L2projection(ftmp,const_cast<FunctionBase*>(f),time);
       }
       break;
 
@@ -2484,9 +2497,8 @@ bool SIMbase::project (RealArray& values, const FunctionBase* f,
       return false;
     }
 
-    if (nFields <= (int)f->dim())
-      ok &= this->injectPatchSolution(values,loc_values,
-                                      myModel[j],f->dim(),basis);
+    if (nFields <= static_cast<int>(f->dim()))
+      ok &= this->injectPatchSolution(values,loc_values,pch,f->dim(),basis);
     else if (f->dim() > 1)
     {
       std::cerr <<" *** SIMbase::project: Cannot interleave non-scalar function"
@@ -2498,10 +2510,10 @@ bool SIMbase::project (RealArray& values, const FunctionBase* f,
       // Interleave
       size_t i, k = iField;
       Vector loc_vector(loc_values.size()*nFields);
-      myModel[j]->extractNodeVec(values,loc_vector,0,basis);
+      pch->extractNodeVec(values,loc_vector,0,basis);
       for (i = 0; i < loc_values.size(); i++, k += nFields)
         loc_vector[k] = loc_values[i];
-      ok &= myModel[j]->injectNodeVec(loc_vector,values,0,basis);
+      ok &= pch->injectNodeVec(loc_vector,values,0,basis);
     }
     else
     {
@@ -2509,9 +2521,16 @@ bool SIMbase::project (RealArray& values, const FunctionBase* f,
                 <<" is out of range [1,"<< nFields <<"]."<< std::endl;
       return false;
     }
+
+    if (!ok)
+    {
+      std::cerr <<" *** SIMbase::project: Failure when projecting patch "
+                << pch->idx+1 <<"."<< std::endl;
+      return false;
+    }
   }
 
-  return ok;
+  return true;
 }
 
 


### PR DESCRIPTION
This replaces #872 which grew a bit too long for a monolithic PR. Reproducing the description which still is valid:

The classes for handling version 1 of the global L2 projection are placed in anonymous namespace in the `GlbL2projection.C` file, to stress that these are purely internal items and not supposed to be exposed to outside apps.
Then, account for element age when doing the projection, omitting elements not born (activated) yet, and skip entirely patches which have no activated elements.

The remaining things from #872 will/may come in a later PR.