### PR TITLE
L2projection enhancements when activating elements

### DIFF
--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -1534,7 +1534,7 @@ void ASMbase::extractElmRes (const Matrix& globRes, Vector& elmRes,
 
 
 bool ASMbase::extractNodalVec (const RealArray& globRes, RealArray& nodeVec,
-                               const int* madof, int ngnod) const
+                               const int* madof, int ngnod, int inod) const
 {
   nodeVec.clear();
   if (ngnod == 0)
@@ -1544,14 +1544,23 @@ bool ASMbase::extractNodalVec (const RealArray& globRes, RealArray& nodeVec,
   }
 
 #ifdef INDEX_CHECK
-  int maxDof = globRes.size();
+  const int maxDof = globRes.size();
 #endif
-  size_t nPchNod = ngnod == -2 ? nnod : MLGN.size();
-  nodeVec.reserve(nf*nPchNod);
-  for (size_t i = 0; i < nPchNod; i++)
+  const int maxNod = ngnod == -2 ? nnod : MLGN.size();
+  const int pchNod = inod > 0 ? 1 : maxNod;
+  nodeVec.reserve(nf*pchNod);
+  for (int i = 0; i < pchNod; i++)
   {
-    int inod = MLGN[i];
-#ifdef INDEX_CHECK
+    if (i > 0 || inod < 1)
+      inod = MLGN[i]; // Extract for all patch nodes
+    else if (inod <= maxNod)
+      inod = MLGN[inod-1]; // Extract only for the specified node
+    else
+    {
+      std::cerr <<" *** ASMbase::extractNodalVec: Local node "<< inod
+                <<" is out of range [1,"<< maxNod <<"]."<< std::endl;
+      return false;
+    }
     if (inod < 1 || (inod > ngnod && ngnod > 0))
     {
       std::cerr <<" *** ASMbase::extractNodalVec: Global node "<< inod;
@@ -1561,7 +1570,6 @@ bool ASMbase::extractNodalVec (const RealArray& globRes, RealArray& nodeVec,
         std::cerr <<" is out of range."<< std::endl;
       return false;
     }
-#endif
     int idof = madof[inod-1] - 1;
     int jdof = madof[inod] - 1;
     if (idof == jdof)
@@ -1570,7 +1578,7 @@ bool ASMbase::extractNodalVec (const RealArray& globRes, RealArray& nodeVec,
     else if (idof < 0 || idof > jdof || jdof > maxDof)
     {
       std::cerr <<" *** ASMbase::extractNodalVec: Global DOFs "
-                << idof+1 <<" "<< jdof
+                << idof+1 <<"..."<< jdof
                 <<" out of range [1,"<< maxDof <<"]."<< std::endl;
       return false;
     }
@@ -1631,6 +1639,44 @@ bool ASMbase::injectNodalVec (const RealArray& nodeVec, RealArray& globVec,
       ldof += ndof;
     }
 
+  return true;
+}
+
+
+bool ASMbase::injectNodalVec (const RealArray& nodeVec, RealArray& globVec,
+                              const int* madof, int inod) const
+{
+  if (inod < 1 || inod > static_cast<int>(MLGN.size()))
+  {
+    std::cerr <<" *** ASMbase::injectNodalVec: Node index "<< inod
+              <<" is out of range. [1,"<< MLGN.size() <<"]."<< std::endl;
+    return false;
+  }
+
+  inod = MLGN[inod-1]; // Inject only for the specified node
+
+  int idof = madof[inod-1] - 1;
+  int ndof = madof[inod] - 1 - idof;
+  if (ndof == 0)
+    return true; // DOF-less node, do nothing
+
+#ifdef INDEX_CHECK
+  int maxDof = globVec.size();
+  if (idof < 0 || ndof < 0 || idof+ndof > maxDof)
+  {
+    std::cerr <<" *** ASMbase::injectNodalVec: Global DOFs "
+              << idof+1 <<"..."<< idof+ndof
+              <<" out of range [1,"<< maxDof <<"]."<< std::endl;
+    return false;
+  }
+  else if (ndof > static_cast<int>(nodeVec.size()))
+  {
+    std::cerr <<" *** ASMbase::injectNodalVec: Nodal array too short "
+              << nodeVec.size() <<" < "<< ndof <<"."<< std::endl;
+    return false;
+  }
+#endif
+  std::copy(nodeVec.begin(), nodeVec.begin()+ndof, globVec.begin()+idof);
   return true;
 }
 

--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -41,7 +41,12 @@ int ASMbase::gNod = 0;
 IntMap ASMbase::xNode;
 IntVec ASMbase::Empty;
 
-ASM::CachePolicy ASM::cachePolicy = ASM::PRE_CACHE;
+
+namespace ASM
+{
+  CachePolicy cachePolicy = PRE_CACHE;
+  bool includeNeighbor_L2 = false;
+}
 
 
 namespace
@@ -1961,6 +1966,12 @@ void ASMbase::getBoundaryElms (int lIndex, IntVec& elms,
 bool ASMbase::isElementActive (int iel, double time) const
 {
   return this->getAge(iel,time) >= 0.0;
+}
+
+
+bool ASMbase::inActiveElement (int iel, double time) const
+{
+  return this->getAge(iel,time,ASM::includeNeighbor_L2) < 0.0;
 }
 
 

--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <functional>
 #include <iomanip>
+#include <numeric>
 
 
 bool ASMbase::fixHomogeneousDirichlet = true;
@@ -188,7 +189,20 @@ void ASMbase::clear (bool retainGeometry)
   dCode.clear();
   mpcs.clear();
 
+  MNEC.clear();
+
   myActiveEls = nullptr;
+}
+
+
+void ASMbase::invertConnectivities ()
+{
+  std::vector<IntSet> tmp(nnod);
+  for (size_t iel = 0; iel < MNPC.size(); iel++)
+    for (int inod : MNPC[iel])
+      tmp[inod].insert(iel);
+
+  MNEC.swap(tmp);
 }
 
 
@@ -286,7 +300,7 @@ std::vector<size_t> ASMbase::getNodeIndices (int globalNum) const
 
 int ASMbase::getNodeID (size_t inod, bool) const
 {
-  return inod < 1 || inod > MLGN.size() ? 0 : MLGN[inod-1];
+  return inod > 0 && --inod < MLGN.size() ? MLGN[inod] : 0;
 }
 
 
@@ -305,17 +319,13 @@ size_t ASMbase::getElmIndex (int globalNum) const
 
 int ASMbase::getElmID (size_t iel) const
 {
-  return iel < 1 || iel > MLGE.size() ? 0 : abs(MLGE[iel-1]);
+  return iel > 0 && --iel < MLGE.size() ? abs(MLGE[iel]) : 0;
 }
 
 
 const IntVec& ASMbase::getElementNodes (int iel) const
 {
-  if (iel > 0 && iel <= static_cast<int>(MNPC.size()))
-    return MNPC[iel-1];
-
-  static IntVec empty;
-  return empty;
+  return iel > 0 && --iel < static_cast<int>(MNPC.size()) ? MNPC[iel] : Empty;
 }
 
 
@@ -377,12 +387,9 @@ size_t ASMbase::getNoElms (bool includeZeroVolElms, bool includeXElms) const
   if (includeZeroVolElms)
     return includeXElms ? MLGE.size() : nel;
 
-  size_t numels = 0;
-  for (int iel : MLGE)
-    if (iel > 0 || (includeXElms && iel < 0))
-      numels++;
-
-  return numels;
+  return std::accumulate(MLGE.begin(), MLGE.end(), 0u,
+                         [&incNeg=includeXElms](size_t n, int iel)
+                         { return iel > 0 || (incNeg && iel < 0) ? n+1u : n; });
 }
 
 
@@ -1983,7 +1990,7 @@ bool ASMbase::inActive (double time) const
 }
 
 
-double ASMbase::getAge (int iel, double time) const
+double ASMbase::getAge (int iel, double time, bool includeNeighbor) const
 {
   if (iel < 0 || iel >= static_cast<int>(MLGE.size()))
     return -1001.0; // element index out of range
@@ -1999,10 +2006,25 @@ double ASMbase::getAge (int iel, double time) const
   if (time < 0.0) time = 0.0; // reset to zero to avoid element deactivation
 
   if (!myElActive)
-    return time; // no activation time, age equals current time
+    return time; // no birth time, age equals current time
 
-  time -= (*myElActive)(1+iel);
-  return time < -1.0e-12 || time > 0.0 ? time : 0.0;
+  double elmAge = time - (*myElActive)(1+iel);
+  if (elmAge < -1.0e-12 && includeNeighbor)
+  {
+    // This element is not born yet, but check its neighbors.
+    // First, construct node-to-element connectivities for this patch.
+#pragma omp critical (ASMbase_MNEC)
+    if (MNEC.empty())
+      const_cast<ASMbase*>(this)->invertConnectivities();
+
+    // Check if this element is connected to other elements already born,
+    // then consider this an active element as well
+    for (int inod : MNPC[iel])
+      for (int jel : MNEC[inod])
+        if (jel != iel && this->isElementActive(jel,time))
+          return 0.0; // connected to an active element
+  }
+  return elmAge < -1.0e-12 || elmAge > 0.0 ? elmAge : 0.0;
 }
 
 

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -54,6 +54,8 @@ namespace ASM {
   class InterfaceChecker;
   using NodeSet  = std::pair<std::string,IntVec>; //!< Named set container type
   using PatchVec = std::vector<ASMbase*>; //!< Spline patch container type
+  //! If \e true, the neighbors to newly activated elements are included
+  extern bool includeNeighbor_L2; //!< in global L2-projection
 }
 
 

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -22,6 +22,7 @@
 #include <array>
 #include <string>
 
+using IntSet = std::set<int>;       //!< General integer set
 using IntVec = std::vector<int>;    //!< General integer vector
 using IntMat = std::vector<IntVec>; //!< General 2D integer matrix
 using Ipair  = std::pair<int,int>;  //!< A pair of integers
@@ -357,10 +358,12 @@ public:
   void setActiveElements(IntVec* active) { myActiveEls = active; }
   //! \brief Returns \e true if element with 0-based index \a iel is active.
   bool isElementActive(int iel, double time = -1.0) const;
+  //! \brief Returns \e true if element with 0-based index \a iel is inactive.
+  bool inActiveElement(int iel, double time) const;
   //! \brief Returns \e true if none of the elements in the patch are active.
   bool inActive(double time = -1.0) const;
   //! \brief Returns the age of the element with 0-based index \a iel.
-  double getAge(int iel, double time) const;
+  double getAge(int iel, double time, bool includeNeighbor = false) const;
   //! \brief Returns \e true if element is in process partition.
   //! \param[in] iel 0-based element index local to current patch
   bool isElementInPartition(int iel) const;
@@ -974,6 +977,9 @@ protected:
   // Miscellaneous methods for internal use
   // ======================================
 
+  //! \brief Constructs the \ref MNEC array for this patch.
+  void invertConnectivities();
+
   //! \brief Helper method used by evalPoint to search for a control point.
   //! \param[in] cit iterator of array of control point coordinates
   //! \param[in] end iterator of array of control point coordinates
@@ -1100,6 +1106,8 @@ protected:
   IntVec myMLGN; //!< The actual Matrix of Local to Global Node numbers
   IntMat myMNPC; //!< The actual Matrix of Nodal Point Correspondance
   IntVec myElms; //!< Elements on patch - used with partitioning
+
+  std::vector<IntSet> MNEC; //!< Matrix of Node to Element Connectivities
 
   //! \brief Numerical integration scheme for this patch.
   //! \details A value in the range [1,10] means use that number of Gauss

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -847,8 +847,9 @@ public:
   //! \param[out] nodeVec Nodal result vector for this patch
   //! \param[in] madof Global Matrix of Accumulated DOFs
   //! \param[in] ngnod Dimension of madof (the default -1 means unknown)
+  //! \param[in] inod 1-based local index of the node to extract (or 0 for all)
   bool extractNodalVec(const RealArray& globVec, RealArray& nodeVec,
-                       const int* madof, int ngnod = -1) const;
+                       const int* madof, int ngnod = -1, int inod = 0) const;
 
   //! \brief Extracts nodal results for this patch from the global vector.
   //! \param[in] globVec Global solution vector in DOF-order
