### PR TITLE
Added: Support for merged patches in SIMoutput::writeGlvBC()

### DIFF
--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -1201,8 +1201,7 @@ bool ASMbase::hasTimeDependentDirichlet (const std::map<int,RealFunc*>& func,
 
 bool ASMbase::updateDirichlet (const std::map<int,RealFunc*>& func,
                                const std::map<int,VecFunc*>& vfunc, double time,
-                               const std::map<int,int>* g2l,
-                               bool tangent)
+                               const std::map<int,int>* g2l, bool tangent)
 {
   std::map<int,RealFunc*>::const_iterator fit;
   std::map<int,VecFunc*>::const_iterator vfit;
@@ -1216,21 +1215,6 @@ bool ASMbase::updateDirichlet (const std::map<int,RealFunc*>& func,
       return false;
     }
 
-    // Lambda function that evaluates either absolute or time-derivative Dirichlet values.
-    auto evalDirichletValue = [tangent](const FunctionBase& f, const Vec4& X)
-    {
-      if (!tangent)
-        return f.getValue(X);
-
-      if (const RealFunc* rf = dynamic_cast<const RealFunc*>(&f); rf)
-        return RealArray(1,rf->timeDerivative(X));
-
-      if (const VecFunc* vf = dynamic_cast<const VecFunc*>(&f); vf)
-        return vf->timeDerivative(X).vec(vf->dim());
-
-      return f.getValue(X);
-    };
-
     int node = cit.first->getSlave().node;
     if (g2l) node = utl::findKey(*g2l,node);
     Vec4 X(this->getCoord(inod),time,node);
@@ -1239,21 +1223,21 @@ bool ASMbase::updateDirichlet (const std::map<int,RealFunc*>& func,
       RealFunc& g = *fit->second;
       if (g.isZero())
         cit.first->setSlaveCoeff(0.0);
+      else if (tangent)
+        cit.first->setSlaveCoeff(g.timeDerivative(X));
       else
-        cit.first->setSlaveCoeff(evalDirichletValue(g,X).front());
+        cit.first->setSlaveCoeff(g(X));
     }
     else if ((vfit = vfunc.find(cit.second)) != vfunc.end())
     {
-      int idof = cit.first->getSlave().dof;
+      int dof = cit.first->getSlave().dof;
       VecFunc& g = *vfit->second;
-      if (g.isZero())
+      if (g.isZero() || dof < 1 || dof > std::min(3,static_cast<int>(g.dim())))
         cit.first->setSlaveCoeff(0.0);
+      else if (tangent)
+        cit.first->setSlaveCoeff(g.timeDerivative(X)(dof));
       else
-      {
-        RealArray val(evalDirichletValue(g,X));
-        cit.first->setSlaveCoeff(idof <= static_cast<int>(val.size()) ?
-                                 val[idof-1] : 0.0);
-      }
+        cit.first->setSlaveCoeff(g(X)(dof));
     }
     else
     {
@@ -1633,10 +1617,9 @@ void ASMbase::extractNodeVec (const RealArray& globRes, RealArray& nodeVec,
     // assumed not to have entries in the globRes vector. In that case, we use
     // the "real" node at that location instead (see, e.g., ASMs2D::getNodeID).
     // The same is assumed if basis < 0 on input (for vector fields) HACK!
-    int n = this->getNodeID(i, nndof == 1 || basis < 0);
-    int lastDof = nndof*n;
+    int lastDof = nndof*this->getNodeID(i, nndof == 1 || basis < 0);
 #ifdef INDEX_CHECK
-    if (n < 1 || lastDof > maxDof)
+    if (lastDof < 1 || lastDof > maxDof)
       std::cerr <<" *** ASMbase::extractNodeVec: Global DOF "<< lastDof
                 <<" is out of range [1,"<< maxDof <<"]."<< std::endl;
 #endif
@@ -1663,17 +1646,13 @@ bool ASMbase::injectNodeVec (const RealArray& nodeVec, RealArray& globRes,
 
   const double* nodeP = nodeVec.data();
   for (size_t i = 0; i < nNod; i++, nodeP += nndof)
-  {
-    int n = MLGN[i];
-    int lastDof = nndof*n;
-    if (n > 0 && lastDof <= maxDof)
+    if (int lastDof = nndof*MLGN[i]; lastDof > 0 && lastDof <= maxDof)
       memcpy(globRes.data()+lastDof-nndof,nodeP,nndof*sizeof(double));
 #ifdef SP_DEBUG
     else // This is most likely OK, print message only in debug mode
       std::cerr <<" *** ASMbase::injectNodeVec: Global DOF "<< lastDof
                 <<" is out of range [1,"<< maxDof <<"]."<< std::endl;
 #endif
-  }
 
   return true;
 }
@@ -1853,6 +1832,12 @@ bool ASMbase::evaluate (const Field*, RealArray&, int) const
 bool ASMbase::evaluate (const FunctionBase*, RealArray&, int, double) const
 {
   return Aerror("evaluate(const FunctionBase*,RealArray&,int,double)");
+}
+
+
+size_t ASMbase::getNoViz (const int*) const
+{
+  return Aerror("getNoViz(const int*)");
 }
 
 

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -793,9 +793,12 @@ public:
   //! \brief Returns the number of elements on refinement basis for this patch.
   virtual size_t getNoRefineElms() const { return this->getNoElms(); }
 
+  //! \brief Returns the total number of visualization points for this patch.
+  //! \param[in] npe Number of visualization nodes over each knot span
+  virtual size_t getNoViz(const int* npe) const;
+
   //! \brief Returns a field using the projection basis.
-  virtual Field* getProjectedField(const Vector&) const
-  { return nullptr; }
+  virtual Field* getProjectedField(const Vector&) const { return nullptr; }
 
   //! \brief Returns a field using the projection basis.
   virtual Fields* getProjectedFields(const Vector&, size_t) const

--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -1388,6 +1388,23 @@ int ASMs1D::findElementContaining (const double* param) const
 }
 
 
+
+size_t ASMs1D::getNoViz (const int* npe) const
+{
+  if (!curv || !npe || npe[0] < 1)
+    return 0;
+
+  int n = curv->numCoefs();
+  int p = curv->order()-1;
+  size_t npt = 1;
+  for (int i = p; i < n; i++)
+    if (this->getKnotSpan(i) > 0.0)
+      npt += npe[0]-1;
+
+  return npt;
+}
+
+
 bool ASMs1D::getGridParameters (RealArray& prm, int nSegPerSpan) const
 {
   if (!curv) return false;

--- a/src/ASM/ASMs1D.h
+++ b/src/ASM/ASMs1D.h
@@ -233,6 +233,10 @@ public:
   //! \return Distance from the point \a X to the found point
   virtual double findPoint(Vec3& X, double* param) const;
 
+  //! \brief Returns the total number of visualization points for this patch.
+  //! \param[in] npe Number of visualization nodes over each knot span
+  virtual size_t getNoViz(const int* npe) const;
+
   //! \brief Creates a line element model of this patch for visualization.
   //! \param[out] grid The generated line grid
   //! \param[in] npe Number of visualization nodes over each knot span

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -2602,6 +2602,30 @@ double ASMs2D::findPoint (Vec3& X, double* param) const
 }
 
 
+size_t ASMs2D::getNoViz (const int* npe) const
+{
+  if (!surf || !npe)
+    return 0;
+
+  size_t nvp = 1;
+  for (int d = 0; d < 2; d++)
+  {
+    if (npe[d] < 1)
+      return 0;
+
+    int n = d == 0 ? surf->numCoefs_u() : surf->numCoefs_v();
+    int p = d == 0 ? surf->order_u()-1  : surf->order_v()-1;
+    size_t npt = 1;
+    for (int i = p; i < n; i++)
+      if (surf->knotSpan(d,i) > 0.0)
+        npt += npe[d]-1;
+    nvp *= npt;
+  }
+
+  return nvp;
+}
+
+
 bool ASMs2D::getGridParameters (RealArray& prm, int dir, int nSegPerSpan) const
 {
   if (!surf) return false;
@@ -3050,12 +3074,12 @@ void ASMs2D::generateThreadGroups (const Integrand& integrand, bool silence,
       const Go::SplineSurface* prj = this->getBasis(ASM::PROJECTION_BASIS_2);
       const int n1 = prj->numCoefs_u();
       const int n2 = prj->numCoefs_v();
-      const int p1 = prj->order_u();
-      const int p2 = prj->order_v();
-      const int nelp = (n1-p1+1)*(n2-p2+1);
-      proj2ThreadGroups.oneGroup(nelp);
+      const int p1 = prj->order_u() - 1;
+      const int p2 = prj->order_v() - 1;
+      proj2ThreadGroups.oneGroup((n1-p1)*(n2-p2));
     }
-  } else
+  }
+  else
     this->generateThreadGroups(surf->order_u()-1, surf->order_v()-1,
                                silence, ignoreGlobalLM);
 }
