### PR TITLE
Abort assembly loop when negative Jacobian determinant is detected

### DIFF
--- a/src/ASM/ASMs1D.C
+++ b/src/ASM/ASMs1D.C
@@ -1123,7 +1123,12 @@ bool ASMs1D::integrate (Integrand& integrand,
     double dL = 0.5*this->getKnotSpan(MNPC[iel][p1-1]);
 
     // Set up control point coordinates for current element
-    ok = this->getElementCoordinates(fe.Xn,1+iel);
+    if (!this->getElementCoordinates(fe.Xn,1+iel))
+    {
+      ok = false;
+      A->destruct();
+      break;
+    }
 
     if (integrand.getIntegrandType() & Integrand::ELEMENT_CORNERS)
       fe.h = this->getElementEnds(p1+iel,fe.XC);
@@ -1144,13 +1149,18 @@ bool ASMs1D::integrate (Integrand& integrand,
     }
 
     // Initialize element matrices
-    ok &= integrand.initElement(MNPC[iel],fe,X,nRed,*A);
+    if (!integrand.initElement(MNPC[iel],fe,X,nRed,*A))
+    {
+      ok = false;
+      A->destruct();
+      break;
+    }
 
     if (xr)
     {
       // --- Selective reduced integration loop --------------------------------
 
-      for (int i = 0; i < nRed && ok; i++)
+      for (int i = 0; i < nRed; i++)
       {
         // Local element coordinates of current integration point
         fe.xi = xr[i];
@@ -1166,14 +1176,17 @@ bool ASMs1D::integrate (Integrand& integrand,
           this->extractBasis(fe.u,fe.N,dNdu);
           // Compute Jacobian inverse and derivatives
           dNdu.multiply(dL); // Derivatives w.r.t. xi=[-1,1]
-          fe.detJxW = utl::Jacobian(Jac,fe.dNdX,fe.Xn,dNdu)*wr[i];
+          ok &= fe.Jacobian(Jac,fe.Xn,dNdu);
+
+          fe.detJxW *= wr[i];
         }
 
         // Cartesian coordinates of current integration point
         X.assign(fe.Xn * fe.N);
 
         // Compute the reduced integration terms of the integrand
-        ok = integrand.reducedInt(*A,fe,X);
+        if (ok && !integrand.reducedInt(*A,fe,X))
+          ok = false;
       }
     }
 
@@ -1183,7 +1196,7 @@ bool ASMs1D::integrate (Integrand& integrand,
     int jp = iel*ng;
     fe.iGP = firstIp + jp; // Global integration point counter
 
-    for (int i = 0; i < ng && ok; i++, fe.iGP++)
+    for (int i = 0; i < ng; i++, fe.iGP++)
     {
       // Local element coordinate of current integration point
       fe.xi = xg[i];
@@ -1205,8 +1218,9 @@ bool ASMs1D::integrate (Integrand& integrand,
       {
         // Compute derivatives in terms of physical coordinates
         dNdu.multiply(dL); // Derivatives w.r.t. xi=[-1,1]
-        fe.detJxW = utl::Jacobian(Jac,fe.dNdX,fe.Xn,dNdu)*wg[i];
-        if (fe.detJxW == 0.0) continue; // skip singular points
+        ok &= fe.Jacobian(Jac,fe.Xn,dNdu);
+
+        fe.detJxW *= wg[i];
 
         // Compute Hessian of coordinate mapping and 2nd order derivatives
         if (integrand.getIntegrandType() & Integrand::SECOND_DERIVATIVES)
@@ -1311,7 +1325,11 @@ bool ASMs1D::integrate (Integrand& integrand, int lIndex,
   fe.iGP = iit == firstBp.end() ? 0 : iit->second;
 
   // Set up control point coordinates for current element
-  bool ok = this->getElementCoordinates(fe.Xn,1+iel);
+  if (!this->getElementCoordinates(fe.Xn,1+iel))
+  {
+    A->destruct();
+    return false;
+  }
 
   if (integrand.getIntegrandType() & Integrand::ELEMENT_CORNERS)
     fe.h = this->getElementEnds(iel+curv->order(),fe.XC);
@@ -1325,7 +1343,11 @@ bool ASMs1D::integrate (Integrand& integrand, int lIndex,
     fe.Te.diag(1.0);
 
   // Initialize element matrices
-  ok &= integrand.initElementBou(MNPC[iel],*A);
+  if (!integrand.initElementBou(MNPC[iel],*A))
+  {
+    A->destruct();
+    return false;
+  }
 
   Vec3 normal;
 
@@ -1353,18 +1375,17 @@ bool ASMs1D::integrate (Integrand& integrand, int lIndex,
 
   // Cartesian coordinates of current integration point
   double param[3] = { fe.u, 0.0, 0.0 };
-  Vec4 X(param,time.t);
-  X.assign(fe.Xn*fe.N);
+  Vec4   X(fe.Xn * fe.N, time.t, param);
 
   // Evaluate the integrand and accumulate element contributions
-  if (ok && !integrand.evalBou(*A,fe,time,X,normal))
-    ok = false;
+  bool ok = integrand.evalBou(*A,fe,time,X,normal);
 
   // Assembly of global system integral
   if (ok && !glInt.assemble(A->ref(),fe.iel))
     ok = false;
 
   A->destruct();
+
   return ok;
 }
 
@@ -1753,8 +1774,8 @@ bool ASMs1D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
     if (!dNdu.empty())
     {
       // Compute the Jacobian inverse and derivatives
-      fe.detJxW = utl::Jacobian(Jac,fe.dNdX,Xtmp,dNdu);
-      if (fe.detJxW == 0.0) continue; // skip singular points
+      if (!fe.Jacobian(Jac,Xtmp,dNdu))
+        continue; // skip singular points
 
       // Compute Hessian of coordinate mapping and 2nd order derivatives
       if (integrand.getIntegrandType() & Integrand::SECOND_DERIVATIVES)

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -1900,8 +1900,12 @@ bool ASMs2D::integrate (Integrand& integrand,
               // Cartesian coordinates of current integration point
               X.assign(Xnod * fe.N);
 
-              // Compute the reduced integration terms of the integrand
+              // Integration point weight
               fe.detJxW *= dA*wr[i]*wr[j];
+              if (integrand.isAxiSymmetric())
+                fe.detJxW *= 2.0*M_PI*X.x;
+
+              // Compute the reduced integration terms of the integrand
               if (ok && !integrand.reducedInt(*A,fe,X))
                 ok = false;
             }
@@ -1958,8 +1962,12 @@ bool ASMs2D::integrate (Integrand& integrand,
             // Cartesian coordinates of current integration point
             X.assign(Xnod * fe.N);
 
-            // Evaluate the integrand and accumulate element contributions
+            // Integration point weight
             fe.detJxW *= dA*wg[0][i]*wg[1][j];
+            if (integrand.isAxiSymmetric())
+              fe.detJxW *= 2.0*M_PI*X.x;
+
+            // Evaluate the integrand and accumulate element contributions
 #ifndef USE_OPENMP
             PROFILE3("Integrand::evalInt");
 #endif
@@ -2169,8 +2177,12 @@ bool ASMs2D::integrate (Integrand& integrand,
           X.assign(Xnod * fe.N);
           X.u = itgPt.data();
 
-          // Evaluate the integrand and accumulate element contributions
+          // Integration point weight
           fe.detJxW *= dA*itgPt[2];
+          if (integrand.isAxiSymmetric())
+            fe.detJxW *= 2.0*M_PI*X.x;
+
+          // Evaluate the integrand and accumulate element contributions
 #ifndef USE_OPENMP
           PROFILE3("Integrand::evalInt");
 #endif
@@ -2345,8 +2357,12 @@ bool ASMs2D::integrate (Integrand& integrand,
             std::cout <<"\n"<< fe;
 #endif
 
-            // Evaluate the integrand and accumulate element contributions
+            // Integration point weight
             fe.detJxW *= dS*wg[i];
+            if (integrand.isAxiSymmetric())
+              fe.detJxW *= 2.0*M_PI*X.x;
+
+            // Evaluate the integrand and accumulate element contributions
             ok = integrand.evalInt(*A,fe,time,X,normal);
           }
         }
@@ -2533,8 +2549,12 @@ bool ASMs2D::integrate (Integrand& integrand, int lIndex,
 	// Cartesian coordinates of current integration point
 	X.assign(Xnod * fe.N);
 
+        // Integration point weight
+        fe.detJxW *= dS*wg[i];
+        if (integrand.isAxiSymmetric())
+          fe.detJxW *= 2.0*M_PI*X.x;
+
 	// Evaluate the integrand and accumulate element contributions
-	fe.detJxW *= dS*wg[i];
 	ok = integrand.evalBou(*A,fe,time,X,normal);
       }
 

--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -1894,15 +1894,15 @@ bool ASMs2D::integrate (Integrand& integrand,
               fe.N = bfs.N;
 
               // Compute Jacobian inverse and derivatives
-              fe.detJxW = utl::Jacobian(Jac,fe.dNdX,Xnod,bfs.dNdu);
-              if (fe.detJxW == 0.0) continue; // skip singular points
+              if (!fe.Jacobian(Jac,Xnod,bfs.dNdu))
+                ok = false;
 
               // Cartesian coordinates of current integration point
               X.assign(Xnod * fe.N);
 
               // Compute the reduced integration terms of the integrand
               fe.detJxW *= dA*wr[i]*wr[j];
-              if (!integrand.reducedInt(*A,fe,X))
+              if (ok && !integrand.reducedInt(*A,fe,X))
                 ok = false;
             }
         }
@@ -1930,8 +1930,8 @@ bool ASMs2D::integrate (Integrand& integrand,
             fe.N = bfs.N;
 
             // Compute Jacobian inverse of coordinate mapping and derivatives
-            fe.detJxW = utl::Jacobian(Jac,fe.dNdX,Xnod,bfs.dNdu);
-            if (fe.detJxW == 0.0) continue; // skip singular points
+            if (!fe.Jacobian(Jac,Xnod,bfs.dNdu))
+              ok = false;
 
             // Compute Hessian of coordinate mapping and 2nd order derivatives
             if (use2ndDer)
@@ -1963,7 +1963,7 @@ bool ASMs2D::integrate (Integrand& integrand,
 #ifndef USE_OPENMP
             PROFILE3("Integrand::evalInt");
 #endif
-            if (!integrand.evalInt(*A,fe,time,X))
+            if (ok && !integrand.evalInt(*A,fe,time,X))
               ok = false;
           }
 
@@ -2144,8 +2144,8 @@ bool ASMs2D::integrate (Integrand& integrand,
             SplineUtils::extractBasis(spline[jp++],fe.N,dNdu);
 
           // Compute Jacobian inverse of coordinate mapping and derivatives
-          fe.detJxW = utl::Jacobian(Jac,fe.dNdX,Xnod,dNdu);
-          if (fe.detJxW == 0.0) continue; // skip singular points
+          if (!fe.Jacobian(Jac,Xnod,dNdu))
+            ok = false;
 
           // Compute Hessian of coordinate mapping and 2nd order derivatives
           if (use2ndDer)
@@ -2174,7 +2174,7 @@ bool ASMs2D::integrate (Integrand& integrand,
 #ifndef USE_OPENMP
           PROFILE3("Integrand::evalInt");
 #endif
-          if (!integrand.evalInt(*A,fe,time,X))
+          if (ok && !integrand.evalInt(*A,fe,time,X))
             ok = false;
         }
 
@@ -2445,7 +2445,7 @@ bool ASMs2D::integrate (Integrand& integrand, int lIndex,
   for (int i2 = p2; i2 <= n2; i2++)
     for (int i1 = p1; i1 <= n1; i1++, iel++)
     {
- #ifdef SP_DEBUG
+#ifdef SP_DEBUG
       int ielm = 1+iel;
       if (dbgElm < 0 && ielm != -dbgElm)
         continue; // Skipping all elements, except for -dbgElm
@@ -3030,8 +3030,8 @@ bool ASMs2D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
       SplineUtils::extractBasis(spline1[i],fe.N,dNdu);
 
     // Compute the Jacobian inverse and derivatives
-    fe.detJxW = utl::Jacobian(fe.G,fe.dNdX,Xtmp,dNdu);
-    if (fe.detJxW == 0.0) continue; // skip singular points
+    if (!fe.Jacobian(fe.G,Xtmp,dNdu))
+      continue; // skip singular points
 
     // Compute Hessian of coordinate mapping and 2nd order derivatives
     if (use2ndDer)

--- a/src/ASM/ASMs2DLag.C
+++ b/src/ASM/ASMs2DLag.C
@@ -399,8 +399,12 @@ bool ASMs2DLag::integrateElm (Integrand& integrand, GlobalIntegral& glInt,
         if (!Def.empty()) integrand.setParam("u", Def * fe.N);
         if (!Vel.empty()) integrand.setParam("v", Vel * fe.N);
 
-        // Compute the reduced integration terms of the integrand
+        // Integration point weight
         fe.detJxW *= wr[i]*wr[j];
+        if (integrand.isAxiSymmetric())
+          fe.detJxW *= 2.0*M_PI*X.x;
+
+        // Compute the reduced integration terms of the integrand
         ok &= integrand.reducedInt(*A,fe,X);
       }
   }
@@ -447,8 +451,12 @@ bool ASMs2DLag::integrateElm (Integrand& integrand, GlobalIntegral& glInt,
       if (!Def.empty()) integrand.setParam("u", Def * fe.N);
       if (!Vel.empty()) integrand.setParam("v", Vel * fe.N);
 
-      // Evaluate the integrand and accumulate element contributions
+      // Integration point weight
       fe.detJxW *= wg[0][i]*wg[1][j];
+      if (integrand.isAxiSymmetric())
+        fe.detJxW *= 2.0*M_PI*X.x;
+
+      // Evaluate the integrand and accumulate element contributions
       ok &= integrand.evalInt(*A,fe,time,X);
     }
 
@@ -648,8 +656,12 @@ bool ASMs2DLag::integrate (Integrand& integrand, int lIndex,
         if (!Def.empty()) integrand.setParam("u", Def * fe.N);
         if (!Vel.empty()) integrand.setParam("v", Vel * fe.N);
 
-        // Evaluate the integrand and accumulate element contributions
+        // Integration point weight
         fe.detJxW *= wg[i];
+        if (integrand.isAxiSymmetric())
+          fe.detJxW *= 2.0*M_PI*X.x;
+
+        // Evaluate the integrand and accumulate element contributions
         if (ok && !integrand.evalBou(*A,fe,time,X,normal))
           ok = false;
       }

--- a/src/ASM/ASMs2DTri.C
+++ b/src/ASM/ASMs2DTri.C
@@ -247,14 +247,16 @@ bool ASMs2DTri::integrate (Integrand& integrand,
             evalBasis(fe.N,dNdu,fe.xi,fe.eta);
 
             // Compute Jacobian inverse and derivatives
-            fe.detJxW = 0.5*utl::Jacobian(Jac,fe.dNdX,Xnod,dNdu);
+            if (!fe.Jacobian(Jac,Xnod,dNdu))
+              ok = false;
 
             // Cartesian coordinates of current integration point
             X.assign(Xnod * fe.N);
 
+            fe.detJxW *= 0.5*wr[j];
+
             // Compute the reduced integration terms of the integrand
-            fe.detJxW *= wr[j];
-            if (!integrand.reducedInt(*A,fe,X))
+            if (ok && !integrand.reducedInt(*A,fe,X))
               ok = false;
           }
 
@@ -275,15 +277,16 @@ bool ASMs2DTri::integrate (Integrand& integrand,
           evalBasis(fe.N,dNdu,fe.xi,fe.eta);
 
           // Compute Jacobian inverse of coordinate mapping and derivatives
-          fe.detJxW = 0.5*utl::Jacobian(Jac,fe.dNdX,Xnod,dNdu);
-          if (fe.detJxW == 0.0) continue; // skip singular points
+          if (!fe.Jacobian(Jac,Xnod,dNdu))
+            ok = false;
 
           // Cartesian coordinates of current integration point
           X.assign(Xnod * fe.N);
 
+          fe.detJxW *= 0.5*wg[j];
+
           // Evaluate the integrand and accumulate element contributions
-          fe.detJxW *= wg[j];
-          if (!integrand.evalInt(*A,fe,time,X))
+          if (ok && !integrand.evalInt(*A,fe,time,X))
             ok = false;
         }
 

--- a/src/ASM/ASMs2DTri.C
+++ b/src/ASM/ASMs2DTri.C
@@ -253,7 +253,8 @@ bool ASMs2DTri::integrate (Integrand& integrand,
             // Cartesian coordinates of current integration point
             X.assign(Xnod * fe.N);
 
-            fe.detJxW *= 0.5*wr[j];
+            // Integration point weight
+            fe.detJxW *= (integrand.isAxiSymmetric() ? M_PI*X.x : 0.5) * wr[j];
 
             // Compute the reduced integration terms of the integrand
             if (ok && !integrand.reducedInt(*A,fe,X))
@@ -283,7 +284,8 @@ bool ASMs2DTri::integrate (Integrand& integrand,
           // Cartesian coordinates of current integration point
           X.assign(Xnod * fe.N);
 
-          fe.detJxW *= 0.5*wg[j];
+          // Integration point weight
+          fe.detJxW *= (integrand.isAxiSymmetric() ? M_PI*X.x : 0.5) * wg[j];
 
           // Evaluate the integrand and accumulate element contributions
           if (ok && !integrand.evalInt(*A,fe,time,X))

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -605,8 +605,12 @@ bool ASMs2Dmx::integrate (Integrand& integrand,
             // Cartesian coordinates of current integration point
             X.assign(Xnod * (separateGeometry ? bfs.back()->N : fe.basis(itgBasis)));
 
-            // Evaluate the integrand and accumulate element contributions
+            // Integration point weight
             fe.detJxW *= dA*wg[0][i]*wg[1][j];
+            if (integrand.isAxiSymmetric())
+              fe.detJxW *= 2.0*M_PI*X.x;
+
+            // Evaluate the integrand and accumulate element contributions
             if (ok && !integrand.evalIntMx(*A,fe,time,X))
               ok = false;
           }
@@ -791,8 +795,12 @@ bool ASMs2Dmx::integrate (Integrand& integrand, int lIndex,
         // Cartesian coordinates of current integration point
         X.assign(Xnod * (separateGeometry ? bfs.back().N : fe.basis(itgBasis)));
 
-        // Evaluate the integrand and accumulate element contributions
+        // Integration point weight
         fe.detJxW *= dS*wg[i];
+        if (integrand.isAxiSymmetric())
+          fe.detJxW *= 2.0*M_PI*X.x;
+
+        // Evaluate the integrand and accumulate element contributions
         if (ok && !integrand.evalBouMx(*A,fe,time,X,normal))
           ok = false;
       }
@@ -974,8 +982,12 @@ bool ASMs2Dmx::integrate (Integrand& integrand,
             // Cartesian coordinates of current integration point
             X.assign(Xnod * fe.basis(itgBasis));
 
-            // Evaluate the integrand and accumulate element contributions
+            // Integration point weight
             fe.detJxW *= dS*wg[i];
+            if (integrand.isAxiSymmetric())
+              fe.detJxW *= 2.0*M_PI*X.x;
+
+            // Evaluate the integrand and accumulate element contributions
             if (ok && !integrand.evalIntMx(*A,fe,time,X,normal))
               ok = false;
           }

--- a/src/ASM/ASMs2Dmx.C
+++ b/src/ASM/ASMs2Dmx.C
@@ -590,14 +590,13 @@ bool ASMs2Dmx::integrate (Integrand& integrand,
             // Compute Jacobian inverse of the coordinate mapping and
             // basis function derivatives w.r.t. Cartesian coordinates
             if (!fe.Jacobian(Jac,Xnod,itgBasis,bfs))
-              continue; // skip singular points
+              ok = false;
+            else if (piola)
+              fe.piolaMapping(Jac,Xnod,bfs);
 
             // Compute Hessian of coordinate mapping and 2nd order derivatives
             if (use2ndDer && !fe.Hessian(Hess,Jac,Xnod,itgBasis,bfs))
               ok = false;
-
-            if (piola)
-              fe.piolaMapping(fe.detJxW, Jac, Xnod, bfs);
 
             // Compute G-matrix
             if (integrand.getIntegrandType() & Integrand::G_MATRIX)
@@ -608,7 +607,7 @@ bool ASMs2Dmx::integrate (Integrand& integrand,
 
             // Evaluate the integrand and accumulate element contributions
             fe.detJxW *= dA*wg[0][i]*wg[1][j];
-            if (!integrand.evalIntMx(*A,fe,time,X))
+            if (ok && !integrand.evalIntMx(*A,fe,time,X))
               ok = false;
           }
 
@@ -740,7 +739,11 @@ bool ASMs2Dmx::integrate (Integrand& integrand, int lIndex,
 
       // Initialize element quantities
       LocalIntegral* A = integrand.getLocalIntegral(elem_size,fe.iel,true);
-      bool ok = integrand.initElementBou(MNPC[iel],elem_size,nb,*A);
+      if (!integrand.initElementBou(MNPC[iel],elem_size,nb,*A))
+      {
+        A->destruct();
+        return false;
+      }
 
 
       // --- Integration loop over all Gauss points along the edge -------------
@@ -748,7 +751,8 @@ bool ASMs2Dmx::integrate (Integrand& integrand, int lIndex,
       int ip = (t1 == 1 ? i2-p2 : i1-p1)*nGauss;
       fe.iGP = firstp + ip; // Global integration point counter
 
-      for (int i = 0; i < nGauss && ok; i++, ip++, fe.iGP++)
+      bool ok = true;
+      for (int i = 0; i < nGauss; i++, ip++, fe.iGP++)
       {
         // Local element coordinates and parameter values
         // of current integration point
@@ -778,19 +782,19 @@ bool ASMs2Dmx::integrate (Integrand& integrand, int lIndex,
         // Compute Jacobian inverse of the coordinate mapping and
         // basis function derivatives w.r.t. Cartesian coordinates
         if (!fe.Jacobian(Jac,normal,Xnod,itgBasis,bfs,t1,t2))
-          continue; // skip singular points
+          ok = false;
+        else if (usePiola)
+          fe.piolaMapping(Jac,Xnod,bfs);
 
         if (edgeDir < 0) normal *= -1.0;
-
-        if (usePiola)
-          fe.piolaMapping(fe.detJxW, Jac, Xnod, bfs);
 
         // Cartesian coordinates of current integration point
         X.assign(Xnod * (separateGeometry ? bfs.back().N : fe.basis(itgBasis)));
 
         // Evaluate the integrand and accumulate element contributions
         fe.detJxW *= dS*wg[i];
-        ok = integrand.evalBouMx(*A,fe,time,X,normal);
+        if (ok && !integrand.evalBouMx(*A,fe,time,X,normal))
+          ok = false;
       }
 
       // Finalize the element quantities
@@ -915,7 +919,7 @@ bool ASMs2Dmx::integrate (Integrand& integrand,
 
           // initialize neighbor element
           LocalIntegral* A_neigh = integrand.getLocalIntegral(elem_size,kel+1);
-          ok &= integrand.initElement(MNPC[kel],fe,elem_size,nb,*A_neigh);
+          ok = integrand.initElement(MNPC[kel],fe,elem_size,nb,*A_neigh);
           if (!A_neigh->vec.empty()) {
             A->vec.resize(origSize+A_neigh->vec.size());
             std::copy(A_neigh->vec.begin(), A_neigh->vec.end(), A->vec.begin()+origSize);
@@ -926,10 +930,11 @@ bool ASMs2Dmx::integrate (Integrand& integrand,
           double dS = 0.5*this->getParametricLength(1+iel,t2);
           if (dS < 0.0) // topology error (probably logic error)
             ok = false;
+          if (!ok) break;
 
           // --- Integration loop over all Gauss points along the edge ---------
 
-          for (int i = 0; i < nGauss && ok; i++)
+          for (int i = 0; i < nGauss; i++)
           {
             // Local element coordinates and parameter values
             // of current integration point
@@ -962,7 +967,7 @@ bool ASMs2Dmx::integrate (Integrand& integrand,
 
             // Compute basis function derivatives and the edge normal
             if (!fe.Jacobian(Jac,normal,Xnod,itgBasis,bfs,t1,t2,nB))
-              continue; // skip singular points
+              ok = false;
 
             if (edgeDir < 0) normal *= -1.0;
 
@@ -971,7 +976,8 @@ bool ASMs2Dmx::integrate (Integrand& integrand,
 
             // Evaluate the integrand and accumulate element contributions
             fe.detJxW *= dS*wg[i];
-            ok = integrand.evalIntMx(*A,fe,time,X,normal);
+            if (ok && !integrand.evalIntMx(*A,fe,time,X,normal))
+              ok = false;
           }
         }
 
@@ -1152,11 +1158,9 @@ bool ASMs2Dmx::evalSolutionPiola (Matrix& sField, const Vector& locSol,
                                    splineg[i].param[0], splineg[i].param[1]);
     Matrix J;
     J.multiply(Xnod, bf.dNdu);
-
-    const Real detJ = J.det();
     fe.basis(1) = splinex[0][i].basisValues;
     fe.basis(2) = splinex[1][i].basisValues;
-    fe.piolaBasis(detJ, J);
+    fe.piolaBasis(J.det(),J);
     coefs.front().push_back(coefs[1].begin(), coefs[1].end());
     fe.P.multiply(coefs.front(), Ytmp);
     if (withPressure)
@@ -1277,7 +1281,7 @@ bool ASMs2Dmx::evalSolution (Matrix& sField, const IntegrandBase& integrand,
       continue; // skip singular points
 
     if (usePiola)
-      fe.piolaMapping(fe.detJxW, Jac, Xtmp, bfs);
+      fe.piolaMapping(Jac,Xtmp,bfs);
 
     // Cartesian coordinates of current integration point
     utl::Point X4(Xtmp * (separateGeometry ? bfs.back().N : fe.basis(itgBasis)),

--- a/src/ASM/ASMs2DmxLag.C
+++ b/src/ASM/ASMs2DmxLag.C
@@ -330,14 +330,14 @@ bool ASMs2DmxLag::integrate (Integrand& integrand,
 
             // Compute Jacobian inverse of coordinate mapping and derivatives
             if (!fe.Jacobian(Jac,Xnod,itgBasis,bfs))
-              continue; // skip singular points
+              ok = false;
 
             // Cartesian coordinates of current integration point
             X.assign(Xnod * fe.basis(itgBasis));
 
             // Evaluate the integrand and accumulate element contributions
             fe.detJxW *= wg[0][i]*wg[1][j];
-            if (!integrand.evalIntMx(*A,fe,time,X))
+            if (ok && !integrand.evalIntMx(*A,fe,time,X))
               ok = false;
           }
 
@@ -429,7 +429,7 @@ bool ASMs2DmxLag::integrate (Integrand& integrand, int lIndex,
       int jp = (t1 == 1 ? i2 : i1)*nGauss;
       fe.iGP = firstp + jp; // Global integration point counter
 
-      for (int i = 0; i < nGauss && ok; i++, fe.iGP++)
+      for (int i = 0; i < nGauss; i++, fe.iGP++)
       {
         // Gauss point coordinates along the edge
         xi[t1-1] = edgeDir < 0 ? -1.0 : 1.0;
@@ -445,7 +445,7 @@ bool ASMs2DmxLag::integrate (Integrand& integrand, int lIndex,
 
         // Compute basis function derivatives and the edge normal
         if (!fe.Jacobian(Jac,normal,Xnod,itgBasis,bfs,t1,t2))
-          continue; // skip singular points
+          ok = false;
 
         if (edgeDir < 0) normal *= -1.0;
 

--- a/src/ASM/ASMs2DmxLag.C
+++ b/src/ASM/ASMs2DmxLag.C
@@ -335,8 +335,12 @@ bool ASMs2DmxLag::integrate (Integrand& integrand,
             // Cartesian coordinates of current integration point
             X.assign(Xnod * fe.basis(itgBasis));
 
-            // Evaluate the integrand and accumulate element contributions
+            // Integration point weight
             fe.detJxW *= wg[0][i]*wg[1][j];
+            if (integrand.isAxiSymmetric())
+              fe.detJxW *= 2.0*M_PI*X.x;
+
+            // Evaluate the integrand and accumulate element contributions
             if (ok && !integrand.evalIntMx(*A,fe,time,X))
               ok = false;
           }
@@ -452,8 +456,11 @@ bool ASMs2DmxLag::integrate (Integrand& integrand, int lIndex,
         // Cartesian coordinates of current integration point
         X.assign(Xnod * fe.basis(itgBasis));
 
-        // Evaluate the integrand and accumulate element contributions
         fe.detJxW *= wg[i];
+        if (integrand.isAxiSymmetric())
+          fe.detJxW *= 2.0*M_PI*X.x;
+
+        // Evaluate the integrand and accumulate element contributions
         if (ok && !integrand.evalBouMx(*A,fe,time,X,normal))
           ok = false;
       }

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -2128,7 +2128,7 @@ bool ASMs3D::integrate (Integrand& integrand,
       for (size_t l = 0; l < groups[g][t].size() && ok; l++)
       {
         int iel = groups[g][t][l];
- #ifdef SP_DEBUG
+#ifdef SP_DEBUG
         if (dbgElm < 0 && 1+iel != -dbgElm)
           continue; // Skipping all elements, except for -dbgElm
 #endif
@@ -2245,14 +2245,15 @@ bool ASMs3D::integrate (Integrand& integrand,
                 fe.N = bfs.N;
 
                 // Compute Jacobian inverse and derivatives
-                fe.detJxW = utl::Jacobian(Jac,fe.dNdX,Xnod,bfs.dNdu);
+                if (!fe.Jacobian(Jac,Xnod,bfs.dNdu))
+                  ok = false;
 
                 // Cartesian coordinates of current integration point
                 X.assign(Xnod * fe.N);
 
                 // Compute the reduced integration terms of the integrand
                 fe.detJxW *= dV*wr[i]*wr[j]*wr[k];
-                if (!integrand.reducedInt(*A,fe,X))
+                if (ok && !integrand.reducedInt(*A,fe,X))
                   ok = false;
               }
         }
@@ -2282,8 +2283,8 @@ bool ASMs3D::integrate (Integrand& integrand,
               fe.N = bfs.N;
 
               // Compute Jacobian inverse of coordinate mapping and derivatives
-              fe.detJxW = utl::Jacobian(Jac,fe.dNdX,Xnod,bfs.dNdu);
-              if (fe.detJxW == 0.0) continue; // skip singular points
+              if (!fe.Jacobian(Jac,Xnod,bfs.dNdu))
+                ok = false;
 
               // Compute Hessian of coordinate mapping and 2nd order derivatives
               if (use2ndDer)
@@ -2307,7 +2308,7 @@ bool ASMs3D::integrate (Integrand& integrand,
 #ifndef USE_OPENMP
               PROFILE3("Integrand::evalInt");
 #endif
-              if (!integrand.evalInt(*A,fe,time,X))
+              if (ok && !integrand.evalInt(*A,fe,time,X))
                 ok = false;
             }
 
@@ -2480,8 +2481,8 @@ bool ASMs3D::integrate (Integrand& integrand,
             SplineUtils::extractBasis(spline[jp++],fe.N,dNdu);
 
           // Compute Jacobian inverse of coordinate mapping and derivatives
-          fe.detJxW = utl::Jacobian(Jac,fe.dNdX,Xnod,dNdu);
-          if (fe.detJxW == 0.0) continue; // skip singular points
+          if (!fe.Jacobian(Jac,Xnod,dNdu))
+            ok = false;
 
           // Compute Hessian of coordinate mapping and 2nd order derivatives
           if (use2ndDer)
@@ -2506,7 +2507,7 @@ bool ASMs3D::integrate (Integrand& integrand,
 #ifndef USE_OPENMP
           PROFILE3("Integrand::evalInt");
 #endif
-          if (!integrand.evalInt(*A,fe,time,X))
+          if (ok && !integrand.evalInt(*A,fe,time,X))
             ok = false;
         }
 
@@ -3477,8 +3478,8 @@ bool ASMs3D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
       SplineUtils::extractBasis(spline1[i],fe.N,dNdu);
 
     // Compute the Jacobian inverse and derivatives
-    fe.detJxW = utl::Jacobian(Jac,fe.dNdX,Xtmp,dNdu);
-    if (fe.detJxW == 0.0) continue; // skip singular points
+    if (!fe.Jacobian(Jac,Xtmp,dNdu))
+      continue; // skip singular points
 
     // Compute Hessian of coordinate mapping and 2nd order derivatives
     if (use2ndDer)

--- a/src/ASM/ASMs3Dmx.C
+++ b/src/ASM/ASMs3Dmx.C
@@ -614,7 +614,7 @@ bool ASMs3Dmx::integrate (Integrand& integrand,
               // Compute Jacobian inverse of the coordinate mapping and
               // basis function derivatives w.r.t. Cartesian coordinates
               if (!fe.Jacobian(Jac,Xnod,itgBasis,bfs))
-                continue; // skip singular points
+                ok = false;
 
               // Compute Hessian of coordinate mapping and 2nd order derivatives
               if (use2ndDer && !fe.Hessian(Hess,Jac,Xnod,itgBasis,bfs))
@@ -629,7 +629,7 @@ bool ASMs3Dmx::integrate (Integrand& integrand,
 
               // Evaluate the integrand and accumulate element contributions
               fe.detJxW *= dV*wg[0][i]*wg[1][j]*wg[2][k];
-              if (!integrand.evalIntMx(*A,fe,time,X))
+              if (ok && !integrand.evalIntMx(*A,fe,time,X))
                 ok = false;
             }
 
@@ -834,7 +834,7 @@ bool ASMs3Dmx::integrate (Integrand& integrand, int lIndex,
             // Compute Jacobian inverse of the coordinate mapping and
             // basis function derivatives w.r.t. Cartesian coordinates
             if (!fe.Jacobian(Jac,normal,Xnod,itgBasis,bfs,t1,t2))
-              continue; // skip singular points
+              ok = false;
 
             if (faceDir < 0) normal *= -1.0;
 
@@ -843,7 +843,7 @@ bool ASMs3Dmx::integrate (Integrand& integrand, int lIndex,
 
             // Evaluate the integrand and accumulate element contributions
             fe.detJxW *= dA*wg[i]*wg[j];
-            if (!integrand.evalBouMx(*A,fe,time,X,normal))
+            if (ok && !integrand.evalBouMx(*A,fe,time,X,normal))
               ok = false;
           }
 
@@ -936,10 +936,10 @@ bool ASMs3Dmx::integrate (Integrand& integrand,
         short int status = iChk.hasContribution(iel,i1,i2,i3);
         if (!status) continue; // no interface contributions for this element
 
-  #if SP_DEBUG > 3
+#if SP_DEBUG > 3
         std::cout <<"\n\nIntegrating interface terms for element "<< fe.iel
                   << std::endl;
-  #endif
+#endif
 
         // Set up control point (nodal) coordinates for current element
         if (!this->getElementCoordinates(Xnod,1+iel)) return false;
@@ -994,6 +994,7 @@ bool ASMs3Dmx::integrate (Integrand& integrand,
             double dA = this->getParametricArea(1+iel,abs(faceDir));
             if (dA < 0.0) // topology error (probably logic error)
               ok = false;
+            if (!ok) break;
 
             // Define some loop control variables depending on which face we are on
             int nf1, j1, j2;
@@ -1007,10 +1008,10 @@ bool ASMs3Dmx::integrate (Integrand& integrand,
 
             int ip = (j2*nGP*nf1 + j1)*nGP;
 
-            // --- Integration loop over all Gauss points along the face ---------
+            // --- Integration loop over all Gauss points along the face -------
 
-            for (int j = 0; j < nGP && ok; j++, ip += nGP*(nf1-1))
-              for (int i = 0; i < nGP && ok; i++, ip++, fe.iGP++)
+            for (int j = 0; j < nGP; j++, ip += nGP*(nf1-1))
+              for (int i = 0; i < nGP; i++, ip++, fe.iGP++)
               {
                 // Local element coordinates and parameter values
                 // of current integration point
@@ -1057,7 +1058,7 @@ bool ASMs3Dmx::integrate (Integrand& integrand,
 
               // Compute basis function derivatives and the edge normal
               if (!fe.Jacobian(Jac,normal,Xnod,itgBasis,bfs,t1,t2,nB))
-                continue; // skip singular points
+                ok = false;
 
               if (faceDir < 0) normal *= -1.0;
 
@@ -1066,7 +1067,8 @@ bool ASMs3Dmx::integrate (Integrand& integrand,
 
               // Evaluate the integrand and accumulate element contributions
               fe.detJxW *= 0.25*dA*wg[i]*wg[j];
-              ok = integrand.evalIntMx(*A,fe,time,X,normal);
+              if (ok && !integrand.evalIntMx(*A,fe,time,X,normal))
+                ok = false;
             }
           }
 

--- a/src/ASM/ASMs3DmxLag.C
+++ b/src/ASM/ASMs3DmxLag.C
@@ -362,14 +362,14 @@ bool ASMs3DmxLag::integrate (Integrand& integrand,
 
               // Compute Jacobian inverse of coordinate mapping and derivatives
               if (!fe.Jacobian(Jac,Xnod,itgBasis,bfs))
-                continue; // skip singular points
+                ok = false;
 
               // Cartesian coordinates of current integration point
               X.assign(Xnod * fe.basis(itgBasis));
 
               // Evaluate the integrand and accumulate element contributions
               fe.detJxW *= wg[0][i]*wg[1][j]*wg[2][k];
-              if (!integrand.evalIntMx(*A,fe,time,X))
+              if (ok && !integrand.evalIntMx(*A,fe,time,X))
                 ok = false;
             }
 
@@ -505,7 +505,7 @@ bool ASMs3DmxLag::integrate (Integrand& integrand, int lIndex,
 
             // Compute basis function derivatives and the edge normal
             if (!fe.Jacobian(Jac,normal,Xnod,itgBasis,bfs,t1,t2))
-              continue; // skip singular points
+              ok = false;
 
             if (faceDir < 0) normal *= -1.0;
 
@@ -514,7 +514,7 @@ bool ASMs3DmxLag::integrate (Integrand& integrand, int lIndex,
 
 	    // Evaluate the integrand and accumulate element contributions
 	    fe.detJxW *= wg[i]*wg[j];
-	    if (!integrand.evalBouMx(*A,fe,time,X,normal))
+	    if (ok && !integrand.evalBouMx(*A,fe,time,X,normal))
               ok = false;
 	  }
 

--- a/src/ASM/FiniteElement.C
+++ b/src/ASM/FiniteElement.C
@@ -15,6 +15,15 @@
 #include "BasisFunctionVals.h"
 #include "CoordinateMapping.h"
 #include "Vec3Oper.h"
+#include "IFEM.h"
+
+
+FiniteElement::FiniteElement (size_t n, size_t i) : ItgPoint(i), N(n), Te(3)
+{
+  p = q = r = 0;
+  age = h = 0.0;
+  detJxW = 1.0;
+}
 
 
 std::ostream& FiniteElement::write (std::ostream& os) const
@@ -42,6 +51,18 @@ std::ostream& FiniteElement::write (std::ostream& os) const
   for (size_t j = 0; j < En.size(); j++)
     os <<"En_"<< j+1 <<": "<< En[j] << std::endl;
   return os;
+}
+
+
+bool FiniteElement::Jacobian (Matrix& Jac, const Matrix& Xnod,
+                              const Matrix& dNdu)
+{
+  detJxW = utl::Jacobian(Jac,dNdX,Xnod,dNdu);
+  if (detJxW > 0.0) return true;
+
+  IFEM::cout <<"  ** Non-positive Jacobian |J|="<< detJxW
+             <<" at itg.point "<< iGP <<" in element "<< iel << std::endl;
+  return false;
 }
 
 
@@ -90,15 +111,17 @@ bool MxFiniteElement::Jacobian (Matrix& Jac, const Matrix& Xnod,
   // Make sure we point to a valid matrix with separate geometry,
   // even if it is not used
   detJxW = utl::Jacobian(Jac, this->grad(separateGeometry ? 1 : gBasis), Xnod,
-                         bfs[gBasis-1]->dNdu,
-                         !separateGeometry);
-  if (detJxW == 0.0) return false; // singular point
+                         bfs[gBasis-1]->dNdu, !separateGeometry);
 
   for (size_t b = 1; b <= this->getNoBasis(); b++)
     if (b != gBasis || separateGeometry)
       this->grad(b).multiply(bfs[b-1]->dNdu, Jac);
 
-  return true;
+  if (detJxW > 0.0) return true;
+
+  IFEM::cout <<"  ** Non-positive Jacobian |J|="<< detJxW
+             <<" at itg.point "<< iGP <<" in element "<< iel << std::endl;
+  return false;
 }
 
 
@@ -117,17 +140,20 @@ bool MxFiniteElement::Jacobian (Matrix& Jac, Vec3& n,
                                 size_t t1, size_t t2, size_t nBasis,
                                 const Matrix* Xnod2)
 {
-  if (nBasis == 0) nBasis = bfs.size();
+  if (nBasis == 0)
+    nBasis = bfs.size();
+
   const bool separateGeometry = nBasis > this->getNoBasis();
-  if (separateGeometry) gBasis = nBasis;
+  if (separateGeometry)
+    gBasis = nBasis;
 
   Matrix dummy;
   if (2*nBasis <= this->getNoBasis())
   {
     // We are are doing interface terms, evaluate for the second element first
-    detJxW = utl::Jacobian(Jac,n,this->grad(nBasis+gBasis),
+    detJxW = utl::Jacobian(Jac, n, this->grad(nBasis+gBasis),
                            Xnod2 ? *Xnod2 : Xnod,
-                           bfs[nBasis+gBasis-1]->dNdu,t1,t2);
+                           bfs[nBasis+gBasis-1]->dNdu, t1, t2);
 
     for (size_t b = 1; b <= nBasis; ++b)
       if (b != gBasis)
@@ -143,7 +169,11 @@ bool MxFiniteElement::Jacobian (Matrix& Jac, Vec3& n,
     if (b != gBasis || separateGeometry)
       this->grad(b).multiply(bfs[b-1]->dNdu,Jac);
 
-  return detJxW != 0.0;
+  if (detJxW > 0.0) return true;
+
+  IFEM::cout <<"  ** Non-positive Jacobian |J|="<< detJxW
+             <<" at itg.point "<< iGP <<" in element "<< iel << std::endl;
+  return false;
 }
 
 
@@ -241,14 +271,14 @@ void MxFiniteElement::piolaGradient (const double detJ,
       bf(b) = this->basis(b)(i);
       for (size_t j = 1; j <= dim; ++j)
         dBf(b,j) = bfs[b-1]->dNdu(i,j);
-      for (size_t d = 1; d <= dim; ++d)
+      for (size_t d = 0; d < dim; ++d)
       {
         Vector tmp(dim), res(dim);
-        dBf.multiply(Ji.getColumn(d), tmp);
-        J.multiply(tmp, res, 1.0 / detJ);
-        Ptmp[d-1].multiply(bf, res, false, 1);
+        dBf.multiply(Ji.getColumn(d+1),tmp);
+        J.multiply(tmp, res, 1.0/detJ);
+        Ptmp[d].multiply(bf, res, false, 1);
         for (size_t j = 1; j <= dim; ++j)
-          dPdX((d-1) * dim + j,k + i) = res(j);
+          dPdX(d*dim+j,k+i) = res(j);
       }
     }
 }

--- a/src/ASM/FiniteElement.C
+++ b/src/ASM/FiniteElement.C
@@ -207,15 +207,14 @@ bool MxFiniteElement::Hessian (Matrix3D& Hess, const Matrix& Jac,
 }
 
 
-void MxFiniteElement::piolaMapping (const double detJ,
-                                    const Matrix& Ji,
+void MxFiniteElement::piolaMapping (const Matrix& Ji,
                                     const Matrix& Xnod,
                                     const BasisValuesPtrs& bfs)
 {
   Matrix J;
   J.multiply(Xnod,bfs.back()->dNdu);
-  this->piolaBasis(detJ, J);
-  this->piolaGradient(detJ, J, Ji, Xnod, bfs);
+  this->piolaBasis(detJxW, J);
+  this->piolaGradient(detJxW, J, Ji, Xnod, bfs);
 }
 
 

--- a/src/ASM/FiniteElement.h
+++ b/src/ASM/FiniteElement.h
@@ -29,8 +29,7 @@ class FiniteElement : public ItgPoint
 {
 public:
   //! \brief Default constructor.
-  explicit FiniteElement(size_t n = 0, size_t i = 0) : ItgPoint(i), N(n), Te(3)
-  { p = q = r = 0; age = h = 0.0; detJxW = 1.0; }
+  explicit FiniteElement(size_t n = 0, size_t i = 0);
 
   //! \brief Returns the number of bases.
   virtual size_t getNoBasis() const { return 1; }
@@ -46,6 +45,12 @@ public:
   virtual const Matrix3D& hess(char) const { return d2NdX2; }
   //! \brief Returns a const reference to the basis function 3nd-derivatives.
   virtual const Matrix4D& hess2(char) const { return d3NdX3; }
+
+  //! \brief Sets up the Jacobian matrix of the coordinate mapping.
+  //! \param[out] Jac The inverse of the Jacobian matrix
+  //! \param[in] Xnod Matrix of element nodal coordinates
+  //! \param[in] dNdu Basis function derivatives
+  bool Jacobian(Matrix& Jac, const Matrix& Xnod, const Matrix& dNdu);
 
 protected:
   //! \brief Returns a reference to the basis function derivatives.
@@ -138,8 +143,7 @@ public:
   //! \param[in] gBasis 1-based index of basis representing the geometry
   //! \param[in] bfs Basis function values and derivatives
   bool Jacobian(Matrix& Jac, const Matrix& Xnod,
-                unsigned short int gBasis,
-                const BasisValuesPtrs& bfs);
+                unsigned short int gBasis, const BasisValuesPtrs& bfs);
 
   //! \brief Sets up the Jacobian matrix of the coordinate mapping on a boundary.
   //! \param[out] Jac The inverse of the Jacobian matrix
@@ -152,8 +156,7 @@ public:
   //! \param[in] nBasis Number of basis functions
   //! \param[in] Xnod2 Matrix of element nodal coordinates for neighbor element
   bool Jacobian(Matrix& Jac, Vec3& n, const Matrix& Xnod,
-                unsigned short int gBasis,
-                const BasisValuesPtrs& bfs,
+                unsigned short int gBasis, const BasisValuesPtrs& bfs,
                 size_t t1, size_t t2, size_t nBasis = 0,
                 const Matrix* Xnod2 = nullptr);
 
@@ -164,18 +167,15 @@ public:
   //! \param[in] gBasis 1-based index of basis representing the geometry
   //! \param[in] bfs Basis function derivatives
   bool Hessian(Matrix3D& Hess, const Matrix& Jac, const Matrix& Xnod,
-               unsigned short int gBasis,
-               const BasisValuesPtrs& bfs);
+               unsigned short int gBasis, const BasisValuesPtrs& bfs);
 
   //! \brief Calculates the Piola basis functions and their derivatives.
   //! \param[in] detJ Determinant of Jacobian of the geometry mapping
   //! \param[in] Ji Inverse jacobian of the geometry mapping
   //! \param[in] Xnod Matrix of element nodal coordinates
   //! \param[in] bfs Derivatives of basis functions
-  void piolaMapping (const double detJ,
-                     const Matrix& Ji,
-                     const Matrix& Xnod,
-                     const BasisValuesPtrs& bfs);
+  void piolaMapping(const double detJ, const Matrix& Ji,
+                    const Matrix& Xnod, const BasisValuesPtrs& bfs);
 
   //! \brief Calculates the Piola basis functions.
   //! \param[in] detJ Determinant of Jacobian of the geometry mapping

--- a/src/ASM/FiniteElement.h
+++ b/src/ASM/FiniteElement.h
@@ -170,11 +170,10 @@ public:
                unsigned short int gBasis, const BasisValuesPtrs& bfs);
 
   //! \brief Calculates the Piola basis functions and their derivatives.
-  //! \param[in] detJ Determinant of Jacobian of the geometry mapping
   //! \param[in] Ji Inverse jacobian of the geometry mapping
   //! \param[in] Xnod Matrix of element nodal coordinates
   //! \param[in] bfs Derivatives of basis functions
-  void piolaMapping(const double detJ, const Matrix& Ji,
+  void piolaMapping(const Matrix& Ji,
                     const Matrix& Xnod, const BasisValuesPtrs& bfs);
 
   //! \brief Calculates the Piola basis functions.

--- a/src/ASM/HasGravityBase.C
+++ b/src/ASM/HasGravityBase.C
@@ -46,7 +46,10 @@ bool HasGravityBase::parse (const tinyxml2::XMLElement* elem)
     utl::getAttribute(elem,"z",gravity.z);
     IFEM::cout <<" "<< gravity.z;
   }
-  IFEM::cout << std::endl;
 
+  if (utl::getAttribute(elem,"rampTime",rampT))
+    IFEM::cout <<"\n\tRamp-up time: "<< rampT;
+
+  IFEM::cout << std::endl;
   return true;
 }

--- a/src/ASM/HasGravityBase.h
+++ b/src/ASM/HasGravityBase.h
@@ -26,23 +26,20 @@ class HasGravityBase : public IntegrandBase
 {
 protected:
   //! \brief The default constructor is protected to allow sub-classes only.
-  explicit HasGravityBase(unsigned char n = 0) : IntegrandBase(n) {}
+  explicit HasGravityBase(unsigned char n = 0) : IntegrandBase(n), rampT(0.0) {}
 
 public:
   //! \brief Parses a data section from an XML-element.
   virtual bool parse(const tinyxml2::XMLElement* elem);
 
   //! \brief Defines the gravitation vector.
-  void setGravity(double gx, double gy = 0.0, double gz = 0.0)
-  { gravity.x = gx; gravity.y = gy; gravity.z = gz; }
-  //! \brief Defines the gravitation vector.
   void setGravity(const Vec3& g) { gravity = g; }
-
   //! \brief Returns the gravitation vector.
   const Vec3& getGravity() const { return gravity; }
 
 protected:
-  Vec3 gravity; //!< Gravitation vector
+  Vec3 gravity; //!< The gravitation vector
+  double rampT; //!< Ramp-up time for full gravity
 };
 
 #endif

--- a/src/ASM/Integrand.h
+++ b/src/ASM/Integrand.h
@@ -180,6 +180,8 @@ public:
   virtual int getReducedIntegration(int) const { return 0; }
   //! \brief Returns the number of boundary integration points.
   virtual int getBouIntegrationPoints(int nGP) const { return nGP; }
+  //! \brief Returns \e true if this is an axial-symmetric problem.
+  virtual bool isAxiSymmetric() const { return false; }
 
   //! \brief Evaluates reduced integration terms at an interior point.
   //! \param elmInt The local integral object to receive the contributions

--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -535,10 +535,7 @@ bool ASMu2D::evaluateBasis (int iel, FiniteElement& fe, int derivs) const
 #endif
 
   Matrix Xnod, Jac;
-  this->getElementCoordinates(Xnod,1+iel);
-  fe.detJxW = utl::Jacobian(Jac,fe.dNdX,Xnod,dNdu);
-
-  return true;
+  return this->getElementCoordinates(Xnod,1+iel) && fe.Jacobian(Jac,Xnod,dNdu);
 }
 
 
@@ -1271,8 +1268,8 @@ bool ASMu2D::integrate (Integrand& integrand,
             fe.N = bfs.N;
 
             // Compute Jacobian inverse and derivatives
-            fe.detJxW = utl::Jacobian(Jac,fe.dNdX,Xnod,bfs.dNdu);
-            if (fe.detJxW == 0.0) continue; // skip singular points
+            if (!fe.Jacobian(Jac,Xnod,bfs.dNdu))
+              ok = false;
 
             // Store tangent vectors in fe.G for shells
             if (nsd > 2) fe.G = Jac;
@@ -1282,7 +1279,7 @@ bool ASMu2D::integrate (Integrand& integrand,
 
             // Compute the reduced integration terms of the integrand
             fe.detJxW *= dA*wr[i]*wr[j];
-            if (!integrand.reducedInt(*A,fe,X))
+            if (ok && !integrand.reducedInt(*A,fe,X))
               ok = false;
           }
       }
@@ -1319,8 +1316,8 @@ bool ASMu2D::integrate (Integrand& integrand,
 #endif
 
           // Compute Jacobian inverse of coordinate mapping and derivatives
-          fe.detJxW = utl::Jacobian(Jac,fe.dNdX,Xnod,bfs.dNdu);
-          if (fe.detJxW == 0.0) continue; // skip singular points
+          if (!fe.Jacobian(Jac,Xnod,bfs.dNdu))
+            ok = false;
 
           // Compute Hessian of coordinate mapping and 2nd order derivatives
           if (use2ndDer)
@@ -1354,7 +1351,7 @@ bool ASMu2D::integrate (Integrand& integrand,
 #ifndef USE_OPENMP
           PROFILE3("Integrand::evalInt");
 #endif
-          if (!integrand.evalInt(*A,fe,time,X))
+          if (ok && !integrand.evalInt(*A,fe,time,X))
             ok = false;
         }
 
@@ -1522,8 +1519,8 @@ bool ASMu2D::integrate (Integrand& integrand,
           SplineUtils::extractBasis(spline1[jp],fe.N,dNdu);
 
         // Compute Jacobian inverse of coordinate mapping and derivatives
-        fe.detJxW = utl::Jacobian(Jac,fe.dNdX,Xnod,dNdu);
-        if (fe.detJxW == 0.0) continue; // skip singular points
+        if (!fe.Jacobian(Jac,Xnod,dNdu))
+          ok = false;
 
         // Compute Hessian of coordinate mapping and 2nd order derivatives
         if (integrand.getIntegrandType() & Integrand::SECOND_DERIVATIVES)
@@ -1551,7 +1548,7 @@ bool ASMu2D::integrate (Integrand& integrand,
 #ifndef USE_OPENMP
         PROFILE3("Integrand::evalInt");
 #endif
-        if (!integrand.evalInt(*A,fe,time,X))
+        if (ok && !integrand.evalInt(*A,fe,time,X))
           ok = false;
       }
 
@@ -2096,11 +2093,11 @@ bool ASMu2D::evalSolution (Matrix& sField, const Vector& locSol,
   fe.p = lrspline->order(0) - 1;
   fe.q = lrspline->order(1) - 1;
   Vector   ptSol;
-  Matrix   dNdu, dNdX, Jac, Xnod, eSol, ptDer;
+  Matrix   dNdu, Jac, Xnod, eSol, ptDer;
   Matrix3D d2Ndu2, d2NdX2, Hess, ptDer2;
 
   Go::BasisDerivsSf2 spline2;
-  int lel = -1;
+  int iel = -1;
 
   // Evaluate the primary solution field at each point
   sField.resize(nComp,nPoints);
@@ -2110,12 +2107,10 @@ bool ASMu2D::evalSolution (Matrix& sField, const Vector& locSol,
     // Sadly, points are not always ordered in the same way as the elements.
     fe.u = gpar[0][i];
     fe.v = gpar[1][i];
-    int iel = lrspline->getElementContaining(fe.u,fe.v);
-
-    if (iel != lel && deriv == 2)
+    if (int jel = lrspline->getElementContaining(fe.u,fe.v); jel != iel)
     {
-      lel = iel; // Set up control point (nodal) coordinates for current element
-      if (!this->getElementCoordinates(Xnod,iel+1))
+      iel = jel;
+      if (deriv == 2 && !this->getElementCoordinates(Xnod,iel+1))
         return false;
     }
 
@@ -2126,25 +2121,24 @@ bool ASMu2D::evalSolution (Matrix& sField, const Vector& locSol,
     switch (deriv)
     {
     case 0: // Evaluate the solution
-      if (!this->evaluateBasis(iel,fe,deriv))
-        return false;
-      sField.fillColumn(1+i, eSol * fe.N);
+      if (this->evaluateBasis(iel,fe,deriv))
+        sField.fillColumn(1+i, eSol * fe.N);
       break;
 
     case 1: // Evaluate first derivatives of the solution
-      if (!this->evaluateBasis(iel,fe,deriv))
-        return false;
-      ptDer.multiply(eSol,fe.dNdX);
-      sField.fillColumn(1+i,ptDer);
+      if (this->evaluateBasis(iel,fe,deriv))
+        sField.fillColumn(1+i, ptDer.multiply(eSol,fe.dNdX));
       break;
 
     case 2: // Evaluate second derivatives of the solution
       this->computeBasis(fe.u,fe.v,spline2,iel);
       SplineUtils::extractBasis(spline2,ptSol,dNdu,d2Ndu2);
-      utl::Jacobian(Jac,dNdX,Xnod,dNdu);
-      utl::Hessian(Hess,d2NdX2,Jac,Xnod,d2Ndu2,dNdu);
-      ptDer2.multiply(eSol,d2NdX2);
-      sField.fillColumn(1+i,ptDer2);
+      if (fe.Jacobian(Jac,Xnod,dNdu))
+      {
+        utl::Hessian(Hess,d2NdX2,Jac,Xnod,d2Ndu2,dNdu);
+        ptDer2.multiply(eSol,d2NdX2);
+        sField.fillColumn(1+i, ptDer2);
+      }
       break;
 
     default:
@@ -2327,7 +2321,8 @@ bool ASMu2D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
     }
 
     // Compute the Jacobian inverse
-    fe.detJxW = utl::Jacobian(Jac,fe.dNdX,Xnod,dNdu);
+    if (!fe.Jacobian(Jac,Xnod,dNdu))
+      continue; // skip singular points
 
     // Compute Hessian of coordinate mapping and 2nd order derivatives
     if (use2ndDer)

--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -1277,8 +1277,12 @@ bool ASMu2D::integrate (Integrand& integrand,
             // Cartesian coordinates of current integration point
             X.assign(Xnod * fe.N);
 
-            // Compute the reduced integration terms of the integrand
+            // Integration point weight
             fe.detJxW *= dA*wr[i]*wr[j];
+            if (integrand.isAxiSymmetric())
+              fe.detJxW *= 2.0*M_PI*X.x;
+
+            // Compute the reduced integration terms of the integrand
             if (ok && !integrand.reducedInt(*A,fe,X))
               ok = false;
           }
@@ -1346,8 +1350,12 @@ bool ASMu2D::integrate (Integrand& integrand,
           // Cartesian coordinates of current integration point
           X.assign(Xnod * fe.N);
 
-          // Evaluate the integrand and accumulate element contributions
+          // Integration point weight
           fe.detJxW *= dA*wg[0][i]*wg[1][j];
+          if (integrand.isAxiSymmetric())
+            fe.detJxW *= 2.0*M_PI*X.x;
+
+          // Evaluate the integrand and accumulate element contributions
 #ifndef USE_OPENMP
           PROFILE3("Integrand::evalInt");
 #endif
@@ -1543,8 +1551,12 @@ bool ASMu2D::integrate (Integrand& integrand,
         X.assign(Xnod * fe.N);
         X.u = elmPts[ip].data();
 
-        // Evaluate the integrand and accumulate element contributions
+        // Integration point weight
         fe.detJxW *= dA*elmPts[ip][2];
+        if (integrand.isAxiSymmetric())
+          fe.detJxW *= 2.0*M_PI*X.x;
+
+        // Evaluate the integrand and accumulate element contributions
 #ifndef USE_OPENMP
         PROFILE3("Integrand::evalInt");
 #endif
@@ -1713,8 +1725,12 @@ bool ASMu2D::integrate (Integrand& integrand, int lIndex,
       // Cartesian coordinates of current integration point
       X.assign(Xnod * fe.N);
 
-      // Evaluate the integrand and accumulate element contributions
+      // Integration point weight
       fe.detJxW *= dS*wg[i];
+      if (integrand.isAxiSymmetric())
+        fe.detJxW *= 2.0*M_PI*X.x;
+
+      // Evaluate the integrand and accumulate element contributions
       ok = integrand.evalBou(*A,fe,time,X,normal);
     }
 
@@ -1859,8 +1875,12 @@ bool ASMu2D::integrate (Integrand& integrand,
             std::cout <<"\n"<< fe;
 #endif
 
-            // Evaluate the integrand and accumulate element contributions
+            // Integration point weight
             fe.detJxW *= dS*wg[g];
+            if (integrand.isAxiSymmetric())
+              fe.detJxW *= 2.0*M_PI*X.x;
+
+            // Evaluate the integrand and accumulate element contributions
             ok = integrand.evalInt(*A,fe,time,X,normal);
           }
         }

--- a/src/ASM/LR/ASMu2Dmx.C
+++ b/src/ASM/LR/ASMu2Dmx.C
@@ -469,8 +469,12 @@ bool ASMu2Dmx::integrate (Integrand& integrand,
           // Cartesian coordinates of current integration point
           X.assign(Xnod * (separateGeometry ? bfs.back()->N : fe.basis(itgBasis)));
 
-          // Evaluate the integrand and accumulate element contributions
+          // Integration point weight
           fe.detJxW *= dA*wg[0][i]*wg[1][j];
+          if (integrand.isAxiSymmetric())
+            fe.detJxW *= 2.0*M_PI*X.x;
+
+          // Evaluate the integrand and accumulate element contributions
           if (ok && !integrand.evalIntMx(*A,fe,time,X))
             ok = false;
         }
@@ -648,8 +652,12 @@ bool ASMu2Dmx::integrate (Integrand& integrand, int lIndex,
       // Cartesian coordinates of current integration point
       X.assign(Xnod * (separateGeometry ? bfs.back().N : fe.basis(itgBasis)));
 
-      // Evaluate the integrand and accumulate element contributions
+      // Integration point weight
       fe.detJxW *= dS*wg[i];
+      if (integrand.isAxiSymmetric())
+        fe.detJxW *= 2.0*M_PI*X.x;
+
+      // Evaluate the integrand and accumulate element contributions
       if (ok && !integrand.evalBouMx(*A,fe,time,X,normal))
         ok = false;
     }
@@ -839,8 +847,12 @@ bool ASMu2Dmx::integrate (Integrand& integrand,
             // Cartesian coordinates of current integration point
             X.assign(Xnod * fe.basis(itgBasis));
 
-            // Evaluate the integrand and accumulate element contributions
+            // Integration point weight
             fe.detJxW *= 0.5*dS*wg[g];
+            if (integrand.isAxiSymmetric())
+              fe.detJxW *= 2.0*M_PI*X.x;
+
+            // Evaluate the integrand and accumulate element contributions
             if (ok && !integrand.evalIntMx(*A,fe,time,X,normal))
               ok = false;
           }

--- a/src/ASM/LR/ASMu2Dmx.C
+++ b/src/ASM/LR/ASMu2Dmx.C
@@ -454,14 +454,13 @@ bool ASMu2Dmx::integrate (Integrand& integrand,
           // Compute Jacobian inverse of the coordinate mapping and
           // basis function derivatives w.r.t. Cartesian coordinates
           if (!fe.Jacobian(Jac,Xnod,itgBasis,bfs))
-            continue; // skip singular points
+            ok = false;
+          else if (piolaMapping)
+            fe.piolaMapping(Jac,Xnod,bfs);
 
           // Compute Hessian of coordinate mapping and 2nd order derivatives
           if (use2ndDer && !fe.Hessian(Hess,Jac,Xnod,itgBasis,bfs))
             ok = false;
-
-          if (piolaMapping)
-            fe.piolaMapping(fe.detJxW, Jac, Xnod, bfs);
 
           // Compute G-matrix
           if (integrand.getIntegrandType() & Integrand::G_MATRIX)
@@ -472,7 +471,7 @@ bool ASMu2Dmx::integrate (Integrand& integrand,
 
           // Evaluate the integrand and accumulate element contributions
           fe.detJxW *= dA*wg[0][i]*wg[1][j];
-          if (!integrand.evalIntMx(*A,fe,time,X))
+          if (ok && !integrand.evalIntMx(*A,fe,time,X))
             ok = false;
         }
 
@@ -592,7 +591,11 @@ bool ASMu2Dmx::integrate (Integrand& integrand, int lIndex,
 
     // Initialize element quantities
     LocalIntegral* A = integrand.getLocalIntegral(elem_sizes,fe.iel,true);
-    bool ok = integrand.initElementBou(MNPC[geoEl],elem_sizes,nb,*A);
+    if (!integrand.initElementBou(MNPC[geoEl],elem_sizes,nb,*A))
+    {
+      A->destruct();
+      return false;
+    }
 
     // Get integration gauss points over this element
     this->getGaussPointParameters(gpar[t2-1],t2-1,nGP,1+geoEl,xg);
@@ -600,7 +603,8 @@ bool ASMu2Dmx::integrate (Integrand& integrand, int lIndex,
 
     // --- Integration loop over all Gauss points along the edge ---------------
 
-    for (int i = 0; i < nGP && ok; i++, fe.iGP++)
+    bool ok = true;
+    for (int i = 0; i < nGP; i++, fe.iGP++)
     {
       // Local element coordinates and parameter values
       // of current integration point
@@ -634,10 +638,9 @@ bool ASMu2Dmx::integrate (Integrand& integrand, int lIndex,
       // Compute Jacobian inverse of the coordinate mapping and
       // basis function derivatives w.r.t. Cartesian coordinates
       if (!fe.Jacobian(Jac,normal,Xnod,itgBasis,bfs,t1,t2))
-        continue; // skip singular points
-
-      if (piolaMapping)
-        fe.piolaMapping(fe.detJxW, Jac, Xnod, bfs);
+        ok = false;
+      else if (piolaMapping)
+        fe.piolaMapping(Jac,Xnod,bfs);
 
       if (edgeDir < 0)
         normal *= -1.0;
@@ -647,7 +650,8 @@ bool ASMu2Dmx::integrate (Integrand& integrand, int lIndex,
 
       // Evaluate the integrand and accumulate element contributions
       fe.detJxW *= dS*wg[i];
-      ok = integrand.evalBouMx(*A,fe,time,X,normal);
+      if (ok && !integrand.evalBouMx(*A,fe,time,X,normal))
+        ok = false;
     }
 
     // Finalize the element quantities
@@ -722,11 +726,16 @@ bool ASMu2Dmx::integrate (Integrand& integrand,
       return false;
 
     LocalIntegral* A = integrand.getLocalIntegral(elem_sizes, iel);
-    bool ok = integrand.initElement(MNPC[els[itgBasis-1]-1],elem_sizes,nb,*A);
+    if (!integrand.initElement(MNPC[els[itgBasis-1]-1],elem_sizes,nb,*A))
+    {
+      A->destruct();
+      return false;
+    }
     size_t origSize = A->vec.size();
 
     int bit = 8;
-    for (int iedge = 4; iedge > 0 && status > 0 && ok; iedge--, bit /= 2) {
+    bool ok = true;
+    for (int iedge = 4; iedge > 0 && status > 0; iedge--, bit /= 2) {
       if (status & bit) {
         const int edgeDir = (iedge+1)/((iedge%2) ? -2 : 2);
         const int t1 = abs(edgeDir);   // Tangent direction normal to the edge
@@ -801,7 +810,7 @@ bool ASMu2Dmx::integrate (Integrand& integrand,
           Matrix Xnod2, Jac2;
           ok &= this->getElementCoordinates(Xnod2,els2[itgBasis-1]);
 
-          for (int g = 0; g < nGP && ok; g++, ++fe.iGP)
+          for (int g = 0; g < nGP; g++, ++fe.iGP)
           {
             // Local element coordinates and parameter values
             // of current integration point
@@ -822,7 +831,7 @@ bool ASMu2Dmx::integrate (Integrand& integrand,
 
             // Compute basis function derivatives and the edge normal
             if (!fe.Jacobian(Jac,normal,Xnod,itgBasis,bfs,t1,t2,nB,&Xnod2))
-              continue; // skip singular points
+              ok = false;
 
             if (edgeDir < 0)
               normal *= -1.0;
@@ -832,7 +841,8 @@ bool ASMu2Dmx::integrate (Integrand& integrand,
 
             // Evaluate the integrand and accumulate element contributions
             fe.detJxW *= 0.5*dS*wg[g];
-            ok = integrand.evalIntMx(*A,fe,time,X,normal);
+            if (ok && !integrand.evalIntMx(*A,fe,time,X,normal))
+              ok = false;
           }
 
           if (iedge == 1 || iedge == 2)
@@ -1071,12 +1081,12 @@ bool ASMu2Dmx::evalSolution (Matrix& sField, const IntegrandBase& integrand,
     if (!fe.Jacobian(Jac,Xnod,itgBasis,bfs))
       continue; // skip singular points
 
+    if (piolaMapping)
+      fe.piolaMapping(Jac,Xnod,bfs);
+
     // Compute Hessian of coordinate mapping and 2nd order derivatives
     if (use2ndDer && !fe.Hessian(Hess,Jac,Xnod,itgBasis,bfs))
       return false;
-
-    if (piolaMapping)
-      fe.piolaMapping(fe.detJxW, Jac, Xnod, bfs);
 
     // Cartesian coordinates of current integration point
     fe.u = gpar[0][i];

--- a/src/ASM/LR/ASMu3D.C
+++ b/src/ASM/LR/ASMu3D.C
@@ -1072,15 +1072,15 @@ bool ASMu3D::integrate (Integrand& integrand,
               fe.N = bfs.N;
 
               // Compute Jacobian inverse and derivatives
-              fe.detJxW = utl::Jacobian(Jac,fe.dNdX,Xnod,bfs.dNdu);
-              if (fe.detJxW == 0.0) continue; // skip singular points
+              if (!fe.Jacobian(Jac,Xnod,bfs.dNdu))
+                ok = false;
 
               // Cartesian coordinates of current integration point
               X.assign(Xnod * fe.N);
 
               // Compute the reduced integration terms of the integrand
               fe.detJxW *= dV*wr[i]*wr[j]*wr[k];
-              if (!integrand.reducedInt(*A,fe,X))
+              if (ok && !integrand.reducedInt(*A,fe,X))
                 ok = false;
             }
       }
@@ -1110,8 +1110,8 @@ bool ASMu3D::integrate (Integrand& integrand,
             fe.N = bfs.N;
 
             // Compute Jacobian inverse of coordinate mapping and derivatives
-            fe.detJxW = utl::Jacobian(Jac,fe.dNdX,Xnod,bfs.dNdu);
-            if (fe.detJxW == 0.0) continue; // skip singular points
+            if (!fe.Jacobian(Jac,Xnod,bfs.dNdu))
+              ok = false;
 
             // Compute Hessian of coordinate mapping and 2nd order derivatives
             if (integrand.getIntegrandType() & Integrand::SECOND_DERIVATIVES)
@@ -1133,7 +1133,7 @@ bool ASMu3D::integrate (Integrand& integrand,
             // Evaluate the integrand and accumulate element contributions
             fe.detJxW *= dV*wg[0][i]*wg[1][j]*wg[2][k];
             PROFILE3("Integrand::evalInt");
-            if (!integrand.evalInt(*A,fe,time,X))
+            if (ok && !integrand.evalInt(*A,fe,time,X))
               ok = false;
           }
 
@@ -1574,43 +1574,46 @@ bool ASMu3D::evalSolution (Matrix& sField, const Vector& locSol,
   Go::BasisPts     spline0;
   Go::BasisDerivs  spline1;
   Go::BasisDerivs2 spline2;
-  int lel = -1;
+  int iel = -1;
 
   // Evaluate the primary solution field at each point
   sField.resize(nComp,nPoints);
   for (size_t i = 0; i < nPoints; i++)
   {
+    const double u = gpar[0][i];
+    const double v = gpar[1][i];
+    const double w = gpar[2][i];
+
     // Fetch element containing evaluation point.
     // Sadly, points are not always ordered in the same way as the elements.
-    int iel = lrspline->getElementContaining(gpar[0][i],gpar[1][i],gpar[2][i]);
-    if (iel < 0) {
-      std::cerr <<" *** ASMu3D::evalSolution: Element at point ("<< gpar[0][i] <<", "
-                << gpar[1][i] <<", "<< gpar[2][i] <<") not found."<< std::endl;
+    if (int jel = lrspline->getElementContaining(u,v,w); jel < 0)
+    {
+      std::cerr <<" *** ASMu3D::evalSolution: Element at point ("
+                << u <<","<< v <<","<< w <<") not found."<< std::endl;
       return false;
+    }
+    else if (jel != iel)
+    {
+      iel = jel;
+      if (deriv > 0 && !this->getElementCoordinates(Xnod,iel+1))
+        return false;
     }
 
     int nskip = MNPC[iel].size() - lrspline->getElement(iel)->nBasisFunctions();
     utl::gather(MNPC[iel],nComp,locSol,eSol,0,nskip);
-
-    if (iel != lel && deriv > 0)
-    {
-      lel = iel; // Set up control point (nodal) coordinates for current element
-      if (!this->getElementCoordinates(Xnod,iel+1))
-        return false;
-    }
 
     // Evaluate basis function values/derivatives at current parametric point
     // and multiply with control point values to get the point-wise solution
     switch (deriv) {
 
     case 0: // Evaluate the solution
-      lrspline->computeBasis(gpar[0][i],gpar[1][i],gpar[2][i],spline0,iel);
+      lrspline->computeBasis(u,v,w,spline0,iel);
       eSol.multiply(spline0.basisValues,ptSol);
       sField.fillColumn(1+i,ptSol);
       break;
 
     case 1: // Evaluate first derivatives of the solution
-      lrspline->computeBasis(gpar[0][i],gpar[1][i],gpar[2][i],spline1,iel);
+      lrspline->computeBasis(u,v,w,spline1,iel);
       SplineUtils::extractBasis(spline1,ptSol,dNdu);
       utl::Jacobian(Jac,dNdX,Xnod,dNdu);
       ptDer.multiply(eSol,dNdX);
@@ -1618,7 +1621,7 @@ bool ASMu3D::evalSolution (Matrix& sField, const Vector& locSol,
       break;
 
     case 2: // Evaluate second derivatives of the solution
-      lrspline->computeBasis(gpar[0][i],gpar[1][i],gpar[2][i],spline2,iel);
+      lrspline->computeBasis(u,v,w,spline2,iel);
       SplineUtils::extractBasis(spline2,ptSol,dNdu,d2Ndu2);
       utl::Jacobian(Jac,dNdX,Xnod,dNdu);
       utl::Hessian(Hess,d2NdX2,Jac,Xnod,d2Ndu2,dNdu);
@@ -1811,8 +1814,8 @@ bool ASMu3D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
     }
 
     // Compute the Jacobian inverse
-    fe.detJxW = utl::Jacobian(Jac,fe.dNdX,Xnod,dNdu);
-    if (fe.detJxW == 0.0) continue;
+    if (!fe.Jacobian(Jac,Xnod,dNdu))
+      continue; // skip singular points
 
     // Compute Hessian of coordinate mapping and 2nd order derivatives
     if (use2ndDer)

--- a/src/ASM/LR/ASMu3Dmx.C
+++ b/src/ASM/LR/ASMu3Dmx.C
@@ -476,7 +476,7 @@ bool ASMu3Dmx::integrate (Integrand& integrand,
             // Compute Jacobian inverse of the coordinate mapping and
             // basis function derivatives w.r.t. Cartesian coordinates
             if (!fe.Jacobian(Jac,Xnod,itgBasis,bfs))
-              continue; // skip singular points
+              ok = false;
 
             // Compute Hessian of coordinate mapping and 2nd order derivatives
             if (use2ndDer && !fe.Hessian(Hess,Jac,Xnod,itgBasis,bfs))
@@ -491,7 +491,7 @@ bool ASMu3Dmx::integrate (Integrand& integrand,
 
             // Evaluate the integrand and accumulate element contributions
             fe.detJxW *= dV*wg[0][i]*wg[1][j]*wg[2][k];
-            if (!integrand.evalIntMx(*A,fe,time,X))
+            if (ok && !integrand.evalIntMx(*A,fe,time,X))
               ok = false;
           }
 
@@ -632,7 +632,7 @@ bool ASMu3Dmx::integrate (Integrand& integrand, int lIndex,
     firstp += nGP*nGP;
 
     for (int j = 0; j < nGP; j++)
-      for (int i = 0; i < nGP && ok; i++, fe.iGP++)
+      for (int i = 0; i < nGP; i++, fe.iGP++)
       {
         // Local element coordinates and parameter values
         // of current integration point
@@ -670,7 +670,7 @@ bool ASMu3Dmx::integrate (Integrand& integrand, int lIndex,
 
         // Compute basis function derivatives and the face normal
         if (!fe.Jacobian(Jac,normal,Xnod,itgBasis,bfs,t1,t2))
-          continue; // skip singular points
+          ok = false;
 
         if (faceDir < 0) normal *= -1.0;
 
@@ -683,7 +683,8 @@ bool ASMu3Dmx::integrate (Integrand& integrand, int lIndex,
 
         // Evaluate the integrand and accumulate element contributions
         fe.detJxW *= dA*wg[i]*wg[j];
-        ok = integrand.evalBouMx(*A,fe,time,X,normal);
+        if (ok && !integrand.evalBouMx(*A,fe,time,X,normal))
+          ok = false;
       }
 
     // Finalize the element quantities

--- a/src/ASM/Test/TestPiolaMapping.C
+++ b/src/ASM/Test/TestPiolaMapping.C
@@ -325,20 +325,20 @@ TEST_CASE("TestPiolaMapping.Gradient2D")
 
   BasisValues bfs(3);
 
-  Matrix X, J, Ji, dNdX;
-  p.extractBasis(u, v, bfs.back().N, bfs.back().dNdu, bfs.back().d2Ndu2);
-  p.getElementCoordinates(X, 1);
-  Real detJ = utl::Jacobian(Ji, dNdX, X, bfs.back().dNdu, true);
-  J.multiply(X,bfs.back().dNdu); // J = X * dNdu
-  Matrix3D H;
-  H.multiply(X,bfs.back().d2Ndu2);
-
   Go::BasisDerivsSf spline1, spline2;
   b.getBasis(1)->computeBasis(u,v,spline1);
   b.getBasis(2)->computeBasis(u,v,spline2);
   MxFiniteElement fe({spline1.basisValues.size(), spline2.basisValues.size()});
   SplineUtils::extractBasis(spline1, fe.basis(1), bfs[0].dNdu);
   SplineUtils::extractBasis(spline2, fe.basis(2), bfs[1].dNdu);
+
+  Matrix X, J, Ji, dNdX;
+  p.extractBasis(u, v, bfs.back().N, bfs.back().dNdu, bfs.back().d2Ndu2);
+  p.getElementCoordinates(X, 1);
+  double detJ = fe.detJxW = utl::Jacobian(Ji, dNdX, X, bfs.back().dNdu, true);
+  J.multiply(X,bfs.back().dNdu); // J = X * dNdu
+  Matrix3D H;
+  H.multiply(X,bfs.back().d2Ndu2);
 
   const auto q = std::array<std::function<double(double)>,3> {
       [](double x) { return (1.0 - x) * (1.0 - x); },
@@ -366,7 +366,7 @@ TEST_CASE("TestPiolaMapping.Gradient2D")
     [](double x) { return 3.0 * x * x; },
   };
 
-  fe.piolaMapping(detJ, Ji, X, bfs);
+  fe.piolaMapping(Ji, X, bfs);
   std::vector<Real> det = utl::determinantGradient(J, Ji, H);
   Matrices dJdX = utl::jacobianGradient(Ji, H);
 
@@ -583,14 +583,6 @@ TEST_CASE("TestPiolaMapping.Gradient3D")
 
   BasisValues bfs(4);
 
-  Matrix X, J, Ji, dNdX;
-  Matrix3D H;
-  p.extractBasis(u, v, w, bfs.back().N, bfs.back().dNdu, bfs.back().d2Ndu2);
-  p.getElementCoordinates(X, 1);
-  Real detJ = utl::Jacobian(Ji, dNdX, X, bfs.back().dNdu, true);
-  H.multiply(X,bfs.back().d2Ndu2);
-  J.multiply(X,bfs.back().dNdu); // J = X * dNdu
-
   Go::BasisDerivs spline1, spline2, spline3;
   b.getBasis(1)->computeBasis(u,v,w,spline1);
   b.getBasis(2)->computeBasis(u,v,w,spline2);
@@ -601,6 +593,14 @@ TEST_CASE("TestPiolaMapping.Gradient3D")
   SplineUtils::extractBasis(spline1, fe.basis(1), bfs[0].dNdu);
   SplineUtils::extractBasis(spline2, fe.basis(2), bfs[1].dNdu);
   SplineUtils::extractBasis(spline3, fe.basis(3), bfs[2].dNdu);
+
+  Matrix X, J, Ji, dNdX;
+  Matrix3D H;
+  p.extractBasis(u, v, w, bfs.back().N, bfs.back().dNdu, bfs.back().d2Ndu2);
+  p.getElementCoordinates(X, 1);
+  double detJ = fe.detJxW = utl::Jacobian(Ji, dNdX, X, bfs.back().dNdu, true);
+  H.multiply(X,bfs.back().d2Ndu2);
+  J.multiply(X,bfs.back().dNdu); // J = X * dNdu
 
   const auto q = std::array<std::function<double(double)>,3> {
       [](double x) { return (1.0 - x) * (1.0 - x); },
@@ -628,7 +628,7 @@ TEST_CASE("TestPiolaMapping.Gradient3D")
     [](double x) { return 3.0 * x * x; },
   };
 
-  fe.piolaMapping(detJ, Ji, X, bfs);
+  fe.piolaMapping(Ji, X, bfs);
   std::vector<Real> det = utl::determinantGradient(J, Ji, H);
   Matrices dJdX = utl::jacobianGradient(Ji, H);
 

--- a/src/SIM/NonLinSIM.C
+++ b/src/SIM/NonLinSIM.C
@@ -151,10 +151,17 @@ bool NonLinSIM::parse (const tinyxml2::XMLElement* elem)
     }
     else if (!strcasecmp(child->Value(),"fromZero"))
       fromIni = true;
-    else if ((value = utl::getValue(child,"updateNewNodes")))
-      updNewN = atoi(value);
     else if (!strcasecmp(child->Value(),"updateNewNodes"))
-      updNewN = 1;
+    {
+      if ((value = utl::getValue(child,"updateNewNodes")))
+        updNewN = std::min(atoi(value),9);
+      else
+        updNewN = 1;
+
+      bool sfree = false;
+      if (utl::getAttribute(child,"stressFree",sfree) && sfree && updNewN > 0)
+        updNewN += 10; // Use stress free-start configuration for new elements
+    }
     else if (!strcasecmp(child->Value(),"printCond"))
       rCond = 0.0; // Compute and report condition number in the iteration log
 
@@ -192,7 +199,9 @@ bool NonLinSIM::advanceStep (TimeStep& param, bool updateTime)
 {
   bool status = this->MultiStepSIM::advanceStep(param,updateTime);
   if (status && updateTime && updNewN && model.hasElementActivator())
-    model.updateForNewElements(solution.front(),param.time,updNewN-1);
+    if (!model.updateForNewElements(solution.front(),param.time,
+                                    updNewN/10, updNewN%10-1))
+      status = false;
   this->pushSolution(); // Update solution vectors between time steps
   return status;
 }

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -1025,10 +1025,16 @@ bool SIMbase::hasElementActivator (double t1, double t0) const
   the current (not yet calculated) step, are assigned initial values
   equal to the mean of the other already activated nodes,
   that are connected to the newly activated element.
+
+  If \a stressFree is \e true, the \a solution vector is not updated. Instead,
+  the initial coordinates of newly activated control/nodal points are updated
+  such that the initial configuration of the newly added elements becomes close
+  to stress-free. This may improve the convergence behaviour when activating
+  elements in the non-linear simulation with large deformations.
 */
 
-void SIMbase::updateForNewElements (Vector& solution, const TimeDomain& time,
-                                    int verbose) const
+bool SIMbase::updateForNewElements (Vector& solution, const TimeDomain& time,
+                                    bool stressFree, int verbose) const
 {
   // Find all elements and nodes that were active in the previous time step
   IntSet oldElms, oldNodes;
@@ -1044,12 +1050,15 @@ void SIMbase::updateForNewElements (Vector& solution, const TimeDomain& time,
 
   // Find the newly activated elements and assign solution values to
   // the nodes of those elements that were inactive in the previous step
+  bool ok = true;
   for (ASMbase* pch : myModel)
     if (pch->getElementActivator())
     {
       RealArray pchSol;
       pch->extractNodeVec(solution,pchSol);
       const size_t nf = pch->getNoFields();
+      const size_t nd = pch->getNoSpaceDim();
+      Vector newSol(stressFree ? nd*pch->getNoNodes(-1) : 0);
       for (size_t iel = 1; iel <= pch->getNoElms(true); iel++)
         if (pch->isElementActive(iel-1,time.t) &&
             oldElms.find(pch->getElmID(iel)) == oldElms.end())
@@ -1093,20 +1102,32 @@ void SIMbase::updateForNewElements (Vector& solution, const TimeDomain& time,
               double* ptr = solution.ptr() + nf*(nodeId-1);
               if (verbose > 0)
                 IFEM::cout <<"\n\tAssigned to new node "<< nodeId;
-              if (verbose > 1)
+              if (verbose > 1 && !stressFree)
               {
                 IFEM::cout <<" (replacing";
                 for (size_t i = 0; i < nf; i++) IFEM::cout <<" "<< ptr[i];
                 IFEM::cout <<")";
               }
-              for (size_t i = 0; i < nf; i++, ptr++)
-                if (mySam->getEquation(nodeId,i+1) > 0)
-                  *ptr = oldSol[i];
+              for (size_t i = 1; i <= nf; i++, ptr++)
+                if (mySam->getEquation(nodeId,i) > 0)
+                {
+                  if (!stressFree)
+                    *ptr = oldSol(i);
+                  else if (i <= nd)
+                    newSol(nd*inod+i) = oldSol(i);
+                }
             }
           if (verbose > 0)
             IFEM::cout << std::endl;
         }
+
+      // Update initial coordinates such that the start configuration
+      // of the new elements is (nearly) stress free
+      if (stressFree && !pch->updateCoords(newSol))
+        ok = false;
     }
+
+  return ok;
 }
 
 

--- a/src/SIM/SIMbase.h
+++ b/src/SIM/SIMbase.h
@@ -275,9 +275,10 @@ public:
   //! \brief Modifies the current solution vector when activating elements.
   //! \param solution Current primary solution vector
   //! \param[in] time Parameters for nonlinear/time-dependent simulations
+  //! \param[in] stressFree If \e true, let new elements be stress-free
   //! \param[in] verbose If &gt;0, print out the newly activated nodes
-  void updateForNewElements(Vector& solution, const TimeDomain& time,
-                            int verbose = 0) const;
+  bool updateForNewElements(Vector& solution, const TimeDomain& time,
+                            bool stressFree = false, int verbose = 0) const;
 
 
   // Computational methods


### PR DESCRIPTION
This is an indication that an element shape is distorted beyond 180 degrees angles, etc. Printing out the element index during assembly is more informative than letting the equation solver fail subsequently due to ill-conditioning.
Notice that this will also prevent solving models with left-hand-side parameterization (which also gives negative energy norms, etc.).

Also in this PR:
* Optional ramp-up time for gravity forces.
* Update the `|J|*w` member in the `FiniteElement` class for axi-symmetric problems (this used to be in the apps before, but belongs in the main library since it is a generic feature).
* Option to update the control point locations instead of assigning (a large) initial displacement elements, when activating elements in an already deformed model.