@@ -873,6 +874,14 @@ public:
   //! \param[in] basis Which basis to inject nodal values for (mixed methods)
   bool injectNodalVec(const RealArray& nodeVec, RealArray& globVec,
                       const IntVec& madof, int basis = 0) const;
+
+  //! \brief Injects nodal results for a single node into the global vector.
+  //! \param[in] nodeVec Nodal result vector
+  //! \param globVec Global solution vector in DOF-order
+  //! \param[in] madof Global Matrix of Accumulated DOFs
+  //! \param[in] inod 1-based local index of the node to inject
+  bool injectNodalVec(const RealArray& nodeVec, RealArray& globVec,
+                      const int* madof, int inod) const;
 
   //! \brief Creates and adds a two-point constraint to this patch.
   //! \param[in] slave Global node number of the node to constrain

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -1744,11 +1744,15 @@ bool ASMs1D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
   // Evaluate the secondary solution field at each point
   const RealArray& upar = *gpar;
   size_t nPoints = upar.size();
+#if SP_DEBUG > 3
+  std::cout <<"\nASMs1D::evalSolution("<< nPoints <<")"<< std::endl;
+#endif
+
   for (size_t i = 0; i < nPoints; i++, fe.iGP++)
   {
     fe.u = param[0] = upar[i];
     int iel = this->findElementContaining(param) - 1;
-    if ((fe.age = this->getAge(iel,X.t) < 0.0))
+    if ((fe.age = this->getAge(iel,X.t,ASM::includeNeighbor_L2)) < 0.0)
       continue; // skip inactive elements
 
     fe.idx = firstEl + iel;
@@ -1806,6 +1810,11 @@ bool ASMs1D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
     else if (sField.empty())
       sField.resize(solPt.size(),nPoints,true);
 
+#if SP_DEBUG > 3
+    std::cout << 1+i <<" "<< 1+iel <<" u = "<< fe.u <<" :";
+    for (double v : solPt) std::cout <<" "<< v;
+    std::cout << std::endl;
+#endif
     sField.fillColumn(1+i,solPt);
   }
 
