### PR TITLE
Added: virtual methods advanceStep()

### DIFF
--- a/src/ASM/IntegrandBase.h
+++ b/src/ASM/IntegrandBase.h
@@ -352,6 +352,11 @@ public:
   //! \brief Returns nodal DOF flags for monolithic coupled integrands.
   virtual void getNodalDofTypes(std::vector<char>&) const {}
 
+  //! \brief Advances the time step scheme one step (for transient problems).
+  virtual bool advanceStep() { return false; }
+  //! \brief Advances the time step scheme one step (for transient problems).
+  virtual bool advanceStep(const TimeDomain&) { return this->advanceStep(); }
+
   //! \brief Returns current time/load parameter for 2ndary solution evaluation.
   double getTimeLevel() const { return myTime; }
 

--- a/src/SIM/SIMoptions.C
+++ b/src/SIM/SIMoptions.C
@@ -16,7 +16,7 @@
 #include "Profiler.h"
 #include "IFEM.h"
 #include "GlbL2projector.h"
-
+#include "print_tol.h"
 #include "tinyxml2.h"
 #ifdef HAVE_MPI
 #include <mpi.h>
@@ -373,6 +373,8 @@ bool SIMoptions::parseOldOptions (int argc, char** argv, int& i)
     ncv = atoi(argv[++i]);
   else if (!strcmp(argv[i],"-shift") && i < argc-1)
     shift = atof(argv[++i]);
+  else if (!strcmp(argv[i],"-zero_print_tol") && i < argc-1)
+    utl::zero_print_tol = atof(argv[++i]);
   else if (!strncasecmp(argv[i],"-indentprof",11))
     Profiler::indentReport = true;
   else if (!strcasecmp(argv[i],"-controller"))

--- a/src/Utility/Vec3Oper.C
+++ b/src/Utility/Vec3Oper.C
@@ -139,7 +139,7 @@ bool operator< (const Vec3& a, const Vec3& b)
 
 std::ostream& operator<< (std::ostream& os, const Vec3& a)
 {
-  return a.print(os);
+  return a.print(os,utl::zero_print_tol);
 }
 
 


### PR DESCRIPTION
Leftover from refactor 6 months ago (first commit).
In addition, the `-zero_print_tol` command-line option is added to adjust the tolerance for printing small values in vectors and matrices. This now also applies to `Vec3` objects as well.