### PR TITLE
Laplacian with diagonal constitutive matrix

### DIFF
--- a/Apps/Utils/EqualOrderOperators.C
+++ b/Apps/Utils/EqualOrderOperators.C
@@ -15,57 +15,39 @@
 #include "Vec3.h"
 #include "Vec3Oper.h"
 
-namespace {
 
-//! \brief Helper for adding an element matrix to one component.
-//! \param[out] EM The element matrix to add to.
-//! \param[in] A The scalar element matrix to add.
-//! \param[in] cmp1 First components to add matrix to
-//! \param[in] cmp2 Second irst components to add matrix to
-//! \param[in] nf Number of components in total matrix.
-void addComponent (Matrix& EM, const Matrix& A,
-                   size_t cmp1, size_t cmp2, size_t nf)
+namespace
 {
-  for (size_t i = 1; i <= A.rows(); ++i)
-    for (size_t j = 1; j <= A.cols(); ++j)
-      EM(nf*(i-1)+cmp1,nf*(j-1)+cmp2) += A(i, j);
-}
+  //! \brief Helper for adding an element matrix to one component.
+  //! \param[out] EM The element matrix to add to
+  //! \param[in] A The scalar element matrix to add
+  //! \param[in] cmp1 First components to add matrix to
+  //! \param[in] cmp2 Second components to add matrix to
+  //! \param[in] nf Number of components in total matrix
+  void addComponent (Matrix& EM, const Matrix& A,
+                     size_t cmp1, size_t cmp2, size_t nf)
+  {
+    for (size_t i = 1; i <= A.rows(); ++i)
+      for (size_t j = 1; j <= A.cols(); ++j)
+        EM(nf*(i-1)+cmp1, nf*(j-1)+cmp2) += A(i, j);
+  }
 
-
-//! \brief Helper for adding an element matrix to several components.
-//! \param[out] EM The element matrix to add to.
-//! \param[in] A The scalar element matrix to add.
-//! \param[in] cmp Number of components to add matrix to
-//! \param[in] nf Number of components in total matrix.
-//! \param[in] scmp Index of first component to add matrix to.
-void addComponents (Matrix& EM, const Matrix& A,
-                    size_t cmp, size_t nf, size_t scmp)
-{
-  if (cmp == 1 && nf == 1)
-    EM += A;
-  else
-    for (size_t k = 1; k <= cmp; ++k)
-      addComponent(EM, A, k+scmp, k+scmp, nf);
-}
-
-
-//! \brief Helper applying a divergence (1) or a gradient (2) operation
-template<int Operation>
-void DivGrad (Matrix& EM, const FiniteElement& fe,
-              double scale, int basis, int tbasis)
-{
-  size_t nsd = fe.grad(basis).cols();
-  for (size_t i = 1; i <= fe.basis(tbasis).size();++i)
-    for (size_t j = 1; j <= fe.basis(basis).size();++j)
-      for (size_t k = 1; k <= nsd; ++k) {
-        double div = fe.basis(basis)(j)*fe.grad(tbasis)(i,k)*fe.detJxW;
-        if (Operation == 2)
-          EM((i-1)*nsd+k,j) += -scale*div;
-        if (Operation == 1)
-          EM(j, (i-1)*nsd+k) += scale*div;
-      }
-}
-
+  //! \brief Helper applying a divergence (1) or a gradient (2) operation.
+  template<int Operation>
+  void DivGrad (Matrix& EM, const FiniteElement& fe,
+                double scale, int basis, int tbasis)
+  {
+    size_t nsd = fe.grad(basis).cols();
+    for (size_t i = 1; i <= fe.basis(tbasis).size(); ++i)
+      for (size_t j = 1; j <= fe.basis(basis).size(); ++j)
+        for (size_t k = 1; k <= nsd; ++k) {
+          double div = fe.basis(basis)(j) * fe.grad(tbasis)(i,k) * fe.detJxW;
+          if (Operation == 2)
+            EM((i-1)*nsd+k, j) -= scale*div;
+          if (Operation == 1)
+            EM(j, (i-1)*nsd+k) += scale*div;
+        }
+  }
 }
 
 
@@ -75,29 +57,29 @@ void EqualOrderOperators::Weak::Advection (Matrix& EM, const FiniteElement& fe,
                                            WeakOperators::ConvectionForm form,
                                            int basis)
 {
-  Matrix C(fe.basis(basis).size(), fe.basis(basis).size());
-  size_t ncmp = EM.rows() / C.rows();
+  const size_t cmp = EM.rows() / fe.basis(basis).size();
+
+  Matrix tmp;
+  Matrix& C = cmp > 1 ? tmp : EM;
 
   // Sum convection for each direction
   for (size_t k = 1; k <= fe.grad(basis).cols(); ++k)
     if (form == WeakOperators::CONVECTIVE)
-      C.outer_product(fe.basis(basis),
-                      fe.grad(basis).getColumn(k), true,
-                      scale*AC[k-1]*fe.detJxW);
+      C.outer_product(fe.basis(basis), fe.grad(basis).getColumn(k),
+                      k > 1 || cmp == 1,  scale*AC[k-1]*fe.detJxW);
     else if (form == WeakOperators::CONSERVATIVE)
-      C.outer_product(fe.grad(basis).getColumn(k),
-                      fe.basis(basis), true,
-                      -scale*AC[k-1]*fe.detJxW);
+      C.outer_product(fe.grad(basis).getColumn(k), fe.basis(basis),
+                      k > 1 || cmp == 1, -scale*AC[k-1]*fe.detJxW);
     else if (form == WeakOperators::SKEWSYMMETRIC) {
-      C.outer_product(fe.basis(basis),
-                      fe.grad(basis).getColumn(k), true,
-                      0.5*scale*AC[k-1]*fe.detJxW);
-      C.outer_product(fe.grad(basis).getColumn(k),
-                      fe.basis(basis), true,
-                      -0.5*scale*AC[k-1]*fe.detJxW);
+      C.outer_product(fe.basis(basis), fe.grad(basis).getColumn(k),
+                      k > 1 || cmp == 1, 0.5*scale*AC[k-1]*fe.detJxW);
+      C.outer_product(fe.grad(basis).getColumn(k), fe.basis(basis),
+                      true,             -0.5*scale*AC[k-1]*fe.detJxW);
     }
 
-  addComponents(EM, C, ncmp, ncmp, 0);
+  if (cmp > 1)
+    for (size_t k = 1; k <= cmp; ++k)
+      addComponent(EM, tmp, k, k, cmp);
 }
 
 