@@ -1860,7 +1869,7 @@ bool ASMs1D::assembleL2matrices (SystemMatrix& A, SystemVector& B,
   for (size_t iel = 0; iel < mlge.size(); iel++)
   {
     if (mlge[iel] < 1) continue; // zero-length element
-    if (checkAge && !this->isElementActive(iel,integrand.getTimeLevel()))
+    if (checkAge && this->inActiveElement(iel,integrand.getTimeLevel()))
       continue; // inactive element
 
     if (continuous)

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -2985,6 +2985,11 @@ bool ASMs2D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
   else
     return false;
 
+#if SP_DEBUG > 3
+  std::cout <<"\nASMs2D::evalSolution("<< nPoints
+            <<","<< std::boolalpha << regular <<")"<< std::endl;
+#endif
+
   const int p1 = surf->order_u();
   const int p2 = surf->order_v();
   const int n1 = surf->numCoefs_u();
@@ -3035,8 +3040,11 @@ bool ASMs2D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
     }
 
     int iel = this->findElementContaining(param) - 1;
-    if ((fe.age = this->getAge(iel,X.t)) < 0.0)
+    if ((fe.age = this->getAge(iel,X.t,ASM::includeNeighbor_L2)) < 0.0)
       continue; // zero-area or inactive element
+
+    fe.idx = firstEl + iel;
+    fe.iel = MLGE[iel];
 
     // Fetch associated control point coordinates
     utl::gather(ip,nsd,Xnod,Xtmp);
@@ -3077,6 +3085,11 @@ bool ASMs2D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
     else if (sField.empty())
       sField.resize(solPt.size(),nPoints,true);
 
+#if SP_DEBUG > 3
+    std::cout << 1+i <<" "<< 1+iel <<" (u,v) = ("<< fe.u <<" "<< fe.v <<") :";
+    for (double v : solPt) std::cout <<" "<< v;
+    std::cout << std::endl;
+#endif
     sField.fillColumn(1+i,solPt);
   }
 