@@ -3063,11 +3087,9 @@ void ASMs2D::generateThreadGroups (const Integrand& integrand, bool silence,
 void ASMs2D::generateThreadGroups (size_t strip1, size_t strip2,
                                    bool silence, bool ignoreGlobalLM)
 {
-  //! \brief Lamba for setting up thread groups for basis.
-  auto&& genThreadGroups = [](ThreadGroups& tg,
-                              const Go::SplineSurface* surf,
-                              const size_t strip1,
-                              const size_t strip2)
+  // Lambda function for setting up thread groups for basis.
+  auto&& genThreadGroups = [](ThreadGroups& tg, const Go::SplineSurface* surf,
+                              int strip1 = 0, int strip2 = 0)
   {
     const int n1 = surf->numCoefs_u();
     const int n2 = surf->numCoefs_v();
@@ -3084,20 +3106,16 @@ void ASMs2D::generateThreadGroups (size_t strip1, size_t strip2,
     for (ii = p2; ii < n2; ii++)
       el2.push_back(surf->knotSpan(1,ii) > 0.0);
 
-    tg.calcGroups(el1,el2,strip1,strip2);
+    tg.calcGroups(el1, el2, strip1 > 0 ? strip1 : p1, strip2 > 0 ? strip2 : p2);
   };
 
   genThreadGroups(threadGroups, surf.get(), strip1, strip2);
-  if (this->separateProjectionBasis()) {
-    const Go::SplineSurface* srf = this->getBasis(ASM::PROJECTION_BASIS);
-    genThreadGroups(projThreadGroups, srf, srf->order_u()-1, srf->order_v()-1);
-  } else {
+  if (this->separateProjectionBasis())
+    genThreadGroups(projThreadGroups, this->getBasis(ASM::PROJECTION_BASIS));
+  else
     projThreadGroups = threadGroups;
-  }
-  if (this->getBasis(ASM::PROJECTION_BASIS_2)) {
-    const Go::SplineSurface* srf = this->getBasis(ASM::PROJECTION_BASIS_2);
-    genThreadGroups(proj2ThreadGroups, srf, srf->order_u()-1, srf->order_v()-1);
-  }
+  if (this->getBasis(ASM::PROJECTION_BASIS_2))
+    genThreadGroups(proj2ThreadGroups, this->getBasis(ASM::PROJECTION_BASIS_2));
   if (silence || threadGroups.size() < 2) return;
 
   IFEM::cout <<"\nMultiple threads are utilized during element assembly.";

--- a/src/ASM/ASMs2D.h
+++ b/src/ASM/ASMs2D.h
@@ -457,6 +457,10 @@ public:
   //! \return Distance from the point \a X to the found point
   virtual double findPoint(Vec3& X, double* param) const;
 
+  //! \brief Returns the total number of visualization points for this patch.
+  //! \param[in] npe Number of visualization nodes over each knot span
+  virtual size_t getNoViz(const int* npe) const;
+
   //! \brief Calculates parameter values for visualization nodal points.
   //! \param[out] prm Parameter values in given direction for all points
   //! \param[in] dir Parameter direction (0,1)

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -858,7 +858,7 @@ bool ASMs3D::collapseFace (int face, int edge, int basis)
   if (swapW && face > 4) // Account for swapped parameter direction
     face = 11-face;
 
-  // Lambda function to verify co-location of nodes and collapse them
+  // Lambda function to verify co-location of nodes and collapse them.
   auto&& collapse = [this](int master, int slave)
   {
     const double xtol = 1.0e-4;
@@ -3046,6 +3046,30 @@ double ASMs3D::findPoint (Vec3& X, double* param) const
 }
 
 
+size_t ASMs3D::getNoViz (const int* npe) const
+{
+  if (!svol || !npe)
+    return 0;
+
+  size_t nvp = 1;
+  for (int d = 0; d < 3; d++)
+  {
+    if (npe[d] < 1)
+      return 0;
+
+    int n = svol->numCoefs(d);
+    int p = svol->order(d)-1;
+    size_t npt = 1;
+    for (int i = p; i < n; i++)
+      if (svol->knotSpan(d,i) > 0.0)
+        npt += npe[d]-1;
+    nvp *= npt;
+  }
+
+  return nvp;
+}
+
+
 bool ASMs3D::getGridParameters (RealArray& prm, int dir, int nSegPerSpan) const
 {
   if (!svol) return false;
@@ -3490,13 +3514,13 @@ void ASMs3D::generateThreadGroups (const Integrand& integrand, bool silence,
       const int n1 = prj->numCoefs(0);
       const int n2 = prj->numCoefs(1);
       const int n3 = prj->numCoefs(2);
-      const int p1 = prj->order(0);
-      const int p2 = prj->order(1);
-      const int p3 = prj->order(2);
-      const int nelp = (n1-p1+1)*(n2-p2+1)*(n3-p3+1);
-      proj2ThreadGroups.oneGroup(nelp);
+      const int p1 = prj->order(0) - 1;
+      const int p2 = prj->order(1) - 1;
+      const int p3 = prj->order(2) - 1;
+      proj2ThreadGroups.oneGroup((n1-p1)*(n2-p2)*(n3-p3));
     }
-  } else
+  }
+  else
     this->generateThreadGroups(svol->order(0)-1, svol->order(1)-1,
                                svol->order(2)-1, silence, ignoreGlobalLM);
 }
@@ -3505,12 +3529,9 @@ void ASMs3D::generateThreadGroups (const Integrand& integrand, bool silence,
 void ASMs3D::generateThreadGroups (size_t strip1, size_t strip2, size_t strip3,
                                    bool silence, bool ignoreGlobalLM)
 {
-  //! \brief Lamda for setting up thread groups for a basis.
-  auto&& genThreadGroups = [](ThreadGroups& tg,
-                              const Go::SplineVolume* svol,
-                              const size_t strip1,
-                              const size_t strip2,
-                              const size_t strip3)
+  // Lambda function for setting up thread groups for a basis.
+  auto&& genThreadGroups = [](ThreadGroups& tg, const Go::SplineVolume* svol,
+                              int strip1 = 0, int strip2 = 0, int strip3 = 0)
   {
     const int p1 = svol->order(0) - 1;
     const int p2 = svol->order(1) - 1;
@@ -3532,22 +3553,19 @@ void ASMs3D::generateThreadGroups (size_t strip1, size_t strip2, size_t strip3,
     for (ii = p3; ii < n3; ii++)
       el3.push_back(svol->knotSpan(2,ii) > 0.0);
 
-    tg.calcGroups(el1,el2,el3,strip1,strip2,strip3);
+    tg.calcGroups(el1, el2, el3,
+                  strip1 > 0 ? strip1 : p1,
+                  strip2 > 0 ? strip2 : p2,
+                  strip3 > 0 ? strip3 : p3);
   };
 
   genThreadGroups(threadGroupsVol, svol.get(), strip1, strip2, strip3);
-  if (this->separateProjectionBasis()) {
-    const Go::SplineVolume* vol = this->getBasis(ASM::PROJECTION_BASIS);
-    genThreadGroups(projThreadGroups, vol,
-                    vol->order(0)-1, vol->order(1)-1, vol->order(2)-1);
-  } else {
+  if (this->separateProjectionBasis())
+    genThreadGroups(projThreadGroups, this->getBasis(ASM::PROJECTION_BASIS));
+  else
     projThreadGroups = threadGroupsVol;
-  }
-  if (this->getBasis(ASM::PROJECTION_BASIS_2)) {
-    const Go::SplineVolume* vol = this->getBasis(ASM::PROJECTION_BASIS_2);
-    genThreadGroups(proj2ThreadGroups, vol,
-                    vol->order(0)-1, vol->order(1)-1, vol->order(2)-1);
-  }
+  if (this->getBasis(ASM::PROJECTION_BASIS_2))
+    genThreadGroups(proj2ThreadGroups, this->getBasis(ASM::PROJECTION_BASIS_2));
   if (silence || threadGroupsVol.size() < 2) return;
 
   IFEM::cout <<"\nMultiple threads are utilized during element assembly.";

--- a/src/ASM/ASMs3D.h
+++ b/src/ASM/ASMs3D.h
@@ -524,6 +524,10 @@ public:
   //! \return Distance from the point \a X to the found point
   virtual double findPoint(Vec3& X, double* param) const;
 
+  //! \brief Returns the total number of visualization points for this patch.
+  //! \param[in] npe Number of visualization nodes over each knot span
+  virtual size_t getNoViz(const int* npe) const;
+
   //! \brief Calculates parameter values for visualization nodal points.
   //! \param[out] prm Parameter values in given direction for all points
   //! \param[in] dir Parameter direction (0,1,2)

--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -802,28 +802,34 @@ bool SIMoutput::writeGlvBC (int& nBlock, int iStep) const
 {
   if (!myVtf)
     return true;
-  if (mergeVtf && myModel.size() > 1)
-    return true; // not implemented for merged patches, ignore
 
+  // Find the last active patch at current time
+  size_t lastActive = 0;
+  if (mergeVtf)
+    for (const ASMbase* pch : myModel)
+      if (!pch->empty() && !pch->inActive())
+        lastActive = pch->idx;
+
+  Matrix singleField;
   Matrix field;
   std::array<IntVec,6> dID;
   std::array<int,6> flag{};
 
-  size_t j, n;
   int geomID = myGeomID;
   for (const ASMbase* pch : myModel)
   {
-    if (pch->empty())
-      continue; // skip empty patches
+    if (pch->empty() || pch->inActive())
+      continue; // skip empty and inactive patches
 
-    ++geomID;
+    if (lastActive == 0)
+      flag.fill(0);
+
     size_t nbc = pch->getNoFields(1);
     size_t nNod = pch->getNoNodes(1);
     Vector bc(nbc*nNod);
-    flag.fill(0);
-    ASMbase::BCVec::const_iterator bit;
-    for (bit = pch->begin_BC(); bit != pch->end_BC(); ++bit)
-      if ((n = pch->getNodeIndex(bit->node,true)) && n <= nNod)
+    for (ASMbase::BCVec::const_iterator bit = pch->begin_BC();
+         bit != pch->end_BC(); ++bit)
+      if (size_t n = pch->getNodeIndex(bit->node,true); n > 0 && n <= nNod)
       {
         size_t offs = nbc*(n-1);
         if (!bit->CX && nbc > 0) bc[offs]   = flag[0] = 1;
@@ -834,26 +840,52 @@ bool SIMoutput::writeGlvBC (int& nBlock, int iStep) const
         if (!bit->RZ && nbc > 5) bc[offs+5] = flag[5] = 1;
       }
 
-    if (std::accumulate(flag.begin(),flag.end(),0) == 0)
-      continue; // nothing on this patch
+    if (std::accumulate(flag.begin(),flag.end(),0) > 0)
+    {
+      if (msgLevel > 1)
+        IFEM::cout <<"Writing boundary conditions for patch "
+                   << pch->idx+1 << std::endl;
 
-    if (msgLevel > 1)
-      IFEM::cout <<"Writing boundary conditions for patch "
-                 << pch->idx+1 << std::endl;
+      if (!pch->evalSolution(field,bc,opt.nViz,nbc))
+        return false;
 
-    if (!pch->evalSolution(field,bc,opt.nViz,nbc))
-      return false;
+      if (lastActive > 0)
+      {
+        // We need to merge the data for all patches before writing them
+        if (!augmentColumns(singleField,field))
+          return false;
+        if (lastActive == pch->idx)
+          std::swap(field,singleField);
+        else
+          continue;
+      }
+    }
+    else if (lastActive == 0)
+    {
+      ++geomID; // no BCs on this patch
+      continue;
+    }
+    else
+    {
+      // No BCs on this patch, but pad result array with zeros
+      singleField.resize(nbc,singleField.cols()+pch->getNoViz(opt.nViz));
+      if (lastActive == pch->idx)
+        std::swap(field,singleField);
+      else
+        continue;
+    }
 
     if (opt.discretization >= ASM::Spline)
       // The BC field values should either be 0 or 1 but in case of extra
       // visualization points for Splines, the extra points get interpolated
       // values between 0 and 1. Reset these to 0 as they don't represent nodes.
-      for (j = 1; j <= 6; j++)
+      for (int j = 1; j <= 6; j++)
         if (flag[j-1])
-          for (n = 1; n <= field.cols(); n++)
+          for (size_t n = 1; n <= field.cols(); n++)
             if (field(j,n) < 0.9999) field(j,n) = 0.0;
 
-    for (j = 0; j < 6; j++)
+    ++geomID;
+    for (int j = 0; j < 6; j++)
       if (flag[j])
       {
         if (!myVtf->writeNres(field.getRow(1+j),++nBlock,geomID))
@@ -866,7 +898,7 @@ bool SIMoutput::writeGlvBC (int& nBlock, int iStep) const
     "fix_X", "fix_Y", "fix_Z", "fix_RX", "fix_RY", "fix_RZ"
   };
 
-  for (j = 0; j < 6; j++)
+  for (int j = 0; j < 6; j++)
     if (!dID[j].empty())
       if (!myVtf->writeSblk(dID[j],label[j],1+j,iStep))
         return false;
@@ -1133,10 +1165,8 @@ int SIMoutput::writeGlvS1 (const Vector& psol, int iStep, int& nBlock,
     if (lastActive > 0)
     {
       // We need to merge the results for all patches before writing them
-      if (singleField.empty())
-        std::swap(singleField,field);
-      else
-        singleField.augmentCols(field);
+      if (!augmentColumns(singleField,field))
+        return -99;
       if (lastActive == pch->idx)
         std::swap(field,singleField);
       else
@@ -1354,10 +1384,8 @@ int SIMoutput::writeGlvS2 (const Vector& psol, int iStep, int& nBlock,
     if (lastActive > 0)
     {
       // We need to merge the results for all patches before writing them
-      if (singleField.empty())
-        std::swap(singleField,field);
-      else
-        singleField.augmentCols(field);
+      if (!augmentColumns(singleField,field))
+        return -99;
       if (lastActive == pch->idx)
         std::swap(field,singleField);
       else
@@ -1396,10 +1424,8 @@ int SIMoutput::writeGlvS2 (const Vector& psol, int iStep, int& nBlock,
       if (lastActive > 0)
       {
         // We need to merge the results for all patches before writing them
-        if (projField.empty())
-          std::swap(projField,field);
-        else
-          projField.augmentCols(field);
+        if (!augmentColumns(projField,field))
+          return -99;
         if (lastActive == pch->idx)
           std::swap(field,projField);
       }
@@ -1576,10 +1602,8 @@ bool SIMoutput::writeGlvP (const RealArray& ssol, int iStep, int& nBlock,
     if (lastActive > 0)
     {
       // We need to merge the results for all patches before writing them
-      if (singleField.empty())
-        std::swap(singleField,field);
-      else
-        singleField.augmentCols(field);
+      if (!augmentColumns(singleField,field))
+        return false;
       if (lastActive == pch->idx)
         std::swap(field,singleField);
       else
@@ -2366,23 +2390,6 @@ bool SIMoutput::evalResults (const Vectors& psol, const ResPointVec& gPoints,
   if (points.empty() && elms.empty() && !allElems)
     return true; // no points in this patch
 
-  // Lambda function augmenting two matrices with the same number of rows.
-  auto&& augment = [](Matrix& A, const Matrix& B)
-  {
-    if (B.empty())
-      return true;
-    else if (A.empty())
-      A = B;
-    else if (!A.augmentCols(B))
-    {
-      std::cerr <<" *** SIMoutput::evalResults: Incompatible matrices, rows(A)="
-                << A.rows() <<" rows(B)="<< B.rows() << std::endl;
-      return false;
-    }
-
-    return true;
-  };
-
   // Extract patch-level control/nodal point values of the primary solution
   Vector& patchSol = myProblem->getSolution();
   patch->extractNodalVec(psol.front(),patchSol,mySam->getMADOF(),-2);
@@ -2404,14 +2411,13 @@ bool SIMoutput::evalResults (const Vectors& psol, const ResPointVec& gPoints,
   if (ok) // Compute application-specific primary solution quantities, if any
     myProblem->primaryScalarFields(tmp);
 
-  if (!ok || !augment(sol1,tmp))
-    return false;
-
-  const bool getNames = compNames && compNames->empty();
-
+  const bool getNames = ok && compNames && compNames->empty();
   if (getNames && !tmp.empty())
     for (size_t i = 0; i < myProblem->getNoFields(1); i++)
       compNames->push_back(myProblem->getField1Name(i));
+
+  if (ok)
+    ok = augmentColumns(sol1,tmp);
 
   if (psol.size() > 2 && (opt.discretization >= ASM::Spline || !points.empty()))
     // Extract nodal point velocity and acceleration
@@ -2423,7 +2429,8 @@ bool SIMoutput::evalResults (const Vectors& psol, const ResPointVec& gPoints,
         ok = patch->evalSolution(tmp,locVec,params.data(),false);
       else
         ok = patch->getSolution(tmp,locVec,points);
-      if (ok) ok = sol1.augmentRows(tmp);
+      if (ok)
+        ok = sol1.augmentRows(tmp);
       if (ok && getNames)
       {
         const char* velacc = idx == 1 ? "velocity" : "acceleration";
@@ -2447,7 +2454,7 @@ bool SIMoutput::evalResults (const Vectors& psol, const ResPointVec& gPoints,
   else // evaluate at specified elements
     ok = patch->evalSolution(tmp,*myProblem,elms);
 
-  if ((ok &= augment(sol2,tmp)) && getNames)
+  if ((ok &= augmentColumns(sol2,tmp)) && getNames)
     for (size_t i = 0; i < myProblem->getNoFields(2); i++)
       compNames->push_back(myProblem->getField2Name(i));
 
@@ -2784,6 +2791,28 @@ bool SIMoutput::writeAddFuncs (int& nBlock, int& idBlock, const Vector& psol,
     if (!this->writeGlvF(*func.second, func.first.c_str(), iStep, nBlock,
                          psol.empty() ? nullptr : &psol, idBlock++, time))
       return false;
+
+  return true;
+}
+
+
+/*!
+  \note If the matrix \b A is empty it will be swapped with matrix \b B
+  such that the latter becomes empty instead.
+*/
+
+bool SIMoutput::augmentColumns (Matrix& A, Matrix& B)
+{
+  if (B.empty())
+    return true;
+  else if (A.empty())
+    std::swap(A,B);
+  else if (!A.augmentCols(B))
+  {
+    std::cerr <<" *** SIMoutput::augmentColumns: Incompatible matrices,"
+              <<" rows(A)="<< A.rows() <<" rows(B)="<< B.rows() << std::endl;
+    return false;
+  }
 
   return true;
 }

--- a/src/SIM/SIMoutput.h
+++ b/src/SIM/SIMoutput.h
@@ -346,6 +346,11 @@ protected:
   virtual bool writeAddFuncs(int& nBlock, int& idBlock, const Vector& psol,
                              int iStep, double time);
 
+  //! \brief Utility concatenating two matrices with the same number of rows.
+  //! \param A The matrix to be expanded
+  //! \param B The matrix to be augmented into matrix \b A
+  static bool augmentColumns(Matrix& A, Matrix& B);
+
 private:
   //! \brief Private helper to initialize patch for solution evaluation.
   bool initPatchForEvaluation(int patchNo) const;


### PR DESCRIPTION
Such that we can check the boundary conditions also when element activation is used in multi-patch models.