@@ -107,8 +89,8 @@ void EqualOrderOperators::Weak::Convection (Matrix& EM, const FiniteElement& fe,
                                             WeakOperators::ConvectionForm form,
                                             int basis)
 {
-  size_t cmp = EM.rows() / fe.basis(basis).size();
-  double coef = scale*fe.detJxW;
+  const size_t cmp = EM.rows() / fe.basis(basis).size();
+  const double coef = scale*fe.detJxW;
 
   const Vector& N = fe.basis(basis);
   const Matrix& D = fe.grad(basis);
@@ -168,7 +150,7 @@ void EqualOrderOperators::Weak::Divergence (Vector& EV,
                                             const Vec3& D,
                                             double scale, int basis)
 {
-  size_t nsd = fe.grad(basis).cols();
+  const size_t nsd = fe.grad(basis).cols();
   fe.grad(basis).multiply(Vector(D.ptr(),nsd),EV,scale*fe.detJxW,1.0);
 }
 
@@ -176,10 +158,17 @@ void EqualOrderOperators::Weak::Divergence (Vector& EV,
 void EqualOrderOperators::Weak::Laplacian (Matrix& EM, const FiniteElement& fe,
                                            double scale, bool stress, int basis)
 {
-  size_t cmp = EM.rows() / fe.basis(basis).size();
-  Matrix A;
-  A.multiply(fe.grad(basis),fe.grad(basis),false,true,false,scale*fe.detJxW);
-  addComponents(EM, A, cmp, cmp, 0);
+  const size_t cmp = EM.rows() / fe.basis(basis).size();
+  if (cmp > 1)
+  {
+    Matrix A;
+    A.multiply(fe.grad(basis),fe.grad(basis),false,true,false,scale*fe.detJxW);
+    for (size_t k = 1; k <= cmp; ++k)
+      addComponent(EM, A, k, k, cmp);
+  }
+  else
+    EM.multiply(fe.grad(basis),fe.grad(basis),false,true,true,scale*fe.detJxW);
+
   if (stress)
     Stress(EM, fe, scale, basis);
 }
@@ -189,13 +178,14 @@ void EqualOrderOperators::Weak::Stress (Matrix& EM,
                                         const FiniteElement& fe,
                                         double scale, int basis)
 {
+  const size_t cmp = EM.rows() / fe.basis(basis).size();
+
   Matrix A;
-  size_t cmp = EM.rows() / fe.basis(basis).size();
   for (size_t k = 1; k <= cmp; k++)
     for (size_t l = 1; l <= cmp; l++) {
       A.outer_product(fe.grad(basis).getColumn(l),
                       fe.grad(basis).getColumn(k),
-                      false, scale * fe.detJxW);
+                      false, scale*fe.detJxW);
       addComponent(EM, A, k, l, cmp);
     }
 }
@@ -211,25 +201,42 @@ void EqualOrderOperators::Weak::LaplacianCoeff (Matrix& EM, const Matrix& K,
 }
 
 
+void EqualOrderOperators::Weak::LaplacianCoeff (Matrix& EM, const Vec3& K,
+                                                const FiniteElement& fe,
+                                                double scale, int basis)
+{
+  Matrix BK(fe.grad(basis));
+  BK.scale((K*scale*fe.detJxW).vec(fe.grad(basis).cols()));
+  EM.multiply(BK,fe.grad(basis),false,true,true);
+}
+
+
 void EqualOrderOperators::Weak::Mass (Matrix& EM, const FiniteElement& fe,
                                       double scale, int basis)
 {
-  size_t ncmp = EM.rows()/fe.basis(basis).size();
-  Matrix A;
-  A.outer_product(fe.basis(basis),fe.basis(basis),false);
-  A *= scale*fe.detJxW;
-  addComponents(EM, A, ncmp, ncmp, 0);
+  const size_t cmp = EM.rows() / fe.basis(basis).size();
+  if (cmp > 1)
+  {
+    Matrix A;
+    A.outer_product(fe.basis(basis),fe.basis(basis),false,scale*fe.detJxW);
+    for (size_t k = 1; k <= cmp; ++k)
+      addComponent(EM, A, k, k, cmp);
+  }
+  else
+    EM.outer_product(fe.basis(basis),fe.basis(basis),true,scale*fe.detJxW);
 }
 
 
 void EqualOrderOperators::Weak::ItgConstraint (Matrix& EM, const FiniteElement& fe,
                                                double scale, int basis)
 {
-  const size_t ncmp = EM.rows() / fe.basis(basis).size();
+  const size_t cmp = EM.rows() / fe.basis(basis).size();
+
   Matrix A(fe.basis(basis).size(), 1);
   A = fe.basis(basis);
   A *= scale*fe.detJxW;
-  addComponents(EM, A, ncmp, ncmp, 0);
+  for (size_t k = 1; k <= cmp; ++k)
+    addComponent(EM, A, k, k, cmp);
 }
 
 
@@ -237,21 +244,22 @@ void EqualOrderOperators::Weak::Source (Vector& EV,
                                         const FiniteElement& fe,
                                         double scale, int cmp, int basis)
 {
-  size_t ncmp = EV.size() / fe.basis(basis).size();
+  const size_t ncmp = EV.size() / fe.basis(basis).size();
+
   if (cmp == 1 && ncmp == 1)
     EV.add(fe.basis(basis), scale*fe.detJxW);
-  else {
-    for (size_t k  = (cmp == 0 ? 1 : cmp);
-                k <= (cmp == 0 ? ncmp : cmp); ++k)
-      EV.add(fe.basis(basis), scale*fe.detJxW, 0, 1, k-1, ncmp);
-  }
+  else if (cmp > 0)
+    EV.add(fe.basis(basis), scale*fe.detJxW, 0, 1, cmp-1, ncmp);
+  else for (size_t k = 0; k < ncmp; k++)
+    EV.add(fe.basis(basis), scale*fe.detJxW, 0, 1, k, ncmp);
 }
 
 
 void EqualOrderOperators::Weak::Source (Vector& EV, const FiniteElement& fe,
                                         const Vec3& f, double scale, int basis)
 {
-  size_t cmp = EV.size() / fe.basis(basis).size();
+  const size_t cmp = EV.size() / fe.basis(basis).size();
+
   for (size_t k = 1; k <= cmp; ++k)
     EV.add(fe.basis(basis), scale*f[k-1]*fe.detJxW, 0, 1, k-1, cmp);
 }
@@ -262,7 +270,8 @@ void EqualOrderOperators::Residual::Advection (Vector& EV,
                                                const Vec3& AC, const Tensor& g,
                                                double scale, int basis)
 {
-  size_t nsd = fe.grad(basis).cols();
+  const size_t nsd = fe.grad(basis).cols();
+
   for (size_t k = 1; k <= nsd; ++k)
     EV.add(fe.basis(basis), (g[k-1]*AC)*scale*fe.detJxW, 0, 1, k-1, nsd);
 }
@@ -276,8 +285,9 @@ void EqualOrderOperators::Residual::Convection (Vector& EV,
                                                 WeakOperators::ConvectionForm form,
                                                 int basis)
 {
-  size_t cmp = EV.size() / fe.basis(basis).size();
-  double coef = scale * fe.detJxW;
+  const size_t cmp = EV.size() / fe.basis(basis).size();
+  const double coef = scale * fe.detJxW;
+
   double conv = 0.0;
   for (size_t i = 1;i <= fe.basis(basis).size();i++)
     for (size_t k = 1;k <= cmp;k++)
@@ -316,12 +326,11 @@ void EqualOrderOperators::Residual::Gradient (Vector& EV,
                                               const FiniteElement& fe,
                                               double scale, int basis)
 {
-  size_t nsd = fe.grad(basis).cols();
+  const size_t nsd = fe.grad(basis).cols();
+
   for (size_t k = 1; k <= nsd; ++k)
     EV.add(fe.grad(basis).getColumn(k), scale*fe.detJxW, 0, 1, k-1, nsd);
 }
-
-
 
 
 void EqualOrderOperators::Residual::Laplacian (Vector& EV,
@@ -329,9 +338,11 @@ void EqualOrderOperators::Residual::Laplacian (Vector& EV,
                                                const Vec3& dUdX,
                                                double scale, int basis)
 {
-  size_t nsd = fe.grad(basis).cols();
+  const size_t nsd = fe.grad(basis).cols();
+
   fe.grad(basis).multiply(Vector(dUdX.ptr(),nsd),EV,-scale*fe.detJxW,1.0);
 }
+
 
 void EqualOrderOperators::Residual::Laplacian (Vector& EV,
                                                const FiniteElement& fe,
@@ -339,9 +350,9 @@ void EqualOrderOperators::Residual::Laplacian (Vector& EV,
                                                double scale,
                                                bool stress, int basis)
 {
-  size_t nsd = fe.grad(1).cols();
-  auto dUdXT = dUdX;
-  dUdXT.transpose();
+  const size_t nsd = fe.grad(1).cols();
+
+  Tensor dUdXT(dUdX,true);
   for (size_t k = 1; k <= nsd; ++k) {
     Vector diff;
     fe.grad(basis).multiply(Vector(dUdXT[k-1].ptr(), nsd), diff);

--- a/Apps/Utils/EqualOrderOperators.h
+++ b/Apps/Utils/EqualOrderOperators.h
@@ -13,10 +13,11 @@
 #ifndef EQUAL_ORDER_OPERATORS_H
 #define EQUAL_ORDER_OPERATORS_H
 
-class Vec3;
-
-#include "FiniteElement.h"
 #include "MatVec.h"
+
+class FiniteElement;
+class Tensor;
+class Vec3;
 
 
 namespace WeakOperators
@@ -109,13 +110,22 @@ public:
     static void Stress(Matrix& EM, const FiniteElement& fe,
                        double scale=1.0, int basis=1);
 
-    //! \brief Compute a heteregenous coefficient laplacian.
+    //! \brief Compute a heterogeneous coefficient laplacian.
     //! \param[out] EM The element matrix to add contribution to
-    //! \param[out] K The coefficient matrix
+    //! \param[in] K The coefficient matrix
     //! \param[in] fe The finite element to evaluate for
     //! \param[in] scale Scaling factor for contribution
     //! \param[in] basis Basis to use
     static void LaplacianCoeff(Matrix& EM, const Matrix& K, const FiniteElement& fe,
+                               double scale=1.0, int basis=1);
+
+    //! \brief Compute a heterogeneous coefficient laplacian.
+    //! \param[out] EM The element matrix to add contribution to
+    //! \param[in] K The diagonal coefficient matrix
+    //! \param[in] fe The finite element to evaluate for
+    //! \param[in] scale Scaling factor for contribution
+    //! \param[in] basis Basis to use
+    static void LaplacianCoeff(Matrix& EM, const Vec3& K, const FiniteElement& fe,
                                double scale=1.0, int basis=1);
 
     //! \brief Compute an integration constraint.

--- a/Apps/Utils/Test/TestEqualOrderOperators.C
+++ b/Apps/Utils/Test/TestEqualOrderOperators.C
@@ -16,45 +16,50 @@
 #include "Catch2Support.h"
 
 
-using DoubleVec = std::vector<std::vector<double>>;
-const auto check_matrix_equal = [](const Matrix& A, const DoubleVec& B)
-                                {
-                                  for (size_t i=1;i<=A.rows();++i)
-                                    for (size_t j=1;j<=A.cols();++j)
-                                      REQUIRE_THAT(A(i,j), WithinRel(B[i-1][j-1]));
-                                };
-
-static FiniteElement getFE()
+namespace
 {
-  FiniteElement fe(2);
-  fe.dNdX.resize(2,2);
-  fe.dNdX(1,1) = 1.0;
-  fe.dNdX(2,1) = 2.0;
-  fe.dNdX(1,2) = 3.0;
-  fe.dNdX(2,2) = 4.0;
-  fe.N(1) = 1.0;
-  fe.N(2) = 2.0;
+  void check_matrix_equal (const Matrix& A, const Real2DMat& B)
+  {
+    for (size_t i = 1; i <= A.rows(); ++i)
+      for (size_t j = 1; j <= A.cols(); ++j)
+        REQUIRE_THAT(A(i,j), WithinRel(B[i-1][j-1]));
+  }
 
-  return fe;
+  class MyElement : public FiniteElement
+  {
+  public:
+    MyElement() : FiniteElement(2)
+    {
+      dNdX.resize(2,2);
+      dNdX(1,1) = 1.0;
+      dNdX(2,1) = 2.0;
+      dNdX(1,2) = 3.0;
+      dNdX(2,2) = 4.0;
+      N(1) = 1.0;
+      N(2) = 2.0;
+    }
+  };
 }
+
 
 TEST_CASE("TestEqualOrderOperators.Advection")
 {
-  FiniteElement fe = getFE();
+  MyElement fe;
 
   Matrix EM_scalar(2, 2);
-  Vec3 U;
-  U[0] = 1.0; U[1] = 2.0;
+  Vec3   U(1.0, 2.0);
+
   // First component only
   EqualOrderOperators::Weak::Advection(EM_scalar, fe, U);
-  const DoubleVec EM_scalar_ref = {{ 7.0, 10},
+  const Real2DMat EM_scalar_ref = {{ 7.0, 10},
                                    {14.0, 20.0}};
   check_matrix_equal(EM_scalar, EM_scalar_ref);
 
   Matrix EM_vec(2*2, 2*2);
-  U[0] = 3.0; U[1] = 4.0;
-  EqualOrderOperators::Weak::Advection(EM_vec, fe, U, 2.0);
-  const DoubleVec EM_vec_ref = {{30.0,  0.0, 44.0,  0.0},
+  Vec3   V(3.0, 4.0);
+
+  EqualOrderOperators::Weak::Advection(EM_vec, fe, V, 2.0);
+  const Real2DMat EM_vec_ref = {{30.0,  0.0, 44.0,  0.0},
                                 { 0.0, 30.0,  0.0, 44.0},
                                 {60.0,  0.0, 88.0,  0.0},
                                 { 0.0, 60.0,  0.0, 88.0}};
@@ -64,17 +69,17 @@ TEST_CASE("TestEqualOrderOperators.Advection")
 
 TEST_CASE("TestEqualOrderOperators.Divergence")
 {
-  FiniteElement fe = getFE();
+  MyElement fe;
 
   Matrix EM_scalar(2, 2*2);
   EqualOrderOperators::Weak::Divergence(EM_scalar, fe);
-  const DoubleVec EM_scalar_ref = {{1.0, 3.0, 2.0, 4.0},
+  const Real2DMat EM_scalar_ref = {{1.0, 3.0, 2.0, 4.0},
                                    {2.0, 6.0, 4.0, 8.0}};
   check_matrix_equal(EM_scalar, EM_scalar_ref);
 
   Vector EV_scalar(4);
-  Vec3 D;
-  D[0] = 1.0; D[1] = 2.0;
+  Vec3   D(1.0, 2.0);
+
   EqualOrderOperators::Weak::Divergence(EV_scalar, fe, D, 1.0);
   REQUIRE_THAT(EV_scalar(1), WithinRel(7.0));
   REQUIRE_THAT(EV_scalar(2), WithinRel(10.0));
@@ -85,12 +90,12 @@ TEST_CASE("TestEqualOrderOperators.Divergence")
 
 TEST_CASE("TestEqualOrderOperators.Gradient")
 {
-  FiniteElement fe = getFE();
+  MyElement fe;
 
   Matrix EM_scalar(2*2,2);
   // single component + pressure
   EqualOrderOperators::Weak::Gradient(EM_scalar, fe);
-  const DoubleVec EM_scalar_ref = {{-1.0,-2.0},
+  const Real2DMat EM_scalar_ref = {{-1.0,-2.0},
                                    {-3.0,-6.0},
                                    {-2.0,-4.0},
                                    {-4.0,-8.0}};
@@ -107,13 +112,13 @@ TEST_CASE("TestEqualOrderOperators.Gradient")
 
 TEST_CASE("TestEqualOrderOperators.Laplacian")
 {
-  FiniteElement fe = getFE();
+  MyElement fe;
 
   // single scalar block
   Matrix EM_scalar(2,2);
   EqualOrderOperators::Weak::Laplacian(EM_scalar, fe);
 
-  const DoubleVec EM_scalar_ref = {{10.0, 14.0},
+  const Real2DMat EM_scalar_ref = {{10.0, 14.0},
                                    {14.0, 20.0}};
 
   check_matrix_equal(EM_scalar, EM_scalar_ref);
@@ -122,7 +127,7 @@ TEST_CASE("TestEqualOrderOperators.Laplacian")
   Matrix EM_multi(2*2,2*2);
   EqualOrderOperators::Weak::Laplacian(EM_multi, fe, 1.0);
 
-  const DoubleVec EM_multi_ref = {{10.0,  0.0, 14.0,  0.0},
+  const Real2DMat EM_multi_ref = {{10.0,  0.0, 14.0,  0.0},
                                   { 0.0, 10.0,  0.0, 14.0},
                                   {14.0,  0.0, 20.0,  0.0},
                                    {0.0, 14.0,  0.0, 20.0}};
@@ -132,7 +137,7 @@ TEST_CASE("TestEqualOrderOperators.Laplacian")
   // stress formulation
   Matrix EM_stress(2*2,2*2);
   EqualOrderOperators::Weak::Laplacian(EM_stress, fe, 1.0, true);
-  const DoubleVec EM_stress_ref = {{11.0,  3.0, 16.0,  6.0},
+  const Real2DMat EM_stress_ref = {{11.0,  3.0, 16.0,  6.0},
                                    { 3.0, 19.0,  4.0, 26.0},
                                    {16.0,  4.0, 24.0,  8.0},
                                    { 6.0, 26.0,  8.0, 36.0}};
@@ -141,26 +146,32 @@ TEST_CASE("TestEqualOrderOperators.Laplacian")
 
   Matrix EM_coeff(2, 2);
   EqualOrderOperators::Weak::LaplacianCoeff(EM_coeff, fe.dNdX, fe, 2.0);
-  const DoubleVec EM_coeff_ref = {{104.0, 148.0},
+  const Real2DMat EM_coeff_ref = {{104.0, 148.0},
                                   {152.0, 216.0}};
   check_matrix_equal(EM_coeff, EM_coeff_ref);
+
+  Matrix EM_coefv(2, 2);
+  EqualOrderOperators::Weak::LaplacianCoeff(EM_coefv, Vec3(1.0, 2.0), fe);
+  const Real2DMat EM_coeff_refv = {{19.0, 26.0},
+                                   {26.0, 36.0}};
+  check_matrix_equal(EM_coefv, EM_coeff_refv);
 }
 
 
 TEST_CASE("TestEqualOrderOperators.Mass")
 {
-  FiniteElement fe = getFE();
+  MyElement fe;
 
   Matrix EM_scalar(2,2);
   EqualOrderOperators::Weak::Mass(EM_scalar, fe, 2.0);
-  const DoubleVec EM_scalar_ref = {{2.0, 4.0},
+  const Real2DMat EM_scalar_ref = {{2.0, 4.0},
                                    {4.0, 8.0}};
   check_matrix_equal(EM_scalar, EM_scalar_ref);
 
   Matrix EM_vec(2*2,2*2);
   EqualOrderOperators::Weak::Mass(EM_vec, fe);
 
-  const DoubleVec EM_vec_ref = {{1.0, 0.0, 2.0, 0.0},
+  const Real2DMat EM_vec_ref = {{1.0, 0.0, 2.0, 0.0},
                                 {0.0, 1.0, 0.0, 2.0},
                                 {2.0, 0.0, 4.0, 0.0},
                                 {0.0, 2.0, 0.0, 4.0}};
@@ -170,7 +181,7 @@ TEST_CASE("TestEqualOrderOperators.Mass")
 
 TEST_CASE("TestEqualOrderOperators.Source")
 {
-  FiniteElement fe = getFE();
+  MyElement fe;
 
   Vector EV_scalar(2);
   EqualOrderOperators::Weak::Source(EV_scalar, fe, 2.0);
@@ -178,8 +189,8 @@ TEST_CASE("TestEqualOrderOperators.Source")
   REQUIRE_THAT(EV_scalar(2), WithinRel(4.0));
 
   Vector EV_vec(4);
-  Vec3 f;
-  f[0] = 1.0; f[1] = 2.0;
+  Vec3 f(1.0, 2.0);
+
   EqualOrderOperators::Weak::Source(EV_vec, fe, f, 1.0);
   REQUIRE_THAT(EV_vec(1), WithinRel(1.0));
   REQUIRE_THAT(EV_vec(2), WithinRel(2.0));

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -1019,7 +1019,8 @@ public:
   //! \brief Connects a list of node pairs to each other.
   //! \param[in] nodes List of node number pairs that should share common DOFs.
   //! \param[in] xtol Coordinate tolerance for matching nodes
-  bool selfInterconnect(const std::vector<Ipair>& nodes, double xtol = 1.0e-8);
+  virtual bool selfInterconnect(const std::vector<Ipair>& nodes,
+                                double xtol = 1.0e-8);
 
 protected:
   //! \brief Returns \e true if \a dirs constains all local DOFs in the patch.

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -1194,8 +1194,7 @@ void ASMs2D::setNodeNumbers (const IntVec& nodes)
 
 bool ASMs2D::updateDirichlet (const std::map<int,RealFunc*>& func,
                               const std::map<int,VecFunc*>& vfunc, double time,
-                              const std::map<int,int>* g2l,
-                              bool tangent)
+                              const std::map<int,int>* g2l, bool tangent)
 {
   std::map<int,RealFunc*>::const_iterator fit;
   std::map<int,VecFunc*>::const_iterator vfit;
@@ -1251,6 +1250,17 @@ bool ASMs2D::updateDirichlet (const std::map<int,RealFunc*>& func,
   // The parent class method takes care of the corner nodes with direct
   // evaluation of the Dirichlet functions (since they are interpolatory)
   return this->ASMbase::updateDirichlet(func,vfunc,time,g2l,tangent);
+}
+
+
+bool ASMs2D::selfInterconnect (const std::vector<Ipair>& nodes, double xtol)
+{
+  if (threadGroups.stripDir != ThreadGroups::NONE)
+    IFEM::cout <<"  ** ASMs2D::selfInterconnect: Multi-threading deactivated"
+               <<" for Patch "<< idx+1 << std::endl;
+  threadGroups.stripDir = ThreadGroups::NONE;
+
+  return this->ASMstruct::selfInterconnect(nodes,xtol);
 }
 
 

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -40,22 +40,18 @@ class ASMs2D : public ASMstruct, public ASM2D
   //! \brief Struct for nodal point data.
   struct IJ
   {
-    int I; //!< Index in first parameter direction
-    int J; //!< Index in second parameter direction
+    int I = 0; //!< Index in first parameter direction
+    int J = 0; //!< Index in second parameter direction
   };
 
-  typedef std::vector<IJ> IndexVec; //!< Node index container
+  using IndexVec = std::vector<IJ>; //!< Node index container
 
   //! \brief Struct for edge node definitions.
   struct Edge
   {
-    int icnod; //!< Global node number of first interior point along the edge
-    int incr;  //!< Increment in the global numbering along the edge
-
-    //! \brief Default constructor.
-    Edge() { icnod = incr = 0; }
-    //! \brief Returns \a icnod which then is incremented.
-    int next();
+    int icnod = 0; //!< Global node number of first interior point along edge
+    int incr  = 0; //!< Increment in the global numbering along the edge
+    int next();    //!< Returns \ref icnod which then is incremented
   };
 
 protected:
@@ -64,16 +60,13 @@ protected:
   {
   public:
     //! \brief The constructor initializes the class.
-    //! \param pch Patch the cache is for
+    //! \param[in] pch Patch the cache is for
     BasisFunctionCache(const ASMs2D& pch);
 
     //! \brief Constructor reusing quadrature info from another instance.
-    //! \param cache Instance holding quadrature information
-    //! \param b Basis to use
+    //! \param[in] cache Instance holding quadrature information
+    //! \param[in] b Basis to use
     BasisFunctionCache(const BasisFunctionCache& cache, int b);
-
-    //! \brief Empty destructor.
-    virtual ~BasisFunctionCache() = default;
 
     //! \brief Returns number of elements in each direction.
     const std::array<size_t,2>& noElms() const { return nel; }
@@ -83,24 +76,25 @@ protected:
     bool internalInit() override;
 
     //! \brief Calculates basis function info in a single integration point.
-    //! \param el Element of integration point (0-indexed)
-    //! \param gp Integration point on element (0-indexed)
-    //! \param reduced If true, returns values for reduced integration scheme
-    BasisFunctionVals calculatePt(size_t el, size_t gp, bool reduced) const override;
+    //! \param[in] el Element of integration point (0-indexed)
+    //! \param[in] gp Integration point on element (0-indexed)
+    //! \param[in] reduced If \e true, calculate for reduced integration scheme
+    BasisFunctionVals calculatePt(size_t el, size_t gp,
+                                  bool reduced) const override;
 
     //! \brief Calculates basis function info in all integration points.
     void calculateAll() override;
 
-    //! \brief Obtain global integration point index.
-    //! \param el Element of integration point (0-indexed)
-    //! \param gp Integration point on element (0-indexed)
-    //! \param reduced True to return index for reduced quadrature
+    //! \brief Returns global integration point index.
+    //! \param[in] el Element of integration point (0-indexed)
+    //! \param[in] gp Integration point on element (0-indexed)
+    //! \param[in] reduced If \e true, return index for reduced quadrature
     size_t index(size_t el, size_t gp, bool reduced) const override;
 
-    //! \brief Setup integration point parameters.
+    //! \brief Sets up the integration point parameters.
     virtual void setupParameters();
 
-    //! \brief Configure quadratures.
+    //! \brief Configures the quadratures.
     bool setupQuadrature();
 
     const ASMs2D& patch; //!< Reference to patch cache is for
@@ -108,8 +102,8 @@ protected:
     std::array<size_t,2> nel{}; //!< Number of elements in each direction
 
   private:
-    //! \brief Obtain structured element indices.
-    //! \param el Global element index
+    //! \brief Returns structured element indices for an element.
+    //! \param[in] el Global index of element to get structured indices for
     std::array<size_t,2> elmIndex(size_t el) const;
   };
 
@@ -118,7 +112,7 @@ public:
   struct BlockNodes
   {
     int  ibnod[4]; //!< Vertex nodes
-    Edge edges[4]; //!< Edge nodes
+    Edge edges[4]; //!< %Edge nodes
     int  iinod;    //!< Global node number of the first interior node
     int  inc[2];   //!< Increment in global node numbering in each direction
     int  nnodI;    //!< Number of nodes in parameter direction I
@@ -136,8 +130,6 @@ public:
   };
 
 private:
-  typedef std::pair<int,int> Ipair; //!< Convenience type
-
   //! \brief Struct representing an inhomogeneous Dirichlet boundary condition.
   struct DirichletEdge
   {
@@ -160,8 +152,6 @@ public:
   public:
     //! \brief The constructor initialises the reference to current patch.
     explicit InterfaceChecker(const ASMs2D& pch) : myPatch(pch) {}
-    //! \brief Empty destructor.
-    virtual ~InterfaceChecker() {}
     //! \brief Returns non-zero if the specified element have contributions.
     //! \param[in] I Index in first parameter direction of the element
     //! \param[in] J Index in second parameter direction of the element
@@ -186,6 +176,7 @@ public:
   virtual const Go::SplineSurface* getBasis(int basis = 1) const;
   //! \brief Copies the parameter domain from the \a other patch.
   virtual void copyParameterDomain(const ASMbase* other);
+
 
   // Methods for model generation
   // ============================
@@ -397,8 +388,12 @@ public:
   //! \param[in] tangent If \e true, use time-derivatives of prescribed values
   virtual bool updateDirichlet(const std::map<int,RealFunc*>& func,
                                const std::map<int,VecFunc*>& vfunc, double time,
-                               const std::map<int,int>* g2l = nullptr,
-                               bool tangent = false);
+                               const std::map<int,int>* g2l, bool tangent);
+
+  //! \brief Connects a list of node pairs to each other.
+  //! \param[in] nodes List of node number pairs that should share common DOFs.
+  //! \param[in] xtol Coordinate tolerance for matching nodes
+  virtual bool selfInterconnect(const std::vector<Ipair>& nodes, double xtol);
 
 
   // Methods for integration of finite element quantities.
@@ -425,8 +420,9 @@ public:
   //! \param glbInt The integrated quantity
   //! \param[in] time Parameters for nonlinear/time-dependent simulations
   //! \param[in] iChk Object checking if an element interface has contributions
-  virtual bool integrate(Integrand& integrand, GlobalIntegral& glbInt,
-                         const TimeDomain& time, const ASM::InterfaceChecker& iChk);
+  virtual bool integrate(Integrand& integrand,
+                         GlobalIntegral& glbInt, const TimeDomain& time,
+                         const ASM::InterfaceChecker& iChk);
 
 protected:
   //! \brief Evaluates an integral over the interior patch domain.

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -1454,8 +1454,7 @@ void ASMs3D::setNodeNumbers (const IntVec& nodes)
 
 bool ASMs3D::updateDirichlet (const std::map<int,RealFunc*>& func,
                               const std::map<int,VecFunc*>& vfunc, double time,
-                              const std::map<int,int>* g2l,
-                              bool tangent)
+                              const std::map<int,int>* g2l, bool tangent)
 {
   std::map<int,RealFunc*>::const_iterator fit;
   std::map<int,VecFunc*>::const_iterator vfit;
@@ -1511,6 +1510,19 @@ bool ASMs3D::updateDirichlet (const std::map<int,RealFunc*>& func,
   // The parent class method takes care of the corner nodes with direct
   // evaluation of the Dirichlet functions (since they are interpolatory)
   return this->ASMbase::updateDirichlet(func,vfunc,time,g2l,tangent);
+}
+
+
+bool ASMs3D::selfInterconnect (const std::vector<Ipair>& nodes, double xtol)
+{
+  if (threadGroupsVol.stripDir != ThreadGroups::NONE)
+    IFEM::cout <<"  ** ASMs3D::selfInterconnect: Multi-threading deactivated"
+               <<" for Patch "<< idx+1 << std::endl;
+  threadGroupsVol.stripDir = ThreadGroups::NONE;
+  for (std::pair<const char,ThreadGroups>& group : threadGroupsFace)
+    group.second.stripDir = ThreadGroups::NONE;
+
+  return this->ASMstruct::selfInterconnect(nodes,xtol);
 }
 
 

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -40,38 +40,30 @@ class ASMs3D : public ASMstruct, public ASM3D
   //! \brief Struct for nodal point data.
   struct IJK
   {
-    int I; //!< Index in first parameter direction
-    int J; //!< Index in second parameter direction
-    int K; //!< Index in third parameter direction
+    int I = 0; //!< Index in first parameter direction
+    int J = 0; //!< Index in second parameter direction
+    int K = 0; //!< Index in third parameter direction
   };
 
-  typedef std::vector<IJK> IndexVec; //!< Node index container
+  using IndexVec = std::vector<IJK> ; //!< Node index container
 
   //! \brief Struct for edge node definitions.
   struct Edge
   {
-    int icnod; //!< Global node number of first interior point along the edge
-    int incr;  //!< Increment in the global numbering along the edge
-
-    //! \brief Default constructor.
-    Edge() { icnod = incr = 0; }
-    //! \brief Returns \a icnod which then is incremented.
-    int next();
+    int icnod = 0; //!< Global node number of first interior point along edge
+    int incr  = 0; //!< Increment in the global numbering along the edge
+    int next();    //!< Returns \ref icnod which then is incremented.
   };
 
   //! \brief Struct for face node definitions.
   struct Face
   {
-    int isnod; //!< Global node number of the first interior point on the face
-    int incrI; //!< Increment in global numbering in the I-direction on the face
-    int incrJ; //!< Increment in global numbering in the J-direction on the face
-    int nnodI; //!< Number of nodes in the local I-direction on the face
-    int indxI; //!< Running node index in the local I-direction
-
-    //! \brief Default constructor.
-    Face() { isnod = incrI = incrJ = nnodI = 0; indxI = 1; }
-    //! \brief Returns \a isnod which then is incremented.
-    int next();
+    int isnod = 0; //!< Global node number of the first interior point on face
+    int incrI = 0; //!< Increment in global numbering in the I-direction on face
+    int incrJ = 0; //!< Increment in global numbering in the J-direction on face
+    int nnodI = 0; //!< Number of nodes in the local I-direction on face
+    int indxI = 1; //!< Running node index in the local I-direction
+    int next();    //!< Returns \ref isnod which then is incremented.
   };
 
 protected:
@@ -80,16 +72,13 @@ protected:
   {
   public:
     //! \brief The constructor initializes the class.
-    //! \param pch Patch the cache is for
+    //! \param[in] pch Patch the cache is for
     BasisFunctionCache(const ASMs3D& pch);
 
     //! \brief Constructor reusing quadrature info from another instance.
-    //! \param cache Instance holding quadrature information
-    //! \param b Basis to use
+    //! \param[in] cache Instance holding quadrature information
+    //! \param[in] b Basis to use
     BasisFunctionCache(const BasisFunctionCache& cache, int b);
-
-    //! \brief Empty destructor.
-    virtual ~BasisFunctionCache() = default;
 
     //! \brief Returns number of elements in each direction.
     const std::array<size_t,3>& noElms() const { return nel; }
@@ -99,24 +88,25 @@ protected:
     bool internalInit() override;
 
     //! \brief Calculates basis function info in a single integration point.
-    //! \param el Element of integration point (0-indexed)
-    //! \param gp Integration point on element (0-indexed)
-    //! \param reduced If true, returns values for reduced integration scheme
-    BasisFunctionVals calculatePt(size_t el, size_t gp, bool reduced) const override;
+    //! \param[in] el Element of integration point (0-indexed)
+    //! \param[in] gp Integration point on element (0-indexed)
+    //! \param[in] reduced If \e true, calculate for reduced integration scheme
+    BasisFunctionVals calculatePt(size_t el, size_t gp,
+                                  bool reduced) const override;
 
     //! \brief Calculates basis function info in all integration points.
     void calculateAll() override;
 
-    //! \brief Obtain global integration point index.
-    //! \param el Element of integration point (0-indexed)
-    //! \param gp Integration point on element (0-indexed)
-    //! \param reduced True to return index for reduced quadrature
+    //! \brief Returns global integration point index.
+    //! \param[in] el Element of integration point (0-indexed)
+    //! \param[in] gp Integration point on element (0-indexed)
+    //! \param[in] reduced If \e true, return index for reduced quadrature
     size_t index(size_t el, size_t gp, bool reduced) const override;
 
-    //! \brief Setup integration point parameters.
+    //! \brief Sets up integration point parameters.
     virtual void setupParameters();
 
-    //! \brief Configure quadratures.
+    //! \brief Configures the quadratures.
     bool setupQuadrature();
 
     const ASMs3D& patch; //!< Reference to patch cache is for
@@ -124,8 +114,8 @@ protected:
     std::array<size_t,3> nel{}; //!< Number of elements in each direction
 
   private:
-    //! \brief Obtain structured element indices.
-    //! \param el Global element index
+    //! \brief Returns structured element indices for an element.
+    //! \param[in] el Global index of element to get structured indices for
     std::array<size_t,3> elmIndex(size_t el) const;
   };
 
@@ -134,8 +124,8 @@ public:
   struct BlockNodes
   {
     int  ibnod[8];  //!< Vertex nodes
-    Edge edges[12]; //!< Edge nodes
-    Face faces[6];  //!< Face nodes
+    Edge edges[12]; //!< %Edge nodes
+    Face faces[6];  //!< %Face nodes
     int  iinod;     //!< Global node number of the first interior node
     int  inc[3];    //!< Increment in global node numbering in each direction
     int  nnodI;     //!< Number of nodes in parameter direction I
@@ -155,8 +145,6 @@ public:
   };
 
 private:
-  typedef std::pair<int,int> Ipair; //!< Convenience type
-
   //! \brief Struct representing an inhomogeneous Dirichlet boundary condition.
   struct DirichletFace
   {
@@ -179,8 +167,6 @@ public:
   public:
     //! \brief The constructor initialises the reference to current patch.
     explicit InterfaceChecker(const ASMs3D& pch) : myPatch(pch) {}
-    //! \brief Empty destructor.
-    virtual ~InterfaceChecker() {}
     //! \brief Returns non-zero if the specified element have contributions.
     //! \param[in] I Index in first parameter direction of the element
     //! \param[in] J Index in second parameter direction of the element
@@ -194,8 +180,6 @@ public:
   ASMs3D(const ASMs3D& patch, unsigned char n_f);
   //! \brief Default copy constructor copying everything.
   ASMs3D(const ASMs3D& patch);
-  //! \brief Empty destructor.
-  virtual ~ASMs3D() {}
 
   //! \brief Returns the spline surface representing a boundary of this patch.
   //! \param[in] dir Parameter direction defining which boundary to return
@@ -206,6 +190,7 @@ public:
   virtual const Go::SplineVolume* getBasis(int basis = 1) const;
   //! \brief Copies the parameter domain from the \a other patch.
   virtual void copyParameterDomain(const ASMbase* other);
+
 
   // Methods for model generation
   // ============================
@@ -463,8 +448,12 @@ public:
   //! \param[in] tangent If \e true, use time-derivatives of prescribed values
   virtual bool updateDirichlet(const std::map<int,RealFunc*>& func,
                                const std::map<int,VecFunc*>& vfunc, double time,
-                               const std::map<int,int>* g2l = nullptr,
-                               bool tangent = false);
+                               const std::map<int,int>* g2l, bool tangent);
+
+  //! \brief Connects a list of node pairs to each other.
+  //! \param[in] nodes List of node number pairs that should share common DOFs.
+  //! \param[in] xtol Coordinate tolerance for matching nodes
+  virtual bool selfInterconnect(const std::vector<Ipair>& nodes, double xtol);
 
 
   // Methods for integration of finite element quantities.
@@ -907,7 +896,7 @@ private:
   //! \param[out] n1 Number of nodes in first local parameter direction on face
   //! \param[out] n2 Number of nodes in second local parameter direction face
   //! \param[in] basis Basis to obtain sizes for
-  //! \param[in] face Face to obtain sizes for
+  //! \param[in] face %Face to obtain sizes for
   bool getFaceSize(int& n1, int& n2, int basis, int face) const;
 
   //! \brief Creates matrix of nodal point correspondance for a spline surface.

--- a/src/LinAlg/Test/MatrixTests.h
+++ b/src/LinAlg/Test/MatrixTests.h
@@ -108,16 +108,14 @@ void multiplyTest()
 {
   utl::vector<Scalar> u(14), v(9), x, y;
   utl::matrix<Scalar> A(3,5), B, B2(3,5), B3;
-  utl::matrix<Scalar> I(5,5), I2(3,3);
+  utl::matrix<Scalar> I(5,5), J(3,3);
 
   std::iota(u.begin(),u.end(),1.0);
   std::iota(v.begin(),v.end(),1.0);
   std::iota(A.begin(),A.end(),1.0);
   std::iota(B2.begin(),B2.end(),1.0);
-  for (size_t i = 1; i <= 5; ++i)
-    I(i,i) = 1.0;
-  for (size_t i = 1; i <= 3; ++i)
-    I2(i,i) = 1.0;
+  I.diag(1.0);
+  J.diag(1.0);
 
   REQUIRE(A.multiply(u,x,1.0,0.0,false,3,4,1,2));
   REQUIRE(A.multiply(v,y,1.0,0.0,true,4,2));
@@ -147,7 +145,7 @@ void multiplyTest()
 
   B.multiplyMat(A, static_cast<const std::vector<Scalar>&>(I));
   B2.multiplyMat(A, static_cast<const std::vector<Scalar>&>(I), false, true);
-  B3.multiplyMat(A, static_cast<const std::vector<Scalar>&>(I2), true, false);
+  B3.multiplyMat(A, static_cast<const std::vector<Scalar>&>(J), true, false);
   REQUIRE(B.rows() == A.rows());
   REQUIRE(B.cols() == A.cols());
   for (size_t i = 1; i <= 3; ++i)
@@ -161,6 +159,19 @@ void multiplyTest()
   REQUIRE_THAT(v(1), WithinRel(135.0));
   REQUIRE_THAT(v(2), WithinRel(150.0));
   REQUIRE_THAT(v(3), WithinRel(165.0));
+
+  u.resize(A.cols());
+  std::iota(u.begin(),u.end(),1.0);
+
+  utl::matrix<Scalar> C(A), D;
+  C.scale(u);
+  D.multiply(A,I.diag(u));
+
+  REQUIRE(C.rows() == D.rows());
+  REQUIRE(C.cols() == D.cols());
+  for (size_t i = 1; i <= C.rows(); ++i)
+    for (size_t j = 1; j <= D.cols(); ++j)
+      REQUIRE_THAT(C(i,j), WithinRel(D(i,j)));
 }
 
 

--- a/src/LinAlg/matrix.h
+++ b/src/LinAlg/matrix.h
@@ -735,6 +735,35 @@ namespace utl //! General utility classes and functions.
         this->elem[r+nrow*r] = d;
       return *this;
     }
+    //! \brief Create a diagonal matrix.
+    matrix<T>& diag(const T* d, size_t dim = 0)
+    {
+      if (dim > 0)
+        this->resize(dim,dim,true);
+      else
+        this->resize(nrow,ncol,true);
+      for (size_t r = 0; r < nrow && r < ncol; r++)
+        this->elem[r+nrow*r] = d[r];
+      return *this;
+    }
+    //! \brief Create a diagonal matrix.
+    matrix<T>& diag(const std::vector<T>& d)
+    {
+      if (d.empty())
+        this->clear();
+      else
+        this->diag(d.data(), d.size());
+      return *this;
+    }
+
+    //! \brief Scale the columns of a matrix.
+    //! \details This is equivalent to post-multiplying with a diagonal matrix.
+    matrix<T>& scale(const T* d, size_t dim);
+    //! \brief Scale the columns of a matrix.
+    matrix<T>& scale(const std::vector<T>& d)
+    {
+      return this->scale(d.data(), d.size());
+    }
 
     //! \brief Replace the current matrix by its transpose.
     matrix<T>& transpose()
@@ -1202,6 +1231,22 @@ namespace utl //! General utility classes and functions.
   }
 
   template<> inline
+  matrix<float>& matrix<float>::scale(const float* d, size_t dim)
+  {
+    for (size_t c = 0; c < dim && c < ncol; c++)
+      cblas_sscal(nrow,d[c],this->ptr(c),1);
+    return *this;
+  }
+
+  template<> inline
+  matrix<double>& matrix<double>::scale(const double* d, size_t dim)
+  {
+    for (size_t c = 0; c < dim && c < ncol; c++)
+      cblas_dscal(nrow,d[c],this->ptr(c),1);
+    return *this;
+  }
+
+  template<> inline
   bool matrix<float>::multiply(const std::vector<float>& X,
                                std::vector<float>& Y,
                                bool transA, char addTo) const
@@ -1608,6 +1653,15 @@ namespace utl //! General utility classes and functions.
   {
     for (T& x : this->elem)
       x *= c;
+    return *this;
+  }
+
+  template<class T> inline
+  matrix<T>& matrix<T>::scale(const T* d, size_t dim)
+  {
+    for (size_t c = 0; c < dim && c < ncol; c++)
+      for (size_t r = 0; r < nrow; r++)
+        this->elem[r+nrow*c] *= d[c];
     return *this;
   }
 


### PR DESCRIPTION
An overloaded `EqualOrderOperators::Weak::LaplacianCoeff()` is added where the constitutive matrix is represented by a `Vec3` object instead of `Matrix` since it will be a diagonal matrix is most cases anyway. Then the implementation can be simplified exploiting its diagonal nature. Another simplification for scalar problems (one-dof-per-node) is to assemble directly into the element matrix instead of going via a temporary matrix.