### PR TITLE
Time dependency for DiracSum and ElementStep

### DIFF
--- a/src/SIM/ElementSteps.C
+++ b/src/SIM/ElementSteps.C
@@ -71,13 +71,18 @@ ElementSteps::ElementSteps (const char* input, const SIMbase& sim,
       if (pch->getElementBBox(X0,X1,iel))
       {
         IFEM::cout <<" -> inside([ " << X0 <<"] - ["<< X1 <<"]) * ";
-        double amp = 1.0;
-        if (value.find('t') == std::string::npos)
+
+        char* endPtr = nullptr;
+        const char* ampExpr = value.c_str();
+        double ampConst = strtod(ampExpr,&endPtr);
+        if (strlen(endPtr) == 0)
         {
-          amp = atof(value.c_str());
-          IFEM::cout << amp << std::endl;
+          ampExpr = nullptr;
+          IFEM::cout << ampConst << std::endl;
         }
-        this->addFuncComp(value.c_str(), new StepXYZFunc(amp,X0,X1,eps));
+        else
+          ampConst = 1.0; // An expression was specified
+        this->addFuncComp(ampExpr, new StepXYZFunc(ampConst,X0,X1,eps));
       }
       else
         IFEM::cout << std::endl;

--- a/src/SIM/ElementSteps.C
+++ b/src/SIM/ElementSteps.C
@@ -22,7 +22,8 @@
 #include <cstring>
 
 
-ElementSteps::ElementSteps (const char* input, const SIMbase& sim, int nsd)
+ElementSteps::ElementSteps (const char* input, const SIMbase& sim,
+                            int nsd, double eps)
 {
   if (!input || input[0] == 0)
     return; // avoid segfault on empty string
@@ -34,7 +35,7 @@ ElementSteps::ElementSteps (const char* input, const SIMbase& sim, int nsd)
     if (cpy[i] == '\\' || cpy[i] == '|')
       cpy[i] = '\n';
 
-  IFEM::cout <<" ElementSteps";
+  IFEM::cout <<" ElementSteps\n";
   std::stringstream str(cpy);
   char temp[512];
   while (str.getline(temp,512))
@@ -42,13 +43,13 @@ ElementSteps::ElementSteps (const char* input, const SIMbase& sim, int nsd)
     {
       std::stringstream sline(temp);
       double p[3] = { 0.0, 0.0, 0.0 };
-      double value = 0.0;
+      std::string value;
       int patch = 1;
       for (int i = 0; i < nsd; i++)
         sline >> p[i];
       sline >> value >> patch;
 
-      IFEM::cout <<"\n\t\tElement("<< p[0];
+      IFEM::cout <<"\t\tElement("<< p[0];
       for (int i = 1; i < nsd; i++)
         IFEM::cout <<", "<< p[i];
       IFEM::cout <<", "<< patch <<") = "<< value;
@@ -69,9 +70,17 @@ ElementSteps::ElementSteps (const char* input, const SIMbase& sim, int nsd)
       Vec3 X0, X1;
       if (pch->getElementBBox(X0,X1,iel))
       {
-        IFEM::cout <<" -> inside([ " << X0 <<"] - ["<< X1 <<"])*"<< value;
-        this->add(new StepXYZFunc(value,X0,X1,0.001));
+        IFEM::cout <<" -> inside([ " << X0 <<"] - ["<< X1 <<"]) * ";
+        double amp = 1.0;
+        if (value.find('t') == std::string::npos)
+        {
+          amp = atof(value.c_str());
+          IFEM::cout << amp << std::endl;
+        }
+        this->addFuncComp(value.c_str(), new StepXYZFunc(amp,X0,X1,eps));
       }
+      else
+        IFEM::cout << std::endl;
     }
   IFEM::cout << std::endl;
 

--- a/src/SIM/ElementSteps.h
+++ b/src/SIM/ElementSteps.h
@@ -30,7 +30,9 @@ public:
   //! \param[in] input The string to parse for function parameters
   //! \param[in] sim The simulator holding the element information
   //! \param[in] nsd Number of spatial dimensions
-  ElementSteps(const char* input, const SIMbase& sim, int nsd);
+  //! \param[in] eps Geometric tolerance
+  ElementSteps(const char* input, const SIMbase& sim,
+               int nsd, double eps = 0.001);
 };
 
 #endif

--- a/src/SIM/FunctionSum.C
+++ b/src/SIM/FunctionSum.C
@@ -128,10 +128,16 @@ void FunctionSum::setParam (const std::string& name, double value)
 
 void RealFuncSum::addFuncComp (const char* ampl, RealFunc* f)
 {
-  if (strstr(ampl,"t"))
-    this->add(new SpaceTimeFunc(f,utl::parseTimeFunc(ampl)));
-  else
-    this->add(f);
+  if (ampl)
+  {
+    if (ScalarFunc* tf = utl::parseTimeFunc(ampl); tf)
+      f = new SpaceTimeFunc(f,tf);
+    else
+      IFEM::cout <<"  ** Malformed time expression \""<< ampl <<"\","
+                 <<" the function component will remain constant."<< std::endl;
+  }
+
+  this->add(f);
 }
 
 
@@ -165,13 +171,17 @@ DiracSum::DiracSum (const char* input, double tol, int nsd)
         IFEM::cout <<", "<< X[i];
       IFEM::cout <<") = ";
 
-      double amp = 1.0;
-      if (value.find('t') == std::string::npos)
+      char* endPtr = nullptr;
+      const char* ampExpr = value.c_str();
+      double ampConst = strtod(ampExpr,&endPtr);
+      if (strlen(endPtr) == 0)
       {
-        amp = atof(value.c_str());
-        IFEM::cout << amp << std::endl;
+        ampExpr = nullptr;
+        IFEM::cout << ampConst << std::endl;
       }
-      this->addFuncComp(value.c_str(), new DiracSpaceFunc(amp,X,tol,nsd));
+      else
+        ampConst = 1.0; // An expression was specified
+      this->addFuncComp(ampExpr, new DiracSpaceFunc(ampConst,X,tol,nsd));
     }
 
   free(cpy);

--- a/src/SIM/FunctionSum.C
+++ b/src/SIM/FunctionSum.C
@@ -14,6 +14,7 @@
 #include "FunctionSum.h"
 #include "Functions.h"
 #include "IFEM.h"
+#include "matrix.h"
 
 #include <sstream>
 #include <cstring>
