### PR TITLE
Couple of fixes for multipatch adaptivity

### DIFF
--- a/src/ASM/LR/ASMLRSpline.C
+++ b/src/ASM/LR/ASMLRSpline.C
@@ -374,9 +374,10 @@ IntVec ASMLRSpline::getBoundaryCovered (const IntSet& nodes) const
   for (int edge = 1; edge <= numbEdges; edge++)
   {
     IntVec bnd = GlobalNodes::getBoundaryNodes(*refB, boundrDim, edge, 0);
+    IntSet bset(bnd.begin(), bnd.end());
     for (const int i : nodes)
-      for (const int j : bnd)
-        if (refB->getBasisfunction(i)->contains(*refB->getBasisfunction(j)))
+      for (int j : this->getOverlappingNodes(i))
+        if (bset.find(j) != bset.end())
           result.insert(j);
   }
 

--- a/src/SIM/SIMinput.C
+++ b/src/SIM/SIMinput.C
@@ -1646,7 +1646,6 @@ bool SIMinput::refine (const LR::RefineData& prm, Vectors& sol)
   }
 
   // Multi-patch models need to pass refinement indices over patch boundaries
-  std::vector<LR::RefineData> prmloc(myModel.size(),LR::RefineData(prm));
   std::vector<IntSet> refineIndices(myModel.size());
   std::vector<IntSet> conformingIndices(myModel.size());
   bool changed = !this->getPatch(1)->isShared();
@@ -1708,7 +1707,12 @@ bool SIMinput::refine (const LR::RefineData& prm, Vectors& sol)
     }
 
     for (size_t i = 0; i < pch.size(); i++)
+    {
+      const size_t n0 = refineIndices[i].size();
       pch[i]->extendRefinementDomain(refineIndices[i],conformingIndices[i]);
+      if (refineIndices[i].size() > n0)
+        changed = true;
+    }
   }
 
   Vectors lsols;


### PR DESCRIPTION
Two copilot identified issues;
1) need to loop again if domain is extended
2) improve getBoundaryCovered - use getOverlappingNodes to also grab detect nodes further "in" from the boundary, which is in particular important for higher polynomial order.