### PR TITLE
Changed: Return type of virtual method NormBase::initIntegration()

### DIFF
--- a/src/ASM/IntegrandBase.h
+++ b/src/ASM/IntegrandBase.h
@@ -387,7 +387,7 @@ public:
   virtual ~NormBase();
 
   //! \brief Initializes the integrand with the number of integration points.
-  virtual void initIntegration(size_t, size_t) {}
+  virtual bool initIntegration(size_t, size_t) { return true; }
   //! \brief Sets the number of projected solutions.
   void initProjection(size_t nproj);
   //! \brief Sets a vector of LocalIntegrals to be used during norm integration.
@@ -546,9 +546,6 @@ public:
   //! \brief Assembles the global forces.
   void assemble(RealArray& force) const;
 
-  //! \brief Initializes the integrand with the number of integration points.
-  virtual void initIntegration(size_t, size_t) {}
-
   using Integrand::getLocalIntegral;
   //! \brief Returns a local integral container for the element \a iEl.
   LocalIntegral* getLocalIntegral(size_t, size_t iEl,
@@ -557,18 +554,15 @@ public:
   //! \brief Dummy implementation (only boundary integration is relevant).
   bool initElement(const std::vector<int>&,
                    LocalIntegral&) override { return false; }
-
   //! \brief Dummy implementation (only boundary integration is relevant).
   bool initElement(const std::vector<int>&,
                    const FiniteElement&, const Vec3&, size_t,
                    LocalIntegral&) override { return false; }
-
   //! \brief Dummy implementation (only boundary integration is relevant).
   bool initElement(const std::vector<int>&,
                    const std::vector<size_t>&,
                    const std::vector<size_t>&,
                    LocalIntegral&) override { return false; }
-
   //! \brief Dummy implementation (only boundary integration is relevant).
   bool initElement(const std::vector<int>&,
                    const MxFiniteElement&,

--- a/src/SIM/SIMbase.C
+++ b/src/SIM/SIMbase.C
@@ -2001,8 +2001,10 @@ bool SIMbase::solutionNorms (const TimeDomain& time,
     IFEM::cout <<"\nIntegrating solution norms ("<< name <<") ..."<< std::endl;
 
   myProblem->initIntegration(time,psol.front());
+  if (!norm->initIntegration(nIntGP,nBouGP))
+    return false;
+
   norm->initProjection(ssol.size());
-  norm->initIntegration(nIntGP,nBouGP);
 
   // Number of recovered solution components
   size_t nNodes = this->getNoNodes(1);
@@ -2375,7 +2377,7 @@ bool SIMbase::project (Matrix& ssol, const Vector& psol,
     myProblem->initIntegration(time,psol);
   }
 
-  // Initialize result point buffers within the integrand (if any).
+  // Pass current time to the integrand for solution evaluation, if needed.
   // The negative second argument is used to flag that we are going to
   // do numerical integration, possibly using integration point buffers instead
   // of the result evaluation buffers.


### PR DESCRIPTION
This is used by integrands with internal integration point buffers, to check that the specified number of quadrature points does not change when integrating norms.