@@ -31,18 +32,19 @@ bool FunctionSum::add (FunctionBase* f, double w)
 {
   if (comps.empty())
   {
-    comps.push_back(std::make_pair(f,w));
+    comps.emplace_back(f,w);
     ncmp = f->dim();
     return true;
   }
   else if (f->dim() == comps.front().first->dim())
   {
-    comps.push_back(std::make_pair(f,w));
+    comps.emplace_back(f,w);
     return true;
   }
 
   std::cerr <<" *** FunctionSum::add: Inconsistent dimensions "
             << f->dim() <<" != "<< comps.front().first->dim() << std::endl;
+  if (ownFunc) delete f;
   return false;
 }
 
@@ -117,6 +119,22 @@ double FunctionSum::getScalarValue (const Vec3& X) const
 }
 
 
+void FunctionSum::setParam (const std::string& name, double value)
+{
+  for (WeightedFunc& func : comps)
+    func.first->setParam(name,value);
+}
+
+
+void RealFuncSum::addFuncComp (const char* ampl, RealFunc* f)
+{
+  if (strstr(ampl,"t"))
+    this->add(new SpaceTimeFunc(f,utl::parseTimeFunc(ampl)));
+  else
+    this->add(f);
+}
+
+
 DiracSum::DiracSum (const char* input, double tol, int nsd)
 {
   if (!input || input[0] == 0)
@@ -129,7 +147,7 @@ DiracSum::DiracSum (const char* input, double tol, int nsd)
     if (cpy[i] == '\\' || cpy[i] == '|')
       cpy[i] = '\n';
 
-  IFEM::cout <<" DiracSum";
+  IFEM::cout <<" DiracSum\n";
   std::stringstream str(cpy);
   char temp[512];
   while (str.getline(temp,512))
@@ -137,19 +155,24 @@ DiracSum::DiracSum (const char* input, double tol, int nsd)
     {
       std::stringstream sline(temp);
       Vec3 X;
-      double value = 0.0;
+      std::string value;
       for (int i = 0; i < nsd; i++)
         sline >> X[i];
       sline >> value;
 
-      IFEM::cout <<"\n\t\tDirac("<< X.x;
+      IFEM::cout <<"\t\tDirac("<< X.x;
       for (int i = 1; i < nsd; i++)
         IFEM::cout <<", "<< X[i];
-      IFEM::cout <<") = "<< value;
+      IFEM::cout <<") = ";
 
-      this->add(new DiracSpaceFunc(value,X,tol,nsd));
+      double amp = 1.0;
+      if (value.find('t') == std::string::npos)
+      {
+        amp = atof(value.c_str());
+        IFEM::cout << amp << std::endl;
+      }
+      this->addFuncComp(value.c_str(), new DiracSpaceFunc(amp,X,tol,nsd));
     }
-  IFEM::cout << std::endl;
 
   free(cpy);
 }

--- a/src/SIM/FunctionSum.h
+++ b/src/SIM/FunctionSum.h
@@ -57,6 +57,9 @@ public:
   //! \brief Returns a representative scalar equivalent of the function value.
   double getScalarValue(const Vec3& X) const override;
 
+  //! \brief Sets an additional parameter in the function.
+  void setParam(const std::string& name, double value) override;
+
 private:
   using WeightedFunc = std::pair<FunctionBase*,double>; //!< Convenience type
 
@@ -81,6 +84,11 @@ protected:
   {
     return this->FunctionSum::getScalarValue(X);
   }
+
+  //! \brief Adds a spatial function to the list of functions to sum.
+  //! \param[in] ampl Function amplitude, constant or an expression in "t"
+  //! \param[in] f Pointer to a spatial function to sum
+  void addFuncComp(const char* ampl, RealFunc* f);
 
 public:
   //! \copydoc FunctionSum::getScalarValue()

--- a/src/Utility/ExprFunctions.C
+++ b/src/Utility/ExprFunctions.C
@@ -13,16 +13,17 @@
 
 #include "ExprFunctions.h"
 #include "Functions.h"
-#include "Vec3.h"
-#include "Tensor.h"
 #include "expreval.h"
 #include <autodiff/reverse/var.hpp>
 #ifdef USE_OPENMP
 #include <omp.h>
 #endif
+#include <type_traits>
 
 
-template<> int EvalFuncScalar<Real>::numError = 0; //!< Explicit instantiation
+namespace ExprEval {
+  int numError = 0; //!< Error counter - set by the exception handler
+}
 
 
 namespace
@@ -91,7 +92,7 @@ void ExprException (const ExprEval::Exception& exc, const char* task,
     std::cerr <<": Unknown exception";
   }
   std::cerr << std::endl;
-  EvalFuncScalar<Real>::numError++;
+  ExprEval::numError++;
 }
 
 
