### PR TITLE
Option to consider newly activated elements stress-free

### DIFF
--- a/src/ASM/ASMbase.C
+++ b/src/ASM/ASMbase.C
@@ -274,6 +274,16 @@ size_t ASMbase::getNodeIndex (int globalNum, bool) const
 }
 
 
+std::vector<size_t> ASMbase::getNodeIndices (int globalNum) const
+{
+  std::vector<int> tmp = utl::findIndices(MLGN,globalNum);
+  std::vector<size_t> indices(tmp.size());
+  for (size_t i = 0; i < tmp.size(); i++)
+    if (tmp[i] >= 0) indices[i] = tmp[i]+1;
+  return indices;
+}
+
+
 int ASMbase::getNodeID (size_t inod, bool) const
 {
   return inod < 1 || inod > MLGN.size() ? 0 : MLGN[inod-1];
@@ -802,14 +812,17 @@ bool ASMbase::addPeriodicity (size_t master, size_t slave, int dir)
 }
 
 
-void ASMbase::makePeriodic (size_t master, size_t slave, int dirs)
+bool ASMbase::makePeriodic (size_t master, size_t slave, int dirs)
 {
   std::set<int> dofs(utl::getDigits(dirs));
   if (dofs.size() == nf && *dofs.rbegin() == nf)
     // If all DOFs are going to be coupled, assign a common global node number
-    ASMbase::collapseNodes(*this,master,*this,slave);
-  else for (int dof : dofs)
-    this->addPeriodicity(master,slave,dof);
+    return ASMbase::collapseNodes(*this,master,*this,slave);
+
+  bool ok = true;
+  for (int dof : dofs)
+    ok &= this->addPeriodicity(master,slave,dof);
+  return ok;
 }
 
 

--- a/src/ASM/ASMbase.h
+++ b/src/ASM/ASMbase.h
@@ -212,15 +212,20 @@ public:
   virtual bool getOrder(int&, int&, int&) const { return false; }
 
   //! \brief Returns local 1-based index of the node with given global number.
-  //! \details If the given node number is not present, 0 is returned.
   //! \param[in] globalNum Global node number
+  //!
+  //! \details If the given node number is not present, 0 is returned.
   virtual size_t getNodeIndex(int globalNum, bool = false) const;
+  //! \brief Returns 1-based indices for all nodes with given global number.
+  //! \param[in] globalNum Global node number
+  std::vector<size_t> getNodeIndices(int globalNum) const;
   //! \brief Returns the global node number for the given node.
   //! \param[in] inod 1-based node index local to current patch
   virtual int getNodeID(size_t inod, bool = false) const;
   //! \brief Returns local 1-based index of element with given global number.
-  //! \details If the given node number is not present, 0 is returned.
   //! \param[in] globalNum Global element number
+  //!
+  //! \details If the given element number is not present, 0 is returned.
   size_t getElmIndex(int globalNum) const;
   //! \brief Returns the global element number for the given element.
   //! \param[in] iel 1-based element index local to current patch
@@ -936,7 +941,7 @@ protected:
   //! \param[in] master 1-based local index of the master node
   //! \param[in] slave 1-based local index of the slave node to constrain
   //! \param[in] dirs Which local DOFs to constrain (1, 2, 3, 12, 23, 123)