--- a/src/ASM/ASMs2DLag.C
+++ b/src/ASM/ASMs2DLag.C
@@ -1136,7 +1136,7 @@ bool ASMs2DLag::assembleL2matrices (SystemMatrix& A, SystemVector& B,
       Matrix dNdX, Xnod, J;
       for (int iel : group)
       {
-        if (checkAge && !this->isElementActive(iel,integrand.getTimeLevel()))
+        if (checkAge && this->inActiveElement(iel,integrand.getTimeLevel()))
           continue; // inactive element
 
         if (!this->getElementCoordinates(Xnod,1+iel)) {

--- a/src/ASM/ASMs2Drecovery.C
+++ b/src/ASM/ASMs2Drecovery.C
@@ -225,7 +225,7 @@ bool ASMs2D::assembleL2matrices (SystemMatrix& A, SystemVector& B,
       Matrix dNdu, Xnod, J;
       for (int iel : projThreadGroups[g][t])
       {
-        if (checkAge && !this->isElementActive(iel,integrand.getTimeLevel()))
+        if (checkAge && this->inActiveElement(iel,integrand.getTimeLevel()))
           continue; // inactive element
 
         const IntVec& mnpc = gmnpc[iel];

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -3423,6 +3423,11 @@ bool ASMs3D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
   else
     return false;
 
+#if SP_DEBUG > 3
+  std::cout <<"\nASMs3D::evalSolution("<< nPoints
+            <<","<< std::boolalpha << regular <<")"<< std::endl;
+#endif
+
   const int p1 = svol->order(0);
   const int p2 = svol->order(1);
   const int p3 = svol->order(2);
@@ -3462,7 +3467,7 @@ bool ASMs3D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
     }
 
     int iel = this->findElementContaining(param) - 1;
-    if ((fe.age = this->getAge(iel,X.t)) < 0.0)
+    if ((fe.age = this->getAge(iel,X.t,ASM::includeNeighbor_L2)) < 0.0)
       continue; // zero-volume or inactive element
 
     fe.idx = firstEl + iel;
@@ -3497,6 +3502,12 @@ bool ASMs3D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
     else if (sField.empty())
       sField.resize(solPt.size(),nPoints,true);
 
+#if SP_DEBUG > 3
+    std::cout << 1+i <<" "<< 1+iel
+              <<" (u,v,w) = ("<< fe.u <<" "<< fe.v <<" "<< fe.w <<") :";
+    for (double v : solPt) std::cout <<" "<< v;
+    std::cout << std::endl;
+#endif
     sField.fillColumn(1+i,solPt);
   }
 

--- a/src/ASM/ASMs3DLag.C
+++ b/src/ASM/ASMs3DLag.C
@@ -1467,7 +1467,7 @@ bool ASMs3DLag::assembleL2matrices (SystemMatrix& A, SystemVector& B,
       Matrix dNdX, Xnod, J;
       for (int iel : group)
       {
-        if (checkAge && !this->isElementActive(iel,integrand.getTimeLevel()))
+        if (checkAge && this->inActiveElement(iel,integrand.getTimeLevel()))
           continue; // inactive element
 
         if (!this->getElementCoordinates(Xnod,1+iel)) {

--- a/src/ASM/ASMs3Drecovery.C
+++ b/src/ASM/ASMs3Drecovery.C
@@ -233,7 +233,7 @@ bool ASMs3D::assembleL2matrices (SystemMatrix& A, SystemVector& B,
       Matrix dNdu, Xnod, J;
       for (int iel : projThreadGroups[g][t])
       {
-        if (checkAge && !this->isElementActive(iel,integrand.getTimeLevel()))
+        if (checkAge && this->inActiveElement(iel,integrand.getTimeLevel()))
           continue; // inactive element
 
         const IntVec& mnpc = gmnpc[iel];

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -2327,9 +2327,17 @@ bool Mode::computeDamping (const SystemMatrix& mat)
 }
 
 
+/*!
+  If \a updNewPt is \e true and the model uses element activation,
+  control point values connected to not-yet activated elements only
+  are initialized to the average of the other control points
+  connected to the same element, before the projection is performed.
+  See extractPatchSolution().
+*/
+
 bool SIMbase::project (Matrix& ssol, const Vector& psol,
-		       SIMoptions::ProjectionMethod method,
-		       const TimeDomain& time) const
+                       SIMoptions::ProjectionMethod method,
+                       const TimeDomain& time, bool updNewPt) const
 {
   PROFILE1("Solution projection");
 
@@ -2338,6 +2346,7 @@ bool SIMbase::project (Matrix& ssol, const Vector& psol,
 
   ssol.clear();
 
+  const double extrTime = updNewPt ? time.t : 0.0;
   size_t ngNodes = this->fieldProjections() ? 0 : this->getNoNodes(1);
   Vector count(myModel.size() > 1 ? ngNodes : 0);
   Matrix values;
@@ -2382,7 +2391,7 @@ bool SIMbase::project (Matrix& ssol, const Vector& psol,
       continue; // skip empty or inactive patches
 
     // Extract the primary solution control point values for this patch
-    if (!this->extractPatchSolution(myProblem,{psol},idx-1,time.t))
+    if (!this->extractPatchSolution(myProblem,{psol},idx-1,extrTime))
       return false;
 
     // Initialize material properties for this patch in case of multiple regions
@@ -2668,6 +2677,11 @@ bool SIMbase::extractPatchSolution (IntegrandBase* problem, const Vectors& sol,
     else
       problem->getSolution(i).clear();
 
+#if SP_DEBUG > 1
+  for (size_t i = 0; i < problem->getNoSolutions(); i++)
+    std::cout <<"\nSolution vector "<< i+1 <<" for Patch "<< pch->idx+1
+              << problem->getSolution(i);
+#endif
   return this->extractPatchDependencies(problem,myModel,pindx);
 }
 

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -2382,7 +2382,7 @@ bool SIMbase::project (Matrix& ssol, const Vector& psol,
       continue; // skip empty or inactive patches
 
     // Extract the primary solution control point values for this patch
-    if (!this->extractPatchSolution(myProblem,{psol},idx-1))
+    if (!this->extractPatchSolution(myProblem,{psol},idx-1,time.t))
       return false;
 
     // Initialize material properties for this patch in case of multiple regions
@@ -2590,8 +2590,15 @@ bool SIMbase::project (RealArray& values, const FunctionBase* f,
 }
 
 
-bool SIMbase::extractPatchSolution (IntegrandBase* problem,
-                                    const Vectors& sol, size_t pindx) const
+/*!
+  If \a time &gt; 0 and element activation is used, this method will also
+  assign solution values to control/nodal points only connected to inactive
+  elements that are connected to other active elements. These values are
+  based on the average nodal values of the connected neighbor element.
+*/
+
+bool SIMbase::extractPatchSolution (IntegrandBase* problem, const Vectors& sol,
+                                    size_t pindx, double time) const
 {
   if (!problem || !mySam) return false;
 
@@ -2599,9 +2606,65 @@ bool SIMbase::extractPatchSolution (IntegrandBase* problem,
   if (!pch) return false;
 
   problem->initNodeMap(pch->getGlobalNodeNums());
+
+  Vectors tmpSol;
+  if (pch->getElementActivator() && time > 0.0)
+  {
+    // We need to assign values to the nodes/control points only connected to
+    // not-yet activated elements that are connected to at least one node that
+    // also is connected to an active element
+
+    // First, find all currently active elements and nodes
+    IntSet activeNodes;
+    IntVec inactiveElms;
+    for (size_t iel = 1; iel <= pch->getNoElms(true); iel++)
+      if (pch->isElementActive(iel-1,time))
+        for (int inod : pch->getElementNodes(iel))
+          activeNodes.insert(pch->getNodeID(1+inod));
+      else
+        inactiveElms.push_back(iel);
+
+    for (int iel : inactiveElms)
+    {
+      // Find mean value for inactive elements connected to active elements
+      size_t nanod = 0;
+      RealArray nodSol;
+      Vectors avgSol(problem->getNoSolutions());
+      for (int inod : pch->getElementNodes(iel))
+        if (activeNodes.find(pch->getNodeID(1+inod)) != activeNodes.end())
+        {
+          ++nanod;
+          for (size_t i = 0; i < avgSol.size(); i++)
+            if (i < sol.size() && !sol[i].empty())
+            {
+              pch->extractNodalVec(sol[i],nodSol,mySam->getMADOF(),-1,1+inod);
+              avgSol[i].add(nodSol);
+            }
+        }
+
+      if (nanod > 0)
+      {
+        for (Vector& s : avgSol)
+          s *= 1.0/static_cast<double>(nanod);
+
+        if (tmpSol.empty())
+          tmpSol = sol;
+
+        // Now assign this value to the connected inactive nodes
+        for (int inod : pch->getElementNodes(iel))
+          if (activeNodes.find(pch->getNodeID(1+inod)) == activeNodes.end())
+            for (size_t i = 0; i < avgSol.size(); i++)
+              if (!avgSol[i].empty())
+                pch->injectNodalVec(avgSol[i],tmpSol[i],mySam->getMADOF(),1+inod);
+      }
+    }
+  }
+
+  const Vectors& psol = tmpSol.empty() ? sol : tmpSol;
+
   for (size_t i = 0; i < problem->getNoSolutions(); i++)
-    if (i < sol.size() && !sol[i].empty())
-      pch->extractNodalVec(sol[i],problem->getSolution(i),mySam->getMADOF());
+    if (i < psol.size() && !psol[i].empty())
+      pch->extractNodalVec(psol[i],problem->getSolution(i),mySam->getMADOF());
     else
       problem->getSolution(i).clear();
 

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -93,9 +93,9 @@ public:
   //! the input file in the refinement step of an adaptive simulation.
   virtual void clearProperties();
 
-  //! \brief Interface for app-specific single-step simulation initialisation.
+  //! \brief %Interface for app-specific single-step simulation initialisation.
   virtual void initForSingleStep() {}
-  //! \brief Interface for app-specific multi-step simulation initialisation.
+  //! \brief %Interface for app-specific multi-step simulation initialisation.
   virtual void initForMultiStep() {}
 
   //! \brief Performs some pre-processing tasks on the FE model.
@@ -522,12 +522,28 @@ public:
   //! \param[in] method Projection method to use
   //! \param[in] time Parameters for nonlinear/time-dependent simulations
   //!
+  //! \details %Interface for amending additional fields to the projection.
+  virtual bool project(Matrix& ssol, const Vector& psol,
+                       SIMoptions::ProjectionMethod method = SIMoptions::GLOBAL,
+                       const TimeDomain& time = TimeDomain()) const
+  {
+    return this->project(ssol,psol,method,time,false);
+  }
+
+  //! \brief Projects the secondary solution associated with a primary solution.
+  //! \param[out] ssol Control point values of the secondary solution
+  //! \param[in] psol Control point values of the primary solution
+  //! \param[in] method Projection method to use
+  //! \param[in] time Parameters for nonlinear/time-dependent simulations
+  //! \param[in] updNewPt If \e true, estimate newly activated point values
+  //!
   //! \details The secondary solution, defined through the Integrand object,
   //! corresponding to the primary solution \a psol is projected onto the
   //! spline basis to obtain the control point values of the secondary solution.
-  virtual bool project(Matrix& ssol, const Vector& psol,
-                       SIMoptions::ProjectionMethod method = SIMoptions::GLOBAL,
-                       const TimeDomain& time = TimeDomain()) const;
+  bool project(Matrix& ssol, const Vector& psol,
+               SIMoptions::ProjectionMethod method,
+               const TimeDomain& time, bool updNewPt) const;
+
   //! \brief Projects the secondary solution associated with a primary solution.
   //! \param[out] ssol Vector of control point values of the secondary solution
   //! \param[in] psol Vector of control point values of the primary solution
@@ -620,7 +636,7 @@ protected:
   //! \param[in] renumMNPC If \e true, also update element connectivity tables
   //! \return Total number of unique nodes in the model, negative on error
   int renumberNodes(bool renumMNPC = false);
-  //! \brief Interface for renumbering of app-specific node number tables.
+  //! \brief %Interface for renumbering of app-specific node number tables.
   virtual bool renumberNodes(const std::map<int,int>&) { return true; }
 
   //! \brief Extracts all local solution vector(s) for a specified patch.

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -627,14 +627,15 @@ protected:
   //! \param[in] problem The integrand to receive patch-level solution vectors
   //! \param[in] sol Global primary solution vectors in DOF-order
   //! \param[in] pindx Local patch index to extract solution vectors for
+  //! \param[in] time Current time (used only if element activators exist)
   //!
   //! \details This method is typically invoked before ASMbase::integrate()
   //! on the specified patch, in order to extract all patch-level vector
   //! quantities needed by the Integrand. This also includes any dependent
   //! vectors from other simulator classes that have been registered.
   //! All patch-level vectors are stored within the provided integrand.
-  virtual bool extractPatchSolution(IntegrandBase* problem,
-                                    const Vectors& sol, size_t pindx) const;
+  virtual bool extractPatchSolution(IntegrandBase* problem, const Vectors& sol,
+                                    size_t pindx, double time = 0.0) const;
 
 public:
   using SIMdependency::registerDependency;


### PR DESCRIPTION
Leftovers from #872. This adds to option to include the not-yet-connected elements which are directly connected to active elements in the L2-projection. And to initialize control/nodal point values based on adjacent mean element values when doing global L2-projection.