@@ -128,7 +129,7 @@ std::vector<std::string> splitComps (const std::string& functions,
 */
 
 template<class ArgType>
-std::pair<size_t,size_t> getNoDims(size_t psize);
+std::pair<size_t,size_t> getNoDims (size_t psize);
 
 
 /*!
@@ -203,9 +204,7 @@ int voigtIdx (int d1, int d2)
 
 
 template<class Scalar>
-EvalFuncScalar<Scalar>::EvalFuncScalar (const char* function,
-                                        const char* x, Real eps)
-  : dx(eps)
+ExpressionHolder<Scalar>::ExpressionHolder (const char* function)
 {
   try {
 #ifdef USE_OPENMP
@@ -216,24 +215,82 @@ EvalFuncScalar<Scalar>::EvalFuncScalar (const char* function,
     expr.resize(nalloc);
     f.resize(nalloc);
     v.resize(nalloc);
-    expr.resize(nalloc);
-    arg.resize(nalloc);
-    for (size_t i = 0; i < nalloc; ++i) {
+    for (size_t i = 0; i < nalloc; i++)
+    {
       expr[i] = std::make_unique<Expression>();
       f[i] = std::make_unique<FunctionList>();
       v[i] = std::make_unique<ValueList>();
       f[i]->AddDefaultFunctions();
       v[i]->AddDefaultValues();
-      v[i]->Add(x,0.0,false);
       expr[i]->SetFunctionList(f[i].get());
       expr[i]->SetValueList(v[i].get());
       expr[i]->Parse(function);
-      arg[i] = v[i]->GetAddress(x);
     }
   }
   catch (ExprEval::Exception& e) {
     ExprException(e,"parsing",function);
   }
+}
+
+
+template<class Scalar>
+ExpressionHolder<Scalar>::~ExpressionHolder () = default;
+
+
+template<class Scalar>
+void ExpressionHolder<Scalar>::setParameter (const std::string& name, Real val)
+{
+  auto setVal = [&name,val](ValueList& v)
+  {
+    Scalar* address = v.GetAddress(name);
+    if (!address)
+      v.Add(name,val,false);
+    else
+      *address = val;
+  };
+
+#ifdef USE_OPENMP
+  if (omp_in_parallel())
+    setVal(*v[omp_get_thread_num()]);
+  else
+#endif
+    for (std::unique_ptr<ValueList>& v1 : v)
+      setVal(*v1);
+}
+
+
+template<class Scalar>
+Real ExpressionHolder<Scalar>::evaluateExpression (size_t i) const
+{
+  Real result = Real(0);
+  if (i >= expr.size() || !expr[i].get())
+    return result;
+
+  try {
+    if constexpr (std::is_same_v<Scalar,Real>)
+      result = expr[i]->Evaluate();
+    else
+      result = expr[i]->Evaluate().expr->val;
+  }
+  catch (ExprEval::Exception& e) {
+    ExprException(e,"evaluating expression");
+  }
+
+  return result;
+}
+
+
+template<class Scalar>
+EvalFuncScalar<Scalar>::EvalFuncScalar (const char* function,
+                                        const char* x, Real eps)
+  : ExpressionHolder<Scalar>(function), dx(eps)
+{
+  if (ExprEval::numError > 0)
+    return; // Faulty expression
+
+  arg.resize(this->expr.size());
+  for (size_t i = 0; i < arg.size(); i++)
+    arg[i] = this->v[i]->GetAddress(x);
 }
 
 
@@ -253,32 +310,20 @@ void EvalFuncScalar<Scalar>::addDerivative (const std::string& function,
 template<class Scalar>
 Real EvalFuncScalar<Scalar>::evaluate (const Real& x) const
 {
-  Real result = Real(0);
 #ifdef USE_OPENMP
   const size_t i = omp_get_thread_num();
 #else
   const size_t i = 0;
 #endif
-  if (i >= arg.size())
-    return result;
-
-  try {
+  if (i < arg.size() && arg[i])
     *arg[i] = x;
-    if constexpr (std::is_same_v<Scalar,Real>)
-      result = expr[i]->Evaluate();
-    else
-      result = expr[i]->Evaluate().expr->val;
-  }
-  catch (ExprEval::Exception& e) {
-    ExprException(e,"evaluating expression");
-  }
 
-  return result;
+  return this->evaluateExpression(i);
 }
 
 
 template<>
-Real EvalFunc::deriv (Real x) const
+Real EvalFuncScalar<Real>::deriv (Real x) const
 {
   if (gradient)
     return gradient->evaluate(x);
@@ -299,13 +344,13 @@ Real EvalFuncScalar<autodiff::var>::deriv (Real x) const
 #else
   const size_t i = 0;
 #endif
-  if (i >= arg.size())
+  if (i >= arg.size() || !arg[i])
     return Real(0);
 
   try {
     *arg[i] = x;
-    return derivativesx(expr[i]->Evaluate(),
-                        autodiff::wrt(*this->arg[i]))[0].expr->val;
+    return derivativesx(this->expr[i]->Evaluate(),
+                        autodiff::wrt(*arg[i]))[0].expr->val;
   }
   catch (ExprEval::Exception& e) {
     ExprException(e,"evaluating expression");
@@ -318,52 +363,23 @@ Real EvalFuncScalar<autodiff::var>::deriv (Real x) const
 template<class Scalar>
 EvalFuncSpatial<Scalar>::EvalFuncSpatial (const char* function,
                                           Real epsX, Real epsT)
-  : dx(epsX), dt(epsT)
+  : ExpressionHolder<Scalar>(function), dx(epsX), dt(epsT)
 {
-  try {
-#ifdef USE_OPENMP
-    size_t nalloc = omp_get_max_threads();
-#else
-    size_t nalloc = 1;
-#endif
-    expr.resize(nalloc);
-    f.resize(nalloc);
-    v.resize(nalloc);
-    expr.resize(nalloc);
-    arg.resize(nalloc);
-    for (size_t i = 0; i < nalloc; ++i) {
-      expr[i] = std::make_unique<Expression>();
-      f[i] = std::make_unique<FunctionList>();
-      v[i] = std::make_unique<ValueList>();
-      f[i]->AddDefaultFunctions();
-      v[i]->AddDefaultValues();
-      v[i]->Add("x",0.0,false);
-      v[i]->Add("y",0.0,false);
-      v[i]->Add("z",0.0,false);
-      v[i]->Add("t",0.0,false);
-      expr[i]->SetFunctionList(f[i].get());
-      expr[i]->SetValueList(v[i].get());
-      expr[i]->Parse(function);
-      arg[i].x = v[i]->GetAddress("x");
-      arg[i].y = v[i]->GetAddress("y");
-      arg[i].z = v[i]->GetAddress("z");
-      arg[i].t = v[i]->GetAddress("t");
-    }
-  }
-  catch (ExprEval::Exception& e) {
-    ExprException(e,"parsing",function);
-  }
+  if (ExprEval::numError > 0)
+    return; // Faulty expression
 
-  // Check if the expression is time-independent by searching for
-  // the occurance of 't' where the next character is not a letter
-  IAmConstant = true;
-  std::string expr(function);
-  size_t i = expr.find_first_of('t');
-  while (i < expr.size() && IAmConstant)
-    if (i+1 < expr.size() && isalpha(expr[i+1]))
-      i = expr.find_first_of('t',i+1);
-    else
-      IAmConstant = false;
+  // Check if the expression is time-dependent
+  const bool isTimeDependent = utl::isTimeExpression(function);
+
+  arg.resize(this->expr.size());
+  for (size_t i = 0; i < arg.size(); i++)
+  {
+    arg[i].x = this->v[i]->GetAddress("x");
+    arg[i].y = this->v[i]->GetAddress("y");
+    arg[i].z = this->v[i]->GetAddress("z");
+    if (isTimeDependent)
+      arg[i].t = this->v[i]->GetAddress("t");
+  }
 }
 
 
@@ -377,60 +393,41 @@ void EvalFuncSpatial<Scalar>::addDerivative (const std::string& function,
                                              int d1, int d2)
 {
   if (d1 > 0 && d1 <= 4 && d2 < 1)
-  {
-    // A first order derivative is specified
-    if (!derivative1[--d1])
-      derivative1[d1] = std::make_unique<FuncType>((variables+function).c_str());
-  }
+    --d1; // A first order derivative is specified
   else if ((d1 = voigtIdx(d1,d2)) >= 0)
-  {
-    // A second order derivative is specified
-    if (!derivative2[d1])
-      derivative2[d1] = std::make_unique<FuncType>((variables+function).c_str());
-  }
+    d1 += 4; // A second order derivative is specified
+  else
+    return;
+
+  if (!derivative[d1])
+    derivative[d1] = std::make_unique<FuncType>((variables+function).c_str());
 }
 
 
 template<class Scalar>
 Real EvalFuncSpatial<Scalar>::evaluate (const Vec3& X) const
 {
-  Real result = Real(0);
 #ifdef USE_OPENMP
   const size_t i = omp_get_thread_num();
 #else
   const size_t i = 0;
 #endif
-  if (i >= arg.size())
-    return result;
+  if (i < arg.size())
+    arg[i] = X;
 
-  try {
-    const Vec4* Xt = dynamic_cast<const Vec4*>(&X);
-    *arg[i].x = X.x;
-    *arg[i].y = X.y;
-    *arg[i].z = X.z;
-    *arg[i].t = Xt ? Xt->t : Real(0);
-    if constexpr (std::is_same_v<Scalar,Real>)
-      result = expr[i]->Evaluate();
-    else
-      result = expr[i]->Evaluate().expr->val;
-  }
-  catch (ExprEval::Exception& e) {
-    ExprException(e,"evaluating expression");
-  }
-
-  return result;
+  return this->evaluateExpression(i);
 }
 
 
 template<>
 Real EvalFuncSpatial<Real>::deriv (const Vec3& X, int dir) const
 {
-  if (dir < 1)
+  if (dir < 1 || (dir > 3 && this->isConstant()))
     return Real(0);
   else if (dir < 4)
   {
-    if (derivative1[--dir])
-      return derivative1[dir]->evaluate(X);
+    if (derivative[--dir])
+      return derivative[dir]->evaluate(X);
 
     // Evaluate spatial derivative using central difference
     Vec4 X0, X1;
@@ -438,10 +435,10 @@ Real EvalFuncSpatial<Real>::deriv (const Vec3& X, int dir) const
     X1.assign(X); X1[dir] += 0.5*dx;
     return (this->evaluate(X1) - this->evaluate(X0)) / dx;
   }
-  else if (!IAmConstant)
+  else
   {
-    if (derivative1[3])
-      return derivative1[3]->evaluate(X);
+    if (derivative[3])
+      return derivative[3]->evaluate(X);
 
     // Evaluate time-derivative using central difference
     Vec4 X0, X1;
@@ -449,71 +446,55 @@ Real EvalFuncSpatial<Real>::deriv (const Vec3& X, int dir) const
     X1.assign(X); X1.t += 0.5*dt;
     return (this->evaluate(X1) - this->evaluate(X0)) / dt;
   }
-  else
-    return Real(0);
 }
 
 
 template<>
 Real EvalFuncSpatial<autodiff::var>::deriv (const Vec3& X, int dir) const
 {
-  if (dir < 1 || dir > 4)
-    return Real(0);
-
 #ifdef USE_OPENMP
   const size_t i = omp_get_thread_num();
 #else
   const size_t i = 0;
 #endif
-  if (i >= arg.size())
+  if (i >= arg.size() || !arg[i].validComp(dir))
     return Real(0);
 
-  const Vec4* Xt = dynamic_cast<const Vec4*>(&X);
-  *arg[i].x = X.x;
-  *arg[i].y = X.y;
-  *arg[i].z = X.z;
-  *arg[i].t = Xt ? Xt->t : Real(0);
+  arg[i] = X;
 
   // Evaluate spatial derivative using auto-diff
-  return derivativesx(expr[i]->Evaluate(),
-                      autodiff::wrt(arg[i].get(dir)))[0].expr->val;
+  return derivativesx(this->expr[i]->Evaluate(),
+                      autodiff::wrt(arg[i](dir)))[0].expr->val;
 }
 
 
 template<>
-Real EvalFuncSpatial<Real>::dderiv (const Vec3& X, int d1, int d2) const
+Real EvalFuncSpatial<Real>::dderiv (const Vec3& X, int i, int j) const
 {
-  if ((d1 = voigtIdx(d1,d2)) < 0)
+  if ((i = voigtIdx(i,j)) < 0)
     return Real(0);
+  else
+    i += 4;
 
-  return derivative2[d1] ? derivative2[d1]->evaluate(X) : Real(0);
+  return derivative[i] ? derivative[i]->evaluate(X) : Real(0);
 }
 
 
 template<>
-Real EvalFuncSpatial<autodiff::var>::dderiv (const Vec3& X, int d1, int d2) const
+Real EvalFuncSpatial<autodiff::var>::dderiv (const Vec3& X, int i, int j) const
 {
-  if (d1 < 1 || d1 > 3 ||
-      d2 < 1 || d2 > 3)
-    return Real(0);
-
 #ifdef USE_OPENMP
-  const size_t i = omp_get_thread_num();
+  const size_t t = omp_get_thread_num();
 #else
-  const size_t i = 0;
+  const size_t t = 0;
 #endif
-  if (i >= arg.size())
+  if (t >= arg.size() || !arg[t].validComp(i) || !arg[t].validComp(j))
     return Real(0);
 
-  const Vec4* Xt = dynamic_cast<const Vec4*>(&X);
-  *arg[i].x = X.x;
-  *arg[i].y = X.y;
-  *arg[i].z = X.z;
-  *arg[i].t = Xt ? Xt->t : Real(0);
-
-  return derivativesx(derivativesx(expr[i]->Evaluate(),
-                                   autodiff::wrt(arg[i].get(d1)))[0],
-                                   autodiff::wrt(arg[i].get(d2)))[0].expr->val;
+  arg[t] = X;
+  return derivativesx(derivativesx(this->expr[t]->Evaluate(),
+                                   autodiff::wrt(arg[t](i)))[0],
+                                   autodiff::wrt(arg[t](j)))[0].expr->val;
 }
 
 
@@ -528,14 +509,10 @@ Vec3 EvalFuncSpatial<autodiff::var>::gradient (const Vec3& X) const
   if (i >= arg.size())
     return Vec3();
 
-  const Vec4* Xt = dynamic_cast<const Vec4*>(&X);
-  *arg[i].x = X.x;
-  *arg[i].y = X.y;
-  *arg[i].z = X.z;
-  *arg[i].t = Xt ? Xt->t : Real(0);
+  arg[i] = X;
 
-  const auto dx = derivativesx(expr[i]->Evaluate(),
-                               autodiff::wrt(*arg[i].x, *arg[i].y, *arg[i].z));
+  const auto dx = derivativesx(this->expr[i]->Evaluate(),
+                               autodiff::wrt(arg[i](1), arg[i](2), arg[i](3)));
 
   return Vec3(dx[0].expr->val, dx[1].expr->val, dx[2].expr->val);
 }
@@ -552,48 +529,22 @@ SymmTensor EvalFuncSpatial<autodiff::var>::hessian (const Vec3& X) const
   if (i >= arg.size())
     return SymmTensor(3);
 
-  const Vec4* Xt = dynamic_cast<const Vec4*>(&X);
-  *arg[i].x = X.x;
-  *arg[i].y = X.y;
-  *arg[i].z = X.z;
-  *arg[i].t = Xt ? Xt->t : Real(0);
+  arg[i] = X;
 
-  const auto dx =
-    derivativesx(expr[i]->Evaluate(), autodiff::wrt(*arg[i].x, *arg[i].y, *arg[i].z));
+  const auto dx = derivativesx(this->expr[i]->Evaluate(),
+                               autodiff::wrt(arg[i](1), arg[i](2), arg[i](3)));
 
   const auto [uxx, uxy, uxz] =
-    derivativesx(dx[0], autodiff::wrt(*arg[i].x, *arg[i].y, *arg[i].z));
+    derivativesx(dx[0], autodiff::wrt(arg[i](1), arg[i](2), arg[i](3)));
 
   const auto [uyy, uyz] =
-    derivativesx(dx[1], autodiff::wrt(*arg[i].y, *arg[i].z));
+    derivativesx(dx[1], autodiff::wrt(arg[i](2), arg[i](3)));
 
   const auto [uzz] =
-    derivativesx(dx[2], autodiff::wrt(*arg[i].z));
+    derivativesx(dx[2], autodiff::wrt(arg[i](3)));
 
   return SymmTensor({uxx.expr->val, uyy.expr->val, uzz.expr->val,
                      uxy.expr->val, uyz.expr->val, uxz.expr->val});
-}
-
-
-template<class Scalar>
-void EvalFuncSpatial<Scalar>::setParam (const std::string& name, Real value)
-{
-  auto setVal = [&name,value](ValueList& v)
-  {
-    Scalar* address = v.GetAddress(name);
-    if (!address)
-      v.Add(name,value,false);
-    else
-      *address = value;
-  };
-
-#ifdef USE_OPENMP
-  if (omp_in_parallel())
-    setVal(*v[omp_get_thread_num()]);
-  else
-#endif
-    for (std::unique_ptr<ValueList>& v1 : v)
-      setVal(*v1);
 }
 
 
@@ -614,7 +565,8 @@ EvalFunctions<Scalar>::~EvalFunctions () = default;
 
 template<class Scalar>
 void EvalFunctions<Scalar>::addDerivative (const std::string& functions,
-                                           const std::string& variables, int d1, int d2)
+                                           const std::string& variables,
+                                           int d1, int d2)
 {
   std::vector<std::string> components = splitComps(functions,variables);
   for (size_t i = 0; i < p.size() && i < components.size(); i++)
@@ -623,31 +575,24 @@ void EvalFunctions<Scalar>::addDerivative (const std::string& functions,
 
 
 template <class ParentFunc, class Ret, class Scalar>
-Ret EvalMultiFunction<ParentFunc,Ret,Scalar>::
-evaluate (const Vec3& X) const
-{
-  std::vector<Real> res_array(this->p.size());
-  for (size_t i = 0; i < this->p.size(); ++i)
-    res_array[i] = (*this->p[i])(X);
-
-  return Ret(res_array);
-}
-
-
-template <class ParentFunc, class Ret, class Scalar>
-void EvalMultiFunction<ParentFunc,Ret,Scalar>::setNoDims ()
+EvalMultiFunction<ParentFunc,Ret,Scalar>::
+EvalMultiFunction (const std::string& functions,
+                   const std::string& variables,
+                   const Real epsX, const Real epsT)
+  : EvalFunctions<Scalar>(functions,variables,epsX,epsT)
 {
   std::tie(this->nsd, this->ncmp) = getNoDims<Ret>(this->p.size());
 }
 
 
-template<class ParentFunc, class Ret, class Scalar>
+template <class ParentFunc, class Ret, class Scalar>
 Ret EvalMultiFunction<ParentFunc,Ret,Scalar>::
-deriv (const Vec3& X, int dir) const
+evaluate (const Vec3& X) const
 {
-  std::vector<Real> tmp(this->p.size());
-  for (size_t i = 0; i < this->p.size(); ++i)
-    tmp[i] = this->p[i]->deriv(X,dir);
+  std::vector<Real> tmp;
+  tmp.reserve(this->p.size());
+  for (const std::unique_ptr<FuncType>& f : this->p)
+    tmp.push_back((*f)(X));
 
   return Ret(tmp);
 }
@@ -655,11 +600,25 @@ deriv (const Vec3& X, int dir) const
 
 template<class ParentFunc, class Ret, class Scalar>
 Ret EvalMultiFunction<ParentFunc,Ret,Scalar>::
-dderiv (const Vec3& X, int d1, int d2) const
+deriv (const Vec3& X, int dir) const
 {
-  std::vector<Real> tmp(this->p.size());
-  for (size_t i = 0; i < this->p.size(); ++i)
-    tmp[i] = this->p[i]->dderiv(X,d1,d2);
+  std::vector<Real> tmp;
+  tmp.reserve(this->p.size());
+  for (const std::unique_ptr<FuncType>& f : this->p)
+    tmp.push_back(f->deriv(X,dir));
+
+  return Ret(tmp);
+}
+
+
+template<class ParentFunc, class Ret, class Scalar>
+Ret EvalMultiFunction<ParentFunc,Ret,Scalar>::
+dderiv (const Vec3& X, int i, int j) const
+{
+  std::vector<Real> tmp;
+  tmp.reserve(this->p.size());
+  for (const std::unique_ptr<FuncType>& f : this->p)
+    tmp.push_back(f->dderiv(X,i,j));
 
   return Ret(tmp);
 }
@@ -670,16 +629,16 @@ std::vector<Real>
 EvalMultiFunction<ParentFunc,Ret,Scalar>::
 evalGradient (const Vec3& X) const
 {
-  std::vector<Real> result;
-  result.reserve(this->ncmp*this->nsd);
   std::vector<Vec3> dx;
   dx.reserve(this->p.size());
   for (const std::unique_ptr<FuncType>& f : this->p)
     dx.push_back(f->gradient(X));
 
+  std::vector<Real> result;
+  result.reserve(this->ncmp*this->nsd);
   for (size_t d = 1; d <= this->nsd; ++d)
-    for (size_t i = 1; i <= this->ncmp; ++i)
-      result.push_back(dx[i-1][d-1]);
+    for (size_t i = 0; i < this->ncmp; ++i)
+      result.push_back(dx[i](d));
 
   return result;
 }
@@ -690,13 +649,13 @@ std::vector<Real>
 EvalMultiFunction<ParentFunc,Ret,Scalar>::
 evalHessian (const Vec3& X) const
 {
-  std::vector<Real> result;
-  result.reserve(this->p.size()*this->nsd*this->nsd);
   std::vector<SymmTensor> dx;
   dx.reserve(this->p.size());
   for (const std::unique_ptr<FuncType>& f : this->p)
     dx.push_back(f->hessian(X));
 
+  std::vector<Real> result;
+  result.reserve(this->p.size()*this->nsd*this->nsd);
   for (size_t d2 = 1; d2 <= this->nsd; ++d2)
     for (size_t d1 = 1; d1 <= this->nsd; ++d1)
       for (size_t i = 0; i < this->p.size(); ++i)
@@ -708,7 +667,8 @@ evalHessian (const Vec3& X) const
 
 template <class ParentFunc, class Ret, class Scalar>
 std::vector<Real>
-EvalMultiFunction<ParentFunc,Ret,Scalar>::evalTimeDerivative (const Vec3& X) const
+EvalMultiFunction<ParentFunc,Ret,Scalar>::
+evalTimeDerivative (const Vec3& X) const
 {
   std::vector<Real> result;
   result.reserve(this->ncmp);
@@ -737,6 +697,8 @@ VecFunc* utl::parseExprVecFunc (const std::string& function, bool autodiff)
 }
 
 
+template class ExpressionHolder<Real>;
+template class ExpressionHolder<autodiff::var>;
 template class EvalFuncScalar<Real>;
 template class EvalFuncScalar<autodiff::var>;
 template class EvalFuncSpatial<Real>;

--- a/src/Utility/ExprFunctions.h
+++ b/src/Utility/ExprFunctions.h
@@ -27,24 +27,23 @@ namespace ExprEval {
   template<class ArgType> class Expression;
   template<class ArgType> class FunctionList;
   template<class ArgType> class ValueList;
+  extern int numError;
 }
 
 
 /*!
-  \brief A scalar-valued function, general expression.
+  \brief Common holder class for expression functions.
 */
 
-template<class Scalar>
-class EvalFuncScalar : public ScalarFunc
+template<class Scalar> class ExpressionHolder
 {
+protected:
   //! Type alias for expression tree
   using Expression = ExprEval::Expression<Scalar>;
   //! Type alias for function list
   using FunctionList = ExprEval::FunctionList<Scalar>;
   //! Type alias for value list
   using ValueList = ExprEval::ValueList<Scalar>;
-  //! Type alias for function
-  using FuncType = EvalFuncScalar<Scalar>;
 
   //! Roots of the expression tree
   std::vector< std::unique_ptr<Expression> > expr;
@@ -53,6 +52,28 @@ class EvalFuncScalar : public ScalarFunc
   //! Lists of variables and constants
   std::vector< std::unique_ptr<ValueList> >     v;
 
+  //! \brief The constructor parses the expression string.
+  explicit ExpressionHolder(const char* function);
+  //! \brief Default destructor.
+  virtual ~ExpressionHolder();
+
+  //! \brief Sets an additional parameter in the variables and/or constants.
+  void setParameter(const std::string& name, Real value);
+
+  //! \brief Evaluates the function expression.
+  Real evaluateExpression(size_t i) const;
+};
+
+
+/*!
+  \brief A scalar-valued function, general expression.
+*/
+
+template<class Scalar>
+class EvalFuncScalar : public ScalarFunc, private ExpressionHolder<Scalar>
+{
+  using FuncType = EvalFuncScalar<Scalar>; //!< Type alias for the function
+
   std::vector<Scalar*> arg; //!< Function argument values
 
   std::unique_ptr<FuncType> gradient; //!< First derivative expression
@@ -60,8 +81,6 @@ class EvalFuncScalar : public ScalarFunc
   Real dx; //!< Domain increment for calculation of numerical derivative
 
 public:
-  static int numError; //!< Error counter - set by the exception handler
-
   //! \brief The constructor parses the expression string.
   explicit EvalFuncScalar(const char* function, const char* x = "x",
                           Real eps = Real(1.0e-8));
@@ -72,6 +91,12 @@ public:
 
   //! \brief Adds an expression function for a first derivative.
   void addDerivative(const std::string& function, const char* x = "x");
+
+  //! \brief Sets an additional parameter in the function.
+  void setParam(const std::string& name, Real value) override
+  {
+    this->setParameter(name,value);
+  }
 
   //! \brief Returns whether the function is time-independent or not.
   bool isConstant() const override { return false; }
@@ -90,23 +115,9 @@ protected:
 */
 
 template<class Scalar>
-class EvalFuncSpatial : public RealFunc
+class EvalFuncSpatial : public RealFunc, private ExpressionHolder<Scalar>
 {
-  //! Type alias for expression tree
-  using Expression = ExprEval::Expression<Scalar>;
-  //! Type alias for function list
-  using FunctionList = ExprEval::FunctionList<Scalar>;
-  //! Type alias for value list
-  using ValueList = ExprEval::ValueList<Scalar>;
-  //! Type alias for function
-  using FuncType = EvalFuncSpatial<Scalar>;
-
-  //! Roots of the expression tree
-  std::vector< std::unique_ptr<Expression> > expr;
-  //! Lists of functions
-  std::vector< std::unique_ptr<FunctionList> >  f;
-  //! Lists of variables and constants
-  std::vector< std::unique_ptr<ValueList> >     v;
+  using FuncType = EvalFuncSpatial<Scalar>; //!< Type alias for the function
 
   //! \brief A struct representing a spatial function argument.
   struct Arg
@@ -116,28 +127,47 @@ class EvalFuncSpatial : public RealFunc
     Scalar* z; //!< Z-coordinate
     Scalar* t; //!< Time
 
-    //! \brief Returns a const ref to a member.
-    //! \param dir One-based index to member
-    const Scalar& get(int dir) const
+    //! \brief Assignment operator;
+    const Arg& operator=(const Vec3& X) const
+    {
+      const Vec4* Xt = dynamic_cast<const Vec4*>(&X);
+      if (x) *x = X.x;
+      if (y) *y = X.y;
+      if (z) *z = X.z;
+      if (t) *t = Xt ? Xt->t : Real(0);
+      return *this;
+    }
+
+    //! \brief Indexing operator (one-based).
+    const Scalar& operator()(int dir) const
+    {
+      static const Scalar dummy{};
+      switch (dir) {
+      case 1: return x ? *x : dummy;
+      case 2: return y ? *y : dummy;
+      case 3: return z ? *z : dummy;
+      case 4: return t ? *t : dummy;
+      }
+      return dummy; // Index out of range, error?
+    }
+
+    //! \brief Checks whether a component is defined or not.
+    bool validComp(int dir) const
     {
       switch (dir) {
-        case  1: return *x;
-        case  2: return *y;
-        case  3: return *z;
-        case  4: return *t;
-        default: return *x;
+      case 1: return x != nullptr;
+      case 2: return y != nullptr;
+      case 3: return z != nullptr;
+      case 4: return t != nullptr;
       }
+      return false;
     }
   };
 
   std::vector<Arg> arg; //!< Function argument values
 
-  //! First order derivative expressions
-  std::array<std::unique_ptr<FuncType>,4> derivative1;
-  //! Second order derivative expressions
-  std::array<std::unique_ptr<FuncType>,6> derivative2;
-
-  bool IAmConstant; //!< Indicates whether the time coordinate is given or not
+  //! First and second order derivative expressions
+  std::array<std::unique_ptr<FuncType>,10> derivative;
 
   Real dx; //!< Domain increment for calculation of numerical derivative
   Real dt; //!< Domain increment for calculation of numerical time-derivative
@@ -155,16 +185,19 @@ public:
   void addDerivative(const std::string& function, const std::string& variables,
                      int d1, int d2 = 0);
 
+  //! \brief Sets an additional parameter in the function.
+  void setParam(const std::string& name, Real value) override
+  {
+    this->setParameter(name,value);
+  }
+
   //! \brief Returns whether the function is time-independent or not.
-  bool isConstant() const override { return IAmConstant; }
+  bool isConstant() const override { return arg.empty() || !arg.front().t; }
 
   //! \brief Returns first-derivative of the function.
   Real deriv(const Vec3& X, int dir) const override;
   //! \brief Returns second-derivative of the function.
-  Real dderiv(const Vec3& X, int dir1, int dir2) const override;
-
-  //! \brief Sets an additional parameter in the function.
-  void setParam(const std::string& name, Real value) override;
+  Real dderiv(const Vec3& X, int i, int j) const override;
 
   //! \brief Evaluates first derivatives of the function.
   Vec3 gradient(const Vec3& X) const override
@@ -204,8 +237,8 @@ protected:
 
 public:
   //! \brief Adds an expression function for a first or second derivative.
-  void addDerivative(const std::string& functions,
-                     const std::string& variables, int d1, int d2 = 0);
+  void addDerivative(const std::string& functions, const std::string& variables,
+                     int d1, int d2 = 0);
 
   //! \brief Returns number of spatial dimension.
   size_t getNoSpaceDim() const { return nsd; }
@@ -221,7 +254,7 @@ protected:
   \details The function is implemented as an array of EvalFunction objects.
 */
 
-template <class ParentFunc, class Ret, class Scalar>
+template<class ParentFunc, class Ret, class Scalar>
 class EvalMultiFunction : public ParentFunc, public EvalFunctions<Scalar>
 {
   //! Type alias for the function
@@ -232,14 +265,7 @@ public:
   explicit EvalMultiFunction(const std::string& functions,
                              const std::string& variables = "",
                              const Real epsX = 1e-8,
-                             const Real epsT = 1e-12)
-    : EvalFunctions<Scalar>(functions,variables,epsX,epsT)
-  {
-    this->setNoDims();
-  }
-
-  //! \brief Empty destructor.
-  virtual ~EvalMultiFunction() {}
+                             const Real epsT = 1e-12);
 
   //! \brief Returns whether the function is time-independent or not.
   bool isConstant() const override
@@ -255,7 +281,7 @@ public:
   //! \brief Returns first-derivative of the function.
   Ret deriv(const Vec3& X, int dir) const override;
   //! \brief Returns second-derivative of the function.
-  Ret dderiv(const Vec3& X, int dir1, int dir2) const override;
+  Ret dderiv(const Vec3& X, int i, int j) const override;
 
   //! \brief Sets an additional parameter in the function.
   void setParam(const std::string& name, Real value) override
@@ -265,9 +291,6 @@ public:
   }
 
 protected:
-  //! \brief Sets the number of spatial dimensions (default implementation).
-  void setNoDims();
-
   //! \brief Evaluates the function expressions.
   Ret evaluate(const Vec3& X) const override;
 
@@ -291,8 +314,5 @@ using VecFuncExpr = EvalMultiFunction<VecFunc,Vec3,Real>;
 using TensorFuncExpr = EvalMultiFunction<TensorFunc,Tensor,Real>;
 //! Symmetric tensor-valued function expression
 using STensorFuncExpr = EvalMultiFunction<STensorFunc,SymmTensor,Real>;
-
-//! \brief Explicit instantiation of error flag.
-template<> int EvalFunc::numError;
 
 #endif

--- a/src/Utility/Function.h
+++ b/src/Utility/Function.h
@@ -17,6 +17,7 @@
 #include "matrixnd.h"
 #include "Tensor.h"
 #include "Vec3.h"
+#include <string>
 #include <cstddef>
 
 
@@ -134,6 +135,9 @@ public:
   Real eval(Real x) const { return this->evaluate(x); }
   //! \brief Returns the first-derivative of the function.
   virtual Real deriv(Real) const { return Real(0); }
+
+  //! \brief Sets an additional parameter in the function.
+  virtual void setParam(const std::string&, Real) {}
 };
 
 