-  void makePeriodic(size_t master, size_t slave, int dirs = 123);
+  bool makePeriodic(size_t master, size_t slave, int dirs = 123);
   //! \brief Adds a patch to the list of neighbors of this patch.
   //! \param[in] pch Pointer to the neighboring patch
   void addNeighbor(ASMbase* pch);

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -1059,6 +1059,7 @@ bool SIMbase::updateForNewElements (Vector& solution, const TimeDomain& time,
       const size_t nf = pch->getNoFields();
       const size_t nd = pch->getNoSpaceDim();
       Vector newSol(stressFree ? nd*pch->getNoNodes(-1) : 0);
+      std::map<int,Vec3> newNodes;
       for (size_t iel = 1; iel <= pch->getNoElms(true); iel++)
         if (pch->isElementActive(iel-1,time.t) &&
             oldElms.find(pch->getElmID(iel)) == oldElms.end())
@@ -1089,8 +1090,8 @@ bool SIMbase::updateForNewElements (Vector& solution, const TimeDomain& time,
           if (verbose > 0)
           {
             IFEM::cout <<"\n  Average solution of new active element "
-                       << pch->getElmID(iel) <<" (from "<< count
-                       <<" of "<< elmNodes.size() <<" nodes):";
+                       << pch->getElmID(iel) <<" in P"<< pch->idx+1 <<" (from "
+                       << count <<" of "<< elmNodes.size() <<" nodes):";
             for (double v : oldSol) IFEM::cout <<" "<< v;
           }
 
@@ -1101,7 +1102,8 @@ bool SIMbase::updateForNewElements (Vector& solution, const TimeDomain& time,
             {
               double* ptr = solution.ptr() + nf*(nodeId-1);
               if (verbose > 0)
-                IFEM::cout <<"\n\tAssigned to new node "<< nodeId;
+                IFEM::cout <<"\n\tAssigned to new node "<< 1+inod
+                           <<" ["<< nodeId <<"]";
               if (verbose > 1 && !stressFree)
               {
                 IFEM::cout <<" (replacing";
@@ -1111,20 +1113,48 @@ bool SIMbase::updateForNewElements (Vector& solution, const TimeDomain& time,
               for (size_t i = 1; i <= nf; i++, ptr++)
                 if (mySam->getEquation(nodeId,i) > 0)
                 {
-                  if (!stressFree)
-                    *ptr = oldSol(i);
-                  else if (i <= nd)
+                  if (stressFree && i <= nd)
                     newSol(nd*inod+i) = oldSol(i);
+                  else
+                    *ptr = oldSol(i);
                 }
+              if (stressFree)
+                newNodes[nodeId] = Vec3(oldSol.ptr(),nd);
             }
           if (verbose > 0)
             IFEM::cout << std::endl;
         }
 
-      // Update initial coordinates such that the start configuration
-      // of the new elements is (nearly) stress free
-      if (stressFree && !pch->updateCoords(newSol))
-        ok = false;
+      if (stressFree)
+      {
+        // Update initial coordinates such that the start configuration
+        // of the new elements is (nearly) stress free
+        if (!pch->updateCoords(newSol))
+          ok = false;
+
+        // Also update the other not-yet-activated patches using the same nodes
+        for (ASMbase* qch : myModel)
+          if (qch->inActive(time.t) && qch != pch)
+          {
+            const size_t nd = qch->getNoSpaceDim();
+            newSol.resize(nd*qch->getNoNodes(-1),true);
+            for (const std::pair<const int,Vec3>& node : newNodes)
+            {
+              std::vector<size_t> indices = qch->getNodeIndices(node.first);
+              for (size_t inod : indices)
+              {
+                for (size_t i = 1; i <= nd; i++)
+                  newSol(nd*inod-nd+i) = node.second(i);
+                if (verbose > 1)
+                  IFEM::cout <<"\tAlso updating node "<< inod <<" ["
+                             << qch->getNodeID(inod) <<"] in P"<< qch->idx+1
+                             <<" with "<< node.second << std::endl;
+              }
+            }
+            if (!qch->updateCoords(newSol))
+              ok = false;
+          }
+      }
     }
 
   return ok;

--- a/src/Utility/Test/TestUtilities.C
+++ b/src/Utility/Test/TestUtilities.C
@@ -228,3 +228,20 @@ TEST_CASE("TestUtilities.GetDirs")
   REQUIRE(utl::getDirs(3) == 123);
   REQUIRE(utl::getDirs(4) == 1234);
 }
+
+
+TEST_CASE("TestUtilities.FindIndex")
+{
+  std::vector<int> data = { 1, 3, 15, 10, 23, 15, 4, 8, 10, 15, 7, 2 };
+  REQUIRE(utl::findIndex(data,10) == 3);
+  REQUIRE(utl::findIndex(data,15) == 2);
+  REQUIRE(utl::findIndex(data,23) == 4);
+  REQUIRE(utl::findIndex(data,1)  == 0);
+  REQUIRE(utl::findIndex(data,2)  == 11);
+  REQUIRE(utl::findIndex(data,5)  == -1);
+  REQUIRE(utl::findIndices(data,10) == std::vector<int>{3,8});
+  REQUIRE(utl::findIndices(data,15) == std::vector<int>{2,5,9});
+  REQUIRE(utl::findIndices(data,23) == std::vector<int>{4});
+  REQUIRE(utl::findIndices(data,1)  == std::vector<int>{0});
+  REQUIRE(utl::findIndices(data,5)  == std::vector<int>{});
+}

--- a/src/Utility/Utilities.C
+++ b/src/Utility/Utilities.C
@@ -15,6 +15,7 @@
 #include "Vec3.h"
 #include "tinyxml2.h"
 #include <algorithm>
+#include <iterator>
 #include <cstdlib>
 #include <cstring>
 
@@ -533,7 +534,17 @@ int utl::findKey (const IntMap& iMap, int iVal)
 int utl::findIndex (const std::vector<int>& iVec, int iVal)
 {
   std::vector<int>::const_iterator it = std::find(iVec.begin(),iVec.end(),iVal);
-  return it == iVec.end() ? -1 : it - iVec.begin();
+  return it == iVec.end() ? -1 : std::distance(iVec.begin(),it);
+}
+
+
+std::vector<int> utl::findIndices (const std::vector<int>& iVec, int iVal)
+{
+  std::vector<int> indices;
+  std::vector<int>::const_iterator it = iVec.begin();
+  while ((it = std::find(it,iVec.end(),iVal)) != iVec.end())
+    indices.push_back(std::distance(iVec.begin(),it++));
+  return indices;
 }
 
 

--- a/src/Utility/Utilities.h
+++ b/src/Utility/Utilities.h
@@ -221,9 +221,12 @@ namespace utl
   //! \brief Returns the key corresponding to the value \a iVal.
   //! \details If not in the map, the value \a iVal is returned.
   int findKey(const IntMap& iMap, int iVal);
-  //! \brief Returns the vector index corresponding to the value \a iVal.
+  //! \brief Returns (first) vector index corresponding to the value \a iVal.
   //! \details If not in the vector, -1 is returned.
   int findIndex(const std::vector<int>& iVec, int iVal);
+  //! \brief Returns all vector indices corresponding to the value \a iVal.
+  //! \details If not in the vector, an empty vector is returned.
+  std::vector<int> findIndices(const std::vector<int>& iVec, int iVal);
 
   //! \brief Merges integer array \a a2 into array \a a1.
   //! \details Does not require the arrays to be sorted.


### PR DESCRIPTION
This is a continuation of 6cc02418b597d6aaf731971f9482a93c1039148f which was the last (unrelated) commit in #896.
When explicitly moving the control points to avoid fictitious large deformations in newly activated elements, we mus also update the control points in associated patches not-yet-activated, sharing common node number with the updated point. otherwise the model will exhibit gaps when adding more and more patches and the simulation results will probably be wrong as well.