--- a/src/Utility/Functions.C
+++ b/src/Utility/Functions.C
@@ -33,9 +33,8 @@ namespace
   const Real zTol = Real(1.0e-12); //!< Zero tolerance on function values
 
   //! \brief Creates a scalar function by parsing a character string.
-  const ScalarFunc* parseFunction (const char* type, char* cline,
-                                   Real C = Real(1), bool print = true,
-                                   bool parseConstant = true)
+  ScalarFunc* parseFunction (const char* type, char* cline, Real C = Real(1),
+                             bool print = true, bool parseConstant = true)
   {
     if (strncasecmp(type,"expr",4) == 0)
     {
@@ -665,6 +664,30 @@ Real Interpolate1D::deriv (const Vec3& X, int ddir) const
 
 
 /*!
+  Check if the expression is time-dependent by searching for the occurence
+  of 't' where neither the next nor the previous characters are alphanumeric.
+*/
+
+bool utl::isTimeExpression (const std::string& expr)
+{
+  auto isAlphaNum = [](char c) -> bool
+  {
+    return isalnum(static_cast<unsigned char>(c)) || c == '_';
+  };
+
+  const size_t n = expr.size();
+  for (size_t i = expr.find('t'); i < n; i = expr.find('t',i+1))
+  {
+    bool ok1 = i   == 0 || !isAlphaNum(expr[i-1]);
+    bool ok2 = i+1 == n || !isAlphaNum(expr[i+1]);
+    if (ok1 && ok2) return true;
+  }
+
+  return false;
+}
+
+
+/*!
   The functions are assumed on the general form
   \f[ f({\bf X},t) = A * g({\bf X}) * h(t) \f]
 
@@ -718,7 +741,7 @@ const RealFunc* utl::parseRealFunc (char* cline, Real A, bool print)
     quadratic = 3;
 
   Real C = A;
-  const RealFunc* f = nullptr;
+  RealFunc* f = nullptr;
   if (linear+quadratic > 0)
     cline = strtok(nullptr," "); // get first function parameter
 
@@ -871,7 +894,7 @@ const RealFunc* utl::parseRealFunc (char* cline, Real A, bool print)
 
   if (print)
     IFEM::cout <<" * ";
-  const ScalarFunc* s = parseFunction(cline,nullptr,C,print,false);
+  ScalarFunc* s = parseFunction(cline,nullptr,C,print,false);
 
   if (f)
     return new SpaceTimeFunc(f,s);

--- a/src/Utility/Functions.C
+++ b/src/Utility/Functions.C
@@ -43,9 +43,9 @@ namespace
       {
         if (print)
           IFEM::cout << cline;
-        EvalFuncScalar<Real>::numError = 0;
+        ExprEval::numError = 0;
         sf = new EvalFunc(cline,"t",C);
-        if (EvalFunc::numError > 0)
+        if (ExprEval::numError > 0)
         {
           delete sf;
           sf = nullptr;
@@ -956,9 +956,9 @@ RealFunc* utl::parseRealFunc (const std::string& func,
   {
     if (print)
       IFEM::cout << func;
-    EvalFunc::numError = 0;
+    ExprEval::numError = 0;
     f = new EvalFunction(func.c_str());
-    if (EvalFunc::numError > 0)
+    if (ExprEval::numError > 0)
     {
       delete f;
       f = nullptr;
@@ -1009,9 +1009,9 @@ VecFunc* utl::parseVecFunc (const std::string& func, const std::string& type,
   else if (type == "expression")
   {
     IFEM::cout <<": "<< func;
-    EvalFunc::numError = 0;
+    ExprEval::numError = 0;
     f = new VecFuncExpr(func,variables);
-    if (EvalFunc::numError > 0)
+    if (ExprEval::numError > 0)
     {
       delete f;
       f = nullptr;

--- a/src/Utility/Functions.h
+++ b/src/Utility/Functions.h
@@ -241,11 +241,11 @@ protected:
 
 class ConstTimeFunc : public RealFunc
 {
-  const ScalarFunc* tfunc; //!< The time-dependent function value
+  ScalarFunc* tfunc; //!< The time-dependent function value
 
 public:
   //! \brief Constructor initializing the function value.
-  explicit ConstTimeFunc(const ScalarFunc* f) : tfunc(f) {}
+  explicit ConstTimeFunc(ScalarFunc* f) : tfunc(f) {}
   //! \brief The destructor frees the time function.
   virtual ~ConstTimeFunc() { delete tfunc; }
 
@@ -256,6 +256,12 @@ public:
 
   //! \brief Returns first-derivative of the function.
   Real deriv(const Vec3& X, int dir) const override;
+
+  //! \brief Sets an additional parameter in the function.
+  void setParam(const std::string& name, Real value) override
+  {
+    tfunc->setParam(name,value);
+  }
 
 protected:
   //! \brief Evaluates the time-varying function.
@@ -271,12 +277,12 @@ protected:
 
 class SpaceTimeFunc : public RealFunc
 {
-  const RealFunc*   sfunc; //!< The space-dependent term
-  const ScalarFunc* tfunc; //!< The time-dependent term
+  RealFunc*   sfunc; //!< The space-dependent term
+  ScalarFunc* tfunc; //!< The time-dependent term
 
 public:
   //! \brief Constructor initializing the function terms.
-  SpaceTimeFunc(const RealFunc* s, const ScalarFunc* t) : sfunc(s), tfunc(t) {}
+  SpaceTimeFunc(RealFunc* s, ScalarFunc* t) : sfunc(s), tfunc(t) {}
   //! \brief The destructor frees the space and time functions.
   virtual ~SpaceTimeFunc() { delete sfunc; delete tfunc; }
 
@@ -289,6 +295,13 @@ public:
   Real deriv(const Vec3& X, int dir) const override;
   //! \brief Returns second-derivative of the function.
   Real dderiv(const Vec3& X, int dir1, int dir2) const override;
+
+  //! \brief Sets an additional parameter in the function.
+  void setParam(const std::string& name, Real value) override
+  {
+    sfunc->setParam(name,value);
+    tfunc->setParam(name,value);
+  }
 
 protected:
   //! \brief Evaluates the space-time function.
@@ -685,6 +698,9 @@ protected:
 
 namespace utl
 {
+  //! \brief Checks if a string is a time-dependent expression.
+  bool isTimeExpression(const std::string& expr);
+
   //! \brief Creates a scalar-valued function by parsing a character string.
   const RealFunc* parseRealFunc(char* cline, Real A = Real(1),
                                 bool print = true);

--- a/src/Utility/Test/TestFunctions.C
+++ b/src/Utility/Test/TestFunctions.C
@@ -1480,6 +1480,18 @@ TEST_CASE("TestEvalFunction.isConstant")
 }
 
 
+TEST_CASE("TestEvalFunction.isTime")
+{
+  REQUIRE(!utl::isTimeExpression("2.0*x*y"));
+  REQUIRE(utl::isTimeExpression("2.0*x*y*sin(t)"));
+  REQUIRE(utl::isTimeExpression("2*t"));
+  REQUIRE(!utl::isTimeExpression("time0*x"));
+  REQUIRE(!utl::isTimeExpression("hat*x+y"));
+  REQUIRE(utl::isTimeExpression("20+5*t"));
+  REQUIRE(!utl::isTimeExpression("3+t_0"));
+}
+
+
 TEST_CASE("TestEvalFunction.Derivatives")
 {
   const char* g    = "sin(x)*sin(y)*sin(z)*sin(t)";


### PR DESCRIPTION
This should restore the functionality probably gone (although no tests for it) when moving these two `FunctionSum` sub-classes out from the Darcy app. Expressions in `t` (time) can now be specified as amplitude instead of a constant, and a `SpaceTimeFunc` object will then be created instead where the time function is a scalar expression function. Also `setParam()` can be used in case the function expressions contain parameters that can be set externally.